### PR TITLE
PR-254 Support setting the catalog type_name explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Add support for setting the `type_name` of a catalog type. This allows
+  other catalog attributes to refer to this type by a friendly name, rather than
+  the randomly generated ID
+
 ## 3.0.0
 
 - Remove SemanticType from catalog types (This has never been used by our

--- a/docs/resources/catalog_type.md
+++ b/docs/resources/catalog_type.md
@@ -58,6 +58,10 @@ resource "incident_catalog_type" "service_tier" {
 - `description` (String) Human readble description of this type
 - `name` (String) Name is the human readable name of this type
 
+### Optional
+
+- `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName "]
+
 ### Read-Only
 
 - `id` (String) ID of this catalog type

--- a/internal/provider/incident_status_resource_test.go
+++ b/internal/provider/incident_status_resource_test.go
@@ -58,9 +58,9 @@ resource "incident_status" "example" {
 
 func incidentStatusDefault() client.IncidentStatusV1 {
 	return client.IncidentStatusV1{
-		Name:        "Complete",
-		Description: "Impact has been fully mitigated.",
-		Category:    client.IncidentStatusV1CategoryClosed,
+		Name:        "Clean up",
+		Description: "We're cleaning up",
+		Category:    client.IncidentStatusV1CategoryLive,
 	}
 }
 


### PR DESCRIPTION
This means that the catalog type can be referred to as `Custom["Team"]` rather than `Custom["012346325AGDFADY612946AN"]`, which is nice!