### PR TITLE
Fix creating severities w/o rank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix API key setting via provider attribute
 - Provide user-agent of terraform-provider-incident/version for all requests
+- Fix creating severities without providing a rank
 
 ## 1.0.1
 

--- a/internal/provider/incident_severity_resource.go
+++ b/internal/provider/incident_severity_resource.go
@@ -92,9 +92,8 @@ func (r *IncidentSeverityResource) Create(ctx context.Context, req resource.Crea
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	var rank *int64
-	if !data.Rank.IsNull() {
+	if !data.Rank.IsUnknown() {
 		rank = lo.ToPtr(data.Rank.ValueInt64())
 	}
 	result, err := r.client.SeveritiesV1CreateWithResponse(ctx, client.SeveritiesV1CreateJSONRequestBody{


### PR DESCRIPTION
This was defaulting the payload to rank 0 rather than leaving it nil when there was no severity defined in the resource.