### PR TITLE
Test non-standard severity name for compatibility with local dev

### DIFF
--- a/internal/provider/incident_severity_resource_test.go
+++ b/internal/provider/incident_severity_resource_test.go
@@ -82,8 +82,8 @@ resource "incident_severity" "example" {
 
 func incidentSeverityDefault() client.SeverityV2 {
 	return client.SeverityV2{
-		Name:        "Major",
-		Description: "Issues causing significant impact. Immediate response is usually required.",
+		Name:        "P0",
+		Description: "All work stops until this issue is resolved.",
 		Rank:        7,
 	}
 }


### PR DESCRIPTION
The test `TestAccIncidentSeverityResource` relies on being able to create, fetch, and then delete an incident severity 'Major'.

In our local test environments this severity already exists, failing the test. 

This PR changes the severity name so that new maintainers can pull master and see green tests against their local.
