### PR TITLE
Catalog type `type_name` requires replace

### DIFF
--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -58,6 +58,9 @@ func (r *IncidentCatalogTypeResource) Schema(ctx context.Context, req resource.S
 				Optional:            true,
 				Computed:            true, // If not provided, we'll use the generated ID
 				MarkdownDescription: apischema.Docstring("CatalogV2CreateTypeRequestBody", "type_name"),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: apischema.Docstring("CatalogV2CreateTypeRequestBody", "description"),


### PR DESCRIPTION
This attribute is immutable, therefore if someone changes it in their terraform code the only valid plan we can create to achieve changing the type_name requires us to first delete the catalog type then recreate it with the new value.

This planmodifier tells Terraform this is so.