### PR TITLE
`incident_schedule` resource

### DIFF
--- a/internal/apischema/openapi.json
+++ b/internal/apischema/openapi.json
@@ -2735,6 +2735,237 @@
         ]
       }
     },
+    "/v2/schedule_entries": {
+      "get": {
+        "tags": [
+          "Schedule Entries V2"
+        ],
+        "summary": "List Schedule Entries V2",
+        "description": "Get a list of schedule entries.",
+        "operationId": "Schedule Entries V2#List",
+        "parameters": [
+          {
+            "name": "schedule_id",
+            "in": "query",
+            "description": "The ID of the schedule to get entries for.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "entry_window_start",
+            "in": "query",
+            "description": "The start of the window to get entries for.",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "entry_window_end",
+            "in": "query",
+            "description": "The end of the window to get entries for.",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/ScheduleEntriesV2ListResponseBody",
+              "required": [
+                "schedule_entries"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
+    "/v2/schedules": {
+      "get": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "List Schedules V2",
+        "description": "List configured schedules.",
+        "operationId": "Schedules V2#List",
+        "parameters": [
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "number of records to return",
+            "required": false,
+            "type": "integer",
+            "default": 25
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A schedule's ID. This endpoint will return a list of schedules after this ID in relation to the API response order.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/SchedulesV2ListResponseBody",
+              "required": [
+                "schedules"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      },
+      "post": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "Create Schedules V2",
+        "description": "Create a new schedule.",
+        "operationId": "Schedules V2#Create",
+        "parameters": [
+          {
+            "name": "CreateRequestBody",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SchedulesV2CreateRequestBody",
+              "required": [
+                "schedule"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created response.",
+            "schema": {
+              "$ref": "#/definitions/SchedulesV2CreateResponseBody",
+              "required": [
+                "schedule"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
+    "/v2/schedules/{id}": {
+      "get": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "Show Schedules V2",
+        "description": "Get a sigle schedule.",
+        "operationId": "Schedules V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique internal ID of the schedule",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/SchedulesV2ShowResponseBody",
+              "required": [
+                "schedule"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      },
+      "put": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "Update Schedules V2",
+        "description": "Update a schedule.",
+        "operationId": "Schedules V2#Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The schedule ID to update.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "UpdateRequestBody",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SchedulesV2UpdateRequestBody",
+              "required": [
+                "schedule",
+                "name",
+                "timezone",
+                "external_provider",
+                "external_provider_id",
+                "created_at",
+                "updated_at"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/SchedulesV2UpdateResponseBody",
+              "required": [
+                "schedule"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "Destroy Schedules V2",
+        "description": "Archives a single schedule.",
+        "operationId": "Schedules V2#Destroy",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique internal ID of the schedule",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted response."
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
     "/v2/users": {
       "get": {
         "tags": [
@@ -6205,6 +6436,30 @@
           "slack_user_id": "U02AYNF2XJM"
         }
       }
+    },
+    "AfterPaginationMetaResultV2ResponseBody": {
+      "title": "AfterPaginationMetaResultV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "after": {
+          "type": "string",
+          "description": "The time, if it exists, of the last entry's end time",
+          "example": "abc123"
+        },
+        "after_url": {
+          "type": "string",
+          "description": "The URL to fetch the next page of entries",
+          "example": "abc123"
+        }
+      },
+      "example": {
+        "after": "abc123",
+        "after_url": "abc123"
+      },
+      "required": [
+        "after",
+        "after_url"
+      ]
     },
     "AlertEventsV2CreateHTTPRequestBody": {
       "title": "AlertEventsV2CreateHTTPRequestBody",
@@ -22348,6 +22603,1839 @@
         "slack_channel_id": "abc123"
       }
     },
+    "ScheduleConfigCreatePayloadV2RequestBody": {
+      "title": "ScheduleConfigCreatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "rotations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleRotationCreatePayloadV2RequestBody"
+          },
+          "example": [
+            {
+              "effective_from": "2021-08-17T13:28:57.801578Z",
+              "handover_start_at": "2021-08-17T13:28:57.801578Z",
+              "handovers": [
+                {
+                  "interval": 1,
+                  "interval_type": "daily"
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layers": [
+                {
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "name": "Layer 1"
+                }
+              ],
+              "name": "My Rotation",
+              "users": [
+                {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                }
+              ],
+              "working_interval": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "tuesday"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "example": {
+        "rotations": [
+          {
+            "effective_from": "2021-08-17T13:28:57.801578Z",
+            "handover_start_at": "2021-08-17T13:28:57.801578Z",
+            "handovers": [
+              {
+                "interval": 1,
+                "interval_type": "daily"
+              }
+            ],
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "layers": [
+              {
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "name": "Layer 1"
+              }
+            ],
+            "name": "My Rotation",
+            "users": [
+              {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              }
+            ],
+            "working_interval": [
+              {
+                "end_time": "17:00",
+                "start_time": "09:00",
+                "weekday": "tuesday"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "ScheduleConfigUpdatePayloadV2RequestBody": {
+      "title": "ScheduleConfigUpdatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "rotations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleRotationUpdatePayloadV2RequestBody"
+          },
+          "example": [
+            {
+              "effective_from": "2021-08-17T13:28:57.801578Z",
+              "handover_start_at": "2021-08-17T13:28:57.801578Z",
+              "handovers": [
+                {
+                  "interval": 1,
+                  "interval_type": "daily"
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layers": [
+                {
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "name": "Layer 1"
+                }
+              ],
+              "name": "My Rotation",
+              "users": [
+                {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                }
+              ],
+              "working_interval": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "tuesday"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "example": {
+        "rotations": [
+          {
+            "effective_from": "2021-08-17T13:28:57.801578Z",
+            "handover_start_at": "2021-08-17T13:28:57.801578Z",
+            "handovers": [
+              {
+                "interval": 1,
+                "interval_type": "daily"
+              }
+            ],
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "layers": [
+              {
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "name": "Layer 1"
+              }
+            ],
+            "name": "My Rotation",
+            "users": [
+              {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              }
+            ],
+            "working_interval": [
+              {
+                "end_time": "17:00",
+                "start_time": "09:00",
+                "weekday": "tuesday"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "ScheduleConfigV2ResponseBody": {
+      "title": "ScheduleConfigV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "rotations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleRotationV2ResponseBody"
+          },
+          "description": "Rotas in this schedule",
+          "example": [
+            {
+              "effective_from": "2021-08-17T13:28:57.801578Z",
+              "handover_start_at": "2021-08-17T13:28:57.801578Z",
+              "handovers": [
+                {
+                  "interval": 1,
+                  "interval_type": "daily"
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layers": [
+                {
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "name": "Layer 1"
+                }
+              ],
+              "name": "Primary On-Call Schedule",
+              "users": [
+                {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              ],
+              "working_interval": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "tuesday"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "example": {
+        "rotations": [
+          {
+            "effective_from": "2021-08-17T13:28:57.801578Z",
+            "handover_start_at": "2021-08-17T13:28:57.801578Z",
+            "handovers": [
+              {
+                "interval": 1,
+                "interval_type": "daily"
+              }
+            ],
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "layers": [
+              {
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "name": "Layer 1"
+              }
+            ],
+            "name": "Primary On-Call Schedule",
+            "users": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
+            "working_interval": [
+              {
+                "end_time": "17:00",
+                "start_time": "09:00",
+                "weekday": "tuesday"
+              }
+            ]
+          }
+        ]
+      },
+      "required": [
+        "rotations",
+        "version"
+      ]
+    },
+    "ScheduleCreatePayloadV2RequestBody": {
+      "title": "ScheduleCreatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/ScheduleConfigCreatePayloadV2RequestBody"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the schedule",
+          "example": "My Schedule"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone of the schedule",
+          "example": "America/Los_Angeles"
+        }
+      },
+      "example": {
+        "config": {
+          "rotations": [
+            {
+              "effective_from": "2021-08-17T13:28:57.801578Z",
+              "handover_start_at": "2021-08-17T13:28:57.801578Z",
+              "handovers": [
+                {
+                  "interval": 1,
+                  "interval_type": "daily"
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layers": [
+                {
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "name": "Layer 1"
+                }
+              ],
+              "name": "My Rotation",
+              "users": [
+                {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                }
+              ],
+              "working_interval": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "tuesday"
+                }
+              ]
+            }
+          ]
+        },
+        "name": "My Schedule",
+        "timezone": "America/Los_Angeles"
+      }
+    },
+    "ScheduleEntriesListPayloadV2ResponseBody": {
+      "title": "ScheduleEntriesListPayloadV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "final": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleEntryV2ResponseBody"
+          },
+          "example": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ]
+        },
+        "overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleEntryV2ResponseBody"
+          },
+          "example": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ]
+        },
+        "scheduled": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleEntryV2ResponseBody"
+          },
+          "example": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ]
+        }
+      },
+      "example": {
+        "final": [
+          {
+            "end_at": "2021-08-17T13:28:57.801578Z",
+            "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+            "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "start_at": "2021-08-17T13:28:57.801578Z",
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          }
+        ],
+        "overrides": [
+          {
+            "end_at": "2021-08-17T13:28:57.801578Z",
+            "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+            "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "start_at": "2021-08-17T13:28:57.801578Z",
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          }
+        ],
+        "scheduled": [
+          {
+            "end_at": "2021-08-17T13:28:57.801578Z",
+            "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+            "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "start_at": "2021-08-17T13:28:57.801578Z",
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          }
+        ]
+      },
+      "required": [
+        "scheduled",
+        "overrides",
+        "final"
+      ]
+    },
+    "ScheduleEntriesV2ListResponseBody": {
+      "title": "ScheduleEntriesV2ListResponseBody",
+      "type": "object",
+      "properties": {
+        "pagination_meta": {
+          "$ref": "#/definitions/AfterPaginationMetaResultV2ResponseBody"
+        },
+        "schedule_entries": {
+          "$ref": "#/definitions/ScheduleEntriesListPayloadV2ResponseBody"
+        }
+      },
+      "example": {
+        "pagination_meta": {
+          "after": "abc123",
+          "after_url": "abc123"
+        },
+        "schedule_entries": {
+          "final": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ],
+          "overrides": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ],
+          "scheduled": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "schedule_entries"
+      ]
+    },
+    "ScheduleEntryV2ResponseBody": {
+      "title": "ScheduleEntryV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "end_at": {
+          "type": "string",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "entry_id": {
+          "type": "string",
+          "description": "Unique identifier of the schedule entry",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "fingerprint": {
+          "type": "string",
+          "description": "A unique identifier for this entry, used to determine a unique shift",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "layer_id": {
+          "type": "string",
+          "description": "If present, the layer this entry applies to on the rota",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYNH"
+        },
+        "rotation_id": {
+          "type": "string",
+          "description": "If present, the rotation this entry applies to on the schedule",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "start_at": {
+          "type": "string",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "user": {
+          "$ref": "#/definitions/UserV2ResponseBody"
+        }
+      },
+      "example": {
+        "end_at": "2021-08-17T13:28:57.801578Z",
+        "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+        "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "start_at": "2021-08-17T13:28:57.801578Z",
+        "user": {
+          "email": "lisa@incident.io",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Lisa Karlin Curtis",
+          "role": "viewer",
+          "slack_user_id": "U02AYNF2XJM"
+        }
+      },
+      "required": [
+        "external_user_id",
+        "start_at",
+        "end_at"
+      ]
+    },
+    "ScheduleLayerCreatePayloadV2RequestBody": {
+      "title": "ScheduleLayerCreatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the layer",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the layer",
+          "example": "Layer 1"
+        }
+      },
+      "example": {
+        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "name": "Layer 1"
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "ScheduleLayerUpdatePayloadV2RequestBody": {
+      "title": "ScheduleLayerUpdatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the layer",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the layer",
+          "example": "Layer 1"
+        }
+      },
+      "example": {
+        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "name": "Layer 1"
+      }
+    },
+    "ScheduleLayerV2ResponseBody": {
+      "title": "ScheduleLayerV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the layer",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the layer",
+          "example": "Layer 1"
+        }
+      },
+      "example": {
+        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "name": "Layer 1"
+      }
+    },
+    "ScheduleRotationCreatePayloadV2RequestBody": {
+      "title": "ScheduleRotationCreatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "effective_from": {
+          "type": "string",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "handover_start_at": {
+          "type": "string",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "handovers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleRotationHandoverV2RequestBody"
+          },
+          "example": [
+            {
+              "interval": 1,
+              "interval_type": "daily"
+            }
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the rotation",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "layers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleLayerCreatePayloadV2RequestBody"
+          },
+          "example": [
+            {
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Layer 1"
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the rotation",
+          "example": "My Rotation"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserReferencePayloadV2RequestBody"
+          },
+          "example": [
+            {
+              "email": "bob@example.com",
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "slack_user_id": "USER123"
+            }
+          ]
+        },
+        "working_interval": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleRotationWorkingIntervalCreatePayloadV2RequestBody"
+          },
+          "example": [
+            {
+              "end_time": "17:00",
+              "start_time": "09:00",
+              "weekday": "tuesday"
+            }
+          ]
+        }
+      },
+      "example": {
+        "effective_from": "2021-08-17T13:28:57.801578Z",
+        "handover_start_at": "2021-08-17T13:28:57.801578Z",
+        "handovers": [
+          {
+            "interval": 1,
+            "interval_type": "daily"
+          }
+        ],
+        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "layers": [
+          {
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "name": "Layer 1"
+          }
+        ],
+        "name": "My Rotation",
+        "users": [
+          {
+            "email": "bob@example.com",
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "slack_user_id": "USER123"
+          }
+        ],
+        "working_interval": [
+          {
+            "end_time": "17:00",
+            "start_time": "09:00",
+            "weekday": "tuesday"
+          }
+        ]
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "ScheduleRotationHandoverV2RequestBody": {
+      "title": "ScheduleRotationHandoverV2RequestBody",
+      "type": "object",
+      "properties": {
+        "interval": {
+          "type": "integer",
+          "example": 1,
+          "format": "int64"
+        },
+        "interval_type": {
+          "type": "string",
+          "example": "daily",
+          "enum": [
+            "hourly",
+            "daily",
+            "weekly"
+          ]
+        }
+      },
+      "example": {
+        "interval": 1,
+        "interval_type": "daily"
+      }
+    },
+    "ScheduleRotationHandoverV2ResponseBody": {
+      "title": "ScheduleRotationHandoverV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "interval": {
+          "type": "integer",
+          "example": 1,
+          "format": "int64"
+        },
+        "interval_type": {
+          "type": "string",
+          "example": "daily",
+          "enum": [
+            "hourly",
+            "daily",
+            "weekly"
+          ]
+        }
+      },
+      "example": {
+        "interval": 1,
+        "interval_type": "daily"
+      }
+    },
+    "ScheduleRotationUpdatePayloadV2RequestBody": {
+      "title": "ScheduleRotationUpdatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "effective_from": {
+          "type": "string",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "handover_start_at": {
+          "type": "string",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "handovers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleRotationHandoverV2RequestBody"
+          },
+          "example": [
+            {
+              "interval": 1,
+              "interval_type": "daily"
+            }
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the rotation",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "layers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleLayerUpdatePayloadV2RequestBody"
+          },
+          "example": [
+            {
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Layer 1"
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the rotation",
+          "example": "My Rotation"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserReferencePayloadV2RequestBody"
+          },
+          "example": [
+            {
+              "email": "bob@example.com",
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "slack_user_id": "USER123"
+            }
+          ]
+        },
+        "working_interval": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleRotationWorkingIntervalUpdatePayloadV2RequestBody"
+          },
+          "example": [
+            {
+              "end_time": "17:00",
+              "start_time": "09:00",
+              "weekday": "tuesday"
+            }
+          ]
+        }
+      },
+      "example": {
+        "effective_from": "2021-08-17T13:28:57.801578Z",
+        "handover_start_at": "2021-08-17T13:28:57.801578Z",
+        "handovers": [
+          {
+            "interval": 1,
+            "interval_type": "daily"
+          }
+        ],
+        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "layers": [
+          {
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "name": "Layer 1"
+          }
+        ],
+        "name": "My Rotation",
+        "users": [
+          {
+            "email": "bob@example.com",
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "slack_user_id": "USER123"
+          }
+        ],
+        "working_interval": [
+          {
+            "end_time": "17:00",
+            "start_time": "09:00",
+            "weekday": "tuesday"
+          }
+        ]
+      }
+    },
+    "ScheduleRotationV2ResponseBody": {
+      "title": "ScheduleRotationV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "effective_from": {
+          "type": "string",
+          "description": "When this rotation config will be effective from",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "handover_start_at": {
+          "type": "string",
+          "description": "Defines the next moment we'll trigger a handover",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "handovers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleRotationHandoverV2ResponseBody"
+          },
+          "description": "Defines the handover intervals for this rota, in order they should apply",
+          "example": [
+            {
+              "interval": 1,
+              "interval_type": "daily"
+            }
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique internal ID of the rotation",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "layers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleLayerV2ResponseBody"
+          },
+          "description": "Controls how many people are on-call concurrently",
+          "example": [
+            {
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Layer 1"
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Human readable name synced from external provider",
+          "example": "Primary On-Call Schedule"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserV2ResponseBody"
+          },
+          "example": [
+            {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          ]
+        },
+        "working_interval": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleRotationWorkingIntervalV2ResponseBody"
+          },
+          "example": [
+            {
+              "end_time": "17:00",
+              "start_time": "09:00",
+              "weekday": "tuesday"
+            }
+          ]
+        }
+      },
+      "example": {
+        "effective_from": "2021-08-17T13:28:57.801578Z",
+        "handover_start_at": "2021-08-17T13:28:57.801578Z",
+        "handovers": [
+          {
+            "interval": 1,
+            "interval_type": "daily"
+          }
+        ],
+        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "layers": [
+          {
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "name": "Layer 1"
+          }
+        ],
+        "name": "Primary On-Call Schedule",
+        "users": [
+          {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          }
+        ],
+        "working_interval": [
+          {
+            "end_time": "17:00",
+            "start_time": "09:00",
+            "weekday": "tuesday"
+          }
+        ]
+      },
+      "required": [
+        "id",
+        "name",
+        "layers",
+        "user_ids",
+        "working_intervals",
+        "handover_start_at",
+        "handovers"
+      ]
+    },
+    "ScheduleRotationWorkingIntervalCreatePayloadV2RequestBody": {
+      "title": "ScheduleRotationWorkingIntervalCreatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "type": "string",
+          "description": "End time of the interval, in 24hr format",
+          "example": "17:00"
+        },
+        "start_time": {
+          "type": "string",
+          "description": "Start time of the interval, in 24hr format",
+          "example": "09:00"
+        },
+        "weekday": {
+          "type": "string",
+          "description": "Weekday this interval applies to",
+          "example": "tuesday",
+          "enum": [
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday"
+          ]
+        }
+      },
+      "example": {
+        "end_time": "17:00",
+        "start_time": "09:00",
+        "weekday": "tuesday"
+      },
+      "required": [
+        "weekday",
+        "start_time",
+        "end_time"
+      ]
+    },
+    "ScheduleRotationWorkingIntervalUpdatePayloadV2RequestBody": {
+      "title": "ScheduleRotationWorkingIntervalUpdatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "type": "string",
+          "description": "End time of the interval, in 24hr format",
+          "example": "17:00"
+        },
+        "start_time": {
+          "type": "string",
+          "description": "Start time of the interval, in 24hr format",
+          "example": "09:00"
+        },
+        "weekday": {
+          "type": "string",
+          "description": "Weekday this interval applies to",
+          "example": "tuesday",
+          "enum": [
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday"
+          ]
+        }
+      },
+      "example": {
+        "end_time": "17:00",
+        "start_time": "09:00",
+        "weekday": "tuesday"
+      }
+    },
+    "ScheduleRotationWorkingIntervalV2ResponseBody": {
+      "title": "ScheduleRotationWorkingIntervalV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "type": "string",
+          "description": "End time of the interval, in 24hr format",
+          "example": "17:00"
+        },
+        "start_time": {
+          "type": "string",
+          "description": "Start time of the interval, in 24hr format",
+          "example": "09:00"
+        },
+        "weekday": {
+          "type": "string",
+          "description": "Weekday this interval applies to",
+          "example": "tuesday",
+          "enum": [
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
+            "sunday"
+          ]
+        }
+      },
+      "example": {
+        "end_time": "17:00",
+        "start_time": "09:00",
+        "weekday": "tuesday"
+      },
+      "required": [
+        "weekday",
+        "start_time",
+        "end_time"
+      ]
+    },
+    "ScheduleUpdatePayloadV2RequestBody": {
+      "title": "ScheduleUpdatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/ScheduleConfigUpdatePayloadV2RequestBody"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the schedule",
+          "example": "My Schedule"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone of the schedule",
+          "example": "America/Los_Angeles"
+        }
+      },
+      "example": {
+        "config": {
+          "rotations": [
+            {
+              "effective_from": "2021-08-17T13:28:57.801578Z",
+              "handover_start_at": "2021-08-17T13:28:57.801578Z",
+              "handovers": [
+                {
+                  "interval": 1,
+                  "interval_type": "daily"
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layers": [
+                {
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "name": "Layer 1"
+                }
+              ],
+              "name": "My Rotation",
+              "users": [
+                {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                }
+              ],
+              "working_interval": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "tuesday"
+                }
+              ]
+            }
+          ]
+        },
+        "name": "My Schedule",
+        "timezone": "America/Los_Angeles"
+      }
+    },
+    "ScheduleV2ResponseBody": {
+      "title": "ScheduleV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/ScheduleConfigV2ResponseBody"
+        },
+        "created_at": {
+          "type": "string",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "current_shifts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleEntryV2ResponseBody"
+          },
+          "description": "Shifts that are on-going for this schedule, if a native schedule",
+          "example": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique internal ID of the schedule",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "name": {
+          "type": "string",
+          "description": "Human readable name synced from external provider",
+          "example": "Primary On-Call Schedule"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone of the schedule, as interpreted at the point of generating the report",
+          "example": "Europe/London"
+        },
+        "updated_at": {
+          "type": "string",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        }
+      },
+      "example": {
+        "config": {
+          "rotations": [
+            {
+              "effective_from": "2021-08-17T13:28:57.801578Z",
+              "handover_start_at": "2021-08-17T13:28:57.801578Z",
+              "handovers": [
+                {
+                  "interval": 1,
+                  "interval_type": "daily"
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layers": [
+                {
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "name": "Layer 1"
+                }
+              ],
+              "name": "Primary On-Call Schedule",
+              "users": [
+                {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              ],
+              "working_interval": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "tuesday"
+                }
+              ]
+            }
+          ]
+        },
+        "created_at": "2021-08-17T13:28:57.801578Z",
+        "current_shifts": [
+          {
+            "end_at": "2021-08-17T13:28:57.801578Z",
+            "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+            "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "start_at": "2021-08-17T13:28:57.801578Z",
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          }
+        ],
+        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "name": "Primary On-Call Schedule",
+        "timezone": "Europe/London",
+        "updated_at": "2021-08-17T13:28:57.801578Z"
+      },
+      "required": [
+        "id",
+        "name",
+        "timezone",
+        "external_provider",
+        "external_provider_id",
+        "created_at",
+        "updated_at"
+      ]
+    },
+    "SchedulesV2CreateRequestBody": {
+      "title": "SchedulesV2CreateRequestBody",
+      "type": "object",
+      "properties": {
+        "schedule": {
+          "$ref": "#/definitions/ScheduleCreatePayloadV2RequestBody"
+        }
+      },
+      "example": {
+        "schedule": {
+          "config": {
+            "rotations": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "My Rotation",
+                "users": [
+                  {
+                    "email": "bob@example.com",
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "slack_user_id": "USER123"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          },
+          "name": "My Schedule",
+          "timezone": "America/Los_Angeles"
+        }
+      },
+      "required": [
+        "schedule"
+      ]
+    },
+    "SchedulesV2CreateResponseBody": {
+      "title": "SchedulesV2CreateResponseBody",
+      "type": "object",
+      "properties": {
+        "schedule": {
+          "$ref": "#/definitions/ScheduleV2ResponseBody"
+        }
+      },
+      "example": {
+        "schedule": {
+          "config": {
+            "rotations": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "Primary On-Call Schedule",
+                "users": [
+                  {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          },
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "current_shifts": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ],
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "name": "Primary On-Call Schedule",
+          "timezone": "Europe/London",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        }
+      },
+      "required": [
+        "schedule"
+      ]
+    },
+    "SchedulesV2ListResponseBody": {
+      "title": "SchedulesV2ListResponseBody",
+      "type": "object",
+      "properties": {
+        "pagination_meta": {
+          "$ref": "#/definitions/PaginationMetaResultWithTotalResponseBody"
+        },
+        "schedules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ScheduleV2ResponseBody"
+          },
+          "example": [
+            {
+              "config": {
+                "rotations": [
+                  {
+                    "effective_from": "2021-08-17T13:28:57.801578Z",
+                    "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                    "handovers": [
+                      {
+                        "interval": 1,
+                        "interval_type": "daily"
+                      }
+                    ],
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "layers": [
+                      {
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "name": "Layer 1"
+                      }
+                    ],
+                    "name": "Primary On-Call Schedule",
+                    "users": [
+                      {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      }
+                    ],
+                    "working_interval": [
+                      {
+                        "end_time": "17:00",
+                        "start_time": "09:00",
+                        "weekday": "tuesday"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "current_shifts": [
+                {
+                  "end_at": "2021-08-17T13:28:57.801578Z",
+                  "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                  "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "start_at": "2021-08-17T13:28:57.801578Z",
+                  "user": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Primary On-Call Schedule",
+              "timezone": "Europe/London",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        }
+      },
+      "example": {
+        "pagination_meta": {
+          "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "page_size": 25,
+          "total_record_count": 238
+        },
+        "schedules": [
+          {
+            "config": {
+              "rotations": [
+                {
+                  "effective_from": "2021-08-17T13:28:57.801578Z",
+                  "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                  "handovers": [
+                    {
+                      "interval": 1,
+                      "interval_type": "daily"
+                    }
+                  ],
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "layers": [
+                    {
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "name": "Layer 1"
+                    }
+                  ],
+                  "name": "Primary On-Call Schedule",
+                  "users": [
+                    {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    }
+                  ],
+                  "working_interval": [
+                    {
+                      "end_time": "17:00",
+                      "start_time": "09:00",
+                      "weekday": "tuesday"
+                    }
+                  ]
+                }
+              ]
+            },
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "current_shifts": [
+              {
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ],
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "name": "Primary On-Call Schedule",
+            "timezone": "Europe/London",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        ]
+      },
+      "required": [
+        "schedules"
+      ]
+    },
+    "SchedulesV2ShowResponseBody": {
+      "title": "SchedulesV2ShowResponseBody",
+      "type": "object",
+      "properties": {
+        "schedule": {
+          "$ref": "#/definitions/ScheduleV2ResponseBody"
+        }
+      },
+      "example": {
+        "schedule": {
+          "config": {
+            "rotations": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "Primary On-Call Schedule",
+                "users": [
+                  {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          },
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "current_shifts": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ],
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "name": "Primary On-Call Schedule",
+          "timezone": "Europe/London",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        }
+      },
+      "required": [
+        "schedule"
+      ]
+    },
+    "SchedulesV2UpdateRequestBody": {
+      "title": "SchedulesV2UpdateRequestBody",
+      "type": "object",
+      "properties": {
+        "schedule": {
+          "$ref": "#/definitions/ScheduleUpdatePayloadV2RequestBody"
+        }
+      },
+      "example": {
+        "schedule": {
+          "config": {
+            "rotations": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "My Rotation",
+                "users": [
+                  {
+                    "email": "bob@example.com",
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "slack_user_id": "USER123"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          },
+          "name": "My Schedule",
+          "timezone": "America/Los_Angeles"
+        }
+      },
+      "required": [
+        "schedule",
+        "name",
+        "timezone",
+        "external_provider",
+        "external_provider_id",
+        "created_at",
+        "updated_at"
+      ]
+    },
+    "SchedulesV2UpdateResponseBody": {
+      "title": "SchedulesV2UpdateResponseBody",
+      "type": "object",
+      "properties": {
+        "schedule": {
+          "$ref": "#/definitions/ScheduleV2ResponseBody"
+        }
+      },
+      "example": {
+        "schedule": {
+          "config": {
+            "rotations": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "Primary On-Call Schedule",
+                "users": [
+                  {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          },
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "current_shifts": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ],
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "name": "Primary On-Call Schedule",
+          "timezone": "Europe/London",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        }
+      },
+      "required": [
+        "schedule"
+      ]
+    },
     "SeveritiesV1CreateRequestBody": {
       "title": "SeveritiesV1CreateRequestBody",
       "type": "object",
@@ -24813,7 +26901,7 @@
       "properties": {
         "actor_user_id": {
           "type": "string",
-          "description": "The ID of the user who performed this action",
+          "description": "The ID of the user who performed this action. If the action was not taken by a user, for example it was taken by a Workflow, this will be empty.",
           "example": "abc123"
         },
         "incident_id": {
@@ -24931,6 +27019,14 @@
     {
       "name": "Incidents V2",
       "description": "Create and read incidents.\n\nIncidents are a core resource, on which many other resources (actions, etc) are created.\n\nCare should be taken around these endpoints, as automation that creates duplicate\nincidents can be distracting, and impact reporting.\n"
+    },
+    {
+      "name": "Schedule Entries V2",
+      "description": "\nBeta: List your historic and future schedule entries.\n"
+    },
+    {
+      "name": "Schedules V2",
+      "description": "Beta: \nView and manage schedules.\nManage your full schedule of on-call rotations, including the users and rotation configuration.\n"
     },
     {
       "name": "Severities V1",

--- a/internal/apischema/openapi3.json
+++ b/internal/apischema/openapi3.json
@@ -2124,7 +2124,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody16"
+                  "$ref": "#/components/schemas/ListResponseBody18"
                 },
                 "example": {
                   "severities": [
@@ -2155,7 +2155,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody11"
+                "$ref": "#/components/schemas/CreateRequestBody12"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2171,7 +2171,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody14"
+                  "$ref": "#/components/schemas/ShowResponseBody15"
                 },
                 "example": {
                   "severity": {
@@ -2244,7 +2244,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody14"
+                  "$ref": "#/components/schemas/ShowResponseBody15"
                 },
                 "example": {
                   "severity": {
@@ -2287,7 +2287,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody11"
+                "$ref": "#/components/schemas/CreateRequestBody12"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2303,7 +2303,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody14"
+                  "$ref": "#/components/schemas/ShowResponseBody15"
                 },
                 "example": {
                   "severity": {
@@ -5456,6 +5456,662 @@
         }
       }
     },
+    "/v2/schedule_entries": {
+      "get": {
+        "tags": [
+          "Schedule Entries V2"
+        ],
+        "summary": "List Schedule Entries V2",
+        "description": "Get a list of schedule entries.",
+        "operationId": "Schedule Entries V2#List",
+        "parameters": [
+          {
+            "name": "schedule_id",
+            "in": "query",
+            "description": "The ID of the schedule to get entries for.",
+            "allowEmptyValue": true,
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The ID of the schedule to get entries for.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+            },
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+          },
+          {
+            "name": "entry_window_start",
+            "in": "query",
+            "description": "The start of the window to get entries for.",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "The start of the window to get entries for.",
+              "example": "2021-01-01T00:00:00Z",
+              "format": "date-time"
+            },
+            "example": "2021-01-01T00:00:00Z"
+          },
+          {
+            "name": "entry_window_end",
+            "in": "query",
+            "description": "The end of the window to get entries for.",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "The end of the window to get entries for.",
+              "example": "2021-01-01T00:00:00Z",
+              "format": "date-time"
+            },
+            "example": "2021-01-01T00:00:00Z"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody16"
+                },
+                "example": {
+                  "pagination_meta": {
+                    "after": "abc123",
+                    "after_url": "abc123"
+                  },
+                  "schedule_entries": {
+                    "final": [
+                      {
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                        "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "start_at": "2021-08-17T13:28:57.801578Z",
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        }
+                      }
+                    ],
+                    "overrides": [
+                      {
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                        "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "start_at": "2021-08-17T13:28:57.801578Z",
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        }
+                      }
+                    ],
+                    "scheduled": [
+                      {
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                        "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "start_at": "2021-08-17T13:28:57.801578Z",
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/schedules": {
+      "get": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "List Schedules V2",
+        "description": "List configured schedules.",
+        "operationId": "Schedules V2#List",
+        "parameters": [
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "number of records to return",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "integer",
+              "description": "number of records to return",
+              "default": 25,
+              "example": 25,
+              "format": "int64"
+            },
+            "example": 25
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "A schedule's ID. This endpoint will return a list of schedules after this ID in relation to the API response order.",
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "string",
+              "description": "A schedule's ID. This endpoint will return a list of schedules after this ID in relation to the API response order.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+            },
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponseBody17"
+                },
+                "example": {
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25,
+                    "total_record_count": 238
+                  },
+                  "schedules": [
+                    {
+                      "config": {
+                        "rotations": [
+                          {
+                            "effective_from": "2021-08-17T13:28:57.801578Z",
+                            "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                            "handovers": [
+                              {
+                                "interval": 1,
+                                "interval_type": "daily"
+                              }
+                            ],
+                            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                            "layers": [
+                              {
+                                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                                "name": "Layer 1"
+                              }
+                            ],
+                            "name": "Primary On-Call Schedule",
+                            "users": [
+                              {
+                                "email": "lisa@incident.io",
+                                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                                "name": "Lisa Karlin Curtis",
+                                "role": "viewer",
+                                "slack_user_id": "U02AYNF2XJM"
+                              }
+                            ],
+                            "working_interval": [
+                              {
+                                "end_time": "17:00",
+                                "start_time": "09:00",
+                                "weekday": "tuesday"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "current_shifts": [
+                        {
+                          "end_at": "2021-08-17T13:28:57.801578Z",
+                          "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                          "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                          "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                          "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                          "start_at": "2021-08-17T13:28:57.801578Z",
+                          "user": {
+                            "email": "lisa@incident.io",
+                            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "name": "Lisa Karlin Curtis",
+                            "role": "viewer",
+                            "slack_user_id": "U02AYNF2XJM"
+                          }
+                        }
+                      ],
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "name": "Primary On-Call Schedule",
+                      "timezone": "Europe/London",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "Create Schedules V2",
+        "description": "Create a new schedule.",
+        "operationId": "Schedules V2#Create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRequestBody11"
+              },
+              "example": {
+                "schedule": {
+                  "config": {
+                    "rotations": [
+                      {
+                        "effective_from": "2021-08-17T13:28:57.801578Z",
+                        "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                        "handovers": [
+                          {
+                            "interval": 1,
+                            "interval_type": "daily"
+                          }
+                        ],
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "layers": [
+                          {
+                            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                            "name": "Layer 1"
+                          }
+                        ],
+                        "name": "My Rotation",
+                        "users": [
+                          {
+                            "email": "bob@example.com",
+                            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                            "slack_user_id": "USER123"
+                          }
+                        ],
+                        "working_interval": [
+                          {
+                            "end_time": "17:00",
+                            "start_time": "09:00",
+                            "weekday": "tuesday"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "name": "My Schedule",
+                  "timezone": "America/Los_Angeles"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody14"
+                },
+                "example": {
+                  "schedule": {
+                    "config": {
+                      "rotations": [
+                        {
+                          "effective_from": "2021-08-17T13:28:57.801578Z",
+                          "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                          "handovers": [
+                            {
+                              "interval": 1,
+                              "interval_type": "daily"
+                            }
+                          ],
+                          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                          "layers": [
+                            {
+                              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                              "name": "Layer 1"
+                            }
+                          ],
+                          "name": "Primary On-Call Schedule",
+                          "users": [
+                            {
+                              "email": "lisa@incident.io",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Lisa Karlin Curtis",
+                              "role": "viewer",
+                              "slack_user_id": "U02AYNF2XJM"
+                            }
+                          ],
+                          "working_interval": [
+                            {
+                              "end_time": "17:00",
+                              "start_time": "09:00",
+                              "weekday": "tuesday"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "current_shifts": [
+                      {
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                        "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "start_at": "2021-08-17T13:28:57.801578Z",
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        }
+                      }
+                    ],
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Primary On-Call Schedule",
+                    "timezone": "Europe/London",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/schedules/{id}": {
+      "delete": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "Destroy Schedules V2",
+        "description": "Archives a single schedule.",
+        "operationId": "Schedules V2#Destroy",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique internal ID of the schedule",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique internal ID of the schedule",
+              "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+            },
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted response."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "Show Schedules V2",
+        "description": "Get a sigle schedule.",
+        "operationId": "Schedules V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique internal ID of the schedule",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique internal ID of the schedule",
+              "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+            },
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody14"
+                },
+                "example": {
+                  "schedule": {
+                    "config": {
+                      "rotations": [
+                        {
+                          "effective_from": "2021-08-17T13:28:57.801578Z",
+                          "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                          "handovers": [
+                            {
+                              "interval": 1,
+                              "interval_type": "daily"
+                            }
+                          ],
+                          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                          "layers": [
+                            {
+                              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                              "name": "Layer 1"
+                            }
+                          ],
+                          "name": "Primary On-Call Schedule",
+                          "users": [
+                            {
+                              "email": "lisa@incident.io",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Lisa Karlin Curtis",
+                              "role": "viewer",
+                              "slack_user_id": "U02AYNF2XJM"
+                            }
+                          ],
+                          "working_interval": [
+                            {
+                              "end_time": "17:00",
+                              "start_time": "09:00",
+                              "weekday": "tuesday"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "current_shifts": [
+                      {
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                        "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "start_at": "2021-08-17T13:28:57.801578Z",
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        }
+                      }
+                    ],
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Primary On-Call Schedule",
+                    "timezone": "Europe/London",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Schedules V2"
+        ],
+        "summary": "Update Schedules V2",
+        "description": "Update a schedule.",
+        "operationId": "Schedules V2#Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The schedule ID to update.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The schedule ID to update.",
+              "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+            },
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRequestBody7"
+              },
+              "example": {
+                "schedule": {
+                  "config": {
+                    "rotations": [
+                      {
+                        "effective_from": "2021-08-17T13:28:57.801578Z",
+                        "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                        "handovers": [
+                          {
+                            "interval": 1,
+                            "interval_type": "daily"
+                          }
+                        ],
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "layers": [
+                          {
+                            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                            "name": "Layer 1"
+                          }
+                        ],
+                        "name": "My Rotation",
+                        "users": [
+                          {
+                            "email": "bob@example.com",
+                            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                            "slack_user_id": "USER123"
+                          }
+                        ],
+                        "working_interval": [
+                          {
+                            "end_time": "17:00",
+                            "start_time": "09:00",
+                            "weekday": "tuesday"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "name": "My Schedule",
+                  "timezone": "America/Los_Angeles"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowResponseBody14"
+                },
+                "example": {
+                  "schedule": {
+                    "config": {
+                      "rotations": [
+                        {
+                          "effective_from": "2021-08-17T13:28:57.801578Z",
+                          "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                          "handovers": [
+                            {
+                              "interval": 1,
+                              "interval_type": "daily"
+                            }
+                          ],
+                          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                          "layers": [
+                            {
+                              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                              "name": "Layer 1"
+                            }
+                          ],
+                          "name": "Primary On-Call Schedule",
+                          "users": [
+                            {
+                              "email": "lisa@incident.io",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Lisa Karlin Curtis",
+                              "role": "viewer",
+                              "slack_user_id": "U02AYNF2XJM"
+                            }
+                          ],
+                          "working_interval": [
+                            {
+                              "end_time": "17:00",
+                              "start_time": "09:00",
+                              "weekday": "tuesday"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "current_shifts": [
+                      {
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                        "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "start_at": "2021-08-17T13:28:57.801578Z",
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        }
+                      }
+                    ],
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Primary On-Call Schedule",
+                    "timezone": "Europe/London",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/users": {
       "get": {
         "tags": [
@@ -5523,7 +6179,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody17"
+                  "$ref": "#/components/schemas/ListResponseBody19"
                 },
                 "example": {
                   "pagination_meta": {
@@ -5588,7 +6244,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody15"
+                  "$ref": "#/components/schemas/ShowResponseBody16"
                 },
                 "example": {
                   "user": {
@@ -5911,6 +6567,29 @@
             "slack_user_id": "U02AYNF2XJM"
           }
         }
+      },
+      "AfterPaginationMetaResultV2": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "type": "string",
+            "description": "The time, if it exists, of the last entry's end time",
+            "example": "abc123"
+          },
+          "after_url": {
+            "type": "string",
+            "description": "The URL to fetch the next page of entries",
+            "example": "abc123"
+          }
+        },
+        "example": {
+          "after": "abc123",
+          "after_url": "abc123"
+        },
+        "required": [
+          "after",
+          "after_url"
+        ]
       },
       "AllResponseBody": {
         "type": "object",
@@ -7906,6 +8585,59 @@
         ]
       },
       "CreateRequestBody11": {
+        "type": "object",
+        "properties": {
+          "schedule": {
+            "$ref": "#/components/schemas/ScheduleCreatePayloadV2"
+          }
+        },
+        "example": {
+          "schedule": {
+            "config": {
+              "rotations": [
+                {
+                  "effective_from": "2021-08-17T13:28:57.801578Z",
+                  "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                  "handovers": [
+                    {
+                      "interval": 1,
+                      "interval_type": "daily"
+                    }
+                  ],
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "layers": [
+                    {
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "name": "Layer 1"
+                    }
+                  ],
+                  "name": "My Rotation",
+                  "users": [
+                    {
+                      "email": "bob@example.com",
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "slack_user_id": "USER123"
+                    }
+                  ],
+                  "working_interval": [
+                    {
+                      "end_time": "17:00",
+                      "start_time": "09:00",
+                      "weekday": "tuesday"
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "My Schedule",
+            "timezone": "America/Los_Angeles"
+          }
+        },
+        "required": [
+          "schedule"
+        ]
+      },
+      "CreateRequestBody12": {
         "type": "object",
         "properties": {
           "description": {
@@ -12704,6 +13436,231 @@
       "ListResponseBody16": {
         "type": "object",
         "properties": {
+          "pagination_meta": {
+            "$ref": "#/components/schemas/AfterPaginationMetaResultV2"
+          },
+          "schedule_entries": {
+            "$ref": "#/components/schemas/ScheduleEntriesListPayloadV2"
+          }
+        },
+        "example": {
+          "pagination_meta": {
+            "after": "abc123",
+            "after_url": "abc123"
+          },
+          "schedule_entries": {
+            "final": [
+              {
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ],
+            "overrides": [
+              {
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ],
+            "scheduled": [
+              {
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "schedule_entries"
+        ]
+      },
+      "ListResponseBody17": {
+        "type": "object",
+        "properties": {
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultWithTotal"
+          },
+          "schedules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleV2"
+            },
+            "example": [
+              {
+                "config": {
+                  "rotations": [
+                    {
+                      "effective_from": "2021-08-17T13:28:57.801578Z",
+                      "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                      "handovers": [
+                        {
+                          "interval": 1,
+                          "interval_type": "daily"
+                        }
+                      ],
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "layers": [
+                        {
+                          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                          "name": "Layer 1"
+                        }
+                      ],
+                      "name": "Primary On-Call Schedule",
+                      "users": [
+                        {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        }
+                      ],
+                      "working_interval": [
+                        {
+                          "end_time": "17:00",
+                          "start_time": "09:00",
+                          "weekday": "tuesday"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "current_shifts": [
+                  {
+                    "end_at": "2021-08-17T13:28:57.801578Z",
+                    "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                    "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "start_at": "2021-08-17T13:28:57.801578Z",
+                    "user": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    }
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "name": "Primary On-Call Schedule",
+                "timezone": "Europe/London",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ]
+          }
+        },
+        "example": {
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25,
+            "total_record_count": 238
+          },
+          "schedules": [
+            {
+              "config": {
+                "rotations": [
+                  {
+                    "effective_from": "2021-08-17T13:28:57.801578Z",
+                    "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                    "handovers": [
+                      {
+                        "interval": 1,
+                        "interval_type": "daily"
+                      }
+                    ],
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "layers": [
+                      {
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "name": "Layer 1"
+                      }
+                    ],
+                    "name": "Primary On-Call Schedule",
+                    "users": [
+                      {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      }
+                    ],
+                    "working_interval": [
+                      {
+                        "end_time": "17:00",
+                        "start_time": "09:00",
+                        "weekday": "tuesday"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "current_shifts": [
+                {
+                  "end_at": "2021-08-17T13:28:57.801578Z",
+                  "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                  "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "start_at": "2021-08-17T13:28:57.801578Z",
+                  "user": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Primary On-Call Schedule",
+              "timezone": "Europe/London",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "required": [
+          "schedules"
+        ]
+      },
+      "ListResponseBody18": {
+        "type": "object",
+        "properties": {
           "severities": {
             "type": "array",
             "items": {
@@ -12737,7 +13694,7 @@
           "severities"
         ]
       },
-      "ListResponseBody17": {
+      "ListResponseBody19": {
         "type": "object",
         "properties": {
           "pagination_meta": {
@@ -14616,6 +15573,1170 @@
           "slack_channel_id": "abc123"
         }
       },
+      "ScheduleConfigCreatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "rotations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRotationCreatePayloadV2"
+            },
+            "example": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "My Rotation",
+                "users": [
+                  {
+                    "email": "bob@example.com",
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "slack_user_id": "USER123"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "rotations": [
+            {
+              "effective_from": "2021-08-17T13:28:57.801578Z",
+              "handover_start_at": "2021-08-17T13:28:57.801578Z",
+              "handovers": [
+                {
+                  "interval": 1,
+                  "interval_type": "daily"
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layers": [
+                {
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "name": "Layer 1"
+                }
+              ],
+              "name": "My Rotation",
+              "users": [
+                {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                }
+              ],
+              "working_interval": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "tuesday"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "ScheduleConfigUpdatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "rotations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRotationUpdatePayloadV2"
+            },
+            "example": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "My Rotation",
+                "users": [
+                  {
+                    "email": "bob@example.com",
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "slack_user_id": "USER123"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "rotations": [
+            {
+              "effective_from": "2021-08-17T13:28:57.801578Z",
+              "handover_start_at": "2021-08-17T13:28:57.801578Z",
+              "handovers": [
+                {
+                  "interval": 1,
+                  "interval_type": "daily"
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layers": [
+                {
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "name": "Layer 1"
+                }
+              ],
+              "name": "My Rotation",
+              "users": [
+                {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                }
+              ],
+              "working_interval": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "tuesday"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "ScheduleConfigV2": {
+        "type": "object",
+        "properties": {
+          "rotations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRotationV2"
+            },
+            "description": "Rotas in this schedule",
+            "example": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "Primary On-Call Schedule",
+                "users": [
+                  {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "rotations": [
+            {
+              "effective_from": "2021-08-17T13:28:57.801578Z",
+              "handover_start_at": "2021-08-17T13:28:57.801578Z",
+              "handovers": [
+                {
+                  "interval": 1,
+                  "interval_type": "daily"
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layers": [
+                {
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "name": "Layer 1"
+                }
+              ],
+              "name": "Primary On-Call Schedule",
+              "users": [
+                {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              ],
+              "working_interval": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "tuesday"
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "rotations",
+          "version"
+        ]
+      },
+      "ScheduleCreatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/ScheduleConfigCreatePayloadV2"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the schedule",
+            "example": "My Schedule"
+          },
+          "timezone": {
+            "type": "string",
+            "description": "Timezone of the schedule",
+            "example": "America/Los_Angeles"
+          }
+        },
+        "example": {
+          "config": {
+            "rotations": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "My Rotation",
+                "users": [
+                  {
+                    "email": "bob@example.com",
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "slack_user_id": "USER123"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          },
+          "name": "My Schedule",
+          "timezone": "America/Los_Angeles"
+        }
+      },
+      "ScheduleEntriesListPayloadV2": {
+        "type": "object",
+        "properties": {
+          "final": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleEntryV2"
+            },
+            "example": [
+              {
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ]
+          },
+          "overrides": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleEntryV2"
+            },
+            "example": [
+              {
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ]
+          },
+          "scheduled": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleEntryV2"
+            },
+            "example": [
+              {
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "final": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ],
+          "overrides": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ],
+          "scheduled": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ]
+        },
+        "required": [
+          "scheduled",
+          "overrides",
+          "final"
+        ]
+      },
+      "ScheduleEntryV2": {
+        "type": "object",
+        "properties": {
+          "end_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "entry_id": {
+            "type": "string",
+            "description": "Unique identifier of the schedule entry",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "fingerprint": {
+            "type": "string",
+            "description": "A unique identifier for this entry, used to determine a unique shift",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "layer_id": {
+            "type": "string",
+            "description": "If present, the layer this entry applies to on the rota",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYNH"
+          },
+          "rotation_id": {
+            "type": "string",
+            "description": "If present, the rotation this entry applies to on the schedule",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "start_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserV1"
+          }
+        },
+        "example": {
+          "end_at": "2021-08-17T13:28:57.801578Z",
+          "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+          "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "start_at": "2021-08-17T13:28:57.801578Z",
+          "user": {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          }
+        },
+        "required": [
+          "external_user_id",
+          "start_at",
+          "end_at"
+        ]
+      },
+      "ScheduleLayerCreatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the layer",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the layer",
+            "example": "Layer 1"
+          }
+        },
+        "example": {
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "name": "Layer 1"
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "ScheduleLayerV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the layer",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the layer",
+            "example": "Layer 1"
+          }
+        },
+        "example": {
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "name": "Layer 1"
+        }
+      },
+      "ScheduleRotationCreatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "effective_from": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "handover_start_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "handovers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRotationHandoverV2"
+            },
+            "example": [
+              {
+                "interval": 1,
+                "interval_type": "daily"
+              }
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the rotation",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "layers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleLayerCreatePayloadV2"
+            },
+            "example": [
+              {
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "name": "Layer 1"
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the rotation",
+            "example": "My Rotation"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserReferencePayloadV1"
+            },
+            "example": [
+              {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              }
+            ]
+          },
+          "working_interval": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRotationWorkingIntervalV2"
+            },
+            "example": [
+              {
+                "end_time": "17:00",
+                "start_time": "09:00",
+                "weekday": "tuesday"
+              }
+            ]
+          }
+        },
+        "example": {
+          "effective_from": "2021-08-17T13:28:57.801578Z",
+          "handover_start_at": "2021-08-17T13:28:57.801578Z",
+          "handovers": [
+            {
+              "interval": 1,
+              "interval_type": "daily"
+            }
+          ],
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "layers": [
+            {
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Layer 1"
+            }
+          ],
+          "name": "My Rotation",
+          "users": [
+            {
+              "email": "bob@example.com",
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "slack_user_id": "USER123"
+            }
+          ],
+          "working_interval": [
+            {
+              "end_time": "17:00",
+              "start_time": "09:00",
+              "weekday": "tuesday"
+            }
+          ]
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "ScheduleRotationHandoverV2": {
+        "type": "object",
+        "properties": {
+          "interval": {
+            "type": "integer",
+            "example": 1,
+            "format": "int64"
+          },
+          "interval_type": {
+            "type": "string",
+            "example": "daily",
+            "enum": [
+              "hourly",
+              "daily",
+              "weekly"
+            ]
+          }
+        },
+        "example": {
+          "interval": 1,
+          "interval_type": "daily"
+        }
+      },
+      "ScheduleRotationUpdatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "effective_from": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "handover_start_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "handovers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRotationHandoverV2"
+            },
+            "example": [
+              {
+                "interval": 1,
+                "interval_type": "daily"
+              }
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the rotation",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "layers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleLayerV2"
+            },
+            "example": [
+              {
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "name": "Layer 1"
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the rotation",
+            "example": "My Rotation"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserReferencePayloadV1"
+            },
+            "example": [
+              {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              }
+            ]
+          },
+          "working_interval": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRotationWorkingIntervalUpdatePayloadV2"
+            },
+            "example": [
+              {
+                "end_time": "17:00",
+                "start_time": "09:00",
+                "weekday": "tuesday"
+              }
+            ]
+          }
+        },
+        "example": {
+          "effective_from": "2021-08-17T13:28:57.801578Z",
+          "handover_start_at": "2021-08-17T13:28:57.801578Z",
+          "handovers": [
+            {
+              "interval": 1,
+              "interval_type": "daily"
+            }
+          ],
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "layers": [
+            {
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Layer 1"
+            }
+          ],
+          "name": "My Rotation",
+          "users": [
+            {
+              "email": "bob@example.com",
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "slack_user_id": "USER123"
+            }
+          ],
+          "working_interval": [
+            {
+              "end_time": "17:00",
+              "start_time": "09:00",
+              "weekday": "tuesday"
+            }
+          ]
+        }
+      },
+      "ScheduleRotationV2": {
+        "type": "object",
+        "properties": {
+          "effective_from": {
+            "type": "string",
+            "description": "When this rotation config will be effective from",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "handover_start_at": {
+            "type": "string",
+            "description": "Defines the next moment we'll trigger a handover",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "handovers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRotationHandoverV2"
+            },
+            "description": "Defines the handover intervals for this rota, in order they should apply",
+            "example": [
+              {
+                "interval": 1,
+                "interval_type": "daily"
+              }
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique internal ID of the rotation",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "layers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleLayerV2"
+            },
+            "description": "Controls how many people are on-call concurrently",
+            "example": [
+              {
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "name": "Layer 1"
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name synced from external provider",
+            "example": "Primary On-Call Schedule"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserV1"
+            },
+            "example": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ]
+          },
+          "working_interval": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleRotationWorkingIntervalV2"
+            },
+            "example": [
+              {
+                "end_time": "17:00",
+                "start_time": "09:00",
+                "weekday": "tuesday"
+              }
+            ]
+          }
+        },
+        "example": {
+          "effective_from": "2021-08-17T13:28:57.801578Z",
+          "handover_start_at": "2021-08-17T13:28:57.801578Z",
+          "handovers": [
+            {
+              "interval": 1,
+              "interval_type": "daily"
+            }
+          ],
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "layers": [
+            {
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Layer 1"
+            }
+          ],
+          "name": "Primary On-Call Schedule",
+          "users": [
+            {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          ],
+          "working_interval": [
+            {
+              "end_time": "17:00",
+              "start_time": "09:00",
+              "weekday": "tuesday"
+            }
+          ]
+        },
+        "required": [
+          "id",
+          "name",
+          "layers",
+          "user_ids",
+          "working_intervals",
+          "handover_start_at",
+          "handovers"
+        ]
+      },
+      "ScheduleRotationWorkingIntervalUpdatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "end_time": {
+            "type": "string",
+            "description": "End time of the interval, in 24hr format",
+            "example": "17:00"
+          },
+          "start_time": {
+            "type": "string",
+            "description": "Start time of the interval, in 24hr format",
+            "example": "09:00"
+          },
+          "weekday": {
+            "type": "string",
+            "description": "Weekday this interval applies to",
+            "example": "tuesday",
+            "enum": [
+              "monday",
+              "tuesday",
+              "wednesday",
+              "thursday",
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        },
+        "example": {
+          "end_time": "17:00",
+          "start_time": "09:00",
+          "weekday": "tuesday"
+        }
+      },
+      "ScheduleRotationWorkingIntervalV2": {
+        "type": "object",
+        "properties": {
+          "end_time": {
+            "type": "string",
+            "description": "End time of the interval, in 24hr format",
+            "example": "17:00"
+          },
+          "start_time": {
+            "type": "string",
+            "description": "Start time of the interval, in 24hr format",
+            "example": "09:00"
+          },
+          "weekday": {
+            "type": "string",
+            "description": "Weekday this interval applies to",
+            "example": "tuesday",
+            "enum": [
+              "monday",
+              "tuesday",
+              "wednesday",
+              "thursday",
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        },
+        "example": {
+          "end_time": "17:00",
+          "start_time": "09:00",
+          "weekday": "tuesday"
+        },
+        "required": [
+          "weekday",
+          "start_time",
+          "end_time"
+        ]
+      },
+      "ScheduleUpdatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/ScheduleConfigUpdatePayloadV2"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the schedule",
+            "example": "My Schedule"
+          },
+          "timezone": {
+            "type": "string",
+            "description": "Timezone of the schedule",
+            "example": "America/Los_Angeles"
+          }
+        },
+        "example": {
+          "config": {
+            "rotations": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "My Rotation",
+                "users": [
+                  {
+                    "email": "bob@example.com",
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "slack_user_id": "USER123"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          },
+          "name": "My Schedule",
+          "timezone": "America/Los_Angeles"
+        }
+      },
+      "ScheduleV2": {
+        "type": "object",
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/ScheduleConfigV2"
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "current_shifts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScheduleEntryV2"
+            },
+            "description": "Shifts that are on-going for this schedule, if a native schedule",
+            "example": [
+              {
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique internal ID of the schedule",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name synced from external provider",
+            "example": "Primary On-Call Schedule"
+          },
+          "timezone": {
+            "type": "string",
+            "description": "Timezone of the schedule, as interpreted at the point of generating the report",
+            "example": "Europe/London"
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "config": {
+            "rotations": [
+              {
+                "effective_from": "2021-08-17T13:28:57.801578Z",
+                "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                "handovers": [
+                  {
+                    "interval": 1,
+                    "interval_type": "daily"
+                  }
+                ],
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layers": [
+                  {
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "name": "Layer 1"
+                  }
+                ],
+                "name": "Primary On-Call Schedule",
+                "users": [
+                  {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                ],
+                "working_interval": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "tuesday"
+                  }
+                ]
+              }
+            ]
+          },
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "current_shifts": [
+            {
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ],
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "name": "Primary On-Call Schedule",
+          "timezone": "Europe/London",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "timezone",
+          "external_provider",
+          "external_provider_id",
+          "created_at",
+          "updated_at"
+        ]
+      },
       "ScimGroupRoleMappingsUpdatedV1ResponseBody": {
         "type": "object",
         "properties": {
@@ -15233,6 +17354,81 @@
       "ShowResponseBody14": {
         "type": "object",
         "properties": {
+          "schedule": {
+            "$ref": "#/components/schemas/ScheduleV2"
+          }
+        },
+        "example": {
+          "schedule": {
+            "config": {
+              "rotations": [
+                {
+                  "effective_from": "2021-08-17T13:28:57.801578Z",
+                  "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                  "handovers": [
+                    {
+                      "interval": 1,
+                      "interval_type": "daily"
+                    }
+                  ],
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "layers": [
+                    {
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "name": "Layer 1"
+                    }
+                  ],
+                  "name": "Primary On-Call Schedule",
+                  "users": [
+                    {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    }
+                  ],
+                  "working_interval": [
+                    {
+                      "end_time": "17:00",
+                      "start_time": "09:00",
+                      "weekday": "tuesday"
+                    }
+                  ]
+                }
+              ]
+            },
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "current_shifts": [
+              {
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "fingerprint": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYNH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ],
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "name": "Primary On-Call Schedule",
+            "timezone": "Europe/London",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "schedule"
+        ]
+      },
+      "ShowResponseBody15": {
+        "type": "object",
+        "properties": {
           "severity": {
             "$ref": "#/components/schemas/SeverityV2"
           }
@@ -15251,7 +17447,7 @@
           "severity"
         ]
       },
-      "ShowResponseBody15": {
+      "ShowResponseBody16": {
         "type": "object",
         "properties": {
           "user": {
@@ -15834,6 +18030,65 @@
           "updated_at"
         ]
       },
+      "UpdateRequestBody7": {
+        "type": "object",
+        "properties": {
+          "schedule": {
+            "$ref": "#/components/schemas/ScheduleUpdatePayloadV2"
+          }
+        },
+        "example": {
+          "schedule": {
+            "config": {
+              "rotations": [
+                {
+                  "effective_from": "2021-08-17T13:28:57.801578Z",
+                  "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                  "handovers": [
+                    {
+                      "interval": 1,
+                      "interval_type": "daily"
+                    }
+                  ],
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "layers": [
+                    {
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "name": "Layer 1"
+                    }
+                  ],
+                  "name": "My Rotation",
+                  "users": [
+                    {
+                      "email": "bob@example.com",
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "slack_user_id": "USER123"
+                    }
+                  ],
+                  "working_interval": [
+                    {
+                      "end_time": "17:00",
+                      "start_time": "09:00",
+                      "weekday": "tuesday"
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "My Schedule",
+            "timezone": "America/Los_Angeles"
+          }
+        },
+        "required": [
+          "schedule",
+          "name",
+          "timezone",
+          "external_provider",
+          "external_provider_id",
+          "created_at",
+          "updated_at"
+        ]
+      },
       "UpdateTypeRequestBody": {
         "type": "object",
         "properties": {
@@ -16239,7 +18494,7 @@
         "properties": {
           "actor_user_id": {
             "type": "string",
-            "description": "The ID of the user who performed this action",
+            "description": "The ID of the user who performed this action. If the action was not taken by a user, for example it was taken by a Workflow, this will be empty.",
             "example": "abc123"
           },
           "incident_id": {
@@ -16353,6 +18608,14 @@
     {
       "name": "Incidents V2",
       "description": "Create and read incidents.\n\nIncidents are a core resource, on which many other resources (actions, etc) are created.\n\nCare should be taken around these endpoints, as automation that creates duplicate\nincidents can be distracting, and impact reporting.\n"
+    },
+    {
+      "name": "Schedule Entries V2",
+      "description": "\nBeta: List your historic and future schedule entries.\n"
+    },
+    {
+      "name": "Schedules V2",
+      "description": "Beta: \nView and manage schedules.\nManage your full schedule of on-call rotations, including the users and rotation configuration.\n"
     },
     {
       "name": "Severities V1",

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -423,6 +423,35 @@ const (
 	IncidentV2VisibilityPublic  IncidentV2Visibility = "public"
 )
 
+// Defines values for ScheduleRotationHandoverV2IntervalType.
+const (
+	Daily  ScheduleRotationHandoverV2IntervalType = "daily"
+	Hourly ScheduleRotationHandoverV2IntervalType = "hourly"
+	Weekly ScheduleRotationHandoverV2IntervalType = "weekly"
+)
+
+// Defines values for ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday.
+const (
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayFriday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "friday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayMonday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "monday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdaySaturday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "saturday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdaySunday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "sunday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayThursday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "thursday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayTuesday   ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "tuesday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayWednesday ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "wednesday"
+)
+
+// Defines values for ScheduleRotationWorkingIntervalV2Weekday.
+const (
+	ScheduleRotationWorkingIntervalV2WeekdayFriday    ScheduleRotationWorkingIntervalV2Weekday = "friday"
+	ScheduleRotationWorkingIntervalV2WeekdayMonday    ScheduleRotationWorkingIntervalV2Weekday = "monday"
+	ScheduleRotationWorkingIntervalV2WeekdaySaturday  ScheduleRotationWorkingIntervalV2Weekday = "saturday"
+	ScheduleRotationWorkingIntervalV2WeekdaySunday    ScheduleRotationWorkingIntervalV2Weekday = "sunday"
+	ScheduleRotationWorkingIntervalV2WeekdayThursday  ScheduleRotationWorkingIntervalV2Weekday = "thursday"
+	ScheduleRotationWorkingIntervalV2WeekdayTuesday   ScheduleRotationWorkingIntervalV2Weekday = "tuesday"
+	ScheduleRotationWorkingIntervalV2WeekdayWednesday ScheduleRotationWorkingIntervalV2Weekday = "wednesday"
+)
+
 // Defines values for UpdateRequestBody2Required.
 const (
 	UpdateRequestBody2RequiredAlways        UpdateRequestBody2Required = "always"
@@ -608,6 +637,15 @@ type ActionV2Status string
 type ActorV2 struct {
 	ApiKey *APIKeyV2 `json:"api_key,omitempty"`
 	User   *UserV1   `json:"user,omitempty"`
+}
+
+// AfterPaginationMetaResultV2 defines model for AfterPaginationMetaResultV2.
+type AfterPaginationMetaResultV2 struct {
+	// After The time, if it exists, of the last entry's end time
+	After string `json:"after"`
+
+	// AfterUrl The URL to fetch the next page of entries
+	AfterUrl string `json:"after_url"`
 }
 
 // CatalogEntryReferenceV2 defines model for CatalogEntryReferenceV2.
@@ -937,6 +975,11 @@ type CreateRequestBody10Visibility string
 
 // CreateRequestBody11 defines model for CreateRequestBody11.
 type CreateRequestBody11 struct {
+	Schedule ScheduleCreatePayloadV2 `json:"schedule"`
+}
+
+// CreateRequestBody12 defines model for CreateRequestBody12.
+type CreateRequestBody12 struct {
 	// Description Description of the severity
 	Description string `json:"description"`
 
@@ -2010,11 +2053,23 @@ type ListResponseBody15 struct {
 
 // ListResponseBody16 defines model for ListResponseBody16.
 type ListResponseBody16 struct {
-	Severities []SeverityV2 `json:"severities"`
+	PaginationMeta  *AfterPaginationMetaResultV2 `json:"pagination_meta,omitempty"`
+	ScheduleEntries ScheduleEntriesListPayloadV2 `json:"schedule_entries"`
 }
 
 // ListResponseBody17 defines model for ListResponseBody17.
 type ListResponseBody17 struct {
+	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
+	Schedules      []ScheduleV2                   `json:"schedules"`
+}
+
+// ListResponseBody18 defines model for ListResponseBody18.
+type ListResponseBody18 struct {
+	Severities []SeverityV2 `json:"severities"`
+}
+
+// ListResponseBody19 defines model for ListResponseBody19.
+type ListResponseBody19 struct {
 	PaginationMeta PaginationMetaResult `json:"pagination_meta"`
 	Users          []UserWithRolesV2    `json:"users"`
 }
@@ -2107,6 +2162,201 @@ type RetrospectiveIncidentOptionsV2 struct {
 	SlackChannelId *string `json:"slack_channel_id,omitempty"`
 }
 
+// ScheduleConfigCreatePayloadV2 defines model for ScheduleConfigCreatePayloadV2.
+type ScheduleConfigCreatePayloadV2 struct {
+	Rotations *[]ScheduleRotationCreatePayloadV2 `json:"rotations,omitempty"`
+}
+
+// ScheduleConfigUpdatePayloadV2 defines model for ScheduleConfigUpdatePayloadV2.
+type ScheduleConfigUpdatePayloadV2 struct {
+	Rotations *[]ScheduleRotationUpdatePayloadV2 `json:"rotations,omitempty"`
+}
+
+// ScheduleConfigV2 defines model for ScheduleConfigV2.
+type ScheduleConfigV2 struct {
+	// Rotations Rotas in this schedule
+	Rotations []ScheduleRotationV2 `json:"rotations"`
+}
+
+// ScheduleCreatePayloadV2 defines model for ScheduleCreatePayloadV2.
+type ScheduleCreatePayloadV2 struct {
+	Config *ScheduleConfigCreatePayloadV2 `json:"config,omitempty"`
+
+	// Name Name of the schedule
+	Name *string `json:"name,omitempty"`
+
+	// Timezone Timezone of the schedule
+	Timezone *string `json:"timezone,omitempty"`
+}
+
+// ScheduleEntriesListPayloadV2 defines model for ScheduleEntriesListPayloadV2.
+type ScheduleEntriesListPayloadV2 struct {
+	Final     []ScheduleEntryV2 `json:"final"`
+	Overrides []ScheduleEntryV2 `json:"overrides"`
+	Scheduled []ScheduleEntryV2 `json:"scheduled"`
+}
+
+// ScheduleEntryV2 defines model for ScheduleEntryV2.
+type ScheduleEntryV2 struct {
+	EndAt time.Time `json:"end_at"`
+
+	// EntryId Unique identifier of the schedule entry
+	EntryId *string `json:"entry_id,omitempty"`
+
+	// Fingerprint A unique identifier for this entry, used to determine a unique shift
+	Fingerprint *string `json:"fingerprint,omitempty"`
+
+	// LayerId If present, the layer this entry applies to on the rota
+	LayerId *string `json:"layer_id,omitempty"`
+
+	// RotationId If present, the rotation this entry applies to on the schedule
+	RotationId *string   `json:"rotation_id,omitempty"`
+	StartAt    time.Time `json:"start_at"`
+	User       *UserV1   `json:"user,omitempty"`
+}
+
+// ScheduleLayerCreatePayloadV2 defines model for ScheduleLayerCreatePayloadV2.
+type ScheduleLayerCreatePayloadV2 struct {
+	// Id Unique identifier of the layer
+	Id *string `json:"id,omitempty"`
+
+	// Name Name of the layer
+	Name string `json:"name"`
+}
+
+// ScheduleLayerV2 defines model for ScheduleLayerV2.
+type ScheduleLayerV2 struct {
+	// Id Unique identifier of the layer
+	Id *string `json:"id,omitempty"`
+
+	// Name Name of the layer
+	Name *string `json:"name,omitempty"`
+}
+
+// ScheduleRotationCreatePayloadV2 defines model for ScheduleRotationCreatePayloadV2.
+type ScheduleRotationCreatePayloadV2 struct {
+	EffectiveFrom   *time.Time                    `json:"effective_from,omitempty"`
+	HandoverStartAt *time.Time                    `json:"handover_start_at,omitempty"`
+	Handovers       *[]ScheduleRotationHandoverV2 `json:"handovers,omitempty"`
+
+	// Id Unique identifier of the rotation
+	Id     *string                         `json:"id,omitempty"`
+	Layers *[]ScheduleLayerCreatePayloadV2 `json:"layers,omitempty"`
+
+	// Name Name of the rotation
+	Name            string                               `json:"name"`
+	Users           *[]UserReferencePayloadV1            `json:"users,omitempty"`
+	WorkingInterval *[]ScheduleRotationWorkingIntervalV2 `json:"working_interval,omitempty"`
+}
+
+// ScheduleRotationHandoverV2 defines model for ScheduleRotationHandoverV2.
+type ScheduleRotationHandoverV2 struct {
+	Interval     *int64                                  `json:"interval,omitempty"`
+	IntervalType *ScheduleRotationHandoverV2IntervalType `json:"interval_type,omitempty"`
+}
+
+// ScheduleRotationHandoverV2IntervalType defines model for ScheduleRotationHandoverV2.IntervalType.
+type ScheduleRotationHandoverV2IntervalType string
+
+// ScheduleRotationUpdatePayloadV2 defines model for ScheduleRotationUpdatePayloadV2.
+type ScheduleRotationUpdatePayloadV2 struct {
+	EffectiveFrom   *time.Time                    `json:"effective_from,omitempty"`
+	HandoverStartAt *time.Time                    `json:"handover_start_at,omitempty"`
+	Handovers       *[]ScheduleRotationHandoverV2 `json:"handovers,omitempty"`
+
+	// Id Unique identifier of the rotation
+	Id     *string            `json:"id,omitempty"`
+	Layers *[]ScheduleLayerV2 `json:"layers,omitempty"`
+
+	// Name Name of the rotation
+	Name            *string                                           `json:"name,omitempty"`
+	Users           *[]UserReferencePayloadV1                         `json:"users,omitempty"`
+	WorkingInterval *[]ScheduleRotationWorkingIntervalUpdatePayloadV2 `json:"working_interval,omitempty"`
+}
+
+// ScheduleRotationV2 defines model for ScheduleRotationV2.
+type ScheduleRotationV2 struct {
+	// EffectiveFrom When this rotation config will be effective from
+	EffectiveFrom *time.Time `json:"effective_from,omitempty"`
+
+	// HandoverStartAt Defines the next moment we'll trigger a handover
+	HandoverStartAt time.Time `json:"handover_start_at"`
+
+	// Handovers Defines the handover intervals for this rota, in order they should apply
+	Handovers []ScheduleRotationHandoverV2 `json:"handovers"`
+
+	// Id Unique internal ID of the rotation
+	Id string `json:"id"`
+
+	// Layers Controls how many people are on-call concurrently
+	Layers []ScheduleLayerV2 `json:"layers"`
+
+	// Name Human readable name synced from external provider
+	Name            string                               `json:"name"`
+	Users           *[]UserV1                            `json:"users,omitempty"`
+	WorkingInterval *[]ScheduleRotationWorkingIntervalV2 `json:"working_interval,omitempty"`
+}
+
+// ScheduleRotationWorkingIntervalUpdatePayloadV2 defines model for ScheduleRotationWorkingIntervalUpdatePayloadV2.
+type ScheduleRotationWorkingIntervalUpdatePayloadV2 struct {
+	// EndTime End time of the interval, in 24hr format
+	EndTime *string `json:"end_time,omitempty"`
+
+	// StartTime Start time of the interval, in 24hr format
+	StartTime *string `json:"start_time,omitempty"`
+
+	// Weekday Weekday this interval applies to
+	Weekday *ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday `json:"weekday,omitempty"`
+}
+
+// ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday Weekday this interval applies to
+type ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday string
+
+// ScheduleRotationWorkingIntervalV2 defines model for ScheduleRotationWorkingIntervalV2.
+type ScheduleRotationWorkingIntervalV2 struct {
+	// EndTime End time of the interval, in 24hr format
+	EndTime string `json:"end_time"`
+
+	// StartTime Start time of the interval, in 24hr format
+	StartTime string `json:"start_time"`
+
+	// Weekday Weekday this interval applies to
+	Weekday ScheduleRotationWorkingIntervalV2Weekday `json:"weekday"`
+}
+
+// ScheduleRotationWorkingIntervalV2Weekday Weekday this interval applies to
+type ScheduleRotationWorkingIntervalV2Weekday string
+
+// ScheduleUpdatePayloadV2 defines model for ScheduleUpdatePayloadV2.
+type ScheduleUpdatePayloadV2 struct {
+	Config *ScheduleConfigUpdatePayloadV2 `json:"config,omitempty"`
+
+	// Name Name of the schedule
+	Name *string `json:"name,omitempty"`
+
+	// Timezone Timezone of the schedule
+	Timezone *string `json:"timezone,omitempty"`
+}
+
+// ScheduleV2 defines model for ScheduleV2.
+type ScheduleV2 struct {
+	Config    *ScheduleConfigV2 `json:"config,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
+
+	// CurrentShifts Shifts that are on-going for this schedule, if a native schedule
+	CurrentShifts *[]ScheduleEntryV2 `json:"current_shifts,omitempty"`
+
+	// Id Unique internal ID of the schedule
+	Id string `json:"id"`
+
+	// Name Human readable name synced from external provider
+	Name string `json:"name"`
+
+	// Timezone Timezone of the schedule, as interpreted at the point of generating the report
+	Timezone  string    `json:"timezone"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 // SeverityV2 defines model for SeverityV2.
 type SeverityV2 struct {
 	// CreatedAt When the action was created
@@ -2161,11 +2411,16 @@ type ShowResponseBody13 struct {
 
 // ShowResponseBody14 defines model for ShowResponseBody14.
 type ShowResponseBody14 struct {
-	Severity SeverityV2 `json:"severity"`
+	Schedule ScheduleV2 `json:"schedule"`
 }
 
 // ShowResponseBody15 defines model for ShowResponseBody15.
 type ShowResponseBody15 struct {
+	Severity SeverityV2 `json:"severity"`
+}
+
+// ShowResponseBody16 defines model for ShowResponseBody16.
+type ShowResponseBody16 struct {
 	User UserWithRolesV2 `json:"user"`
 }
 
@@ -2318,6 +2573,11 @@ type UpdateRequestBody6 struct {
 
 	// Name Unique name of this status
 	Name string `json:"name"`
+}
+
+// UpdateRequestBody7 defines model for UpdateRequestBody7.
+type UpdateRequestBody7 struct {
+	Schedule ScheduleUpdatePayloadV2 `json:"schedule"`
 }
 
 // UpdateTypeRequestBody defines model for UpdateTypeRequestBody.
@@ -2551,6 +2811,27 @@ type IncidentsV2ListParams struct {
 	Mode *map[string][]string `form:"mode,omitempty" json:"mode,omitempty"`
 }
 
+// ScheduleEntriesV2ListParams defines parameters for ScheduleEntriesV2List.
+type ScheduleEntriesV2ListParams struct {
+	// ScheduleId The ID of the schedule to get entries for.
+	ScheduleId string `form:"schedule_id" json:"schedule_id"`
+
+	// EntryWindowStart The start of the window to get entries for.
+	EntryWindowStart *time.Time `form:"entry_window_start,omitempty" json:"entry_window_start,omitempty"`
+
+	// EntryWindowEnd The end of the window to get entries for.
+	EntryWindowEnd *time.Time `form:"entry_window_end,omitempty" json:"entry_window_end,omitempty"`
+}
+
+// SchedulesV2ListParams defines parameters for SchedulesV2List.
+type SchedulesV2ListParams struct {
+	// PageSize number of records to return
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// After A schedule's ID. This endpoint will return a list of schedules after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
+}
+
 // UsersV2ListParams defines parameters for UsersV2List.
 type UsersV2ListParams struct {
 	// Email Filter by email address
@@ -2603,10 +2884,10 @@ type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody6
 type IncidentsV1CreateJSONRequestBody = CreateRequestBody9
 
 // SeveritiesV1CreateJSONRequestBody defines body for SeveritiesV1Create for application/json ContentType.
-type SeveritiesV1CreateJSONRequestBody = CreateRequestBody11
+type SeveritiesV1CreateJSONRequestBody = CreateRequestBody12
 
 // SeveritiesV1UpdateJSONRequestBody defines body for SeveritiesV1Update for application/json ContentType.
-type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody11
+type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody12
 
 // AlertEventsV2CreateHTTPJSONRequestBody defines body for AlertEventsV2CreateHTTP for application/json ContentType.
 type AlertEventsV2CreateHTTPJSONRequestBody = CreateHTTPRequestBody
@@ -2643,6 +2924,12 @@ type IncidentsV2CreateJSONRequestBody = CreateRequestBody10
 
 // IncidentsV2EditJSONRequestBody defines body for IncidentsV2Edit for application/json ContentType.
 type IncidentsV2EditJSONRequestBody = EditRequestBody
+
+// SchedulesV2CreateJSONRequestBody defines body for SchedulesV2Create for application/json ContentType.
+type SchedulesV2CreateJSONRequestBody = CreateRequestBody11
+
+// SchedulesV2UpdateJSONRequestBody defines body for SchedulesV2Update for application/json ContentType.
+type SchedulesV2UpdateJSONRequestBody = UpdateRequestBody7
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -2990,6 +3277,28 @@ type ClientInterface interface {
 	IncidentsV2EditWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	IncidentsV2Edit(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ScheduleEntriesV2List request
+	ScheduleEntriesV2List(ctx context.Context, params *ScheduleEntriesV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2List request
+	SchedulesV2List(ctx context.Context, params *SchedulesV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2Create request with any body
+	SchedulesV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SchedulesV2Create(ctx context.Context, body SchedulesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2Destroy request
+	SchedulesV2Destroy(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2Show request
+	SchedulesV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2Update request with any body
+	SchedulesV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SchedulesV2Update(ctx context.Context, id string, body SchedulesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UsersV2List request
 	UsersV2List(ctx context.Context, params *UsersV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4188,6 +4497,102 @@ func (c *Client) IncidentsV2EditWithBody(ctx context.Context, id string, content
 
 func (c *Client) IncidentsV2Edit(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewIncidentsV2EditRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ScheduleEntriesV2List(ctx context.Context, params *ScheduleEntriesV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewScheduleEntriesV2ListRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2List(ctx context.Context, params *SchedulesV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2ListRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2CreateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2Create(ctx context.Context, body SchedulesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2CreateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2Destroy(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2DestroyRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2UpdateRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2Update(ctx context.Context, id string, body SchedulesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2UpdateRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7368,6 +7773,299 @@ func NewIncidentsV2EditRequestWithBody(server string, id string, contentType str
 	return req, nil
 }
 
+// NewScheduleEntriesV2ListRequest generates requests for ScheduleEntriesV2List
+func NewScheduleEntriesV2ListRequest(server string, params *ScheduleEntriesV2ListParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedule_entries")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if queryFrag, err := runtime.StyleParamWithLocation("form", true, "schedule_id", runtime.ParamLocationQuery, params.ScheduleId); err != nil {
+		return nil, err
+	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+		return nil, err
+	} else {
+		for k, v := range parsed {
+			for _, v2 := range v {
+				queryValues.Add(k, v2)
+			}
+		}
+	}
+
+	if params.EntryWindowStart != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "entry_window_start", runtime.ParamLocationQuery, *params.EntryWindowStart); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.EntryWindowEnd != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "entry_window_end", runtime.ParamLocationQuery, *params.EntryWindowEnd); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSchedulesV2ListRequest generates requests for SchedulesV2List
+func NewSchedulesV2ListRequest(server string, params *SchedulesV2ListParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedules")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.PageSize != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page_size", runtime.ParamLocationQuery, *params.PageSize); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.After != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSchedulesV2CreateRequest calls the generic SchedulesV2Create builder with application/json body
+func NewSchedulesV2CreateRequest(server string, body SchedulesV2CreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSchedulesV2CreateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewSchedulesV2CreateRequestWithBody generates requests for SchedulesV2Create with any type of body
+func NewSchedulesV2CreateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedules")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewSchedulesV2DestroyRequest generates requests for SchedulesV2Destroy
+func NewSchedulesV2DestroyRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedules/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSchedulesV2ShowRequest generates requests for SchedulesV2Show
+func NewSchedulesV2ShowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedules/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSchedulesV2UpdateRequest calls the generic SchedulesV2Update builder with application/json body
+func NewSchedulesV2UpdateRequest(server string, id string, body SchedulesV2UpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSchedulesV2UpdateRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewSchedulesV2UpdateRequestWithBody generates requests for SchedulesV2Update with any type of body
+func NewSchedulesV2UpdateRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedules/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewUsersV2ListRequest generates requests for UsersV2List
 func NewUsersV2ListRequest(server string, params *UsersV2ListParams) (*http.Request, error) {
 	var err error
@@ -7813,6 +8511,28 @@ type ClientWithResponsesInterface interface {
 	IncidentsV2EditWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error)
 
 	IncidentsV2EditWithResponse(ctx context.Context, id string, body IncidentsV2EditJSONRequestBody, reqEditors ...RequestEditorFn) (*IncidentsV2EditResponse, error)
+
+	// ScheduleEntriesV2List request
+	ScheduleEntriesV2ListWithResponse(ctx context.Context, params *ScheduleEntriesV2ListParams, reqEditors ...RequestEditorFn) (*ScheduleEntriesV2ListResponse, error)
+
+	// SchedulesV2List request
+	SchedulesV2ListWithResponse(ctx context.Context, params *SchedulesV2ListParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListResponse, error)
+
+	// SchedulesV2Create request with any body
+	SchedulesV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2CreateResponse, error)
+
+	SchedulesV2CreateWithResponse(ctx context.Context, body SchedulesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2CreateResponse, error)
+
+	// SchedulesV2Destroy request
+	SchedulesV2DestroyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SchedulesV2DestroyResponse, error)
+
+	// SchedulesV2Show request
+	SchedulesV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SchedulesV2ShowResponse, error)
+
+	// SchedulesV2Update request with any body
+	SchedulesV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateResponse, error)
+
+	SchedulesV2UpdateWithResponse(ctx context.Context, id string, body SchedulesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateResponse, error)
 
 	// UsersV2List request
 	UsersV2ListWithResponse(ctx context.Context, params *UsersV2ListParams, reqEditors ...RequestEditorFn) (*UsersV2ListResponse, error)
@@ -8588,7 +9308,7 @@ func (r UtilitiesV1OpenAPIV3Response) StatusCode() int {
 type SeveritiesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody16
+	JSON200      *ListResponseBody18
 }
 
 // Status returns HTTPResponse.Status
@@ -8610,7 +9330,7 @@ func (r SeveritiesV1ListResponse) StatusCode() int {
 type SeveritiesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody14
+	JSON201      *ShowResponseBody15
 }
 
 // Status returns HTTPResponse.Status
@@ -8653,7 +9373,7 @@ func (r SeveritiesV1DeleteResponse) StatusCode() int {
 type SeveritiesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody14
+	JSON200      *ShowResponseBody15
 }
 
 // Status returns HTTPResponse.Status
@@ -8675,7 +9395,7 @@ func (r SeveritiesV1ShowResponse) StatusCode() int {
 type SeveritiesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody14
+	JSON200      *ShowResponseBody15
 }
 
 // Status returns HTTPResponse.Status
@@ -9438,10 +10158,141 @@ func (r IncidentsV2EditResponse) StatusCode() int {
 	return 0
 }
 
-type UsersV2ListResponse struct {
+type ScheduleEntriesV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListResponseBody16
+}
+
+// Status returns HTTPResponse.Status
+func (r ScheduleEntriesV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ScheduleEntriesV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SchedulesV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *ListResponseBody17
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SchedulesV2CreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ShowResponseBody14
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2CreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2CreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SchedulesV2DestroyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2DestroyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2DestroyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SchedulesV2ShowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody14
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2ShowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2ShowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SchedulesV2UpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowResponseBody14
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2UpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2UpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UsersV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListResponseBody19
 }
 
 // Status returns HTTPResponse.Status
@@ -9463,7 +10314,7 @@ func (r UsersV2ListResponse) StatusCode() int {
 type UsersV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody15
+	JSON200      *ShowResponseBody16
 }
 
 // Status returns HTTPResponse.Status
@@ -10356,6 +11207,76 @@ func (c *ClientWithResponses) IncidentsV2EditWithResponse(ctx context.Context, i
 	return ParseIncidentsV2EditResponse(rsp)
 }
 
+// ScheduleEntriesV2ListWithResponse request returning *ScheduleEntriesV2ListResponse
+func (c *ClientWithResponses) ScheduleEntriesV2ListWithResponse(ctx context.Context, params *ScheduleEntriesV2ListParams, reqEditors ...RequestEditorFn) (*ScheduleEntriesV2ListResponse, error) {
+	rsp, err := c.ScheduleEntriesV2List(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScheduleEntriesV2ListResponse(rsp)
+}
+
+// SchedulesV2ListWithResponse request returning *SchedulesV2ListResponse
+func (c *ClientWithResponses) SchedulesV2ListWithResponse(ctx context.Context, params *SchedulesV2ListParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListResponse, error) {
+	rsp, err := c.SchedulesV2List(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2ListResponse(rsp)
+}
+
+// SchedulesV2CreateWithBodyWithResponse request with arbitrary body returning *SchedulesV2CreateResponse
+func (c *ClientWithResponses) SchedulesV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2CreateResponse, error) {
+	rsp, err := c.SchedulesV2CreateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2CreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) SchedulesV2CreateWithResponse(ctx context.Context, body SchedulesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2CreateResponse, error) {
+	rsp, err := c.SchedulesV2Create(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2CreateResponse(rsp)
+}
+
+// SchedulesV2DestroyWithResponse request returning *SchedulesV2DestroyResponse
+func (c *ClientWithResponses) SchedulesV2DestroyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SchedulesV2DestroyResponse, error) {
+	rsp, err := c.SchedulesV2Destroy(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2DestroyResponse(rsp)
+}
+
+// SchedulesV2ShowWithResponse request returning *SchedulesV2ShowResponse
+func (c *ClientWithResponses) SchedulesV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SchedulesV2ShowResponse, error) {
+	rsp, err := c.SchedulesV2Show(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2ShowResponse(rsp)
+}
+
+// SchedulesV2UpdateWithBodyWithResponse request with arbitrary body returning *SchedulesV2UpdateResponse
+func (c *ClientWithResponses) SchedulesV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateResponse, error) {
+	rsp, err := c.SchedulesV2UpdateWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2UpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) SchedulesV2UpdateWithResponse(ctx context.Context, id string, body SchedulesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateResponse, error) {
+	rsp, err := c.SchedulesV2Update(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2UpdateResponse(rsp)
+}
+
 // UsersV2ListWithResponse request returning *UsersV2ListResponse
 func (c *ClientWithResponses) UsersV2ListWithResponse(ctx context.Context, params *UsersV2ListParams, reqEditors ...RequestEditorFn) (*UsersV2ListResponse, error) {
 	rsp, err := c.UsersV2List(ctx, params, reqEditors...)
@@ -11239,7 +12160,7 @@ func ParseSeveritiesV1ListResponse(rsp *http.Response) (*SeveritiesV1ListRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody16
+		var dest ListResponseBody18
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -11265,7 +12186,7 @@ func ParseSeveritiesV1CreateResponse(rsp *http.Response) (*SeveritiesV1CreateRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody14
+		var dest ShowResponseBody15
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -11307,7 +12228,7 @@ func ParseSeveritiesV1ShowResponse(rsp *http.Response) (*SeveritiesV1ShowRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody14
+		var dest ShowResponseBody15
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -11333,7 +12254,7 @@ func ParseSeveritiesV1UpdateResponse(rsp *http.Response) (*SeveritiesV1UpdateRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody14
+		var dest ShowResponseBody15
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -12188,6 +13109,152 @@ func ParseIncidentsV2EditResponse(rsp *http.Response) (*IncidentsV2EditResponse,
 	return response, nil
 }
 
+// ParseScheduleEntriesV2ListResponse parses an HTTP response from a ScheduleEntriesV2ListWithResponse call
+func ParseScheduleEntriesV2ListResponse(rsp *http.Response) (*ScheduleEntriesV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ScheduleEntriesV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListResponseBody16
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2ListResponse parses an HTTP response from a SchedulesV2ListWithResponse call
+func ParseSchedulesV2ListResponse(rsp *http.Response) (*SchedulesV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListResponseBody17
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2CreateResponse parses an HTTP response from a SchedulesV2CreateWithResponse call
+func ParseSchedulesV2CreateResponse(rsp *http.Response) (*SchedulesV2CreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2CreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ShowResponseBody14
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2DestroyResponse parses an HTTP response from a SchedulesV2DestroyWithResponse call
+func ParseSchedulesV2DestroyResponse(rsp *http.Response) (*SchedulesV2DestroyResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2DestroyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2ShowResponse parses an HTTP response from a SchedulesV2ShowWithResponse call
+func ParseSchedulesV2ShowResponse(rsp *http.Response) (*SchedulesV2ShowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody14
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2UpdateResponse parses an HTTP response from a SchedulesV2UpdateWithResponse call
+func ParseSchedulesV2UpdateResponse(rsp *http.Response) (*SchedulesV2UpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2UpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowResponseBody14
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseUsersV2ListResponse parses an HTTP response from a UsersV2ListWithResponse call
 func ParseUsersV2ListResponse(rsp *http.Response) (*UsersV2ListResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -12203,7 +13270,7 @@ func ParseUsersV2ListResponse(rsp *http.Response) (*UsersV2ListResponse, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody17
+		var dest ListResponseBody19
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -12229,7 +13296,7 @@ func ParseUsersV2ShowResponse(rsp *http.Response) (*UsersV2ShowResponse, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody15
+		var dest ShowResponseBody16
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -483,8 +483,7 @@ func (r *IncidentScheduleResource) buildModel(schedule client.ScheduleV2) *Incid
 						}
 					})
 
-					var users []types.String
-
+					users := []types.String{}
 					if rotation.Users != nil {
 						users = lo.Map(lo.FromPtr(rotation.Users), func(user client.UserV1, _ int) types.String {
 							return types.StringValue(user.Id)

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -1,0 +1,514 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/incident-io/terraform-provider-incident/internal/apischema"
+	"github.com/incident-io/terraform-provider-incident/internal/client"
+	"github.com/samber/lo"
+)
+
+var (
+	_ resource.Resource                = &IncidentScheduleResource{}
+	_ resource.ResourceWithImportState = &IncidentScheduleResource{}
+)
+
+type IncidentScheduleResource struct {
+	client *client.ClientWithResponses
+}
+
+type IncidentScheduleResourceModel struct {
+	ID        types.String `tfsdk:"id"`
+	Name      types.String `tfsdk:"name"`
+	Timezone  types.String `tfsdk:"timezone"`
+	Rotations []Rotation   `tfsdk:"rotations"`
+}
+
+type Rotation struct {
+	ID              types.String      `tfsdk:"id"`
+	HandoverStartAt types.String      `tfsdk:"handover_start_at"`
+	Name            types.String      `tfsdk:"name"`
+	Versions        []RotationVersion `tfsdk:"versions"`
+}
+
+type RotationVersion struct {
+	EffectiveFrom    types.String      `tfsdk:"effective_from"`
+	Handovers        []Handover        `tfsdk:"handovers"`
+	Users            []types.String    `tfsdk:"users"`
+	WorkingIntervals []WorkingInterval `tfsdk:"working_intervals"`
+	Layers           []Layer           `tfsdk:"layers"`
+}
+
+type WorkingInterval struct {
+	Start types.String `tfsdk:"start"`
+	End   types.String `tfsdk:"end"`
+	Day   types.String `tfsdk:"day"`
+}
+
+type Layer struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+type Handover struct {
+	Interval     types.Int64  `tfsdk:"interval"`
+	IntervalType types.String `tfsdk:"interval_type"`
+}
+
+func NewIncidentScheduleResource() resource.Resource {
+	return &IncidentScheduleResource{}
+}
+
+func (r *IncidentScheduleResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_schedule"
+}
+
+func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: apischema.TagDocstring("Schedules V2"),
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"timezone": schema.StringAttribute{
+				Required: true,
+			},
+			"rotations": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Required: true,
+						},
+						"name": schema.StringAttribute{
+							Required: true,
+						},
+						"handover_start_at": schema.StringAttribute{
+							Required: true,
+						},
+						"versions": schema.ListNestedAttribute{
+							Required: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"users": schema.ListAttribute{
+										Required:    true,
+										ElementType: types.StringType,
+									},
+									"effective_from": schema.StringAttribute{
+										Optional: true,
+									},
+									"working_intervals": schema.ListNestedAttribute{
+										Optional: true,
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"start": schema.StringAttribute{
+													Required: true,
+												},
+												"end": schema.StringAttribute{
+													Required: true,
+												},
+												"day": schema.StringAttribute{
+													Required: true,
+												},
+											},
+										},
+									},
+									"layers": schema.ListNestedAttribute{
+										Required: true,
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"id": schema.StringAttribute{
+													Required: true,
+												},
+												"name": schema.StringAttribute{
+													Required: true,
+												},
+											},
+										},
+									},
+									"handovers": schema.ListNestedAttribute{
+										Optional: true,
+										NestedObject: schema.NestedAttributeObject{
+											Attributes: map[string]schema.Attribute{
+												"interval": schema.Int64Attribute{
+													Required: true,
+												},
+												"interval_type": schema.StringAttribute{
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: true,
+			},
+		},
+	}
+}
+
+func (r *IncidentScheduleResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*client.ClientWithResponses)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *IncidentScheduleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *IncidentScheduleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	rotationArray, err := buildScheduleCreatePayload(data, resp)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create schedule, got error: %s", err))
+		return
+	}
+
+	result, err := r.client.SchedulesV2CreateWithResponse(ctx, client.SchedulesV2CreateJSONRequestBody{
+		Schedule: client.ScheduleCreatePayloadV2{
+			Name:     data.Name.ValueStringPointer(),
+			Timezone: data.Timezone.ValueStringPointer(),
+			Config: &client.ScheduleConfigCreatePayloadV2{
+				Rotations: &rotationArray,
+			},
+		},
+	})
+	if err == nil && result.StatusCode() >= 400 {
+		err = fmt.Errorf(string(result.Body))
+	}
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create schedule, got error: %s", err))
+		return
+	}
+
+	tflog.Trace(ctx, fmt.Sprintf("created an incident schedule resource with id=%s", result.JSON201.Schedule.Id))
+	data = r.buildModel(result.JSON201.Schedule)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *IncidentScheduleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *IncidentScheduleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	result, err := r.client.SchedulesV2ShowWithResponse(ctx, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read schedule, got error: %s", err))
+		return
+	}
+
+	if result.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read schedule, got status code: %d", result.StatusCode()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	data = r.buildModel(result.JSON200.Schedule)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *IncidentScheduleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var old *IncidentScheduleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &old)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	rotationArray, err := buildScheduleUpdatePayload(old, resp)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update schedule, got error: %s", err))
+		return
+	}
+
+	result, err := r.client.SchedulesV2UpdateWithResponse(ctx, old.ID.ValueString(), client.SchedulesV2UpdateJSONRequestBody{
+		Schedule: client.ScheduleUpdatePayloadV2{
+			Name:     old.Name.ValueStringPointer(),
+			Timezone: old.Timezone.ValueStringPointer(),
+			Config: &client.ScheduleConfigUpdatePayloadV2{
+				Rotations: &rotationArray,
+			},
+		},
+	})
+	if err == nil && result.StatusCode() >= 400 {
+		err = fmt.Errorf(string(result.Body))
+	}
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update schedule, got error: %s", err))
+		return
+	}
+
+	old = r.buildModel(result.JSON200.Schedule)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &old)...)
+}
+
+func (r *IncidentScheduleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *IncidentScheduleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.client.SchedulesV2DestroyWithResponse(ctx, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete schedule, got error: %s", err))
+		return
+	}
+}
+
+func (r *IncidentScheduleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func buildScheduleCreatePayload(data *IncidentScheduleResourceModel, resp *resource.CreateResponse) ([]client.ScheduleRotationCreatePayloadV2, error) {
+	rotationArray := make([]client.ScheduleRotationCreatePayloadV2, 0, len(data.Rotations))
+	for _, rotation := range data.Rotations {
+		for _, version := range rotation.Versions {
+			workingIntervals := make([]client.ScheduleRotationWorkingIntervalV2, 0, len(version.WorkingIntervals))
+			for _, workingInterval := range version.WorkingIntervals {
+				workingIntervalWeekday := client.ScheduleRotationWorkingIntervalV2Weekday(workingInterval.Day.ValueString())
+				workingIntervals = append(workingIntervals, client.ScheduleRotationWorkingIntervalV2{
+					StartTime: workingInterval.Start.ValueString(),
+					EndTime:   workingInterval.End.ValueString(),
+					Weekday:   workingIntervalWeekday,
+				})
+			}
+
+			layers := make([]client.ScheduleLayerCreatePayloadV2, 0, len(version.Layers))
+			for _, layer := range version.Layers {
+				layers = append(layers, client.ScheduleLayerCreatePayloadV2{
+					Id:   layer.ID.ValueStringPointer(),
+					Name: layer.Name.ValueString(),
+				})
+			}
+
+			handoverStartAt, err := time.Parse(time.RFC3339, rotation.HandoverStartAt.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create schedule, got error: %s", err))
+				return nil, err
+			}
+
+			effectiveFrom := buildEffectiveFrom(version.EffectiveFrom)
+			handovers := buildHandoversArray(version.Handovers)
+			users := buildUsersArray(version.Users)
+
+			rotationArray = append(rotationArray, client.ScheduleRotationCreatePayloadV2{
+				Id:              rotation.ID.ValueStringPointer(),
+				Name:            rotation.Name.ValueString(),
+				HandoverStartAt: &handoverStartAt,
+				EffectiveFrom:   effectiveFrom,
+				Handovers:       &handovers,
+				Users:           &users,
+				WorkingInterval: &workingIntervals,
+				Layers:          &layers,
+			})
+		}
+	}
+	return rotationArray, nil
+}
+
+func buildScheduleUpdatePayload(data *IncidentScheduleResourceModel, resp *resource.UpdateResponse) ([]client.ScheduleRotationUpdatePayloadV2, error) {
+	rotationArray := make([]client.ScheduleRotationUpdatePayloadV2, 0, len(data.Rotations))
+	for _, rotation := range data.Rotations {
+		for _, version := range rotation.Versions {
+			workingIntervals := make([]client.ScheduleRotationWorkingIntervalUpdatePayloadV2, 0, len(version.WorkingIntervals))
+			for _, workingInterval := range version.WorkingIntervals {
+				workingIntervalWeekday := client.ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday(workingInterval.Day.ValueString())
+				workingIntervals = append(workingIntervals, client.ScheduleRotationWorkingIntervalUpdatePayloadV2{
+					StartTime: workingInterval.Start.ValueStringPointer(),
+					EndTime:   workingInterval.End.ValueStringPointer(),
+					Weekday:   &workingIntervalWeekday,
+				})
+			}
+
+			layers := make([]client.ScheduleLayerV2, 0, len(version.Layers))
+			for _, layer := range version.Layers {
+				layers = append(layers, client.ScheduleLayerV2{
+					Id:   layer.ID.ValueStringPointer(),
+					Name: layer.Name.ValueStringPointer(),
+				})
+			}
+
+			handoverStartAt, err := time.Parse(time.RFC3339, rotation.HandoverStartAt.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create schedule, got error: %s", err))
+				return nil, err
+			}
+
+			effectiveFrom := buildEffectiveFrom(version.EffectiveFrom)
+			handovers := buildHandoversArray(version.Handovers)
+			users := buildUsersArray(version.Users)
+
+			rotationArray = append(rotationArray, client.ScheduleRotationUpdatePayloadV2{
+				Id:              rotation.ID.ValueStringPointer(),
+				Name:            rotation.Name.ValueStringPointer(),
+				HandoverStartAt: &handoverStartAt,
+				EffectiveFrom:   effectiveFrom,
+				Handovers:       &handovers,
+				Users:           &users,
+				WorkingInterval: &workingIntervals,
+				Layers:          &layers,
+			})
+		}
+	}
+	return rotationArray, nil
+}
+
+// buildUsersArray converts a list of user IDs to a list of user references.
+func buildUsersArray(users []types.String) []client.UserReferencePayloadV1 {
+	return lo.Map(users, func(user types.String, _ int) client.UserReferencePayloadV1 {
+		return client.UserReferencePayloadV1{
+			Id: user.ValueStringPointer(),
+		}
+	})
+}
+
+// buildHandoversArray converts a list of handovers to a list of handover references.
+func buildHandoversArray(handovers []Handover) []client.ScheduleRotationHandoverV2 {
+	clientHandovers := lo.Map(handovers, func(handover Handover, _ int) client.ScheduleRotationHandoverV2 {
+		intervalType := client.ScheduleRotationHandoverV2IntervalType(handover.IntervalType.ValueString())
+		return client.ScheduleRotationHandoverV2{
+			Interval:     handover.Interval.ValueInt64Pointer(),
+			IntervalType: &intervalType,
+		}
+	})
+	return clientHandovers
+}
+
+// buildEffectiveFrom converts a string to a time.Time pointer.
+func buildEffectiveFrom(effectiveFrom types.String) *time.Time {
+	if effectiveFrom.IsNull() {
+		return nil
+	}
+
+	effectiveFromParsed, err := time.Parse(time.RFC3339, effectiveFrom.ValueString())
+	if err != nil {
+		return nil
+	}
+
+	return &effectiveFromParsed
+}
+
+// buildModel converts a schedule from the API to a resource model
+// this involves taking schedule rotations, grouping them by ID,
+// extracting the shared data, and then building the nested structure.
+func (r *IncidentScheduleResource) buildModel(schedule client.ScheduleV2) *IncidentScheduleResourceModel {
+	rotationsGroupedByID := lo.GroupBy(schedule.Config.Rotations, func(rotation client.ScheduleRotationV2) string {
+		return rotation.Id
+	})
+
+	type RotationName struct {
+		ID              string
+		Name            string
+		HandoverStartAt time.Time
+	}
+
+	rotationNames := lo.Map(schedule.Config.Rotations, func(rotation client.ScheduleRotationV2, _ int) RotationName {
+		return RotationName{
+			ID:              rotation.Id,
+			Name:            rotation.Name,
+			HandoverStartAt: rotation.HandoverStartAt,
+		}
+	})
+
+	rotationNames = lo.Uniq(rotationNames)
+
+	return &IncidentScheduleResourceModel{
+		Name:     types.StringValue(schedule.Name),
+		ID:       types.StringValue(schedule.Id),
+		Timezone: types.StringValue(schedule.Timezone),
+		Rotations: lo.Map(rotationNames, func(rotation RotationName, _ int) Rotation {
+			handoverStartAt := rotation.HandoverStartAt.Format(time.RFC3339)
+			newRotation := Rotation{
+				ID:              types.StringValue(rotation.ID),
+				Name:            types.StringValue(rotation.Name),
+				HandoverStartAt: types.StringValue(handoverStartAt),
+				Versions: lo.Map(rotationsGroupedByID[rotation.ID], func(rotation client.ScheduleRotationV2, idx int) RotationVersion {
+					var workingIntervals []WorkingInterval
+					if rotation.WorkingInterval != nil {
+						workingIntervals = lo.Map(*rotation.WorkingInterval, func(interval client.ScheduleRotationWorkingIntervalV2, _ int) WorkingInterval {
+							weekdayString := string(interval.Weekday)
+							return WorkingInterval{
+								Start: types.StringValue(interval.StartTime),
+								End:   types.StringValue(interval.EndTime),
+								Day:   types.StringValue(weekdayString),
+							}
+						})
+					}
+
+					layers := lo.Map(rotation.Layers, func(layer client.ScheduleLayerV2, _ int) Layer {
+						return Layer{
+							ID:   types.StringPointerValue(layer.Id),
+							Name: types.StringPointerValue(layer.Name),
+						}
+					})
+
+					handovers := lo.Map(rotation.Handovers, func(handover client.ScheduleRotationHandoverV2, _ int) Handover {
+						intervalTypeString := string(*handover.IntervalType)
+						return Handover{
+							Interval:     types.Int64Value(lo.FromPtr(handover.Interval)),
+							IntervalType: types.StringValue(intervalTypeString),
+						}
+					})
+
+					var users []types.String
+
+					if rotation.Users != nil {
+						users = lo.Map(lo.FromPtr(rotation.Users), func(user client.UserV1, _ int) types.String {
+							return types.StringValue(user.Id)
+						})
+					}
+
+					var effectiveFrom types.String
+					if rotation.EffectiveFrom != nil {
+						effectiveFromValue := rotation.EffectiveFrom.Format(time.RFC3339)
+						effectiveFrom = types.StringValue(effectiveFromValue)
+					} else {
+						effectiveFrom = types.StringNull()
+					}
+
+					return RotationVersion{
+						EffectiveFrom:    effectiveFrom,
+						Handovers:        handovers,
+						Users:            users,
+						WorkingIntervals: workingIntervals,
+						Layers:           layers,
+					}
+				}),
+			}
+			return newRotation
+		}),
+	}
+}

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -154,7 +154,6 @@ func generateRotationsArray(rotations []client.ScheduleRotationV2) string {
 		result += "  {\n"
 		result += "    id              = " + quote(rotation[0].Id) + "\n"
 		result += "    name            = " + quote(rotation[0].Name) + "\n"
-		result += "    handover_start_at = " + quote(rotation[0].HandoverStartAt.Format(time.RFC3339)) + "\n"
 		result += "    versions        = " + generateVersionsArray(rotation) + "\n"
 		result += "  },\n"
 	}
@@ -170,6 +169,7 @@ func generateVersionsArray(versions []client.ScheduleRotationV2) string {
 		if version.EffectiveFrom != nil {
 			result += "    effective_from   = " + quote(version.EffectiveFrom.Format(time.RFC3339)) + "\n"
 		}
+		result += "    handover_start_at = " + quote(version.HandoverStartAt.Format(time.RFC3339)) + "\n"
 		result += "    handovers       = " + generateHandoversArray(version.Handovers) + "\n"
 		result += "    layers          = " + generateLayersArray(version.Layers) + "\n"
 		result += "    users           = " + generateUsersArray(version.Users) + "\n"

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -18,41 +18,8 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and read
 			{
-				Config: testAccIncidentScheduleResourceConfig(nil),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"incident_schedule.example", "name", incidentScheduleDefault().Name),
-					resource.TestCheckResourceAttr(
-						"incident_severity.example", "timezone", incidentScheduleDefault().Timezone),
-				),
-			},
-			// Import
-			{
-				ResourceName:      "incident_schedule.example",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and read
-			{
 				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
-					Name: "Godawful",
-				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"incident_schedule.example", "name", incidentScheduleDefault().Name),
-				),
-			},
-		},
-	})
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and read
-			{
-				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
-					Name:     "Godawful",
+					Name:     "example",
 					Timezone: "Europe/London",
 					Config: &client.ScheduleConfigV2{
 						Rotations: []client.ScheduleRotationV2{
@@ -103,18 +70,9 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"incident_schedule.example", "name", "Godawful"),
+						"incident_schedule.example", "name", "example"),
 					resource.TestCheckResourceAttr(
 						"incident_schedule.example", "timezone", "Europe/London",
-					),
-					resource.TestCheckResourceAttr(
-						"incident_schedule.example", "rotations", generateRotationsArray([]client.ScheduleRotationV2{
-							{
-								Id:              "rota-primary",
-								HandoverStartAt: time.Date(2024, 4, 26, 16, 0, 0, 0, time.UTC),
-								Name:            "Rota",
-							},
-						}),
 					),
 				),
 			},
@@ -209,7 +167,9 @@ func generateVersionsArray(versions []client.ScheduleRotationV2) string {
 	result += "[\n"
 	for _, version := range versions {
 		result += "  {\n"
-		result += "    effective_from   = " + quote(version.EffectiveFrom.Format(time.RFC3339)) + "\n"
+		if version.EffectiveFrom != nil {
+			result += "    effective_from   = " + quote(version.EffectiveFrom.Format(time.RFC3339)) + "\n"
+		}
 		result += "    handovers       = " + generateHandoversArray(version.Handovers) + "\n"
 		result += "    layers          = " + generateLayersArray(version.Layers) + "\n"
 		result += "    users           = " + generateUsersArray(version.Users) + "\n"
@@ -250,6 +210,9 @@ func generateLayersArray(layers []client.ScheduleLayerV2) string {
 
 func generateUsersArray(users *[]client.UserV1) string {
 	var result string
+	if users == nil {
+		return "[]"
+	}
 	result += "[\n"
 	for _, user := range *users {
 		result += "  {\n"

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -1,0 +1,293 @@
+package provider
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/incident-io/terraform-provider-incident/internal/client"
+	"github.com/samber/lo"
+)
+
+func TestAccIncidentScheduleResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and read
+			{
+				Config: testAccIncidentScheduleResourceConfig(nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "name", incidentScheduleDefault().Name),
+					resource.TestCheckResourceAttr(
+						"incident_severity.example", "timezone", incidentScheduleDefault().Timezone),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "incident_schedule.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and read
+			{
+				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
+					Name: "Godawful",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "name", incidentScheduleDefault().Name),
+				),
+			},
+		},
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and read
+			{
+				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
+					Name:     "Godawful",
+					Timezone: "Europe/London",
+					Config: &client.ScheduleConfigV2{
+						Rotations: []client.ScheduleRotationV2{
+							{
+								Id:              "rota-primary",
+								HandoverStartAt: time.Date(2024, 4, 26, 16, 0, 0, 0, time.UTC),
+								Name:            "Rota",
+								Handovers: []client.ScheduleRotationHandoverV2{
+									{
+										IntervalType: lo.ToPtr(client.ScheduleRotationHandoverV2IntervalType("weekly")),
+										Interval:     lo.ToPtr(int64(1)),
+									},
+								},
+								Layers: []client.ScheduleLayerV2{
+									{
+										Id:   lo.ToPtr("rota-primary-layer-one"),
+										Name: lo.ToPtr("Primary Layer One"),
+									},
+								},
+							},
+							{
+								Id:              "rota-primary",
+								HandoverStartAt: time.Date(2024, 4, 26, 16, 0, 0, 0, time.UTC),
+								EffectiveFrom:   lo.ToPtr(time.Now().Add(time.Hour * 24)),
+								Name:            "Rota",
+								Handovers: []client.ScheduleRotationHandoverV2{
+									{
+										IntervalType: lo.ToPtr(client.ScheduleRotationHandoverV2IntervalType("weekly")),
+										Interval:     lo.ToPtr(int64(1)),
+									},
+								},
+								Layers: []client.ScheduleLayerV2{
+									{
+										Id:   lo.ToPtr("rota-primary-layer-one"),
+										Name: lo.ToPtr("Primary Layer One"),
+									},
+								},
+								WorkingInterval: &[]client.ScheduleRotationWorkingIntervalV2{
+									{
+										StartTime: "09:00",
+										EndTime:   "17:00",
+										Weekday:   "monday",
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "name", "Godawful"),
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "timezone", "Europe/London",
+					),
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "rotations", generateRotationsArray([]client.ScheduleRotationV2{
+							{
+								Id:              "rota-primary",
+								HandoverStartAt: time.Date(2024, 4, 26, 16, 0, 0, 0, time.UTC),
+								Name:            "Rota",
+							},
+						}),
+					),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "incident_schedule.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func incidentScheduleDefault() client.ScheduleV2 {
+	var (
+		effectiveFrom1, _   = time.Parse(time.RFC3339, "2024-04-26T16:00:00Z")
+		handoverStartAt1, _ = time.Parse(time.RFC3339, "2024-04-26T16:00:00Z")
+	)
+
+	return client.ScheduleV2{
+		Name:     "ONC",
+		Timezone: "Europe/London",
+		Config: &client.ScheduleConfigV2{
+			Rotations: []client.ScheduleRotationV2{
+				{
+					Id:              "rota-primary",
+					EffectiveFrom:   &effectiveFrom1,
+					HandoverStartAt: handoverStartAt1,
+					Handovers: []client.ScheduleRotationHandoverV2{
+						{
+							IntervalType: lo.ToPtr(client.ScheduleRotationHandoverV2IntervalType("weekly")),
+							Interval:     lo.ToPtr(int64(1)),
+						},
+					},
+					Layers: []client.ScheduleLayerV2{
+						{
+							Id:   lo.ToPtr("rota-primary-layer-one"),
+							Name: lo.ToPtr("Primary Layer One"),
+						},
+					},
+					Name:            "Rota",
+					Users:           new([]client.UserV1),
+					WorkingInterval: nil,
+				},
+			},
+		},
+	}
+}
+
+func quote(s string) string {
+	return `"` + s + `"`
+}
+
+func generateScheduleTerraform(name string, schedule *client.ScheduleV2) string {
+	var result string
+
+	result += "resource \"incident_schedule\" \"example\" {\n"
+	result += "  name     = " + quote(name) + "\n"
+	result += "  timezone = " + quote(schedule.Timezone) + "\n"
+	result += "  " + generateRotationsArray(schedule.Config.Rotations)
+	result += "}\n"
+	return result
+}
+
+func generateRotationsArray(rotations []client.ScheduleRotationV2) string {
+	var result string
+
+	rotationsByID := lo.GroupBy(rotations, func(rotation client.ScheduleRotationV2) string {
+		return rotation.Id
+	})
+
+	result += "rotations = [\n"
+	for _, rotation := range rotationsByID {
+
+		if len(rotation) == 0 {
+			continue
+		}
+
+		result += "  {\n"
+		result += "    id              = " + quote(rotation[0].Id) + "\n"
+		result += "    name            = " + quote(rotation[0].Name) + "\n"
+		result += "    handover_start_at = " + quote(rotation[0].HandoverStartAt.Format(time.RFC3339)) + "\n"
+		result += "    versions        = " + generateVersionsArray(rotation) + "\n"
+		result += "  },\n"
+	}
+	result += "]\n"
+	return result
+}
+
+func generateVersionsArray(versions []client.ScheduleRotationV2) string {
+	var result string
+	result += "[\n"
+	for _, version := range versions {
+		result += "  {\n"
+		result += "    effective_from   = " + quote(version.EffectiveFrom.Format(time.RFC3339)) + "\n"
+		result += "    handovers       = " + generateHandoversArray(version.Handovers) + "\n"
+		result += "    layers          = " + generateLayersArray(version.Layers) + "\n"
+		result += "    users           = " + generateUsersArray(version.Users) + "\n"
+		if version.WorkingInterval != nil {
+			result += "    working_interval = " + generateWorkingIntervalsArray(version.WorkingInterval) + "\n"
+		}
+		result += "  },\n"
+	}
+	result += "]\n"
+	return result
+}
+
+func generateHandoversArray(handovers []client.ScheduleRotationHandoverV2) string {
+	var result string
+	result += "[\n"
+	for _, handover := range handovers {
+		result += "  {\n"
+		result += "    interval_type = " + quote(string(*handover.IntervalType)) + "\n"
+		result += "    interval      = " + quote(strconv.FormatInt(*handover.Interval, 10)) + "\n"
+		result += "  },\n"
+	}
+	result += "]\n"
+	return result
+}
+
+func generateLayersArray(layers []client.ScheduleLayerV2) string {
+	var result string
+	result += "[\n"
+	for _, layer := range layers {
+		result += "  {\n"
+		result += "    id   = " + quote(*layer.Id) + "\n"
+		result += "    name = " + quote(*layer.Name) + "\n"
+		result += "  },\n"
+	}
+	result += "]\n"
+	return result
+}
+
+func generateUsersArray(users *[]client.UserV1) string {
+	var result string
+	result += "[\n"
+	for _, user := range *users {
+		result += "  {\n"
+		result += "    id   = " + quote(user.Id) + "\n"
+		result += "  },\n"
+	}
+	result += "]\n"
+	return result
+}
+
+func generateWorkingIntervalsArray(workingIntervals *[]client.ScheduleRotationWorkingIntervalV2) string {
+	var result string
+	result += "[\n"
+	for _, workingInterval := range *workingIntervals {
+		result += "  {\n"
+		result += "    start_time = " + quote(workingInterval.StartTime) + "\n"
+		result += "    end_time   = " + quote(workingInterval.EndTime) + "\n"
+		result += "    weekday    = " + quote(string(workingInterval.Weekday)) + "\n"
+		result += "  },\n"
+	}
+	result += "]\n"
+	return result
+}
+
+func testAccIncidentScheduleResourceConfig(override *client.ScheduleV2) string {
+	model := incidentScheduleDefault()
+
+	// Merge any non-zero fields in override into the model.
+	if override != nil {
+		for idx := 0; idx < reflect.TypeOf(*override).NumField(); idx++ {
+			field := reflect.ValueOf(*override).Field(idx)
+			if !field.IsZero() {
+				reflect.ValueOf(&model).Elem().Field(idx).Set(field)
+			}
+		}
+	}
+
+	terraformText := generateScheduleTerraform("example", &model)
+
+	return terraformText
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -133,6 +133,7 @@ func (p *IncidentProvider) Resources(ctx context.Context) []func() resource.Reso
 		NewIncidentRoleResource,
 		NewIncidentSeverityResource,
 		NewIncidentStatusResource,
+		NewIncidentScheduleResource,
 	}
 }
 


### PR DESCRIPTION
Allow users to configure incident.io schedules in Terraform using the Schedules API.

Example below:

```hcl
resource "incident_schedule" "testing_my_provider" {
  name = "Testing Terraform"

  // from tz database
  timezone = "Europe/London"

  rotations = [{
    id                = "01HPFH8T92MPGSQS5C1SPAF4V0"
    name              = "Testing TF 2 TF 2222"
    handover_start_at = "2024-05-01T12:54:13Z"
    versions = [
      {

        users = [
          data.incident_user.martha.id,
        ]

        layers = [
          {
            id   = "01HPFH8T92MPGSQS5C1SPAF4V0"
            name = "oncall"
          }
        ]

        // handovers are optional
        handovers = [
          {
            interval_type = "daily"
            interval      = 1
          }
        ]
      },
      {
        effective_from = "2024-05-14T12:54:13Z"
        users = [
          data.incident_user.martha.id,
          data.incident_user.rory.id,
        ]

        layers = [
          {
            id   = "01HPFH8T92MPGSQS5C1SPAF4V0"
            name = "oncall"
          }
        ]

        // handovers are optional
        handovers = [
          {
            interval_type = "daily"
            interval      = 1
          }
        ]
      },
    ]
  }]
}
```