### PR TITLE
Fix issues with API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix API key setting via provider attribute
+
 ## 1.0.1
 
 - Severity rank is computed (https://github.com/incident-io/terraform-provider-incident/pull/2)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -79,14 +79,14 @@ func (p *IncidentProvider) Configure(ctx context.Context, req provider.Configure
 	var endpoint string
 	if override := os.Getenv("INCIDENT_ENDPOINT"); override != "" {
 		endpoint = override
-	} else if data.Endpoint.IsNull() {
+	} else if data.Endpoint.IsNull() || data.Endpoint.IsUnknown() {
 		endpoint = "https://api.incident.io"
 	} else {
 		endpoint = data.Endpoint.String()
 	}
 
 	var apiKey string
-	if data.APIKey.IsNull() {
+	if data.APIKey.IsNull() || data.APIKey.IsUnknown() {
 		apiKey = os.Getenv("INCIDENT_API_KEY")
 	} else {
 		apiKey = data.APIKey.String()


### PR DESCRIPTION
We should be using IsUnknown rather than IsNull. This would've caused issues for anyone not setting via envars.