### PR TITLE
Correctly handle 404 for custom fields

### DIFF
--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -211,7 +211,13 @@ func (r *IncidentCatalogEntryResource) Read(ctx context.Context, req resource.Re
 
 	result, err := r.client.CatalogV2ShowEntryWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read incident severity, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read catalog entry, got error: %s", err))
+		return
+	}
+
+	if result.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read catalog entry, got status code: %d", result.StatusCode()))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/incident_custom_field_option_resource.go
+++ b/internal/provider/incident_custom_field_option_resource.go
@@ -131,6 +131,12 @@ func (r *IncidentCustomFieldOptionResource) Read(ctx context.Context, req resour
 		return
 	}
 
+	if result.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read custom field option, got status code: %d", result.StatusCode()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data = r.buildModel(result.JSON200.CustomFieldOption)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/incident_custom_field_resource.go
+++ b/internal/provider/incident_custom_field_resource.go
@@ -126,6 +126,7 @@ func (r *IncidentCustomFieldResource) Read(ctx context.Context, req resource.Rea
 	}
 
 	if result.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read custom field, got status code: %d", result.StatusCode()))
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/incident_custom_field_resource.go
+++ b/internal/provider/incident_custom_field_resource.go
@@ -125,6 +125,11 @@ func (r *IncidentCustomFieldResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	if result.StatusCode() == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data = r.buildModel(result.JSON200.CustomField)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/incident_severity_resource.go
+++ b/internal/provider/incident_severity_resource.go
@@ -127,6 +127,12 @@ func (r *IncidentSeverityResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	if result.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read incident severity, got status code: %d", result.StatusCode()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data = r.buildModel(result.JSON200.Severity)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/incident_status_resource.go
+++ b/internal/provider/incident_status_resource.go
@@ -124,6 +124,11 @@ func (r *IncidentStatusResource) Read(ctx context.Context, req resource.ReadRequ
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read incident status, got error: %s", err))
 		return
 	}
+	if result.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read incident status, got status code: %d", result.StatusCode()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	data = r.buildModel(result.JSON200.IncidentStatus)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
If a `custom_field` has been deleted in the UI, or programatically via the API, or any other funkiness, it will return a 404.

The provider wouldn't check for a `404` response code, only a `200`, so would attempt to pull the body from a `nil` pointer. Hence the boom.

Here, we check for a `404` before reading the body, and if we have one, remove the resource from state which is the suggested behaviour here.