### PR TITLE
terraform: fix loading of variables from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Bugfix for terraform provider variables
+
 ## 1.0.2
 
 - Fix API key setting via provider attribute

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -84,14 +84,14 @@ func (p *IncidentProvider) Configure(ctx context.Context, req provider.Configure
 	} else if data.Endpoint.IsNull() || data.Endpoint.IsUnknown() {
 		endpoint = "https://api.incident.io"
 	} else {
-		endpoint = data.Endpoint.String()
+		endpoint = data.Endpoint.ValueString()
 	}
 
 	var apiKey string
 	if data.APIKey.IsNull() || data.APIKey.IsUnknown() {
 		apiKey = os.Getenv("INCIDENT_API_KEY")
 	} else {
-		apiKey = data.APIKey.String()
+		apiKey = data.APIKey.ValueString()
 	}
 
 	bearerTokenProvider, bearerTokenProviderErr := securityprovider.NewSecurityProviderBearerToken(apiKey)


### PR DESCRIPTION
* before, this was including "" in the actual string
* we may wish to handle receiving HTTP 401s a bit better as well