### PR TITLE
Set user-agent for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix API key setting via provider attribute
+- Provide user-agent of terraform-provider-incident/version for all requests
 
 ## 1.0.1
 


### PR DESCRIPTION
So we (incident.io) can track who is using which version of the provider, so we can offer better support.