### PR TITLE
Don't panic when a catalog type is 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.3
+
+- Handle 404 for catalog types without panicking
+
 ## 1.4.2
 
 - Fix bug in framework patch that meant we never defaulted our log level

--- a/internal/provider/incident_catalog_type_attribute_resource.go
+++ b/internal/provider/incident_catalog_type_attribute_resource.go
@@ -180,6 +180,9 @@ func (r *IncidentCatalogTypeAttributeResource) Read(ctx context.Context, req res
 	}
 
 	result, err := r.client.CatalogV2ShowTypeWithResponse(ctx, data.CatalogTypeID.ValueString())
+	if err == nil && result.StatusCode() >= 400 {
+		err = fmt.Errorf(string(result.Body))
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read catalog type, got error: %s", err))
 		return


### PR DESCRIPTION
We need to check the status code before trying to access the response.