### PR TITLE
Catalog entries support alias and rank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- Support alias and rank for catalog_entry
+
 ## 1.2.0
 
 - Technically new feature, this represents attribute values on catalog entries

--- a/docs/resources/catalog_entry.md
+++ b/docs/resources/catalog_entry.md
@@ -85,9 +85,14 @@ resource "incident_catalog_entry" "service_tier" {
 
 ### Required
 
-- `attribute_values` (Attributes List) (see [below for nested schema](#nestedatt--attribute_values))
+- `attribute_values` (Attributes Set) (see [below for nested schema](#nestedatt--attribute_values))
 - `catalog_type_id` (String) ID of this catalog type
 - `name` (String) Name is the human readable name of this entry
+
+### Optional
+
+- `alias` (String) An optional alias that must uniquely identify this type
+- `rank` (Number) When catalog type is ranked, this is used to help order things
 
 ### Read-Only
 

--- a/internal/apischema/openapi.json
+++ b/internal/apischema/openapi.json
@@ -496,7 +496,7 @@
           "Incident Attachments V1"
         ],
         "summary": "List Incident Attachments V1",
-        "description": "List all incident attachements for an external resouce",
+        "description": "List all incident attachements for a given external resource or incident. You must provide either a specific incident ID or a specific external resource type and external ID.",
         "operationId": "Incident Attachments V1#List",
         "parameters": [
           {
@@ -1335,6 +1335,21 @@
             "description": "ID of this catalog type",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "Integer number of records to return",
+            "required": false,
+            "type": "integer",
+            "default": 25
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {
@@ -1344,7 +1359,8 @@
               "$ref": "#/definitions/CatalogV2ListEntriesResponseBody",
               "required": [
                 "catalog_type",
-                "catalog_entries"
+                "catalog_entries",
+                "pagination_meta"
               ]
             }
           }
@@ -1370,10 +1386,7 @@
               "required": [
                 "catalog_type_id",
                 "name",
-                "attribute_values",
-                "id",
-                "created_at",
-                "updated_at"
+                "attribute_values"
               ]
             }
           }
@@ -1450,10 +1463,7 @@
               "$ref": "#/definitions/CatalogV2UpdateEntryRequestBody",
               "required": [
                 "name",
-                "attribute_values",
-                "catalog_type_id",
-                "created_at",
-                "updated_at"
+                "attribute_values"
               ]
             }
           }
@@ -1538,13 +1548,8 @@
             "schema": {
               "$ref": "#/definitions/CatalogV2CreateTypeRequestBody",
               "required": [
-                "id",
                 "name",
-                "description",
-                "semantic_type",
-                "schema",
-                "created_at",
-                "updated_at"
+                "description"
               ]
             }
           }
@@ -1620,11 +1625,7 @@
               "$ref": "#/definitions/CatalogV2UpdateTypeRequestBody",
               "required": [
                 "name",
-                "description",
-                "semantic_type",
-                "schema",
-                "created_at",
-                "updated_at"
+                "description"
               ]
             }
           }
@@ -1698,7 +1699,10 @@
                 "name",
                 "description",
                 "semantic_type",
+                "ranked",
                 "schema",
+                "icon",
+                "color",
                 "created_at",
                 "updated_at"
               ]
