### PR TITLE
Don't panic if payload.CatalogEntryId is unset

### DIFF
--- a/internal/provider/incident_catalog_entries_resource.go
+++ b/internal/provider/incident_catalog_entries_resource.go
@@ -560,7 +560,7 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 						err = fmt.Errorf(string(result.Body))
 					}
 					if err != nil {
-						return errors.Wrap(err, fmt.Sprintf("unable to update catalog entry with id=%s, got error", *payload.CatalogEntryID))
+						return errors.Wrap(err, fmt.Sprintf("unable to update catalog entry with id=%s, got error", entry.Id))
 					}
 
 					tflog.Debug(ctx, fmt.Sprintf("updated catalog entry with id=%s", entry.Id))


### PR DESCRIPTION
This isn't guaranteed to be set, so we should interpolate the entry ID instead which cannot be nil