### PR TITLE
Catalog handles omitted empty lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Handle omission of empty list or null array_value in catalog entries (#36)
+
+## 2.0.1
+
 - Update client to latest API schema
 - Remove any disclaimers about the catalog being in beta ahead of launch
 

--- a/internal/provider/incident_catalog_entries_resource_test.go
+++ b/internal/provider/incident_catalog_entries_resource_test.go
@@ -22,11 +22,13 @@ func TestAccIncidentCatalogEntriesResource(t *testing.T) {
 						Name:        "One",
 						ExternalID:  "one",
 						Description: "This is the first entry",
+						ArrayValue:  "null",
 					},
 					{
 						Name:        "Two",
 						ExternalID:  "two",
 						Description: "This is the second entry",
+						ArrayValue:  "[]",
 					},
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -49,11 +51,13 @@ func TestAccIncidentCatalogEntriesResource(t *testing.T) {
 						Name:        "One",
 						ExternalID:  "one",
 						Description: "This is the first entry",
+						ArrayValue:  "null",
 					},
 					{
 						Name:        "Three",
 						ExternalID:  "two",
 						Description: "This is the third entry",
+						ArrayValue:  "[]",
 					},
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -78,6 +82,14 @@ resource "incident_catalog_type_attribute" "example_description" {
   type = "Text"
 }
 
+resource "incident_catalog_type_attribute" "example_array" {
+  catalog_type_id = incident_catalog_type.example.id
+
+  name  = "Array"
+  type  = "String"
+  array = true
+}
+
 resource "incident_catalog_entries" "example" {
   id = incident_catalog_type.example.id
 
@@ -91,6 +103,9 @@ resource "incident_catalog_entries" "example" {
         (incident_catalog_type_attribute.example_description.id) = {
           value = {{ quote .Description }}
         }
+        (incident_catalog_type_attribute.example_array.id) = {
+          array_value = {{ .ArrayValue }}
+        }
       }
     },
   {{ end }}
@@ -103,6 +118,7 @@ type catalogEntryElement struct {
 	ExternalID  string
 	Aliases     []string
 	Description string
+	ArrayValue  string
 }
 
 func testAccIncidentCatalogEntriesResourceConfig(entries []catalogEntryElement) string {


### PR DESCRIPTION
If we try creating a catalog entry with an array attribute value giving:
```json
{ "array_value": null }
```

The response from the API will omit the attribute. Similarly, this payload:
```json
{ "array_value": [] }
```

Will also result in an empty attribute response. The problem is that if your terraform code had the array_value attribute set to either null or empty list, terraform will remember the distinction, and when the API returns a list of attribute values where there is no value, terraform will perceive this as a state difference and die with the following error:

```
Error: Provider produced inconsistent result after apply

When applying changes to incident_catalog_entries.Service, provider
"provider[\"registry.terraform.io/incident-io/incident\"]" produced an
unexpected new value:
.entries["attr"].attribute_values["01H7Y6V5P9DP8HMCF2FN48SM6M"].array_value:
was null, but now cty.ListValEmpty(cty.String).
```

To handle this, we have changed how we build the terraform state from the API response so that when we think it's possible that the API omitted the attribute, we check our state and use the value in the state to ensure terraform is happy.