@@ -1960,6 +1964,51 @@
             "description": "OK response.",
             "schema": {
               "$ref": "#/definitions/IncidentsV2ShowResponseBody",
+              "required": [
+                "incident"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
+    "/v2/incidents/{id}/actions/edit": {
+      "post": {
+        "tags": [
+          "Incidents V2"
+        ],
+        "summary": "Edit Incidents V2",
+        "description": "Edit an existing incident.\n\nThis endpoint allows you to edit the properties of an existing incident: e.g. set the severity or update custom fields.\n\nWhen using this endpoint, only fields that are provided will be edited (omitted fields \nwill be ignored).\n",
+        "operationId": "Incidents V2#Edit",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the incident that you want to edit",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "EditRequestBody",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/IncidentsV2EditRequestBody",
+              "required": [
+                "incident",
+                "notify_incident_channel"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/IncidentsV2EditResponseBody",
               "required": [
                 "incident"
               ]
@@ -2536,6 +2585,7 @@
             {
               "catalog_entry": {
                 "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "catalog_entry_name": "Primary escalation",
                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
               "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2555,6 +2605,7 @@
           {
             "catalog_entry": {
               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "catalog_entry_name": "Primary escalation",
               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2567,6 +2618,7 @@
         "value": {
           "catalog_entry": {
             "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "catalog_entry_name": "Primary escalation",
             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
           "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2627,6 +2679,7 @@
       "example": {
         "catalog_entry": {
           "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "catalog_entry_name": "Primary escalation",
           "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
         },
         "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2649,6 +2702,11 @@
           "description": "ID of this catalog entry",
           "example": "01FCNDV6P870EA6S7TK1DSYDG0"
         },
+        "catalog_entry_name": {
+          "type": "string",
+          "description": "The name of this entry",
+          "example": "Primary escalation"
+        },
         "catalog_type_id": {
           "type": "string",
           "description": "ID of this catalog type",
@@ -2657,17 +2715,24 @@
       },
       "example": {
         "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+        "catalog_entry_name": "Primary escalation",
         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
       },
       "required": [
         "catalog_type_id",
-        "catalog_entry_id"
+        "catalog_entry_id",
+        "catalog_entry_name"
       ]
     },
     "CatalogEntryV2ResponseBody": {
       "title": "CatalogEntryV2ResponseBody",
       "type": "object",
       "properties": {
+        "alias": {
+          "type": "string",
+          "description": "An optional alias that must uniquely identify this type",
+          "example": "incident-io/core"
+        },
         "attribute_values": {
           "type": "object",
           "description": "Values of this entry",
@@ -2677,6 +2742,7 @@
                 {
                   "catalog_entry": {
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2689,6 +2755,7 @@
               "value": {
                 "catalog_entry": {
                   "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2724,6 +2791,12 @@
           "description": "Name is the human readable name of this entry",
           "example": "Primary On-call"
         },
+        "rank": {
+          "type": "integer",
+          "description": "When catalog type is ranked, this is used to help order things",
+          "example": 3,
+          "format": "int32"
+        },
         "updated_at": {
           "type": "string",
           "description": "When this entry was last updated",
@@ -2732,12 +2805,14 @@
         }
       },
       "example": {
+        "alias": "incident-io/core",
         "attribute_values": {
           "abc123": {
             "array_value": [
               {
                 "catalog_entry": {
                   "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2750,6 +2825,7 @@
             "value": {
               "catalog_entry": {
                 "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "catalog_entry_name": "Primary escalation",
                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
               "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2764,12 +2840,14 @@
         "created_at": "2021-08-17T13:28:57.801578Z",
         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
         "name": "Primary On-call",
+        "rank": 3,
         "updated_at": "2021-08-17T13:28:57.801578Z"
       },
       "required": [
         "id",
         "catalog_type_id",
         "name",
+        "rank",
         "attribute_values",
         "created_at",
         "updated_at"
@@ -2781,30 +2859,30 @@
       "properties": {
         "array": {
           "type": "boolean",
-          "description": "Whether this column is an array",
+          "description": "Whether this attribute is an array",
           "example": false
         },
         "id": {
           "type": "string",
-          "description": "The ID of this column",
+          "description": "The ID of this attribute",
           "example": "01GW2G3V0S59R238FAHPDS1R66"
         },
         "name": {
           "type": "string",
-          "description": "Unique name of this column",
+          "description": "Unique name of this attribute",
           "example": "tier"
         },
         "type": {
           "type": "string",
-          "description": "The type of this column",
-          "example": "tier"
+          "description": "Catalog type name for this attribute",
+          "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
         }
       },
       "example": {
         "array": false,
         "id": "01GW2G3V0S59R238FAHPDS1R66",
         "name": "tier",
-        "type": "tier"
+        "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
       },
       "required": [
         "name",
@@ -2818,30 +2896,30 @@
       "properties": {
         "array": {
           "type": "boolean",
-          "description": "Whether this column is an array",
+          "description": "Whether this attribute is an array",
           "example": false
         },
         "id": {
           "type": "string",
-          "description": "The ID of this column",
+          "description": "The ID of this attribute",
           "example": "01GW2G3V0S59R238FAHPDS1R66"
         },
         "name": {
           "type": "string",
-          "description": "Unique name of this column",
+          "description": "Unique name of this attribute",
           "example": "tier"
         },
         "type": {
           "type": "string",
-          "description": "The type of this column",
-          "example": "tier"
+          "description": "Catalog type name for this attribute",
+          "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
         }
       },
       "example": {
         "array": false,
         "id": "01GW2G3V0S59R238FAHPDS1R66",
         "name": "tier",
-        "type": "tier"
+        "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
       },
       "required": [
         "id",
@@ -2865,7 +2943,7 @@
               "array": false,
               "id": "01GW2G3V0S59R238FAHPDS1R66",
               "name": "tier",
-              "type": "tier"
+              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
             }
           ]
         },
@@ -2882,7 +2960,7 @@
             "array": false,
             "id": "01GW2G3V0S59R238FAHPDS1R66",
             "name": "tier",
-            "type": "tier"
+            "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
           }
         ],
         "version": 1
@@ -2896,6 +2974,19 @@
       "title": "CatalogTypeV2ResponseBody",
       "type": "object",
       "properties": {
+        "color": {
+          "type": "string",
+          "description": "Sets the display color of this type in the dashboard",
+          "example": "slate",
+          "enum": [
+            "slate",
+            "red",
+            "yellow",
+            "green",
+            "blue",
+            "violet"
+          ]
+        },
         "created_at": {
           "type": "string",
           "description": "When this type was created",
@@ -2907,6 +2998,27 @@
           "description": "Human readble description of this type",
           "example": "Represents Kubernetes clusters that we run inside of GKE."
         },
+        "estimated_count": {
+          "type": "integer",
+          "description": "If populated, gives an estimated count of entries for this type",
+          "example": 7,
+          "format": "int64"
+        },
+        "icon": {
+          "type": "string",
+          "description": "Sets the display icon of this type in the dashboard",
+          "example": "box",
+          "enum": [
+            "box",
+            "briefcase",
+            "bulb",
+            "clock",
+            "cog",
+            "doc",
+            "email",
+            "users"
+          ]
+        },
         "id": {
           "type": "string",
           "description": "ID of this resource",
@@ -2917,13 +3029,29 @@
           "description": "Name is the human readable name of this type",
           "example": "Kubernetes Cluster"
         },
+        "ranked": {
+          "type": "boolean",
+          "description": "If this type should be ranked",
+          "example": true
+        },
+        "required_integrations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "abc123"
+          },
+          "description": "If populated, the integrations required for this type",
+          "example": [
+            "pager_duty"
+          ]
+        },
         "schema": {
           "$ref": "#/definitions/CatalogTypeSchemaV2ResponseBody"
         },
         "semantic_type": {
           "type": "string",
           "description": "Semantic type of this resource",
-          "example": "service"
+          "example": "custom"
         },
         "updated_at": {
           "type": "string",
@@ -2933,22 +3061,29 @@
         }
       },
       "example": {
+        "color": "slate",
         "created_at": "2021-08-17T13:28:57.801578Z",
         "description": "Represents Kubernetes clusters that we run inside of GKE.",
+        "estimated_count": 7,
+        "icon": "box",
         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
         "name": "Kubernetes Cluster",
+        "ranked": true,
+        "required_integrations": [
+          "pager_duty"
+        ],
         "schema": {
           "attributes": [
             {
               "array": false,
               "id": "01GW2G3V0S59R238FAHPDS1R66",
               "name": "tier",
-              "type": "tier"
+              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
             }
           ],
           "version": 1
         },
-        "semantic_type": "service",
+        "semantic_type": "custom",
         "updated_at": "2021-08-17T13:28:57.801578Z"
       },
       "required": [
@@ -2956,7 +3091,10 @@
         "name",
         "description",
         "semantic_type",
+        "ranked",
         "schema",
+        "icon",
+        "color",
         "created_at",
         "updated_at"
       ]
@@ -2965,6 +3103,11 @@
       "title": "CatalogV2CreateEntryRequestBody",
       "type": "object",
       "properties": {
+        "alias": {
+          "type": "string",
+          "description": "An optional alias that must uniquely identify this type",
+          "example": "incident-io/core"
+        },
         "attribute_values": {
           "type": "object",
           "description": "Values of this entry",
@@ -2993,9 +3136,16 @@
           "type": "string",
           "description": "Name is the human readable name of this entry",
           "example": "Primary On-call"
+        },
+        "rank": {
+          "type": "integer",
+          "description": "When catalog type is ranked, this is used to help order things",
+          "example": 3,
+          "format": "int32"
         }
       },
       "example": {
+        "alias": "incident-io/core",
         "attribute_values": {
           "abc123": {
             "array_value": [
@@ -3009,15 +3159,13 @@
           }
         },
         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-        "name": "Primary On-call"
+        "name": "Primary On-call",
+        "rank": 3
       },
       "required": [
         "catalog_type_id",
         "name",
-        "attribute_values",
-        "id",
-        "created_at",
-        "updated_at"
+        "attribute_values"
       ]
     },
     "CatalogV2CreateEntryResponseBody": {
@@ -3030,12 +3178,14 @@
       },
       "example": {
         "catalog_entry": {
+          "alias": "incident-io/core",
           "attribute_values": {
             "abc123": {
               "array_value": [
                 {
                   "catalog_entry": {
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3048,6 +3198,7 @@
               "value": {
                 "catalog_entry": {
                   "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3062,6 +3213,7 @@
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Primary On-call",
+          "rank": 3,
           "updated_at": "2021-08-17T13:28:57.801578Z"
         }
       },
@@ -3073,35 +3225,66 @@
       "title": "CatalogV2CreateTypeRequestBody",
       "type": "object",
       "properties": {
+        "color": {
+          "type": "string",
+          "description": "Sets the display color of this type in the dashboard",
+          "example": "slate",
+          "enum": [
+            "slate",
+            "red",
+            "yellow",
+            "green",
+            "blue",
+            "violet"
+          ]
+        },
         "description": {
           "type": "string",
           "description": "Human readble description of this type",
           "example": "Represents Kubernetes clusters that we run inside of GKE."
+        },
+        "icon": {
+          "type": "string",
+          "description": "Sets the display icon of this type in the dashboard",
+          "example": "box",
+          "enum": [
+            "box",
+            "briefcase",
+            "bulb",
+            "clock",
+            "cog",
+            "doc",
+            "email",
+            "users"
+          ]
         },
         "name": {
           "type": "string",
           "description": "Name is the human readable name of this type",
           "example": "Kubernetes Cluster"
         },
+        "ranked": {
+          "type": "boolean",
+          "description": "If this type should be ranked",
+          "example": true
+        },
         "semantic_type": {
           "type": "string",
           "description": "Semantic type of this resource",
-          "example": "service"
+          "example": "custom"
         }
       },
       "example": {
+        "color": "slate",
         "description": "Represents Kubernetes clusters that we run inside of GKE.",
+        "icon": "box",
         "name": "Kubernetes Cluster",
-        "semantic_type": "service"
+        "ranked": true,
+        "semantic_type": "custom"
       },
       "required": [
-        "id",
         "name",
-        "description",
-        "semantic_type",
-        "schema",
-        "created_at",
-        "updated_at"
+        "description"
       ]
     },
     "CatalogV2CreateTypeResponseBody": {
@@ -3114,22 +3297,29 @@
       },
       "example": {
         "catalog_type": {
+          "color": "slate",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "estimated_count": 7,
+          "icon": "box",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Kubernetes Cluster",
+          "ranked": true,
+          "required_integrations": [
+            "pager_duty"
+          ],
           "schema": {
             "attributes": [
               {
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ],
             "version": 1
           },
-          "semantic_type": "service",
+          "semantic_type": "custom",
           "updated_at": "2021-08-17T13:28:57.801578Z"
         }
       },
@@ -3148,12 +3338,14 @@
           },
           "example": [
             {
+              "alias": "incident-io/core",
               "attribute_values": {
                 "abc123": {
                   "array_value": [
                     {
                       "catalog_entry": {
                         "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
                       "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3166,6 +3358,7 @@
                   "value": {
                     "catalog_entry": {
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3180,23 +3373,29 @@
               "created_at": "2021-08-17T13:28:57.801578Z",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "name": "Primary On-call",
+              "rank": 3,
               "updated_at": "2021-08-17T13:28:57.801578Z"
             }
           ]
         },
         "catalog_type": {
           "$ref": "#/definitions/CatalogTypeV2ResponseBody"
+        },
+        "pagination_meta": {
+          "$ref": "#/definitions/PaginationMetaResponseBody"
         }
       },
       "example": {
         "catalog_entries": [
           {
+            "alias": "incident-io/core",
             "attribute_values": {
               "abc123": {
                 "array_value": [
                   {
                     "catalog_entry": {
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3209,6 +3408,7 @@
                 "value": {
                   "catalog_entry": {
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3223,32 +3423,45 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Primary On-call",
+            "rank": 3,
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         ],
         "catalog_type": {
+          "color": "slate",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "estimated_count": 7,
+          "icon": "box",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Kubernetes Cluster",
+          "ranked": true,
+          "required_integrations": [
+            "pager_duty"
+          ],
           "schema": {
             "attributes": [
               {
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ],
             "version": 1
           },
-          "semantic_type": "service",
+          "semantic_type": "custom",
           "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "pagination_meta": {
+          "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "page_size": 25
         }
       },
       "required": [
         "catalog_type",
-        "catalog_entries"
+        "catalog_entries",
+        "pagination_meta"
       ]
     },
     "CatalogV2ListTypesResponseBody": {
@@ -3262,22 +3475,29 @@
           },
           "example": [
             {
+              "color": "slate",
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Represents Kubernetes clusters that we run inside of GKE.",
+              "estimated_count": 7,
+              "icon": "box",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "name": "Kubernetes Cluster",
+              "ranked": true,
+              "required_integrations": [
+                "pager_duty"
+              ],
               "schema": {
                 "attributes": [
                   {
                     "array": false,
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
                     "name": "tier",
-                    "type": "tier"
+                    "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                   }
                 ],
                 "version": 1
               },
-              "semantic_type": "service",
+              "semantic_type": "custom",
               "updated_at": "2021-08-17T13:28:57.801578Z"
             }
           ]
@@ -3286,22 +3506,29 @@
       "example": {
         "catalog_types": [
           {
+            "color": "slate",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "estimated_count": 7,
+            "icon": "box",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Kubernetes Cluster",
+            "ranked": true,
+            "required_integrations": [
+              "pager_duty"
+            ],
             "schema": {
               "attributes": [
                 {
                   "array": false,
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
                   "name": "tier",
-                  "type": "tier"
+                  "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                 }
               ],
               "version": 1
             },
-            "semantic_type": "service",
+            "semantic_type": "custom",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         ]
@@ -3323,12 +3550,14 @@
       },
       "example": {
         "catalog_entry": {
+          "alias": "incident-io/core",
           "attribute_values": {
             "abc123": {
               "array_value": [
                 {
                   "catalog_entry": {
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3341,6 +3570,7 @@
               "value": {
                 "catalog_entry": {
                   "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3355,25 +3585,33 @@
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Primary On-call",
+          "rank": 3,
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "catalog_type": {
+          "color": "slate",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "estimated_count": 7,
+          "icon": "box",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Kubernetes Cluster",
+          "ranked": true,
+          "required_integrations": [
+            "pager_duty"
+          ],
           "schema": {
             "attributes": [
               {
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ],
             "version": 1
           },
-          "semantic_type": "service",
+          "semantic_type": "custom",
           "updated_at": "2021-08-17T13:28:57.801578Z"
         }
       },
@@ -3392,22 +3630,29 @@
       },
       "example": {
         "catalog_type": {
+          "color": "slate",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "estimated_count": 7,
+          "icon": "box",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Kubernetes Cluster",
+          "ranked": true,
+          "required_integrations": [
+            "pager_duty"
+          ],
           "schema": {
             "attributes": [
               {
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ],
             "version": 1
           },
-          "semantic_type": "service",
+          "semantic_type": "custom",
           "updated_at": "2021-08-17T13:28:57.801578Z"
         }
       },
@@ -3419,6 +3664,11 @@
       "title": "CatalogV2UpdateEntryRequestBody",
       "type": "object",
       "properties": {
+        "alias": {
+          "type": "string",
+          "description": "An optional alias that must uniquely identify this type",
+          "example": "incident-io/core"
+        },
         "attribute_values": {
           "type": "object",
           "description": "Values of this entry",
@@ -3442,9 +3692,16 @@
           "type": "string",
           "description": "Name is the human readable name of this entry",
           "example": "Primary On-call"
+        },
+        "rank": {
+          "type": "integer",
+          "description": "When catalog type is ranked, this is used to help order things",
+          "example": 3,
+          "format": "int32"
         }
       },
       "example": {
+        "alias": "incident-io/core",
         "attribute_values": {
           "abc123": {
             "array_value": [
@@ -3457,14 +3714,12 @@
             }
           }
         },
-        "name": "Primary On-call"
+        "name": "Primary On-call",
+        "rank": 3
       },
       "required": [
         "name",
-        "attribute_values",
-        "catalog_type_id",
-        "created_at",
-        "updated_at"
+        "attribute_values"
       ]
     },
     "CatalogV2UpdateEntryResponseBody": {
@@ -3480,12 +3735,14 @@
       },
       "example": {
         "catalog_entry": {
+          "alias": "incident-io/core",
           "attribute_values": {
             "abc123": {
               "array_value": [
                 {
                   "catalog_entry": {
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3498,6 +3755,7 @@
               "value": {
                 "catalog_entry": {
                   "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -3512,25 +3770,33 @@
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Primary On-call",
+          "rank": 3,
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "catalog_type": {
+          "color": "slate",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "estimated_count": 7,
+          "icon": "box",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Kubernetes Cluster",
+          "ranked": true,
+          "required_integrations": [
+            "pager_duty"
+          ],
           "schema": {
             "attributes": [
               {
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ],
             "version": 1
           },
-          "semantic_type": "service",
+          "semantic_type": "custom",
           "updated_at": "2021-08-17T13:28:57.801578Z"
         }
       },
@@ -3543,34 +3809,66 @@
       "title": "CatalogV2UpdateTypeRequestBody",
       "type": "object",
       "properties": {
+        "color": {
+          "type": "string",
+          "description": "Sets the display color of this type in the dashboard",
+          "example": "slate",
+          "enum": [
+            "slate",
+            "red",
+            "yellow",
+            "green",
+            "blue",
+            "violet"
+          ]
+        },
         "description": {
           "type": "string",
           "description": "Human readble description of this type",
           "example": "Represents Kubernetes clusters that we run inside of GKE."
+        },
+        "icon": {
+          "type": "string",
+          "description": "Sets the display icon of this type in the dashboard",
+          "example": "box",
+          "enum": [
+            "box",
+            "briefcase",
+            "bulb",
+            "clock",
+            "cog",
+            "doc",
+            "email",
+            "users"
+          ]
         },
         "name": {
           "type": "string",
           "description": "Name is the human readable name of this type",
           "example": "Kubernetes Cluster"
         },
+        "ranked": {
+          "type": "boolean",
+          "description": "If this type should be ranked",
+          "example": true
+        },
         "semantic_type": {
           "type": "string",
           "description": "Semantic type of this resource",
-          "example": "service"
+          "example": "custom"
         }
       },
       "example": {
+        "color": "slate",
         "description": "Represents Kubernetes clusters that we run inside of GKE.",
+        "icon": "box",
         "name": "Kubernetes Cluster",
-        "semantic_type": "service"
+        "ranked": true,
+        "semantic_type": "custom"
       },
       "required": [
         "name",
-        "description",
-        "semantic_type",
-        "schema",
-        "created_at",
-        "updated_at"
+        "description"
       ]
     },
     "CatalogV2UpdateTypeResponseBody": {
@@ -3583,22 +3881,29 @@
       },
       "example": {
         "catalog_type": {
+          "color": "slate",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "estimated_count": 7,
+          "icon": "box",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Kubernetes Cluster",
+          "ranked": true,
+          "required_integrations": [
+            "pager_duty"
+          ],
           "schema": {
             "attributes": [
               {
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ],
             "version": 1
           },
-          "semantic_type": "service",
+          "semantic_type": "custom",
           "updated_at": "2021-08-17T13:28:57.801578Z"
         }
       },
@@ -3620,7 +3925,7 @@
               "array": false,
               "id": "01GW2G3V0S59R238FAHPDS1R66",
               "name": "tier",
-              "type": "tier"
+              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
             }
           ]
         },
@@ -3636,7 +3941,7 @@
             "array": false,
             "id": "01GW2G3V0S59R238FAHPDS1R66",
             "name": "tier",
-            "type": "tier"
+            "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
           }
         ],
         "version": 1
@@ -3647,7 +3952,10 @@
         "name",
         "description",
         "semantic_type",
+        "ranked",
         "schema",
+        "icon",
+        "color",
         "created_at",
         "updated_at"
       ]
@@ -3662,22 +3970,29 @@
       },
       "example": {
         "catalog_type": {
+          "color": "slate",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "estimated_count": 7,
+          "icon": "box",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Kubernetes Cluster",
+          "ranked": true,
+          "required_integrations": [
+            "pager_duty"
+          ],
           "schema": {
             "attributes": [
               {
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ],
             "version": 1
           },
-          "semantic_type": "service",
+          "semantic_type": "custom",
           "updated_at": "2021-08-17T13:28:57.801578Z"
         }
       },
@@ -4206,6 +4521,7 @@
         "show_before_closure",
         "show_before_update",
         "options",
+        "is_usable",
         "conditions",
         "created_at",
         "updated_at"
@@ -4286,6 +4602,7 @@
         "show_before_closure",
         "show_before_update",
         "options",
+        "is_usable",
         "conditions",
         "created_at",
         "updated_at"
@@ -5035,6 +5352,7 @@
             "enum": [
               "viewer",
               "incident_creator",
+              "incident_editor",
               "global_access",
               "manage_settings"
             ]
@@ -5218,6 +5536,88 @@
       "required": [
         "incident_attachments"
       ]
+    },
+    "IncidentEditPayloadV2RequestBody": {
+      "title": "IncidentEditPayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "custom_field_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CustomFieldEntryPayloadV2RequestBody"
+          },
+          "description": "Set the incident's custom fields to these values",
+          "example": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ]
+        },
+        "incident_timestamp_values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IncidentTimestampValuePayloadV2RequestBody"
+          },
+          "description": "Assign the incident's timestamps to these values",
+          "example": [
+            {
+              "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "value": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Explanation of the incident",
+          "example": "Our database is sad"
+        },
+        "severity_id": {
+          "type": "string",
+          "description": "Severity to change incident to",
+          "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Detailed description of the incident",
+          "example": "Our database is really really sad, and we don't know why yet."
+        }
+      },
+      "example": {
+        "custom_field_entries": [
+          {
+            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "values": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_link": "https://google.com/",
+                "value_numeric": "123.456",
+                "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_text": "This is my text field, I hope you like it",
+                "value_timestamp": ""
+              }
+            ]
+          }
+        ],
+        "incident_timestamp_values": [
+          {
+            "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "value": "2021-08-17T13:28:57.801578Z"
+          }
+        ],
+        "name": "Our database is sad",
+        "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+        "summary": "Our database is really really sad, and we don't know why yet."
+      }
     },
     "IncidentRoleAssignmentPayloadV1RequestBody": {
       "title": "IncidentRoleAssignmentPayloadV1RequestBody",
@@ -7954,6 +8354,11 @@
             }
           ]
         },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the incident",
+          "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+        },
         "idempotency_key": {
           "type": "string",
           "description": "Unique string used to de-duplicate incident create requests",
@@ -8059,6 +8464,7 @@
             ]
           }
         ],
+        "id": "01FDAG4SAP5TYPT98WGR2N7W91",
         "idempotency_key": "alert-uuid",
         "incident_role_assignments": [
           {
@@ -8095,6 +8501,193 @@
     },
     "IncidentsV2CreateResponseBody": {
       "title": "IncidentsV2CreateResponseBody",
+      "type": "object",
+      "properties": {
+        "incident": {
+          "$ref": "#/definitions/IncidentV2ResponseBody"
+        }
+      },
+      "example": {
+        "incident": {
+          "call_url": "https://zoom.us/foo",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "creator": {
+            "api_key": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My test API key"
+            },
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          },
+          "custom_field_entries": [
+            {
+              "custom_field": {
+                "description": "Which team is impacted by this issue",
+                "field_type": "single_select",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Affected Team",
+                "options": [
+                  {
+                    "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "sort_key": 10,
+                    "value": "Product"
+                  }
+                ]
+              },
+              "values": [
+                {
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option": {
+                    "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "sort_key": 10,
+                    "value": "Product"
+                  },
+                  "value_text": "This is my text field, I hope you like it"
+                }
+              ]
+            }
+          ],
+          "external_issue_reference": {
+            "issue_name": "INC-123",
+            "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+            "provider": "asana"
+          },
+          "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "role": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "The person currently coordinating the incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "required": true,
+                "role_type": "lead",
+                "shortform": "lead",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            }
+          ],
+          "incident_status": {
+            "category": "triage",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Closed",
+            "rank": 4,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "incident_timestamp_values": [
+            {
+              "incident_timestamp": {
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Impact started",
+                "rank": 1
+              },
+              "value": {
+                "value": "2021-08-17T13:28:57.801578Z"
+              }
+            }
+          ],
+          "incident_type": {
+            "create_in_triage": "always",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Customer facing production outages",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_default": false,
+            "name": "Production Outage",
+            "private_incidents_only": false,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "mode": "standard",
+          "name": "Our database is sad",
+          "permalink": "https://app.incident.io/incidents/123",
+          "postmortem_document_url": "https://docs.google.com/my_doc_id",
+          "reference": "INC-123",
+          "severity": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Issues with **low impact**.",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Minor",
+            "rank": 1,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "slack_channel_id": "C02AW36C1M5",
+          "slack_channel_name": "inc-165-green-parrot",
+          "slack_team_id": "T02A1FSLE8J",
+          "summary": "Our database is really really sad, and we don't know why yet.",
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "visibility": "public"
+        }
+      },
+      "required": [
+        "incident"
+      ]
+    },
+    "IncidentsV2EditRequestBody": {
+      "title": "IncidentsV2EditRequestBody",
+      "type": "object",
+      "properties": {
+        "incident": {
+          "$ref": "#/definitions/IncidentEditPayloadV2RequestBody"
+        },
+        "notify_incident_channel": {
+          "type": "boolean",
+          "description": "Should we send Slack channel notifications to inform responders of this update? Note that this won't work if the Slack channel has already been archived.",
+          "example": true
+        }
+      },
+      "example": {
+        "incident": {
+          "custom_field_entries": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ],
+          "incident_timestamp_values": [
+            {
+              "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "value": "2021-08-17T13:28:57.801578Z"
+            }
+          ],
+          "name": "Our database is sad",
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "summary": "Our database is really really sad, and we don't know why yet."
+        },
+        "notify_incident_channel": true
+      },
+      "required": [
+        "incident",
+        "notify_incident_channel"
+      ]
+    },
+    "IncidentsV2EditResponseBody": {
+      "title": "IncidentsV2EditResponseBody",
       "type": "object",
       "properties": {
         "incident": {
@@ -8666,6 +9259,7 @@
         "page_size": {
           "type": "integer",
           "description": "What was the maximum number of results requested",
+          "default": 25,
           "example": 25,
           "format": "int64"
         }
@@ -8690,6 +9284,7 @@
         "page_size": {
           "type": "integer",
           "description": "What was the maximum number of results requested",
+          "default": 25,
           "example": 25,
           "format": "int64"
         },

--- a/internal/apischema/openapi3.json
+++ b/internal/apischema/openapi3.json
@@ -718,7 +718,7 @@
           "Incident Attachments V1"
         ],
         "summary": "List Incident Attachments V1",
-        "description": "List all incident attachements for an external resouce",
+        "description": "List all incident attachements for a given external resource or incident. You must provide either a specific incident ID or a specific external resource type and external ID.",
         "operationId": "Incident Attachments V1#List",
         "parameters": [
           {
@@ -2177,6 +2177,32 @@
               "example": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "Integer number of records to return",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "integer",
+              "description": "Integer number of records to return",
+              "default": 25,
+              "example": 25,
+              "format": "int64"
+            },
+            "example": 25
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+            },
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
           }
         ],
         "responses": {
@@ -2190,12 +2216,14 @@
                 "example": {
                   "catalog_entries": [
                     {
+                      "alias": "incident-io/core",
                       "attribute_values": {
                         "abc123": {
                           "array_value": [
                             {
                               "catalog_entry": {
                                 "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                                "catalog_entry_name": "Primary escalation",
                                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                               },
                               "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2208,6 +2236,7 @@
                           "value": {
                             "catalog_entry": {
                               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
                             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2222,27 +2251,39 @@
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call",
+                      "rank": 3,
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     }
                   ],
                   "catalog_type": {
+                    "color": "slate",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "estimated_count": 7,
+                    "icon": "box",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "tier"
+                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                         }
                       ],
                       "version": 1
                     },
-                    "semantic_type": "service",
+                    "semantic_type": "custom",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
+                  },
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
                   }
                 }
               }
@@ -2265,6 +2306,7 @@
                 "$ref": "#/components/schemas/CreateEntryRequestBody"
               },
               "example": {
+                "alias": "incident-io/core",
                 "attribute_values": {
                   "abc123": {
                     "array_value": [
@@ -2278,7 +2320,8 @@
                   }
                 },
                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Primary On-call"
+                "name": "Primary On-call",
+                "rank": 3
               }
             }
           }
@@ -2293,12 +2336,14 @@
                 },
                 "example": {
                   "catalog_entry": {
+                    "alias": "incident-io/core",
                     "attribute_values": {
                       "abc123": {
                         "array_value": [
                           {
                             "catalog_entry": {
                               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
                             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2311,6 +2356,7 @@
                         "value": {
                           "catalog_entry": {
                             "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
                           "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2325,6 +2371,7 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Primary On-call",
+                    "rank": 3,
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -2393,12 +2440,14 @@
                 },
                 "example": {
                   "catalog_entry": {
+                    "alias": "incident-io/core",
                     "attribute_values": {
                       "abc123": {
                         "array_value": [
                           {
                             "catalog_entry": {
                               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
                             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2411,6 +2460,7 @@
                         "value": {
                           "catalog_entry": {
                             "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
                           "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2425,25 +2475,33 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Primary On-call",
+                    "rank": 3,
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   },
                   "catalog_type": {
+                    "color": "slate",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "estimated_count": 7,
+                    "icon": "box",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "tier"
+                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                         }
                       ],
                       "version": 1
                     },
-                    "semantic_type": "service",
+                    "semantic_type": "custom",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -2481,6 +2539,7 @@
                 "$ref": "#/components/schemas/UpdateEntryRequestBody"
               },
               "example": {
+                "alias": "incident-io/core",
                 "attribute_values": {
                   "abc123": {
                     "array_value": [
@@ -2493,7 +2552,8 @@
                     }
                   }
                 },
-                "name": "Primary On-call"
+                "name": "Primary On-call",
+                "rank": 3
               }
             }
           }
@@ -2508,12 +2568,14 @@
                 },
                 "example": {
                   "catalog_entry": {
+                    "alias": "incident-io/core",
                     "attribute_values": {
                       "abc123": {
                         "array_value": [
                           {
                             "catalog_entry": {
                               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
                             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2526,6 +2588,7 @@
                         "value": {
                           "catalog_entry": {
                             "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
                           "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -2540,25 +2603,33 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Primary On-call",
+                    "rank": 3,
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   },
                   "catalog_type": {
+                    "color": "slate",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "estimated_count": 7,
+                    "icon": "box",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "tier"
+                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                         }
                       ],
                       "version": 1
                     },
-                    "semantic_type": "service",
+                    "semantic_type": "custom",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -2587,22 +2658,29 @@
                 "example": {
                   "catalog_types": [
                     {
+                      "color": "slate",
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                      "estimated_count": 7,
+                      "icon": "box",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Kubernetes Cluster",
+                      "ranked": true,
+                      "required_integrations": [
+                        "pager_duty"
+                      ],
                       "schema": {
                         "attributes": [
                           {
                             "array": false,
                             "id": "01GW2G3V0S59R238FAHPDS1R66",
                             "name": "tier",
-                            "type": "tier"
+                            "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                           }
                         ],
                         "version": 1
                       },
-                      "semantic_type": "service",
+                      "semantic_type": "custom",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     }
                   ]
@@ -2627,9 +2705,12 @@
                 "$ref": "#/components/schemas/CreateTypeRequestBody"
               },
               "example": {
+                "color": "slate",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                "icon": "box",
                 "name": "Kubernetes Cluster",
-                "semantic_type": "service"
+                "ranked": true,
+                "semantic_type": "custom"
               }
             }
           }
@@ -2644,22 +2725,29 @@
                 },
                 "example": {
                   "catalog_type": {
+                    "color": "slate",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "estimated_count": 7,
+                    "icon": "box",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "tier"
+                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                         }
                       ],
                       "version": 1
                     },
-                    "semantic_type": "service",
+                    "semantic_type": "custom",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -2728,22 +2816,29 @@
                 },
                 "example": {
                   "catalog_type": {
+                    "color": "slate",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "estimated_count": 7,
+                    "icon": "box",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "tier"
+                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                         }
                       ],
                       "version": 1
                     },
-                    "semantic_type": "service",
+                    "semantic_type": "custom",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -2778,12 +2873,15 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateTypeRequestBody"
+                "$ref": "#/components/schemas/CreateTypeRequestBody"
               },
               "example": {
+                "color": "slate",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                "icon": "box",
                 "name": "Kubernetes Cluster",
-                "semantic_type": "service"
+                "ranked": true,
+                "semantic_type": "custom"
               }
             }
           }
@@ -2798,22 +2896,29 @@
                 },
                 "example": {
                   "catalog_type": {
+                    "color": "slate",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "estimated_count": 7,
+                    "icon": "box",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "tier"
+                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                         }
                       ],
                       "version": 1
                     },
-                    "semantic_type": "service",
+                    "semantic_type": "custom",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -2858,7 +2963,7 @@
                     "array": false,
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
                     "name": "tier",
-                    "type": "tier"
+                    "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                   }
                 ],
                 "version": 1
@@ -2876,22 +2981,29 @@
                 },
                 "example": {
                   "catalog_type": {
+                    "color": "slate",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "estimated_count": 7,
+                    "icon": "box",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
                     "schema": {
                       "attributes": [
                         {
                           "array": false,
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
                           "name": "tier",
-                          "type": "tier"
+                          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                         }
                       ],
                       "version": 1
                     },
-                    "semantic_type": "service",
+                    "semantic_type": "custom",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 }
@@ -3473,6 +3585,7 @@
                     ]
                   }
                 ],
+                "id": "01FDAG4SAP5TYPT98WGR2N7W91",
                 "idempotency_key": "alert-uuid",
                 "incident_role_assignments": [
                   {
@@ -3669,6 +3782,209 @@
             "example": "01FDAG4SAP5TYPT98WGR2N7W91"
           }
         ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody9"
+                },
+                "example": {
+                  "incident": {
+                    "call_url": "https://zoom.us/foo",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "creator": {
+                      "api_key": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My test API key"
+                      },
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      }
+                    },
+                    "custom_field_entries": [
+                      {
+                        "custom_field": {
+                          "description": "Which team is impacted by this issue",
+                          "field_type": "single_select",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Affected Team",
+                          "options": [
+                            {
+                              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "sort_key": 10,
+                              "value": "Product"
+                            }
+                          ]
+                        },
+                        "values": [
+                          {
+                            "value_link": "https://google.com/",
+                            "value_numeric": "123.456",
+                            "value_option": {
+                              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "sort_key": 10,
+                              "value": "Product"
+                            },
+                            "value_text": "This is my text field, I hope you like it"
+                          }
+                        ]
+                      }
+                    ],
+                    "external_issue_reference": {
+                      "issue_name": "INC-123",
+                      "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                      "provider": "asana"
+                    },
+                    "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                    "incident_role_assignments": [
+                      {
+                        "assignee": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        },
+                        "role": {
+                          "created_at": "2021-08-17T13:28:57.801578Z",
+                          "description": "The person currently coordinating the incident",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                          "name": "Incident Lead",
+                          "required": true,
+                          "role_type": "lead",
+                          "shortform": "lead",
+                          "updated_at": "2021-08-17T13:28:57.801578Z"
+                        }
+                      }
+                    ],
+                    "incident_status": {
+                      "category": "triage",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                      "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                      "name": "Closed",
+                      "rank": 4,
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    },
+                    "incident_timestamp_values": [
+                      {
+                        "incident_timestamp": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                          "name": "Impact started",
+                          "rank": 1
+                        },
+                        "value": {
+                          "value": "2021-08-17T13:28:57.801578Z"
+                        }
+                      }
+                    ],
+                    "incident_type": {
+                      "create_in_triage": "always",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Customer facing production outages",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "is_default": false,
+                      "name": "Production Outage",
+                      "private_incidents_only": false,
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    },
+                    "mode": "standard",
+                    "name": "Our database is sad",
+                    "permalink": "https://app.incident.io/incidents/123",
+                    "postmortem_document_url": "https://docs.google.com/my_doc_id",
+                    "reference": "INC-123",
+                    "severity": {
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Issues with **low impact**.",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Minor",
+                      "rank": 1,
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    },
+                    "slack_channel_id": "C02AW36C1M5",
+                    "slack_channel_name": "inc-165-green-parrot",
+                    "slack_team_id": "T02A1FSLE8J",
+                    "summary": "Our database is really really sad, and we don't know why yet.",
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "visibility": "public"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/incidents/{id}/actions/edit": {
+      "post": {
+        "tags": [
+          "Incidents V2"
+        ],
+        "summary": "Edit Incidents V2",
+        "description": "Edit an existing incident.\n\nThis endpoint allows you to edit the properties of an existing incident: e.g. set the severity or update custom fields.\n\nWhen using this endpoint, only fields that are provided will be edited (omitted fields \nwill be ignored).\n",
+        "operationId": "Incidents V2#Edit",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The unique identifier of the incident that you want to edit",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The unique identifier of the incident that you want to edit",
+              "example": "01G18REBY9AYH6CMWCJ2CVCYCH"
+            },
+            "example": "01G18REBY9AYH6CMWCJ2CVCYCH"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditRequestBody"
+              },
+              "example": {
+                "incident": {
+                  "custom_field_entries": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "values": [
+                        {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "value_link": "https://google.com/",
+                          "value_numeric": "123.456",
+                          "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "value_text": "This is my text field, I hope you like it",
+                          "value_timestamp": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "incident_timestamp_values": [
+                    {
+                      "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                      "value": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ],
+                  "name": "Our database is sad",
+                  "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+                  "summary": "Our database is really really sad, and we don't know why yet."
+                },
+                "notify_incident_channel": true
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK response.",
@@ -4354,6 +4670,7 @@
               {
                 "catalog_entry": {
                   "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4373,6 +4690,7 @@
             {
               "catalog_entry": {
                 "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "catalog_entry_name": "Primary escalation",
                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
               "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4385,6 +4703,7 @@
           "value": {
             "catalog_entry": {
               "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "catalog_entry_name": "Primary escalation",
               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
             "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4443,6 +4762,7 @@
         "example": {
           "catalog_entry": {
             "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "catalog_entry_name": "Primary escalation",
             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
           "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4464,6 +4784,11 @@
             "description": "ID of this catalog entry",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
+          "catalog_entry_name": {
+            "type": "string",
+            "description": "The name of this entry",
+            "example": "Primary escalation"
+          },
           "catalog_type_id": {
             "type": "string",
             "description": "ID of this catalog type",
@@ -4472,16 +4797,23 @@
         },
         "example": {
           "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "catalog_entry_name": "Primary escalation",
           "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
         },
         "required": [
           "catalog_type_id",
-          "catalog_entry_id"
+          "catalog_entry_id",
+          "catalog_entry_name"
         ]
       },
       "CatalogEntryV2": {
         "type": "object",
         "properties": {
+          "alias": {
+            "type": "string",
+            "description": "An optional alias that must uniquely identify this type",
+            "example": "incident-io/core"
+          },
           "attribute_values": {
             "type": "object",
             "description": "Values of this entry",
@@ -4491,6 +4823,7 @@
                   {
                     "catalog_entry": {
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4503,6 +4836,7 @@
                 "value": {
                   "catalog_entry": {
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4538,6 +4872,12 @@
             "description": "Name is the human readable name of this entry",
             "example": "Primary On-call"
           },
+          "rank": {
+            "type": "integer",
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32"
+          },
           "updated_at": {
             "type": "string",
             "description": "When this entry was last updated",
@@ -4546,12 +4886,14 @@
           }
         },
         "example": {
+          "alias": "incident-io/core",
           "attribute_values": {
             "abc123": {
               "array_value": [
                 {
                   "catalog_entry": {
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4564,6 +4906,7 @@
               "value": {
                 "catalog_entry": {
                   "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
                 "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4578,12 +4921,14 @@
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Primary On-call",
+          "rank": 3,
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "required": [
           "id",
           "catalog_type_id",
           "name",
+          "rank",
           "attribute_values",
           "created_at",
           "updated_at"
@@ -4594,30 +4939,30 @@
         "properties": {
           "array": {
             "type": "boolean",
-            "description": "Whether this column is an array",
+            "description": "Whether this attribute is an array",
             "example": false
           },
           "id": {
             "type": "string",
-            "description": "The ID of this column",
+            "description": "The ID of this attribute",
             "example": "01GW2G3V0S59R238FAHPDS1R66"
           },
           "name": {
             "type": "string",
-            "description": "Unique name of this column",
+            "description": "Unique name of this attribute",
             "example": "tier"
           },
           "type": {
             "type": "string",
-            "description": "The type of this column",
-            "example": "tier"
+            "description": "Catalog type name for this attribute",
+            "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
           }
         },
         "example": {
           "array": false,
           "id": "01GW2G3V0S59R238FAHPDS1R66",
           "name": "tier",
-          "type": "tier"
+          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
         },
         "required": [
           "name",
@@ -4630,30 +4975,30 @@
         "properties": {
           "array": {
             "type": "boolean",
-            "description": "Whether this column is an array",
+            "description": "Whether this attribute is an array",
             "example": false
           },
           "id": {
             "type": "string",
-            "description": "The ID of this column",
+            "description": "The ID of this attribute",
             "example": "01GW2G3V0S59R238FAHPDS1R66"
           },
           "name": {
             "type": "string",
-            "description": "Unique name of this column",
+            "description": "Unique name of this attribute",
             "example": "tier"
           },
           "type": {
             "type": "string",
-            "description": "The type of this column",
-            "example": "tier"
+            "description": "Catalog type name for this attribute",
+            "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
           }
         },
         "example": {
           "array": false,
           "id": "01GW2G3V0S59R238FAHPDS1R66",
           "name": "tier",
-          "type": "tier"
+          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
         },
         "required": [
           "id",
@@ -4676,7 +5021,7 @@
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ]
           },
@@ -4693,7 +5038,7 @@
               "array": false,
               "id": "01GW2G3V0S59R238FAHPDS1R66",
               "name": "tier",
-              "type": "tier"
+              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
             }
           ],
           "version": 1
@@ -4706,6 +5051,19 @@
       "CatalogTypeV2": {
         "type": "object",
         "properties": {
+          "color": {
+            "type": "string",
+            "description": "Sets the display color of this type in the dashboard",
+            "example": "slate",
+            "enum": [
+              "slate",
+              "red",
+              "yellow",
+              "green",
+              "blue",
+              "violet"
+            ]
+          },
           "created_at": {
             "type": "string",
             "description": "When this type was created",
@@ -4717,6 +5075,27 @@
             "description": "Human readble description of this type",
             "example": "Represents Kubernetes clusters that we run inside of GKE."
           },
+          "estimated_count": {
+            "type": "integer",
+            "description": "If populated, gives an estimated count of entries for this type",
+            "example": 7,
+            "format": "int64"
+          },
+          "icon": {
+            "type": "string",
+            "description": "Sets the display icon of this type in the dashboard",
+            "example": "box",
+            "enum": [
+              "box",
+              "briefcase",
+              "bulb",
+              "clock",
+              "cog",
+              "doc",
+              "email",
+              "users"
+            ]
+          },
           "id": {
             "type": "string",
             "description": "ID of this resource",
@@ -4727,13 +5106,29 @@
             "description": "Name is the human readable name of this type",
             "example": "Kubernetes Cluster"
           },
+          "ranked": {
+            "type": "boolean",
+            "description": "If this type should be ranked",
+            "example": true
+          },
+          "required_integrations": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "If populated, the integrations required for this type",
+            "example": [
+              "pager_duty"
+            ]
+          },
           "schema": {
             "$ref": "#/components/schemas/CatalogTypeSchemaV2"
           },
           "semantic_type": {
             "type": "string",
             "description": "Semantic type of this resource",
-            "example": "service"
+            "example": "custom"
           },
           "updated_at": {
             "type": "string",
@@ -4743,22 +5138,29 @@
           }
         },
         "example": {
+          "color": "slate",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "estimated_count": 7,
+          "icon": "box",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Kubernetes Cluster",
+          "ranked": true,
+          "required_integrations": [
+            "pager_duty"
+          ],
           "schema": {
             "attributes": [
               {
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ],
             "version": 1
           },
-          "semantic_type": "service",
+          "semantic_type": "custom",
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "required": [
@@ -4766,7 +5168,10 @@
           "name",
           "description",
           "semantic_type",
+          "ranked",
           "schema",
+          "icon",
+          "color",
           "created_at",
           "updated_at"
         ]
@@ -4774,6 +5179,11 @@
       "CreateEntryRequestBody": {
         "type": "object",
         "properties": {
+          "alias": {
+            "type": "string",
+            "description": "An optional alias that must uniquely identify this type",
+            "example": "incident-io/core"
+          },
           "attribute_values": {
             "type": "object",
             "description": "Values of this entry",
@@ -4802,9 +5212,16 @@
             "type": "string",
             "description": "Name is the human readable name of this entry",
             "example": "Primary On-call"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32"
           }
         },
         "example": {
+          "alias": "incident-io/core",
           "attribute_values": {
             "abc123": {
               "array_value": [
@@ -4818,15 +5235,13 @@
             }
           },
           "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "name": "Primary On-call"
+          "name": "Primary On-call",
+          "rank": 3
         },
         "required": [
           "catalog_type_id",
           "name",
-          "attribute_values",
-          "id",
-          "created_at",
-          "updated_at"
+          "attribute_values"
         ]
       },
       "CreateEntryResponseBody": {
@@ -4838,12 +5253,14 @@
         },
         "example": {
           "catalog_entry": {
+            "alias": "incident-io/core",
             "attribute_values": {
               "abc123": {
                 "array_value": [
                   {
                     "catalog_entry": {
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4856,6 +5273,7 @@
                 "value": {
                   "catalog_entry": {
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -4870,6 +5288,7 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Primary On-call",
+            "rank": 3,
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
@@ -5322,6 +5741,11 @@
               }
             ]
           },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the incident",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+          },
           "idempotency_key": {
             "type": "string",
             "description": "Unique string used to de-duplicate incident create requests",
@@ -5427,6 +5851,7 @@
               ]
             }
           ],
+          "id": "01FDAG4SAP5TYPT98WGR2N7W91",
           "idempotency_key": "alert-uuid",
           "incident_role_assignments": [
             {
@@ -5518,35 +5943,66 @@
       "CreateTypeRequestBody": {
         "type": "object",
         "properties": {
+          "color": {
+            "type": "string",
+            "description": "Sets the display color of this type in the dashboard",
+            "example": "slate",
+            "enum": [
+              "slate",
+              "red",
+              "yellow",
+              "green",
+              "blue",
+              "violet"
+            ]
+          },
           "description": {
             "type": "string",
             "description": "Human readble description of this type",
             "example": "Represents Kubernetes clusters that we run inside of GKE."
+          },
+          "icon": {
+            "type": "string",
+            "description": "Sets the display icon of this type in the dashboard",
+            "example": "box",
+            "enum": [
+              "box",
+              "briefcase",
+              "bulb",
+              "clock",
+              "cog",
+              "doc",
+              "email",
+              "users"
+            ]
           },
           "name": {
             "type": "string",
             "description": "Name is the human readable name of this type",
             "example": "Kubernetes Cluster"
           },
+          "ranked": {
+            "type": "boolean",
+            "description": "If this type should be ranked",
+            "example": true
+          },
           "semantic_type": {
             "type": "string",
             "description": "Semantic type of this resource",
-            "example": "service"
+            "example": "custom"
           }
         },
         "example": {
+          "color": "slate",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "icon": "box",
           "name": "Kubernetes Cluster",
-          "semantic_type": "service"
+          "ranked": true,
+          "semantic_type": "custom"
         },
         "required": [
-          "id",
           "name",
-          "description",
-          "semantic_type",
-          "schema",
-          "created_at",
-          "updated_at"
+          "description"
         ]
       },
       "CreateTypeResponseBody": {
@@ -5558,22 +6014,29 @@
         },
         "example": {
           "catalog_type": {
+            "color": "slate",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "estimated_count": 7,
+            "icon": "box",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Kubernetes Cluster",
+            "ranked": true,
+            "required_integrations": [
+              "pager_duty"
+            ],
             "schema": {
               "attributes": [
                 {
                   "array": false,
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
                   "name": "tier",
-                  "type": "tier"
+                  "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                 }
               ],
               "version": 1
             },
-            "semantic_type": "service",
+            "semantic_type": "custom",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
@@ -5799,6 +6262,7 @@
           "show_before_closure",
           "show_before_update",
           "options",
+          "is_usable",
           "conditions",
           "created_at",
           "updated_at"
@@ -6005,6 +6469,52 @@
           "value_text": "This is my text field, I hope you like it"
         }
       },
+      "EditRequestBody": {
+        "type": "object",
+        "properties": {
+          "incident": {
+            "$ref": "#/components/schemas/IncidentEditPayloadV2"
+          },
+          "notify_incident_channel": {
+            "type": "boolean",
+            "description": "Should we send Slack channel notifications to inform responders of this update? Note that this won't work if the Slack channel has already been archived.",
+            "example": true
+          }
+        },
+        "example": {
+          "incident": {
+            "custom_field_entries": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ],
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "value": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "name": "Our database is sad",
+            "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+            "summary": "Our database is really really sad, and we don't know why yet."
+          },
+          "notify_incident_channel": true
+        },
+        "required": [
+          "incident",
+          "notify_incident_channel"
+        ]
+      },
       "ExternalIssueReferenceV1": {
         "type": "object",
         "properties": {
@@ -6163,6 +6673,7 @@
               "enum": [
                 "viewer",
                 "incident_creator",
+                "incident_editor",
                 "global_access",
                 "manage_settings"
               ]
@@ -6219,6 +6730,87 @@
           "creator",
           "created_at"
         ]
+      },
+      "IncidentEditPayloadV2": {
+        "type": "object",
+        "properties": {
+          "custom_field_entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+            },
+            "description": "Set the incident's custom fields to these values",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ]
+          },
+          "incident_timestamp_values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentTimestampValuePayloadV2"
+            },
+            "description": "Assign the incident's timestamps to these values",
+            "example": [
+              {
+                "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "value": "2021-08-17T13:28:57.801578Z"
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Explanation of the incident",
+            "example": "Our database is sad"
+          },
+          "severity_id": {
+            "type": "string",
+            "description": "Severity to change incident to",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Detailed description of the incident",
+            "example": "Our database is really really sad, and we don't know why yet."
+          }
+        },
+        "example": {
+          "custom_field_entries": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ],
+          "incident_timestamp_values": [
+            {
+              "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "value": "2021-08-17T13:28:57.801578Z"
+            }
+          ],
+          "name": "Our database is sad",
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "summary": "Our database is really really sad, and we don't know why yet."
+        }
       },
       "IncidentRoleAssignmentPayloadV1": {
         "type": "object",
@@ -7405,12 +7997,14 @@
             },
             "example": [
               {
+                "alias": "incident-io/core",
                 "attribute_values": {
                   "abc123": {
                     "array_value": [
                       {
                         "catalog_entry": {
                           "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "catalog_entry_name": "Primary escalation",
                           "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                         },
                         "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -7423,6 +8017,7 @@
                     "value": {
                       "catalog_entry": {
                         "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
                       "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -7437,23 +8032,29 @@
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "name": "Primary On-call",
+                "rank": 3,
                 "updated_at": "2021-08-17T13:28:57.801578Z"
               }
             ]
           },
           "catalog_type": {
             "$ref": "#/components/schemas/CatalogTypeV2"
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
           }
         },
         "example": {
           "catalog_entries": [
             {
+              "alias": "incident-io/core",
               "attribute_values": {
                 "abc123": {
                   "array_value": [
                     {
                       "catalog_entry": {
                         "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
                       "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -7466,6 +8067,7 @@
                   "value": {
                     "catalog_entry": {
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -7480,32 +8082,45 @@
               "created_at": "2021-08-17T13:28:57.801578Z",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "name": "Primary On-call",
+              "rank": 3,
               "updated_at": "2021-08-17T13:28:57.801578Z"
             }
           ],
           "catalog_type": {
+            "color": "slate",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "estimated_count": 7,
+            "icon": "box",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Kubernetes Cluster",
+            "ranked": true,
+            "required_integrations": [
+              "pager_duty"
+            ],
             "schema": {
               "attributes": [
                 {
                   "array": false,
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
                   "name": "tier",
-                  "type": "tier"
+                  "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                 }
               ],
               "version": 1
             },
-            "semantic_type": "service",
+            "semantic_type": "custom",
             "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
           }
         },
         "required": [
           "catalog_type",
-          "catalog_entries"
+          "catalog_entries",
+          "pagination_meta"
         ]
       },
       "ListResponseBody": {
@@ -8523,22 +9138,29 @@
             },
             "example": [
               {
+                "color": "slate",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                "estimated_count": 7,
+                "icon": "box",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "name": "Kubernetes Cluster",
+                "ranked": true,
+                "required_integrations": [
+                  "pager_duty"
+                ],
                 "schema": {
                   "attributes": [
                     {
                       "array": false,
                       "id": "01GW2G3V0S59R238FAHPDS1R66",
                       "name": "tier",
-                      "type": "tier"
+                      "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                     }
                   ],
                   "version": 1
                 },
-                "semantic_type": "service",
+                "semantic_type": "custom",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
               }
             ]
@@ -8547,22 +9169,29 @@
         "example": {
           "catalog_types": [
             {
+              "color": "slate",
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Represents Kubernetes clusters that we run inside of GKE.",
+              "estimated_count": 7,
+              "icon": "box",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "name": "Kubernetes Cluster",
+              "ranked": true,
+              "required_integrations": [
+                "pager_duty"
+              ],
               "schema": {
                 "attributes": [
                   {
                     "array": false,
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
                     "name": "tier",
-                    "type": "tier"
+                    "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                   }
                 ],
                 "version": 1
               },
-              "semantic_type": "service",
+              "semantic_type": "custom",
               "updated_at": "2021-08-17T13:28:57.801578Z"
             }
           ]
@@ -8582,6 +9211,7 @@
           "page_size": {
             "type": "integer",
             "description": "What was the maximum number of results requested",
+            "default": 25,
             "example": 25,
             "format": "int64"
           }
@@ -8605,6 +9235,7 @@
           "page_size": {
             "type": "integer",
             "description": "What was the maximum number of results requested",
+            "default": 25,
             "example": 25,
             "format": "int64"
           },
@@ -9252,12 +9883,14 @@
         },
         "example": {
           "catalog_entry": {
+            "alias": "incident-io/core",
             "attribute_values": {
               "abc123": {
                 "array_value": [
                   {
                     "catalog_entry": {
                       "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
                     "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -9270,6 +9903,7 @@
                 "value": {
                   "catalog_entry": {
                     "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
                   "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
@@ -9284,25 +9918,33 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Primary On-call",
+            "rank": 3,
             "updated_at": "2021-08-17T13:28:57.801578Z"
           },
           "catalog_type": {
+            "color": "slate",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "estimated_count": 7,
+            "icon": "box",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Kubernetes Cluster",
+            "ranked": true,
+            "required_integrations": [
+              "pager_duty"
+            ],
             "schema": {
               "attributes": [
                 {
                   "array": false,
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
                   "name": "tier",
-                  "type": "tier"
+                  "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
                 }
               ],
               "version": 1
             },
-            "semantic_type": "service",
+            "semantic_type": "custom",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
@@ -9769,6 +10411,11 @@
       "UpdateEntryRequestBody": {
         "type": "object",
         "properties": {
+          "alias": {
+            "type": "string",
+            "description": "An optional alias that must uniquely identify this type",
+            "example": "incident-io/core"
+          },
           "attribute_values": {
             "type": "object",
             "description": "Values of this entry",
@@ -9792,9 +10439,16 @@
             "type": "string",
             "description": "Name is the human readable name of this entry",
             "example": "Primary On-call"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32"
           }
         },
         "example": {
+          "alias": "incident-io/core",
           "attribute_values": {
             "abc123": {
               "array_value": [
@@ -9807,14 +10461,12 @@
               }
             }
           },
-          "name": "Primary On-call"
+          "name": "Primary On-call",
+          "rank": 3
         },
         "required": [
           "name",
-          "attribute_values",
-          "catalog_type_id",
-          "created_at",
-          "updated_at"
+          "attribute_values"
         ]
       },
       "UpdateRequestBody": {
@@ -9989,39 +10641,6 @@
           "updated_at"
         ]
       },
-      "UpdateTypeRequestBody": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "Human readble description of this type",
-            "example": "Represents Kubernetes clusters that we run inside of GKE."
-          },
-          "name": {
-            "type": "string",
-            "description": "Name is the human readable name of this type",
-            "example": "Kubernetes Cluster"
-          },
-          "semantic_type": {
-            "type": "string",
-            "description": "Semantic type of this resource",
-            "example": "service"
-          }
-        },
-        "example": {
-          "description": "Represents Kubernetes clusters that we run inside of GKE.",
-          "name": "Kubernetes Cluster",
-          "semantic_type": "service"
-        },
-        "required": [
-          "name",
-          "description",
-          "semantic_type",
-          "schema",
-          "created_at",
-          "updated_at"
-        ]
-      },
       "UpdateTypeSchemaRequestBody": {
         "type": "object",
         "properties": {
@@ -10035,7 +10654,7 @@
                 "array": false,
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
                 "name": "tier",
-                "type": "tier"
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
               }
             ]
           },
@@ -10051,7 +10670,7 @@
               "array": false,
               "id": "01GW2G3V0S59R238FAHPDS1R66",
               "name": "tier",
-              "type": "tier"
+              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]"
             }
           ],
           "version": 1
@@ -10062,7 +10681,10 @@
           "name",
           "description",
           "semantic_type",
+          "ranked",
           "schema",
+          "icon",
+          "color",
           "created_at",
           "updated_at"
         ]

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -26,6 +26,28 @@ const (
 	Outstanding ActionV1Status = "outstanding"
 )
 
+// Defines values for CatalogTypeV2Color.
+const (
+	CatalogTypeV2ColorBlue   CatalogTypeV2Color = "blue"
+	CatalogTypeV2ColorGreen  CatalogTypeV2Color = "green"
+	CatalogTypeV2ColorRed    CatalogTypeV2Color = "red"
+	CatalogTypeV2ColorSlate  CatalogTypeV2Color = "slate"
+	CatalogTypeV2ColorViolet CatalogTypeV2Color = "violet"
+	CatalogTypeV2ColorYellow CatalogTypeV2Color = "yellow"
+)
+
+// Defines values for CatalogTypeV2Icon.
+const (
+	CatalogTypeV2IconBox       CatalogTypeV2Icon = "box"
+	CatalogTypeV2IconBriefcase CatalogTypeV2Icon = "briefcase"
+	CatalogTypeV2IconBulb      CatalogTypeV2Icon = "bulb"
+	CatalogTypeV2IconClock     CatalogTypeV2Icon = "clock"
+	CatalogTypeV2IconCog       CatalogTypeV2Icon = "cog"
+	CatalogTypeV2IconDoc       CatalogTypeV2Icon = "doc"
+	CatalogTypeV2IconEmail     CatalogTypeV2Icon = "email"
+	CatalogTypeV2IconUsers     CatalogTypeV2Icon = "users"
+)
+
 // Defines values for CreateRequestBody2FieldType.
 const (
 	CreateRequestBody2FieldTypeLink         CreateRequestBody2FieldType = "link"
@@ -96,6 +118,28 @@ const (
 	CreateRequestBody7VisibilityPublic  CreateRequestBody7Visibility = "public"
 )
 
+// Defines values for CreateTypeRequestBodyColor.
+const (
+	CreateTypeRequestBodyColorBlue   CreateTypeRequestBodyColor = "blue"
+	CreateTypeRequestBodyColorGreen  CreateTypeRequestBodyColor = "green"
+	CreateTypeRequestBodyColorRed    CreateTypeRequestBodyColor = "red"
+	CreateTypeRequestBodyColorSlate  CreateTypeRequestBodyColor = "slate"
+	CreateTypeRequestBodyColorViolet CreateTypeRequestBodyColor = "violet"
+	CreateTypeRequestBodyColorYellow CreateTypeRequestBodyColor = "yellow"
+)
+
+// Defines values for CreateTypeRequestBodyIcon.
+const (
+	CreateTypeRequestBodyIconBox       CreateTypeRequestBodyIcon = "box"
+	CreateTypeRequestBodyIconBriefcase CreateTypeRequestBodyIcon = "briefcase"
+	CreateTypeRequestBodyIconBulb      CreateTypeRequestBodyIcon = "bulb"
+	CreateTypeRequestBodyIconClock     CreateTypeRequestBodyIcon = "clock"
+	CreateTypeRequestBodyIconCog       CreateTypeRequestBodyIcon = "cog"
+	CreateTypeRequestBodyIconDoc       CreateTypeRequestBodyIcon = "doc"
+	CreateTypeRequestBodyIconEmail     CreateTypeRequestBodyIcon = "email"
+	CreateTypeRequestBodyIconUsers     CreateTypeRequestBodyIcon = "users"
+)
+
 // Defines values for CustomFieldTypeInfoV1FieldType.
 const (
 	CustomFieldTypeInfoV1FieldTypeLink         CustomFieldTypeInfoV1FieldType = "link"
@@ -157,6 +201,7 @@ const (
 const (
 	IdentityV1RolesGlobalAccess    IdentityV1Roles = "global_access"
 	IdentityV1RolesIncidentCreator IdentityV1Roles = "incident_creator"
+	IdentityV1RolesIncidentEditor  IdentityV1Roles = "incident_editor"
 	IdentityV1RolesManageSettings  IdentityV1Roles = "manage_settings"
 	IdentityV1RolesViewer          IdentityV1Roles = "viewer"
 )
@@ -348,12 +393,18 @@ type CatalogEntryReferenceV2 struct {
 	// CatalogEntryId ID of this catalog entry
 	CatalogEntryId string `json:"catalog_entry_id"`
 
+	// CatalogEntryName The name of this entry
+	CatalogEntryName string `json:"catalog_entry_name"`
+
 	// CatalogTypeId ID of this catalog type
 	CatalogTypeId string `json:"catalog_type_id"`
 }
 
 // CatalogEntryV2 defines model for CatalogEntryV2.
 type CatalogEntryV2 struct {
+	// Alias An optional alias that must uniquely identify this type
+	Alias *string `json:"alias,omitempty"`
+
 	// AttributeValues Values of this entry
 	AttributeValues map[string]CatalogAttributeBindingV2 `json:"attribute_values"`
 
@@ -369,37 +420,40 @@ type CatalogEntryV2 struct {
 	// Name Name is the human readable name of this entry
 	Name string `json:"name"`
 
+	// Rank When catalog type is ranked, this is used to help order things
+	Rank int32 `json:"rank"`
+
 	// UpdatedAt When this entry was last updated
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // CatalogTypeAttributePayloadV2 defines model for CatalogTypeAttributePayloadV2.
 type CatalogTypeAttributePayloadV2 struct {
-	// Array Whether this column is an array
+	// Array Whether this attribute is an array
 	Array bool `json:"array"`
 
-	// Id The ID of this column
+	// Id The ID of this attribute
 	Id *string `json:"id,omitempty"`
 
-	// Name Unique name of this column
+	// Name Unique name of this attribute
 	Name string `json:"name"`
 
-	// Type The type of this column
+	// Type Catalog type name for this attribute
 	Type string `json:"type"`
 }
 
 // CatalogTypeAttributeV2 defines model for CatalogTypeAttributeV2.
 type CatalogTypeAttributeV2 struct {
-	// Array Whether this column is an array
+	// Array Whether this attribute is an array
 	Array bool `json:"array"`
 
-	// Id The ID of this column
+	// Id The ID of this attribute
 	Id string `json:"id"`
 
-	// Name Unique name of this column
+	// Name Unique name of this attribute
 	Name string `json:"name"`
 
-	// Type The type of this column
+	// Type Catalog type name for this attribute
 	Type string `json:"type"`
 }
 
@@ -414,18 +468,33 @@ type CatalogTypeSchemaV2 struct {
 
 // CatalogTypeV2 defines model for CatalogTypeV2.
 type CatalogTypeV2 struct {
+	// Color Sets the display color of this type in the dashboard
+	Color CatalogTypeV2Color `json:"color"`
+
 	// CreatedAt When this type was created
 	CreatedAt time.Time `json:"created_at"`
 
 	// Description Human readble description of this type
 	Description string `json:"description"`
 
+	// EstimatedCount If populated, gives an estimated count of entries for this type
+	EstimatedCount *int64 `json:"estimated_count,omitempty"`
+
+	// Icon Sets the display icon of this type in the dashboard
+	Icon CatalogTypeV2Icon `json:"icon"`
+
 	// Id ID of this resource
 	Id string `json:"id"`
 
 	// Name Name is the human readable name of this type
-	Name   string              `json:"name"`
-	Schema CatalogTypeSchemaV2 `json:"schema"`
+	Name string `json:"name"`
+
+	// Ranked If this type should be ranked
+	Ranked bool `json:"ranked"`
+
+	// RequiredIntegrations If populated, the integrations required for this type
+	RequiredIntegrations *[]string           `json:"required_integrations,omitempty"`
+	Schema               CatalogTypeSchemaV2 `json:"schema"`
 
 	// SemanticType Semantic type of this resource
 	SemanticType string `json:"semantic_type"`
@@ -434,8 +503,17 @@ type CatalogTypeV2 struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// CatalogTypeV2Color Sets the display color of this type in the dashboard
+type CatalogTypeV2Color string
+
+// CatalogTypeV2Icon Sets the display icon of this type in the dashboard
+type CatalogTypeV2Icon string
+
 // CreateEntryRequestBody defines model for CreateEntryRequestBody.
 type CreateEntryRequestBody struct {
+	// Alias An optional alias that must uniquely identify this type
+	Alias *string `json:"alias,omitempty"`
+
 	// AttributeValues Values of this entry
 	AttributeValues map[string]CatalogAttributeBindingPayloadV2 `json:"attribute_values"`
 
@@ -444,6 +522,9 @@ type CreateEntryRequestBody struct {
 
 	// Name Name is the human readable name of this entry
 	Name string `json:"name"`
+
+	// Rank When catalog type is ranked, this is used to help order things
+	Rank *int32 `json:"rank,omitempty"`
 }
 
 // CreateEntryResponseBody defines model for CreateEntryResponseBody.
@@ -601,6 +682,9 @@ type CreateRequestBody7 struct {
 	// CustomFieldEntries Set the incident's custom fields to these values
 	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
 
+	// Id Unique identifier for the incident
+	Id *string `json:"id,omitempty"`
+
 	// IdempotencyKey Unique string used to de-duplicate incident create requests
 	IdempotencyKey string `json:"idempotency_key"`
 
@@ -661,15 +745,30 @@ type CreateResponseBody struct {
 
 // CreateTypeRequestBody defines model for CreateTypeRequestBody.
 type CreateTypeRequestBody struct {
+	// Color Sets the display color of this type in the dashboard
+	Color *CreateTypeRequestBodyColor `json:"color,omitempty"`
+
 	// Description Human readble description of this type
 	Description string `json:"description"`
+
+	// Icon Sets the display icon of this type in the dashboard
+	Icon *CreateTypeRequestBodyIcon `json:"icon,omitempty"`
 
 	// Name Name is the human readable name of this type
 	Name string `json:"name"`
 
+	// Ranked If this type should be ranked
+	Ranked *bool `json:"ranked,omitempty"`
+
 	// SemanticType Semantic type of this resource
-	SemanticType string `json:"semantic_type"`
+	SemanticType *string `json:"semantic_type,omitempty"`
 }
+
+// CreateTypeRequestBodyColor Sets the display color of this type in the dashboard
+type CreateTypeRequestBodyColor string
+
+// CreateTypeRequestBodyIcon Sets the display icon of this type in the dashboard
+type CreateTypeRequestBodyIcon string
 
 // CreateTypeResponseBody defines model for CreateTypeResponseBody.
 type CreateTypeResponseBody struct {
@@ -808,6 +907,14 @@ type CustomFieldValueV1 struct {
 	ValueText *string `json:"value_text,omitempty"`
 }
 
+// EditRequestBody defines model for EditRequestBody.
+type EditRequestBody struct {
+	Incident IncidentEditPayloadV2 `json:"incident"`
+
+	// NotifyIncidentChannel Should we send Slack channel notifications to inform responders of this update? Note that this won't work if the Slack channel has already been archived.
+	NotifyIncidentChannel bool `json:"notify_incident_channel"`
+}
+
 // ExternalIssueReferenceV1 defines model for ExternalIssueReferenceV1.
 type ExternalIssueReferenceV1 struct {
 	// IssueName Human readable ID for the issue
@@ -881,6 +988,24 @@ type IncidentAttachmentV1 struct {
 	// IncidentId Unique identifier of the incident
 	IncidentId string             `json:"incident_id"`
 	Resource   ExternalResourceV1 `json:"resource"`
+}
+
+// IncidentEditPayloadV2 defines model for IncidentEditPayloadV2.
+type IncidentEditPayloadV2 struct {
+	// CustomFieldEntries Set the incident's custom fields to these values
+	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
+
+	// IncidentTimestampValues Assign the incident's timestamps to these values
+	IncidentTimestampValues *[]IncidentTimestampValuePayloadV2 `json:"incident_timestamp_values,omitempty"`
+
+	// Name Explanation of the incident
+	Name *string `json:"name,omitempty"`
+
+	// SeverityId Severity to change incident to
+	SeverityId *string `json:"severity_id,omitempty"`
+
+	// Summary Detailed description of the incident
+	Summary *string `json:"summary,omitempty"`
 }
 
 // IncidentRoleAssignmentPayloadV1 defines model for IncidentRoleAssignmentPayloadV1.
@@ -1189,6 +1314,7 @@ type IncidentV2Visibility string
 type ListEntriesResponseBody struct {
 	CatalogEntries []CatalogEntryV2 `json:"catalog_entries"`
 	CatalogType    CatalogTypeV2    `json:"catalog_type"`
+	PaginationMeta PaginationMeta   `json:"pagination_meta"`
 }
 
 // ListResponseBody defines model for ListResponseBody.
@@ -1365,11 +1491,17 @@ type ShowResponseBody9 struct {
 
 // UpdateEntryRequestBody defines model for UpdateEntryRequestBody.
 type UpdateEntryRequestBody struct {
+	// Alias An optional alias that must uniquely identify this type
+	Alias *string `json:"alias,omitempty"`
+
 	// AttributeValues Values of this entry
 	AttributeValues map[string]CatalogAttributeBindingPayloadV2 `json:"attribute_values"`
 
 	// Name Name is the human readable name of this entry
 	Name string `json:"name"`
+
+	// Rank When catalog type is ranked, this is used to help order things
+	Rank *int32 `json:"rank,omitempty"`
 }
 
 // UpdateRequestBody defines model for UpdateRequestBody.
@@ -1433,18 +1565,6 @@ type UpdateRequestBody4 struct {
 
 	// Name Unique name of this status
 	Name string `json:"name"`
-}
-
-// UpdateTypeRequestBody defines model for UpdateTypeRequestBody.
-type UpdateTypeRequestBody struct {
-	// Description Human readble description of this type
-	Description string `json:"description"`
-
-	// Name Name is the human readable name of this type
-	Name string `json:"name"`
-
-	// SemanticType Semantic type of this resource
-	SemanticType string `json:"semantic_type"`
 }
 
 // UpdateTypeSchemaRequestBody defines model for UpdateTypeSchemaRequestBody.
@@ -1544,6 +1664,12 @@ type IncidentsV1ListParams struct {
 type CatalogV2ListEntriesParams struct {
 	// CatalogTypeId ID of this catalog type
 	CatalogTypeId string `form:"catalog_type_id" json:"catalog_type_id"`
+
+	// PageSize Integer number of records to return
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// After An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
 }
 
 // IncidentUpdatesV2ListParams defines parameters for IncidentUpdatesV2List.
@@ -1628,13 +1754,16 @@ type CatalogV2UpdateEntryJSONRequestBody = UpdateEntryRequestBody
 type CatalogV2CreateTypeJSONRequestBody = CreateTypeRequestBody
 
 // CatalogV2UpdateTypeJSONRequestBody defines body for CatalogV2UpdateType for application/json ContentType.
-type CatalogV2UpdateTypeJSONRequestBody = UpdateTypeRequestBody
+type CatalogV2UpdateTypeJSONRequestBody = CreateTypeRequestBody
 
 // CatalogV2UpdateTypeSchemaJSONRequestBody defines body for CatalogV2UpdateTypeSchema for application/json ContentType.
 type CatalogV2UpdateTypeSchemaJSONRequestBody = UpdateTypeSchemaRequestBody
 
 // IncidentsV2CreateJSONRequestBody defines body for IncidentsV2Create for application/json ContentType.
 type IncidentsV2CreateJSONRequestBody = CreateRequestBody7
+
+// IncidentsV2EditJSONRequestBody defines body for IncidentsV2Edit for application/json ContentType.
+type IncidentsV2EditJSONRequestBody = EditRequestBody
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -1906,6 +2035,11 @@ type ClientInterface interface {
 
 	// IncidentsV2Show request
 	IncidentsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// IncidentsV2Edit request with any body
+	IncidentsV2EditWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	IncidentsV2Edit(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) ActionsV1List(ctx context.Context, params *ActionsV1ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -2762,6 +2896,30 @@ func (c *Client) IncidentsV2Create(ctx context.Context, body IncidentsV2CreateJS
 
 func (c *Client) IncidentsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewIncidentsV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentsV2EditWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentsV2EditRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IncidentsV2Edit(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIncidentsV2EditRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4297,6 +4455,38 @@ func NewCatalogV2ListEntriesRequest(server string, params *CatalogV2ListEntriesP
 		}
 	}
 
+	if params.PageSize != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page_size", runtime.ParamLocationQuery, *params.PageSize); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.After != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
 	queryURL.RawQuery = queryValues.Encode()
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -5048,6 +5238,53 @@ func NewIncidentsV2ShowRequest(server string, id string) (*http.Request, error) 
 	return req, nil
 }
 
+// NewIncidentsV2EditRequest calls the generic IncidentsV2Edit builder with application/json body
+func NewIncidentsV2EditRequest(server string, id string, body IncidentsV2EditJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewIncidentsV2EditRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewIncidentsV2EditRequestWithBody generates requests for IncidentsV2Edit with any type of body
+func NewIncidentsV2EditRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/incidents/%s/actions/edit", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -5288,6 +5525,11 @@ type ClientWithResponsesInterface interface {
 
 	// IncidentsV2Show request
 	IncidentsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*IncidentsV2ShowResponse, error)
+
+	// IncidentsV2Edit request with any body
+	IncidentsV2EditWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error)
+
+	IncidentsV2EditWithResponse(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error)
 }
 
 type ActionsV1ListResponse struct {
@@ -6470,6 +6712,28 @@ func (r IncidentsV2ShowResponse) StatusCode() int {
 	return 0
 }
 
+type IncidentsV2EditResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody9
+}
+
+// Status returns HTTPResponse.Status
+func (r IncidentsV2EditResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IncidentsV2EditResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 // ActionsV1ListWithResponse request returning *ActionsV1ListResponse
 func (c *ClientWithResponses) ActionsV1ListWithResponse(ctx context.Context, params *ActionsV1ListParams, reqEditors ...RequestEditorFn) (*ActionsV1ListResponse, error) {
 	rsp, err := c.ActionsV1List(ctx, params, reqEditors...)
@@ -7098,6 +7362,23 @@ func (c *ClientWithResponses) IncidentsV2ShowWithResponse(ctx context.Context, i
 		return nil, err
 	}
 	return ParseIncidentsV2ShowResponse(rsp)
+}
+
+// IncidentsV2EditWithBodyWithResponse request with arbitrary body returning *IncidentsV2EditResponse
+func (c *ClientWithResponses) IncidentsV2EditWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error) {
+	rsp, err := c.IncidentsV2EditWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentsV2EditResponse(rsp)
+}
+
+func (c *ClientWithResponses) IncidentsV2EditWithResponse(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error) {
+	rsp, err := c.IncidentsV2Edit(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIncidentsV2EditResponse(rsp)
 }
 
 // ParseActionsV1ListResponse parses an HTTP response from a ActionsV1ListWithResponse call
@@ -8407,6 +8688,32 @@ func ParseIncidentsV2ShowResponse(rsp *http.Response) (*IncidentsV2ShowResponse,
 	}
 
 	response := &IncidentsV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody9
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIncidentsV2EditResponse parses an HTTP response from a IncidentsV2EditWithResponse call
+func ParseIncidentsV2EditResponse(rsp *http.Response) (*IncidentsV2EditResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IncidentsV2EditResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -101,7 +101,7 @@ func (r *IncidentCatalogTypeResource) Create(ctx context.Context, req resource.C
 	result, err := r.client.CatalogV2CreateTypeWithResponse(ctx, client.CreateTypeRequestBody{
 		Name:         data.Name.ValueString(),
 		Description:  data.Description.ValueString(),
-		SemanticType: semanticType,
+		SemanticType: &semanticType,
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))
@@ -149,7 +149,7 @@ func (r *IncidentCatalogTypeResource) Update(ctx context.Context, req resource.U
 	result, err := r.client.CatalogV2UpdateTypeWithResponse(ctx, data.ID.ValueString(), client.CatalogV2UpdateTypeJSONRequestBody{
 		Name:         data.Name.ValueString(),
 		Description:  data.Description.ValueString(),
-		SemanticType: semanticType,
+		SemanticType: &semanticType,
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))


### PR DESCRIPTION
This allows:
- An alias to be set that can be used to unique identify the entry, usually set to a 'slug' or other human-friendly ID.
- Rank allows setting a numeric value that applies a semantic ordering to entries within the same type.