### PR TITLE
Add remaining fields to workflows model

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -19,7 +19,7 @@ A draft version of the public API for workflows.
 
 - `condition_groups` (Attributes Set) (see [below for nested schema](#nestedatt--condition_groups))
 - `continue_on_step_error` (Boolean)
-- `expressions` (Attributes Map) (see [below for nested schema](#nestedatt--expressions))
+- `expressions` (Attributes Set) (see [below for nested schema](#nestedatt--expressions))
 - `include_private_incidents` (Boolean)
 - `name` (String)
 - `once_for` (List of String)
@@ -91,6 +91,7 @@ Required:
 
 - `label` (String)
 - `operations` (Attributes List) (see [below for nested schema](#nestedatt--expressions--operations))
+- `reference` (String)
 - `root_reference` (String)
 
 Optional:

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -3,12 +3,12 @@
 page_title: "incident_workflow Resource - terraform-provider-incident"
 subcategory: ""
 description: |-
-  A draft version of the public API for workflows. For now, this is a carbon copy of our private API
+  A draft version of the public API for workflows.
 ---
 
 # incident_workflow (Resource)
 
-A draft version of the public API for workflows. For now, this is a carbon copy of our private API
+A draft version of the public API for workflows.
 
 
 
@@ -18,15 +18,22 @@ A draft version of the public API for workflows. For now, this is a carbon copy 
 ### Required
 
 - `condition_groups` (Attributes Set) (see [below for nested schema](#nestedatt--condition_groups))
-- `expressions` (Attributes List) (see [below for nested schema](#nestedatt--expressions))
+- `continue_on_step_error` (Boolean)
+- `expressions` (Attributes Map) (see [below for nested schema](#nestedatt--expressions))
+- `include_private_incidents` (Boolean)
 - `name` (String)
+- `once_for` (List of String)
+- `runs_on_incident_modes` (List of String)
+- `runs_on_incidents` (String)
+- `state` (String)
 - `steps` (Attributes List) (see [below for nested schema](#nestedatt--steps))
-- `terraform_repo_url` (String)
 - `trigger` (String)
 
 ### Optional
 
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--delay))
 - `folder` (String)
+- `managed_source_url` (String)
 
 ### Read-Only
 
@@ -84,7 +91,6 @@ Required:
 
 - `label` (String)
 - `operations` (Attributes List) (see [below for nested schema](#nestedatt--expressions--operations))
-- `reference` (String)
 - `root_reference` (String)
 
 Optional:
@@ -122,42 +128,50 @@ Required:
 
 Required:
 
-- `conditions` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--conditions))
+- `condition_groups` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--condition_groups))
 - `result` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--result))
 
-<a id="nestedatt--expressions--operations--branches--returns--conditions"></a>
-### Nested Schema for `expressions.operations.branches.returns.conditions`
+<a id="nestedatt--expressions--operations--branches--returns--condition_groups"></a>
+### Nested Schema for `expressions.operations.branches.returns.condition_groups`
+
+Required:
+
+- `conditions` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--condition_groups--conditions))
+
+<a id="nestedatt--expressions--operations--branches--returns--condition_groups--conditions"></a>
+### Nested Schema for `expressions.operations.branches.returns.condition_groups.conditions`
 
 Required:
 
 - `operation` (String)
-- `param_bindings` (Attributes List) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--conditions--param_bindings))
+- `param_bindings` (Attributes List) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--condition_groups--conditions--param_bindings))
 - `subject` (String)
 
-<a id="nestedatt--expressions--operations--branches--returns--conditions--param_bindings"></a>
-### Nested Schema for `expressions.operations.branches.returns.conditions.subject`
+<a id="nestedatt--expressions--operations--branches--returns--condition_groups--conditions--param_bindings"></a>
+### Nested Schema for `expressions.operations.branches.returns.condition_groups.conditions.subject`
 
 Optional:
 
-- `array_value` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--conditions--subject--array_value))
-- `value` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--conditions--subject--value))
+- `array_value` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--condition_groups--conditions--subject--array_value))
+- `value` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--branches--returns--condition_groups--conditions--subject--value))
 
-<a id="nestedatt--expressions--operations--branches--returns--conditions--subject--array_value"></a>
-### Nested Schema for `expressions.operations.branches.returns.conditions.subject.value`
+<a id="nestedatt--expressions--operations--branches--returns--condition_groups--conditions--subject--array_value"></a>
+### Nested Schema for `expressions.operations.branches.returns.condition_groups.conditions.subject.value`
+
+Optional:
+
+- `literal` (String)
+- `reference` (String)
+
+
+<a id="nestedatt--expressions--operations--branches--returns--condition_groups--conditions--subject--value"></a>
+### Nested Schema for `expressions.operations.branches.returns.condition_groups.conditions.subject.value`
 
 Optional:
 
 - `literal` (String)
 - `reference` (String)
 
-
-<a id="nestedatt--expressions--operations--branches--returns--conditions--subject--value"></a>
-### Nested Schema for `expressions.operations.branches.returns.conditions.subject.value`
-
-Optional:
-
-- `literal` (String)
-- `reference` (String)
 
 
 
@@ -205,41 +219,49 @@ Required:
 
 Required:
 
-- `conditions` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--filter--conditions))
+- `condition_groups` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups))
 
-<a id="nestedatt--expressions--operations--filter--conditions"></a>
-### Nested Schema for `expressions.operations.filter.conditions`
+<a id="nestedatt--expressions--operations--filter--condition_groups"></a>
+### Nested Schema for `expressions.operations.filter.condition_groups`
+
+Required:
+
+- `conditions` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions))
+
+<a id="nestedatt--expressions--operations--filter--condition_groups--conditions"></a>
+### Nested Schema for `expressions.operations.filter.condition_groups.conditions`
 
 Required:
 
 - `operation` (String)
-- `param_bindings` (Attributes List) (see [below for nested schema](#nestedatt--expressions--operations--filter--conditions--param_bindings))
+- `param_bindings` (Attributes List) (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings))
 - `subject` (String)
 
-<a id="nestedatt--expressions--operations--filter--conditions--param_bindings"></a>
-### Nested Schema for `expressions.operations.filter.conditions.param_bindings`
+<a id="nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings"></a>
+### Nested Schema for `expressions.operations.filter.condition_groups.conditions.subject`
 
 Optional:
 
-- `array_value` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--filter--conditions--param_bindings--array_value))
-- `value` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--filter--conditions--param_bindings--value))
+- `array_value` (Attributes Set) (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--subject--array_value))
+- `value` (Attributes) (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--subject--value))
 
-<a id="nestedatt--expressions--operations--filter--conditions--param_bindings--array_value"></a>
-### Nested Schema for `expressions.operations.filter.conditions.param_bindings.value`
+<a id="nestedatt--expressions--operations--filter--condition_groups--conditions--subject--array_value"></a>
+### Nested Schema for `expressions.operations.filter.condition_groups.conditions.subject.value`
+
+Optional:
+
+- `literal` (String)
+- `reference` (String)
+
+
+<a id="nestedatt--expressions--operations--filter--condition_groups--conditions--subject--value"></a>
+### Nested Schema for `expressions.operations.filter.condition_groups.conditions.subject.value`
 
 Optional:
 
 - `literal` (String)
 - `reference` (String)
 
-
-<a id="nestedatt--expressions--operations--filter--conditions--param_bindings--value"></a>
-### Nested Schema for `expressions.operations.filter.conditions.param_bindings.value`
-
-Optional:
-
-- `literal` (String)
-- `reference` (String)
 
 
 
@@ -348,5 +370,16 @@ Optional:
 
 - `literal` (String)
 - `reference` (String)
+
+
+
+
+<a id="nestedatt--delay"></a>
+### Nested Schema for `delay`
+
+Required:
+
+- `conditions_apply_over_delay` (Boolean)
+- `delay_for_seconds` (Number)
 
 

--- a/internal/apischema/openapi3.json
+++ b/internal/apischema/openapi3.json
@@ -5877,7 +5877,7 @@
           "Schedules V2"
         ],
         "summary": "Show Schedules V2",
-        "description": "Get a sigle schedule.",
+        "description": "Get a single schedule.",
         "operationId": "Schedules V2#Show",
         "parameters": [
           {
@@ -6285,6 +6285,1428 @@
                     "name": "Lisa Karlin Curtis",
                     "role": "viewer",
                     "slack_user_id": "U02AYNF2XJM"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/workflows": {
+      "get": {
+        "tags": [
+          "Workflows V2"
+        ],
+        "summary": "ListWorkflows Workflows V2",
+        "description": "List all workflows",
+        "operationId": "Workflows V2#ListWorkflows",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListWorkflowsResponseBody"
+                },
+                "example": {
+                  "workflows": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "continue_on_step_error": true,
+                      "delay": {
+                        "conditions_apply_over_delay": false,
+                        "for_seconds": 60
+                      },
+                      "expressions": [
+                        {
+                          "else_branch": {
+                            "result": {
+                              "array_value": [
+                                {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          },
+                          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                          "label": "Team Slack channel",
+                          "operations": [
+                            {
+                              "branches": {
+                                "branches": [
+                                  {
+                                    "condition_groups": [
+                                      {
+                                        "conditions": [
+                                          {
+                                            "operation": {
+                                              "label": "Lawrence Jones",
+                                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                            },
+                                            "param_bindings": [
+                                              {
+                                                "array_value": [
+                                                  {
+                                                    "label": "Lawrence Jones",
+                                                    "literal": "SEV123",
+                                                    "reference": "incident.severity"
+                                                  }
+                                                ],
+                                                "value": {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              }
+                                            ],
+                                            "subject": {
+                                              "label": "Incident Severity",
+                                              "reference": "incident.severity"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ],
+                                    "result": {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "returns": {
+                                  "array": true,
+                                  "type": "IncidentStatus"
+                                }
+                              },
+                              "filter": {
+                                "condition_groups": [
+                                  {
+                                    "conditions": [
+                                      {
+                                        "operation": {
+                                          "label": "Lawrence Jones",
+                                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                        },
+                                        "param_bindings": [
+                                          {
+                                            "array_value": [
+                                              {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            ],
+                                            "value": {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          }
+                                        ],
+                                        "subject": {
+                                          "label": "Incident Severity",
+                                          "reference": "incident.severity"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              "navigate": {
+                                "reference": "1235",
+                                "reference_label": "Teams"
+                              },
+                              "operation_type": "navigate",
+                              "parse": {
+                                "returns": {
+                                  "array": true,
+                                  "type": "IncidentStatus"
+                                },
+                                "source": "metadata.annotations[\"github.com/repo\"]"
+                              },
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            }
+                          ],
+                          "reference": "abc123",
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          },
+                          "root_reference": "incident.status"
+                        }
+                      ],
+                      "folder": "My folder 01",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "include_private_incidents": true,
+                      "managed_source_url": "https://github.com/my-company/incident-io-workflows",
+                      "name": "My workflow",
+                      "once_for": [
+                        {
+                          "array": false,
+                          "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                          "label": "Incident -> Affected Team",
+                          "type": "IncidentSeverity"
+                        }
+                      ],
+                      "runs_from": "2021-08-17T13:28:57.801578Z",
+                      "runs_on_incident_modes": [
+                        "standard",
+                        "retrospective"
+                      ],
+                      "runs_on_incidents": "newly_created",
+                      "state": "active",
+                      "steps": [
+                        {
+                          "label": "PagerDuty Escalate",
+                          "name": "pagerduty.escalate"
+                        }
+                      ],
+                      "trigger": {
+                        "label": "Incident Updated",
+                        "name": "incident.updated"
+                      },
+                      "version": 3
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Workflows V2"
+        ],
+        "summary": "CreateWorkflow Workflows V2",
+        "description": "Create a new workflow",
+        "operationId": "Workflows V2#CreateWorkflow",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkflowRequestBody"
+              },
+              "example": {
+                "annotations": {
+                  "abc123": "abc123"
+                },
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "continue_on_step_error": true,
+                "delay": {
+                  "conditions_apply_over_delay": false,
+                  "for_seconds": 60
+                },
+                "expressions": [
+                  {
+                    "else_branch": {
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    },
+                    "label": "Team Slack channel",
+                    "operations": [
+                      {
+                        "branches": {
+                          "branches": [
+                            {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": "one_of",
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": "incident.severity"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "result": {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            }
+                          ],
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
+                        "filter": {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "navigate": {
+                          "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                        },
+                        "operation_type": "navigate",
+                        "parse": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          },
+                          "source": "metadata.annotations[\"github.com/repo\"]"
+                        }
+                      }
+                    ],
+                    "reference": "abc123",
+                    "root_reference": "incident.status"
+                  }
+                ],
+                "folder": "My folder 01",
+                "include_private_incidents": true,
+                "managed_source_url": "https://github.com/my-company/incident-io-workflows",
+                "name": "My workflow",
+                "once_for": [
+                  "incident.url"
+                ],
+                "runs_on_incident_modes": [
+                  "standard",
+                  "retrospective"
+                ],
+                "runs_on_incidents": "newly_created",
+                "state": "active",
+                "steps": [
+                  {
+                    "for_each": "abc123",
+                    "id": "abc123",
+                    "name": "pagerduty.escalate",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "trigger": "incident.updated"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowWorkflowResponseBody"
+                },
+                "example": {
+                  "workflow": {
+                    "annotations": {
+                      "abc123": "abc123"
+                    },
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "continue_on_step_error": true,
+                    "delay": {
+                      "conditions_apply_over_delay": false,
+                      "for_seconds": 60
+                    },
+                    "expressions": [
+                      {
+                        "else_branch": {
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "label": "Team Slack channel",
+                        "operations": [
+                          {
+                            "branches": {
+                              "branches": [
+                                {
+                                  "condition_groups": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "operation": {
+                                            "label": "Lawrence Jones",
+                                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                          },
+                                          "param_bindings": [
+                                            {
+                                              "array_value": [
+                                                {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              ],
+                                              "value": {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            }
+                                          ],
+                                          "subject": {
+                                            "label": "Incident Severity",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "result": {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                }
+                              ],
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            },
+                            "filter": {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "navigate": {
+                              "reference": "1235",
+                              "reference_label": "Teams"
+                            },
+                            "operation_type": "navigate",
+                            "parse": {
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              },
+                              "source": "metadata.annotations[\"github.com/repo\"]"
+                            },
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          }
+                        ],
+                        "reference": "abc123",
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "root_reference": "incident.status"
+                      }
+                    ],
+                    "folder": "My folder 01",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "include_private_incidents": true,
+                    "managed_source_url": "https://github.com/my-company/incident-io-workflows",
+                    "name": "My workflow",
+                    "once_for": [
+                      {
+                        "array": false,
+                        "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                        "label": "Incident -> Affected Team",
+                        "type": "IncidentSeverity"
+                      }
+                    ],
+                    "runs_from": "2021-08-17T13:28:57.801578Z",
+                    "runs_on_incident_modes": [
+                      "standard",
+                      "retrospective"
+                    ],
+                    "runs_on_incidents": "newly_created",
+                    "state": "active",
+                    "steps": [
+                      {
+                        "for_each": "abc123",
+                        "id": "abc123",
+                        "label": "PagerDuty Escalate",
+                        "name": "pagerduty.escalate",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "trigger": {
+                      "label": "Incident Updated",
+                      "name": "incident.updated"
+                    },
+                    "version": 3
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/workflows/{id}": {
+      "delete": {
+        "tags": [
+          "Workflows V2"
+        ],
+        "summary": "DestroyWorkflow Workflows V2",
+        "description": "Archives a workflow",
+        "operationId": "Workflows V2#DestroyWorkflow",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the workflow",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the workflow",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Workflows V2"
+        ],
+        "summary": "ShowWorkflow Workflows V2",
+        "description": "Show a workflow by ID",
+        "operationId": "Workflows V2#ShowWorkflow",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for the workflow",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for the workflow",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowWorkflowResponseBody"
+                },
+                "example": {
+                  "workflow": {
+                    "annotations": {
+                      "abc123": "abc123"
+                    },
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "continue_on_step_error": true,
+                    "delay": {
+                      "conditions_apply_over_delay": false,
+                      "for_seconds": 60
+                    },
+                    "expressions": [
+                      {
+                        "else_branch": {
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "label": "Team Slack channel",
+                        "operations": [
+                          {
+                            "branches": {
+                              "branches": [
+                                {
+                                  "condition_groups": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "operation": {
+                                            "label": "Lawrence Jones",
+                                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                          },
+                                          "param_bindings": [
+                                            {
+                                              "array_value": [
+                                                {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              ],
+                                              "value": {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            }
+                                          ],
+                                          "subject": {
+                                            "label": "Incident Severity",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "result": {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                }
+                              ],
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            },
+                            "filter": {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "navigate": {
+                              "reference": "1235",
+                              "reference_label": "Teams"
+                            },
+                            "operation_type": "navigate",
+                            "parse": {
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              },
+                              "source": "metadata.annotations[\"github.com/repo\"]"
+                            },
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          }
+                        ],
+                        "reference": "abc123",
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "root_reference": "incident.status"
+                      }
+                    ],
+                    "folder": "My folder 01",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "include_private_incidents": true,
+                    "managed_source_url": "https://github.com/my-company/incident-io-workflows",
+                    "name": "My workflow",
+                    "once_for": [
+                      {
+                        "array": false,
+                        "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                        "label": "Incident -> Affected Team",
+                        "type": "IncidentSeverity"
+                      }
+                    ],
+                    "runs_from": "2021-08-17T13:28:57.801578Z",
+                    "runs_on_incident_modes": [
+                      "standard",
+                      "retrospective"
+                    ],
+                    "runs_on_incidents": "newly_created",
+                    "state": "active",
+                    "steps": [
+                      {
+                        "for_each": "abc123",
+                        "id": "abc123",
+                        "label": "PagerDuty Escalate",
+                        "name": "pagerduty.escalate",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "trigger": {
+                      "label": "Incident Updated",
+                      "name": "incident.updated"
+                    },
+                    "version": 3
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Workflows V2"
+        ],
+        "summary": "UpdateWorkflow Workflows V2",
+        "description": "Updates a workflow",
+        "operationId": "Workflows V2#UpdateWorkflow",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the workflow to update",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "ID of the workflow to update",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkflowRequestBody"
+              },
+              "example": {
+                "annotations": {
+                  "abc123": "abc123"
+                },
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "continue_on_step_error": true,
+                "delay": {
+                  "conditions_apply_over_delay": false,
+                  "for_seconds": 60
+                },
+                "expressions": [
+                  {
+                    "else_branch": {
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    },
+                    "label": "Team Slack channel",
+                    "operations": [
+                      {
+                        "branches": {
+                          "branches": [
+                            {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": "one_of",
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": "incident.severity"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "result": {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            }
+                          ],
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
+                        "filter": {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "navigate": {
+                          "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                        },
+                        "operation_type": "navigate",
+                        "parse": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          },
+                          "source": "metadata.annotations[\"github.com/repo\"]"
+                        }
+                      }
+                    ],
+                    "reference": "abc123",
+                    "root_reference": "incident.status"
+                  }
+                ],
+                "folder": "My folder 01",
+                "include_private_incidents": true,
+                "managed_source_url": "https://github.com/my-company/incident-io-workflows",
+                "name": "My workflow",
+                "once_for": [
+                  "incident.url"
+                ],
+                "runs_on_incident_modes": [
+                  "standard",
+                  "retrospective"
+                ],
+                "runs_on_incidents": "newly_created",
+                "state": "active",
+                "steps": [
+                  {
+                    "for_each": "abc123",
+                    "id": "abc123",
+                    "name": "pagerduty.escalate",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShowWorkflowResponseBody"
+                },
+                "example": {
+                  "workflow": {
+                    "annotations": {
+                      "abc123": "abc123"
+                    },
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "continue_on_step_error": true,
+                    "delay": {
+                      "conditions_apply_over_delay": false,
+                      "for_seconds": 60
+                    },
+                    "expressions": [
+                      {
+                        "else_branch": {
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "label": "Team Slack channel",
+                        "operations": [
+                          {
+                            "branches": {
+                              "branches": [
+                                {
+                                  "condition_groups": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "operation": {
+                                            "label": "Lawrence Jones",
+                                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                          },
+                                          "param_bindings": [
+                                            {
+                                              "array_value": [
+                                                {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              ],
+                                              "value": {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            }
+                                          ],
+                                          "subject": {
+                                            "label": "Incident Severity",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "result": {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                }
+                              ],
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            },
+                            "filter": {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "navigate": {
+                              "reference": "1235",
+                              "reference_label": "Teams"
+                            },
+                            "operation_type": "navigate",
+                            "parse": {
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              },
+                              "source": "metadata.annotations[\"github.com/repo\"]"
+                            },
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          }
+                        ],
+                        "reference": "abc123",
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "root_reference": "incident.status"
+                      }
+                    ],
+                    "folder": "My folder 01",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "include_private_incidents": true,
+                    "managed_source_url": "https://github.com/my-company/incident-io-workflows",
+                    "name": "My workflow",
+                    "once_for": [
+                      {
+                        "array": false,
+                        "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                        "label": "Incident -> Affected Team",
+                        "type": "IncidentSeverity"
+                      }
+                    ],
+                    "runs_from": "2021-08-17T13:28:57.801578Z",
+                    "runs_on_incident_modes": [
+                      "standard",
+                      "retrospective"
+                    ],
+                    "runs_on_incidents": "newly_created",
+                    "state": "active",
+                    "steps": [
+                      {
+                        "for_each": "abc123",
+                        "id": "abc123",
+                        "label": "PagerDuty Escalate",
+                        "name": "pagerduty.escalate",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "trigger": {
+                      "label": "Incident Updated",
+                      "name": "incident.updated"
+                    },
+                    "version": 3
                   }
                 }
               }
@@ -7515,6 +8937,152 @@
           "before_custom_role_slugs": "engineering,security"
         }
       },
+      "CatalogEntryEngineParamBindingV2": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CatalogEntryEngineParamBindingValueV2"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "catalog_entry": {
+                  "archived_at": "2021-08-17T14:28:57.801578Z",
+                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
+                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "helptext": "Collection of standalone automations like auto-closing incidents.",
+                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "is_image_slack_icon": false,
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity",
+                "sort_key": "000020",
+                "unavailable": false,
+                "value": "abc123"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/CatalogEntryEngineParamBindingValueV2"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "catalog_entry": {
+                "archived_at": "2021-08-17T14:28:57.801578Z",
+                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "catalog_entry_name": "Primary escalation",
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "helptext": "Collection of standalone automations like auto-closing incidents.",
+              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+              "is_image_slack_icon": false,
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity",
+              "sort_key": "000020",
+              "unavailable": false,
+              "value": "abc123"
+            }
+          ],
+          "value": {
+            "catalog_entry": {
+              "archived_at": "2021-08-17T14:28:57.801578Z",
+              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "catalog_entry_name": "Primary escalation",
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "helptext": "Collection of standalone automations like auto-closing incidents.",
+            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+            "is_image_slack_icon": false,
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity",
+            "sort_key": "000020",
+            "unavailable": false,
+            "value": "abc123"
+          }
+        }
+      },
+      "CatalogEntryEngineParamBindingValueV2": {
+        "type": "object",
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryReferenceV2"
+          },
+          "helptext": {
+            "type": "string",
+            "description": "Gives a description of the option to the user",
+            "example": "Collection of standalone automations like auto-closing incidents."
+          },
+          "image_url": {
+            "type": "string",
+            "description": "If appropriate, URL to an image that can be displayed alongside the option",
+            "example": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg"
+          },
+          "is_image_slack_icon": {
+            "type": "boolean",
+            "description": "If true, the image_url is a Slack icon and should be displayed as such",
+            "example": false
+          },
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          },
+          "sort_key": {
+            "type": "string",
+            "description": "Gives an indication of how to sort the options when displayed to the user",
+            "example": "000020"
+          },
+          "unavailable": {
+            "type": "boolean",
+            "description": "Unavailable is true if we've failed to build the value for this binding",
+            "example": false
+          },
+          "value": {
+            "type": "string",
+            "description": "Either the reference or the literal: this field is designed purely to make working with react-select easier",
+            "example": "abc123"
+          }
+        },
+        "example": {
+          "catalog_entry": {
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "catalog_entry_name": "Primary escalation",
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "helptext": "Collection of standalone automations like auto-closing incidents.",
+          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+          "is_image_slack_icon": false,
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity",
+          "sort_key": "000020",
+          "unavailable": false,
+          "value": "abc123"
+        },
+        "required": [
+          "label",
+          "sort_key"
+        ]
+      },
       "CatalogEntryReferenceV2": {
         "type": "object",
         "properties": {
@@ -7617,7 +9185,7 @@
               }
             },
             "additionalProperties": {
-              "$ref": "#/components/schemas/EngineParamBindingV2"
+              "$ref": "#/components/schemas/CatalogEntryEngineParamBindingV2"
             }
           },
           "catalog_type_id": {
@@ -8213,39 +9781,15 @@
                   {
                     "array_value": [
                       {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     ],
                     "value": {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   }
                 ],
@@ -8268,39 +9812,15 @@
                 {
                   "array_value": [
                     {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   ],
                   "value": {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                    "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "000020",
-                    "unavailable": false,
-                    "value": "abc123"
+                    "reference": "incident.severity"
                   }
                 }
               ],
@@ -8429,46 +9949,22 @@
           "param_bindings": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV3"
+              "$ref": "#/components/schemas/EngineParamBindingV2"
             },
             "description": "Bindings for the operation parameters",
             "example": [
               {
                 "array_value": [
                   {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                    "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "000020",
-                    "unavailable": false,
-                    "value": "abc123"
+                    "reference": "incident.severity"
                   }
                 ],
                 "value": {
-                  "catalog_entry": {
-                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "catalog_entry_name": "Primary escalation",
-                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                  },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                  "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "reference": "incident.severity",
-                  "sort_key": "000020",
-                  "unavailable": false,
-                  "value": "abc123"
+                  "reference": "incident.severity"
                 }
               }
             ]
@@ -8486,39 +9982,15 @@
             {
               "array_value": [
                 {
-                  "catalog_entry": {
-                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "catalog_entry_name": "Primary escalation",
-                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                  },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                  "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "reference": "incident.severity",
-                  "sort_key": "000020",
-                  "unavailable": false,
-                  "value": "abc123"
+                  "reference": "incident.severity"
                 }
               ],
               "value": {
-                "catalog_entry": {
-                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "catalog_entry_name": "Primary escalation",
-                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
-                "reference": "incident.severity",
-                "sort_key": "000020",
-                "unavailable": false,
-                "value": "abc123"
+                "reference": "incident.severity"
               }
             }
           ],
@@ -9799,9 +11271,20 @@
           "catalog_type"
         ]
       },
-      "CreateWorkflowPayload": {
+      "CreateWorkflowRequestBody": {
         "type": "object",
         "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that track internal metadata about this workflow",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
           "condition_groups": {
             "type": "array",
             "items": {
@@ -9966,16 +11449,6 @@
             "description": "Whether to include private incidents",
             "example": true
           },
-          "include_retrospective_incidents": {
-            "type": "boolean",
-            "description": "Whether to include retrospective incidents",
-            "example": true
-          },
-          "include_test_incidents": {
-            "type": "boolean",
-            "description": "Whether to include test incidents",
-            "example": true
-          },
           "managed_source_url": {
             "type": "string",
             "description": "The url of the external repository where this workflow is managed",
@@ -9997,6 +11470,23 @@
               "incident.url"
             ]
           },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "test",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
           "runs_on_incidents": {
             "type": "string",
             "description": "Which incidents should the workflow be applied to?",
@@ -10013,7 +11503,6 @@
             "enum": [
               "active",
               "disabled",
-              "disabled_draft",
               "draft",
               "error"
             ]
@@ -10053,6 +11542,9 @@
           }
         },
         "example": {
+          "annotations": {
+            "abc123": "abc123"
+          },
           "condition_groups": [
             {
               "conditions": [
@@ -10192,12 +11684,14 @@
           ],
           "folder": "My folder 01",
           "include_private_incidents": true,
-          "include_retrospective_incidents": true,
-          "include_test_incidents": true,
           "managed_source_url": "https://github.com/my-company/incident-io-workflows",
           "name": "My workflow",
           "once_for": [
             "incident.url"
+          ],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
           ],
           "runs_on_incidents": "newly_created",
           "state": "active",
@@ -10230,196 +11724,11 @@
           "once_for",
           "condition_groups",
           "steps",
+          "expressions",
           "include_private_incidents",
-          "include_test_incidents",
-          "include_retrospective_incidents",
+          "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents"
-        ]
-      },
-      "CreateWorkflowRequestBody": {
-        "type": "object",
-        "properties": {
-          "workflow": {
-            "$ref": "#/components/schemas/CreateWorkflowPayload"
-          }
-        },
-        "example": {
-          "workflow": {
-            "condition_groups": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ],
-            "continue_on_step_error": true,
-            "delay": {
-              "conditions_apply_over_delay": false,
-              "for_seconds": 60
-            },
-            "expressions": [
-              {
-                "else_branch": {
-                  "result": {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                },
-                "label": "Team Slack channel",
-                "operations": [
-                  {
-                    "branches": {
-                      "branches": [
-                        {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": "one_of",
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": "incident.severity"
-                                }
-                              ]
-                            }
-                          ],
-                          "result": {
-                            "array_value": [
-                              {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        }
-                      ],
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    },
-                    "filter": {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": "one_of",
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": "incident.severity"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "navigate": {
-                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                    },
-                    "operation_type": "navigate",
-                    "parse": {
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      },
-                      "source": "metadata.annotations[\"github.com/repo\"]"
-                    }
-                  }
-                ],
-                "reference": "abc123",
-                "root_reference": "incident.status"
-              }
-            ],
-            "folder": "My folder 01",
-            "include_private_incidents": true,
-            "include_retrospective_incidents": true,
-            "include_test_incidents": true,
-            "managed_source_url": "https://github.com/my-company/incident-io-workflows",
-            "name": "My workflow",
-            "once_for": [
-              "incident.url"
-            ],
-            "runs_on_incidents": "newly_created",
-            "state": "active",
-            "steps": [
-              {
-                "for_each": "abc123",
-                "id": "abc123",
-                "name": "pagerduty.escalate",
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "trigger": "incident.updated"
-          }
-        },
-        "required": [
-          "workflow"
         ]
       },
       "CustomFieldEntryPayloadV1": {
@@ -11116,21 +12425,9 @@
             "description": "If array_value is set, this helps render the values",
             "example": [
               {
-                "catalog_entry": {
-                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "catalog_entry_name": "Primary escalation",
-                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
-                "reference": "incident.severity",
-                "sort_key": "000020",
-                "unavailable": false,
-                "value": "abc123"
+                "reference": "incident.severity"
               }
             ]
           },
@@ -11141,45 +12438,17 @@
         "example": {
           "array_value": [
             {
-              "catalog_entry": {
-                "archived_at": "2021-08-17T14:28:57.801578Z",
-                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "catalog_entry_name": "Primary escalation",
-                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              },
-              "helptext": "Collection of standalone automations like auto-closing incidents.",
-              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-              "is_image_slack_icon": false,
               "label": "Lawrence Jones",
               "literal": "SEV123",
-              "reference": "incident.severity",
-              "sort_key": "000020",
-              "unavailable": false,
-              "value": "abc123"
+              "reference": "incident.severity"
             }
           ],
           "value": {
-            "catalog_entry": {
-              "archived_at": "2021-08-17T14:28:57.801578Z",
-              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "catalog_entry_name": "Primary escalation",
-              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-            },
-            "helptext": "Collection of standalone automations like auto-closing incidents.",
-            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-            "is_image_slack_icon": false,
             "label": "Lawrence Jones",
             "literal": "SEV123",
-            "reference": "incident.severity",
-            "sort_key": "000020",
-            "unavailable": false,
-            "value": "abc123"
+            "reference": "incident.severity"
           }
         }
-      },
-      "EngineParamBindingV3": {
-        "type": "object",
-        "example": {}
       },
       "EngineParamBindingValuePayloadV2": {
         "type": "object",
@@ -11203,24 +12472,6 @@
       "EngineParamBindingValueV2": {
         "type": "object",
         "properties": {
-          "catalog_entry": {
-            "$ref": "#/components/schemas/CatalogEntryReferenceV2"
-          },
-          "helptext": {
-            "type": "string",
-            "description": "Gives a description of the option to the user",
-            "example": "Collection of standalone automations like auto-closing incidents."
-          },
-          "image_url": {
-            "type": "string",
-            "description": "If appropriate, URL to an image that can be displayed alongside the option",
-            "example": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg"
-          },
-          "is_image_slack_icon": {
-            "type": "boolean",
-            "description": "If true, the image_url is a Slack icon and should be displayed as such",
-            "example": false
-          },
           "label": {
             "type": "string",
             "description": "Human readable label to be displayed for user to select",
@@ -11235,43 +12486,15 @@
             "type": "string",
             "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
             "example": "incident.severity"
-          },
-          "sort_key": {
-            "type": "string",
-            "description": "Gives an indication of how to sort the options when displayed to the user",
-            "example": "000020"
-          },
-          "unavailable": {
-            "type": "boolean",
-            "description": "Unavailable is true if we've failed to build the value for this binding",
-            "example": false
-          },
-          "value": {
-            "type": "string",
-            "description": "Either the reference or the literal: this field is designed purely to make working with react-select easier",
-            "example": "abc123"
           }
         },
         "example": {
-          "catalog_entry": {
-            "archived_at": "2021-08-17T14:28:57.801578Z",
-            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "catalog_entry_name": "Primary escalation",
-            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-          },
-          "helptext": "Collection of standalone automations like auto-closing incidents.",
-          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-          "is_image_slack_icon": false,
           "label": "Lawrence Jones",
           "literal": "SEV123",
-          "reference": "incident.severity",
-          "sort_key": "000020",
-          "unavailable": false,
-          "value": "abc123"
+          "reference": "incident.severity"
         },
         "required": [
-          "label",
-          "sort_key"
+          "label"
         ]
       },
       "EngineReferenceV2": {
@@ -11415,39 +12638,15 @@
                       {
                         "array_value": [
                           {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         ],
                         "value": {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       }
                     ],
@@ -11461,7 +12660,7 @@
             ]
           },
           "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV3"
+            "$ref": "#/components/schemas/EngineParamBindingV2"
           }
         },
         "example": {
@@ -11477,39 +12676,15 @@
                     {
                       "array_value": [
                         {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       ],
                       "value": {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     }
                   ],
@@ -11524,39 +12699,15 @@
           "result": {
             "array_value": [
               {
-                "catalog_entry": {
-                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "catalog_entry_name": "Primary escalation",
-                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
-                "reference": "incident.severity",
-                "sort_key": "000020",
-                "unavailable": false,
-                "value": "abc123"
+                "reference": "incident.severity"
               }
             ],
             "value": {
-              "catalog_entry": {
-                "archived_at": "2021-08-17T14:28:57.801578Z",
-                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "catalog_entry_name": "Primary escalation",
-                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              },
-              "helptext": "Collection of standalone automations like auto-closing incidents.",
-              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-              "is_image_slack_icon": false,
               "label": "Lawrence Jones",
               "literal": "SEV123",
-              "reference": "incident.severity",
-              "sort_key": "000020",
-              "unavailable": false,
-              "value": "abc123"
+              "reference": "incident.severity"
             }
           }
         },
@@ -11693,39 +12844,15 @@
                           {
                             "array_value": [
                               {
-                                "catalog_entry": {
-                                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                  "catalog_entry_name": "Primary escalation",
-                                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                },
-                                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                "is_image_slack_icon": false,
                                 "label": "Lawrence Jones",
                                 "literal": "SEV123",
-                                "reference": "incident.severity",
-                                "sort_key": "000020",
-                                "unavailable": false,
-                                "value": "abc123"
+                                "reference": "incident.severity"
                               }
                             ],
                             "value": {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           }
                         ],
@@ -11740,39 +12867,15 @@
                 "result": {
                   "array_value": [
                     {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   ],
                   "value": {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                    "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "000020",
-                    "unavailable": false,
-                    "value": "abc123"
+                    "reference": "incident.severity"
                   }
                 }
               }
@@ -11797,39 +12900,15 @@
                         {
                           "array_value": [
                             {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           ],
                           "value": {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         }
                       ],
@@ -11844,39 +12923,15 @@
               "result": {
                 "array_value": [
                   {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                    "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "000020",
-                    "unavailable": false,
-                    "value": "abc123"
+                    "reference": "incident.severity"
                   }
                 ],
                 "value": {
-                  "catalog_entry": {
-                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "catalog_entry_name": "Primary escalation",
-                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                  },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                  "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "reference": "incident.severity",
-                  "sort_key": "000020",
-                  "unavailable": false,
-                  "value": "abc123"
+                  "reference": "incident.severity"
                 }
               }
             }
@@ -11920,46 +12975,22 @@
         "type": "object",
         "properties": {
           "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV3"
+            "$ref": "#/components/schemas/EngineParamBindingV2"
           }
         },
         "example": {
           "result": {
             "array_value": [
               {
-                "catalog_entry": {
-                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "catalog_entry_name": "Primary escalation",
-                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
-                "reference": "incident.severity",
-                "sort_key": "000020",
-                "unavailable": false,
-                "value": "abc123"
+                "reference": "incident.severity"
               }
             ],
             "value": {
-              "catalog_entry": {
-                "archived_at": "2021-08-17T14:28:57.801578Z",
-                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "catalog_entry_name": "Primary escalation",
-                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              },
-              "helptext": "Collection of standalone automations like auto-closing incidents.",
-              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-              "is_image_slack_icon": false,
               "label": "Lawrence Jones",
               "literal": "SEV123",
-              "reference": "incident.severity",
-              "sort_key": "000020",
-              "unavailable": false,
-              "value": "abc123"
+              "reference": "incident.severity"
             }
           }
         },
@@ -12053,39 +13084,15 @@
                       {
                         "array_value": [
                           {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         ],
                         "value": {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       }
                     ],
@@ -12112,39 +13119,15 @@
                     {
                       "array_value": [
                         {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       ],
                       "value": {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     }
                   ],
@@ -12373,39 +13356,15 @@
                           {
                             "array_value": [
                               {
-                                "catalog_entry": {
-                                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                  "catalog_entry_name": "Primary escalation",
-                                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                },
-                                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                "is_image_slack_icon": false,
                                 "label": "Lawrence Jones",
                                 "literal": "SEV123",
-                                "reference": "incident.severity",
-                                "sort_key": "000020",
-                                "unavailable": false,
-                                "value": "abc123"
+                                "reference": "incident.severity"
                               }
                             ],
                             "value": {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           }
                         ],
@@ -12420,39 +13379,15 @@
                 "result": {
                   "array_value": [
                     {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   ],
                   "value": {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                    "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "000020",
-                    "unavailable": false,
-                    "value": "abc123"
+                    "reference": "incident.severity"
                   }
                 }
               }
@@ -12475,39 +13410,15 @@
                       {
                         "array_value": [
                           {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         ],
                         "value": {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       }
                     ],
@@ -12832,39 +13743,15 @@
                                 {
                                   "array_value": [
                                     {
-                                      "catalog_entry": {
-                                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                        "catalog_entry_name": "Primary escalation",
-                                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                      },
-                                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                      "is_image_slack_icon": false,
                                       "label": "Lawrence Jones",
                                       "literal": "SEV123",
-                                      "reference": "incident.severity",
-                                      "sort_key": "000020",
-                                      "unavailable": false,
-                                      "value": "abc123"
+                                      "reference": "incident.severity"
                                     }
                                   ],
                                   "value": {
-                                    "catalog_entry": {
-                                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                      "catalog_entry_name": "Primary escalation",
-                                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                    },
-                                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                    "is_image_slack_icon": false,
                                     "label": "Lawrence Jones",
                                     "literal": "SEV123",
-                                    "reference": "incident.severity",
-                                    "sort_key": "000020",
-                                    "unavailable": false,
-                                    "value": "abc123"
+                                    "reference": "incident.severity"
                                   }
                                 }
                               ],
@@ -12879,39 +13766,15 @@
                       "result": {
                         "array_value": [
                           {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         ],
                         "value": {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       }
                     }
@@ -12934,39 +13797,15 @@
                             {
                               "array_value": [
                                 {
-                                  "catalog_entry": {
-                                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                    "catalog_entry_name": "Primary escalation",
-                                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                  },
-                                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                  "is_image_slack_icon": false,
                                   "label": "Lawrence Jones",
                                   "literal": "SEV123",
-                                  "reference": "incident.severity",
-                                  "sort_key": "000020",
-                                  "unavailable": false,
-                                  "value": "abc123"
+                                  "reference": "incident.severity"
                                 }
                               ],
                               "value": {
-                                "catalog_entry": {
-                                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                  "catalog_entry_name": "Primary escalation",
-                                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                },
-                                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                "is_image_slack_icon": false,
                                 "label": "Lawrence Jones",
                                 "literal": "SEV123",
-                                "reference": "incident.severity",
-                                "sort_key": "000020",
-                                "unavailable": false,
-                                "value": "abc123"
+                                "reference": "incident.severity"
                               }
                             }
                           ],
@@ -13017,39 +13856,15 @@
             "result": {
               "array_value": [
                 {
-                  "catalog_entry": {
-                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "catalog_entry_name": "Primary escalation",
-                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                  },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                  "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "reference": "incident.severity",
-                  "sort_key": "000020",
-                  "unavailable": false,
-                  "value": "abc123"
+                  "reference": "incident.severity"
                 }
               ],
               "value": {
-                "catalog_entry": {
-                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "catalog_entry_name": "Primary escalation",
-                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
-                "reference": "incident.severity",
-                "sort_key": "000020",
-                "unavailable": false,
-                "value": "abc123"
+                "reference": "incident.severity"
               }
             }
           },
@@ -13072,39 +13887,15 @@
                               {
                                 "array_value": [
                                   {
-                                    "catalog_entry": {
-                                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                      "catalog_entry_name": "Primary escalation",
-                                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                    },
-                                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                    "is_image_slack_icon": false,
                                     "label": "Lawrence Jones",
                                     "literal": "SEV123",
-                                    "reference": "incident.severity",
-                                    "sort_key": "000020",
-                                    "unavailable": false,
-                                    "value": "abc123"
+                                    "reference": "incident.severity"
                                   }
                                 ],
                                 "value": {
-                                  "catalog_entry": {
-                                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                    "catalog_entry_name": "Primary escalation",
-                                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                  },
-                                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                  "is_image_slack_icon": false,
                                   "label": "Lawrence Jones",
                                   "literal": "SEV123",
-                                  "reference": "incident.severity",
-                                  "sort_key": "000020",
-                                  "unavailable": false,
-                                  "value": "abc123"
+                                  "reference": "incident.severity"
                                 }
                               }
                             ],
@@ -13119,39 +13910,15 @@
                     "result": {
                       "array_value": [
                         {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       ],
                       "value": {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     }
                   }
@@ -13174,39 +13941,15 @@
                           {
                             "array_value": [
                               {
-                                "catalog_entry": {
-                                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                  "catalog_entry_name": "Primary escalation",
-                                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                },
-                                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                "is_image_slack_icon": false,
                                 "label": "Lawrence Jones",
                                 "literal": "SEV123",
-                                "reference": "incident.severity",
-                                "sort_key": "000020",
-                                "unavailable": false,
-                                "value": "abc123"
+                                "reference": "incident.severity"
                               }
                             ],
                             "value": {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           }
                         ],
@@ -17305,39 +18048,15 @@
                           {
                             "array_value": [
                               {
-                                "catalog_entry": {
-                                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                  "catalog_entry_name": "Primary escalation",
-                                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                },
-                                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                "is_image_slack_icon": false,
                                 "label": "Lawrence Jones",
                                 "literal": "SEV123",
-                                "reference": "incident.severity",
-                                "sort_key": "000020",
-                                "unavailable": false,
-                                "value": "abc123"
+                                "reference": "incident.severity"
                               }
                             ],
                             "value": {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           }
                         ],
@@ -17360,39 +18079,15 @@
                       "result": {
                         "array_value": [
                           {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         ],
                         "value": {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       }
                     },
@@ -17415,39 +18110,15 @@
                                         {
                                           "array_value": [
                                             {
-                                              "catalog_entry": {
-                                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                                "catalog_entry_name": "Primary escalation",
-                                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                              },
-                                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                              "is_image_slack_icon": false,
                                               "label": "Lawrence Jones",
                                               "literal": "SEV123",
-                                              "reference": "incident.severity",
-                                              "sort_key": "000020",
-                                              "unavailable": false,
-                                              "value": "abc123"
+                                              "reference": "incident.severity"
                                             }
                                           ],
                                           "value": {
-                                            "catalog_entry": {
-                                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                              "catalog_entry_name": "Primary escalation",
-                                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                            },
-                                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                            "is_image_slack_icon": false,
                                             "label": "Lawrence Jones",
                                             "literal": "SEV123",
-                                            "reference": "incident.severity",
-                                            "sort_key": "000020",
-                                            "unavailable": false,
-                                            "value": "abc123"
+                                            "reference": "incident.severity"
                                           }
                                         }
                                       ],
@@ -17462,39 +18133,15 @@
                               "result": {
                                 "array_value": [
                                   {
-                                    "catalog_entry": {
-                                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                      "catalog_entry_name": "Primary escalation",
-                                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                    },
-                                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                    "is_image_slack_icon": false,
                                     "label": "Lawrence Jones",
                                     "literal": "SEV123",
-                                    "reference": "incident.severity",
-                                    "sort_key": "000020",
-                                    "unavailable": false,
-                                    "value": "abc123"
+                                    "reference": "incident.severity"
                                   }
                                 ],
                                 "value": {
-                                  "catalog_entry": {
-                                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                    "catalog_entry_name": "Primary escalation",
-                                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                  },
-                                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                  "is_image_slack_icon": false,
                                   "label": "Lawrence Jones",
                                   "literal": "SEV123",
-                                  "reference": "incident.severity",
-                                  "sort_key": "000020",
-                                  "unavailable": false,
-                                  "value": "abc123"
+                                  "reference": "incident.severity"
                                 }
                               }
                             }
@@ -17517,39 +18164,15 @@
                                     {
                                       "array_value": [
                                         {
-                                          "catalog_entry": {
-                                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                            "catalog_entry_name": "Primary escalation",
-                                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                          },
-                                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                          "is_image_slack_icon": false,
                                           "label": "Lawrence Jones",
                                           "literal": "SEV123",
-                                          "reference": "incident.severity",
-                                          "sort_key": "000020",
-                                          "unavailable": false,
-                                          "value": "abc123"
+                                          "reference": "incident.severity"
                                         }
                                       ],
                                       "value": {
-                                        "catalog_entry": {
-                                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                          "catalog_entry_name": "Primary escalation",
-                                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                        },
-                                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                        "is_image_slack_icon": false,
                                         "label": "Lawrence Jones",
                                         "literal": "SEV123",
-                                        "reference": "incident.severity",
-                                        "sort_key": "000020",
-                                        "unavailable": false,
-                                        "value": "abc123"
+                                        "reference": "incident.severity"
                                       }
                                     }
                                   ],
@@ -17591,8 +18214,6 @@
                 "folder": "My folder 01",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "include_private_incidents": true,
-                "include_retrospective_incidents": true,
-                "include_test_incidents": true,
                 "managed_source_url": "https://github.com/my-company/incident-io-workflows",
                 "name": "My workflow",
                 "once_for": [
@@ -17604,6 +18225,10 @@
                   }
                 ],
                 "runs_from": "2021-08-17T13:28:57.801578Z",
+                "runs_on_incident_modes": [
+                  "standard",
+                  "retrospective"
+                ],
                 "runs_on_incidents": "newly_created",
                 "state": "active",
                 "steps": [
@@ -17636,39 +18261,15 @@
                         {
                           "array_value": [
                             {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           ],
                           "value": {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         }
                       ],
@@ -17691,39 +18292,15 @@
                     "result": {
                       "array_value": [
                         {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       ],
                       "value": {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     }
                   },
@@ -17746,39 +18323,15 @@
                                       {
                                         "array_value": [
                                           {
-                                            "catalog_entry": {
-                                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                              "catalog_entry_name": "Primary escalation",
-                                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                            },
-                                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                            "is_image_slack_icon": false,
                                             "label": "Lawrence Jones",
                                             "literal": "SEV123",
-                                            "reference": "incident.severity",
-                                            "sort_key": "000020",
-                                            "unavailable": false,
-                                            "value": "abc123"
+                                            "reference": "incident.severity"
                                           }
                                         ],
                                         "value": {
-                                          "catalog_entry": {
-                                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                            "catalog_entry_name": "Primary escalation",
-                                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                          },
-                                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                          "is_image_slack_icon": false,
                                           "label": "Lawrence Jones",
                                           "literal": "SEV123",
-                                          "reference": "incident.severity",
-                                          "sort_key": "000020",
-                                          "unavailable": false,
-                                          "value": "abc123"
+                                          "reference": "incident.severity"
                                         }
                                       }
                                     ],
@@ -17793,39 +18346,15 @@
                             "result": {
                               "array_value": [
                                 {
-                                  "catalog_entry": {
-                                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                    "catalog_entry_name": "Primary escalation",
-                                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                  },
-                                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                  "is_image_slack_icon": false,
                                   "label": "Lawrence Jones",
                                   "literal": "SEV123",
-                                  "reference": "incident.severity",
-                                  "sort_key": "000020",
-                                  "unavailable": false,
-                                  "value": "abc123"
+                                  "reference": "incident.severity"
                                 }
                               ],
                               "value": {
-                                "catalog_entry": {
-                                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                  "catalog_entry_name": "Primary escalation",
-                                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                },
-                                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                "is_image_slack_icon": false,
                                 "label": "Lawrence Jones",
                                 "literal": "SEV123",
-                                "reference": "incident.severity",
-                                "sort_key": "000020",
-                                "unavailable": false,
-                                "value": "abc123"
+                                "reference": "incident.severity"
                               }
                             }
                           }
@@ -17848,39 +18377,15 @@
                                   {
                                     "array_value": [
                                       {
-                                        "catalog_entry": {
-                                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                          "catalog_entry_name": "Primary escalation",
-                                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                        },
-                                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                        "is_image_slack_icon": false,
                                         "label": "Lawrence Jones",
                                         "literal": "SEV123",
-                                        "reference": "incident.severity",
-                                        "sort_key": "000020",
-                                        "unavailable": false,
-                                        "value": "abc123"
+                                        "reference": "incident.severity"
                                       }
                                     ],
                                     "value": {
-                                      "catalog_entry": {
-                                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                        "catalog_entry_name": "Primary escalation",
-                                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                      },
-                                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                      "is_image_slack_icon": false,
                                       "label": "Lawrence Jones",
                                       "literal": "SEV123",
-                                      "reference": "incident.severity",
-                                      "sort_key": "000020",
-                                      "unavailable": false,
-                                      "value": "abc123"
+                                      "reference": "incident.severity"
                                     }
                                   }
                                 ],
@@ -17922,8 +18427,6 @@
               "folder": "My folder 01",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "include_private_incidents": true,
-              "include_retrospective_incidents": true,
-              "include_test_incidents": true,
               "managed_source_url": "https://github.com/my-company/incident-io-workflows",
               "name": "My workflow",
               "once_for": [
@@ -17935,6 +18438,10 @@
                 }
               ],
               "runs_from": "2021-08-17T13:28:57.801578Z",
+              "runs_on_incident_modes": [
+                "standard",
+                "retrospective"
+              ],
               "runs_on_incidents": "newly_created",
               "state": "active",
               "steps": [
@@ -21478,6 +21985,9 @@
         },
         "example": {
           "workflow": {
+            "annotations": {
+              "abc123": "abc123"
+            },
             "condition_groups": [
               {
                 "conditions": [
@@ -21490,39 +22000,15 @@
                       {
                         "array_value": [
                           {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         ],
                         "value": {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       }
                     ],
@@ -21545,39 +22031,15 @@
                   "result": {
                     "array_value": [
                       {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     ],
                     "value": {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   }
                 },
@@ -21600,39 +22062,15 @@
                                     {
                                       "array_value": [
                                         {
-                                          "catalog_entry": {
-                                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                            "catalog_entry_name": "Primary escalation",
-                                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                          },
-                                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                          "is_image_slack_icon": false,
                                           "label": "Lawrence Jones",
                                           "literal": "SEV123",
-                                          "reference": "incident.severity",
-                                          "sort_key": "000020",
-                                          "unavailable": false,
-                                          "value": "abc123"
+                                          "reference": "incident.severity"
                                         }
                                       ],
                                       "value": {
-                                        "catalog_entry": {
-                                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                          "catalog_entry_name": "Primary escalation",
-                                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                        },
-                                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                        "is_image_slack_icon": false,
                                         "label": "Lawrence Jones",
                                         "literal": "SEV123",
-                                        "reference": "incident.severity",
-                                        "sort_key": "000020",
-                                        "unavailable": false,
-                                        "value": "abc123"
+                                        "reference": "incident.severity"
                                       }
                                     }
                                   ],
@@ -21647,39 +22085,15 @@
                           "result": {
                             "array_value": [
                               {
-                                "catalog_entry": {
-                                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                  "catalog_entry_name": "Primary escalation",
-                                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                },
-                                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                "is_image_slack_icon": false,
                                 "label": "Lawrence Jones",
                                 "literal": "SEV123",
-                                "reference": "incident.severity",
-                                "sort_key": "000020",
-                                "unavailable": false,
-                                "value": "abc123"
+                                "reference": "incident.severity"
                               }
                             ],
                             "value": {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           }
                         }
@@ -21702,39 +22116,15 @@
                                 {
                                   "array_value": [
                                     {
-                                      "catalog_entry": {
-                                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                        "catalog_entry_name": "Primary escalation",
-                                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                      },
-                                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                      "is_image_slack_icon": false,
                                       "label": "Lawrence Jones",
                                       "literal": "SEV123",
-                                      "reference": "incident.severity",
-                                      "sort_key": "000020",
-                                      "unavailable": false,
-                                      "value": "abc123"
+                                      "reference": "incident.severity"
                                     }
                                   ],
                                   "value": {
-                                    "catalog_entry": {
-                                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                      "catalog_entry_name": "Primary escalation",
-                                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                    },
-                                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                    "is_image_slack_icon": false,
                                     "label": "Lawrence Jones",
                                     "literal": "SEV123",
-                                    "reference": "incident.severity",
-                                    "sort_key": "000020",
-                                    "unavailable": false,
-                                    "value": "abc123"
+                                    "reference": "incident.severity"
                                   }
                                 }
                               ],
@@ -21776,8 +22166,6 @@
             "folder": "My folder 01",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "include_private_incidents": true,
-            "include_retrospective_incidents": true,
-            "include_test_incidents": true,
             "managed_source_url": "https://github.com/my-company/incident-io-workflows",
             "name": "My workflow",
             "once_for": [
@@ -21789,6 +22177,10 @@
               }
             ],
             "runs_from": "2021-08-17T13:28:57.801578Z",
+            "runs_on_incident_modes": [
+              "standard",
+              "retrospective"
+            ],
             "runs_on_incidents": "newly_created",
             "state": "active",
             "steps": [
@@ -21801,39 +22193,15 @@
                   {
                     "array_value": [
                       {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     ],
                     "value": {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   }
                 ]
@@ -21876,46 +22244,22 @@
           "param_bindings": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV3"
+              "$ref": "#/components/schemas/EngineParamBindingV2"
             },
             "description": "Bindings for the step parameters",
             "example": [
               {
                 "array_value": [
                   {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                    "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "000020",
-                    "unavailable": false,
-                    "value": "abc123"
+                    "reference": "incident.severity"
                   }
                 ],
                 "value": {
-                  "catalog_entry": {
-                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "catalog_entry_name": "Primary escalation",
-                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                  },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                  "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "reference": "incident.severity",
-                  "sort_key": "000020",
-                  "unavailable": false,
-                  "value": "abc123"
+                  "reference": "incident.severity"
                 }
               }
             ]
@@ -21930,39 +22274,15 @@
             {
               "array_value": [
                 {
-                  "catalog_entry": {
-                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "catalog_entry_name": "Primary escalation",
-                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                  },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                  "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
-                  "reference": "incident.severity",
-                  "sort_key": "000020",
-                  "unavailable": false,
-                  "value": "abc123"
+                  "reference": "incident.severity"
                 }
               ],
               "value": {
-                "catalog_entry": {
-                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "catalog_entry_name": "Primary escalation",
-                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
-                "reference": "incident.severity",
-                "sort_key": "000020",
-                "unavailable": false,
-                "value": "abc123"
+                "reference": "incident.severity"
               }
             }
           ]
@@ -22640,9 +22960,20 @@
           "mode"
         ]
       },
-      "UpdateWorkflowPayload": {
+      "UpdateWorkflowRequestBody": {
         "type": "object",
         "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that track internal metadata about this workflow",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
           "condition_groups": {
             "type": "array",
             "items": {
@@ -22807,16 +23138,6 @@
             "description": "Whether to include private incidents",
             "example": true
           },
-          "include_retrospective_incidents": {
-            "type": "boolean",
-            "description": "Whether to include retrospective incidents",
-            "example": true
-          },
-          "include_test_incidents": {
-            "type": "boolean",
-            "description": "Whether to include test incidents",
-            "example": true
-          },
           "managed_source_url": {
             "type": "string",
             "description": "The url of the external repository where this workflow is managed",
@@ -22838,6 +23159,23 @@
               "incident.url"
             ]
           },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "test",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
           "runs_on_incidents": {
             "type": "string",
             "description": "Which incidents should the workflow be applied to?",
@@ -22854,7 +23192,6 @@
             "enum": [
               "active",
               "disabled",
-              "disabled_draft",
               "draft",
               "error"
             ]
@@ -22889,6 +23226,9 @@
           }
         },
         "example": {
+          "annotations": {
+            "abc123": "abc123"
+          },
           "condition_groups": [
             {
               "conditions": [
@@ -23028,12 +23368,14 @@
           ],
           "folder": "My folder 01",
           "include_private_incidents": true,
-          "include_retrospective_incidents": true,
-          "include_test_incidents": true,
           "managed_source_url": "https://github.com/my-company/incident-io-workflows",
           "name": "My workflow",
           "once_for": [
             "incident.url"
+          ],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
           ],
           "runs_on_incidents": "newly_created",
           "state": "active",
@@ -23064,208 +23406,11 @@
           "once_for",
           "condition_groups",
           "steps",
+          "expressions",
           "include_private_incidents",
-          "include_test_incidents",
-          "include_retrospective_incidents",
+          "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents"
-        ]
-      },
-      "UpdateWorkflowRequestBody": {
-        "type": "object",
-        "properties": {
-          "workflow": {
-            "$ref": "#/components/schemas/UpdateWorkflowPayload"
-          }
-        },
-        "example": {
-          "workflow": {
-            "condition_groups": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ],
-            "continue_on_step_error": true,
-            "delay": {
-              "conditions_apply_over_delay": false,
-              "for_seconds": 60
-            },
-            "expressions": [
-              {
-                "else_branch": {
-                  "result": {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                },
-                "label": "Team Slack channel",
-                "operations": [
-                  {
-                    "branches": {
-                      "branches": [
-                        {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": "one_of",
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": "incident.severity"
-                                }
-                              ]
-                            }
-                          ],
-                          "result": {
-                            "array_value": [
-                              {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        }
-                      ],
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    },
-                    "filter": {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": "one_of",
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": "incident.severity"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "navigate": {
-                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                    },
-                    "operation_type": "navigate",
-                    "parse": {
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      },
-                      "source": "metadata.annotations[\"github.com/repo\"]"
-                    }
-                  }
-                ],
-                "reference": "abc123",
-                "root_reference": "incident.status"
-              }
-            ],
-            "folder": "My folder 01",
-            "include_private_incidents": true,
-            "include_retrospective_incidents": true,
-            "include_test_incidents": true,
-            "managed_source_url": "https://github.com/my-company/incident-io-workflows",
-            "name": "My workflow",
-            "once_for": [
-              "incident.url"
-            ],
-            "runs_on_incidents": "newly_created",
-            "state": "active",
-            "steps": [
-              {
-                "for_each": "abc123",
-                "id": "abc123",
-                "name": "pagerduty.escalate",
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        "required": [
-          "workflow",
-          "name",
-          "trigger",
-          "version",
-          "expressions",
-          "condition_groups",
-          "steps",
-          "include_private_incidents",
-          "include_test_incidents",
-          "include_retrospective_incidents",
-          "continue_on_step_error",
-          "runs_on_incidents",
-          "once_for",
-          "state"
         ]
       },
       "UserReferencePayloadV1": {
@@ -23563,6 +23708,17 @@
       "Workflow": {
         "type": "object",
         "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that track internal metadata about this workflow",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
           "condition_groups": {
             "type": "array",
             "items": {
@@ -23581,39 +23737,15 @@
                       {
                         "array_value": [
                           {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         ],
                         "value": {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       }
                     ],
@@ -23646,39 +23778,15 @@
                   "result": {
                     "array_value": [
                       {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     ],
                     "value": {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   }
                 },
@@ -23701,39 +23809,15 @@
                                     {
                                       "array_value": [
                                         {
-                                          "catalog_entry": {
-                                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                            "catalog_entry_name": "Primary escalation",
-                                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                          },
-                                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                          "is_image_slack_icon": false,
                                           "label": "Lawrence Jones",
                                           "literal": "SEV123",
-                                          "reference": "incident.severity",
-                                          "sort_key": "000020",
-                                          "unavailable": false,
-                                          "value": "abc123"
+                                          "reference": "incident.severity"
                                         }
                                       ],
                                       "value": {
-                                        "catalog_entry": {
-                                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                          "catalog_entry_name": "Primary escalation",
-                                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                        },
-                                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                        "is_image_slack_icon": false,
                                         "label": "Lawrence Jones",
                                         "literal": "SEV123",
-                                        "reference": "incident.severity",
-                                        "sort_key": "000020",
-                                        "unavailable": false,
-                                        "value": "abc123"
+                                        "reference": "incident.severity"
                                       }
                                     }
                                   ],
@@ -23748,39 +23832,15 @@
                           "result": {
                             "array_value": [
                               {
-                                "catalog_entry": {
-                                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                  "catalog_entry_name": "Primary escalation",
-                                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                },
-                                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                "is_image_slack_icon": false,
                                 "label": "Lawrence Jones",
                                 "literal": "SEV123",
-                                "reference": "incident.severity",
-                                "sort_key": "000020",
-                                "unavailable": false,
-                                "value": "abc123"
+                                "reference": "incident.severity"
                               }
                             ],
                             "value": {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           }
                         }
@@ -23803,39 +23863,15 @@
                                 {
                                   "array_value": [
                                     {
-                                      "catalog_entry": {
-                                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                        "catalog_entry_name": "Primary escalation",
-                                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                      },
-                                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                      "is_image_slack_icon": false,
                                       "label": "Lawrence Jones",
                                       "literal": "SEV123",
-                                      "reference": "incident.severity",
-                                      "sort_key": "000020",
-                                      "unavailable": false,
-                                      "value": "abc123"
+                                      "reference": "incident.severity"
                                     }
                                   ],
                                   "value": {
-                                    "catalog_entry": {
-                                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                      "catalog_entry_name": "Primary escalation",
-                                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                    },
-                                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                    "is_image_slack_icon": false,
                                     "label": "Lawrence Jones",
                                     "literal": "SEV123",
-                                    "reference": "incident.severity",
-                                    "sort_key": "000020",
-                                    "unavailable": false,
-                                    "value": "abc123"
+                                    "reference": "incident.severity"
                                   }
                                 }
                               ],
@@ -23890,16 +23926,6 @@
             "description": "Whether to include private incidents",
             "example": true
           },
-          "include_retrospective_incidents": {
-            "type": "boolean",
-            "description": "Whether to include retrospective incidents",
-            "example": true
-          },
-          "include_test_incidents": {
-            "type": "boolean",
-            "description": "Whether to include test incidents",
-            "example": true
-          },
           "managed_source_url": {
             "type": "string",
             "description": "The url of the external repository where this workflow is managed",
@@ -23931,6 +23957,23 @@
             "example": "2021-08-17T13:28:57.801578Z",
             "format": "date-time"
           },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "test",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
           "runs_on_incidents": {
             "type": "string",
             "description": "Which incidents should the workflow be applied to?",
@@ -23947,7 +23990,6 @@
             "enum": [
               "active",
               "disabled",
-              "disabled_draft",
               "draft",
               "error"
             ]
@@ -23968,39 +24010,15 @@
                   {
                     "array_value": [
                       {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     ],
                     "value": {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   }
                 ]
@@ -24018,6 +24036,9 @@
           }
         },
         "example": {
+          "annotations": {
+            "abc123": "abc123"
+          },
           "condition_groups": [
             {
               "conditions": [
@@ -24030,39 +24051,15 @@
                     {
                       "array_value": [
                         {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       ],
                       "value": {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     }
                   ],
@@ -24085,39 +24082,15 @@
                 "result": {
                   "array_value": [
                     {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   ],
                   "value": {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                    "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "000020",
-                    "unavailable": false,
-                    "value": "abc123"
+                    "reference": "incident.severity"
                   }
                 }
               },
@@ -24140,39 +24113,15 @@
                                   {
                                     "array_value": [
                                       {
-                                        "catalog_entry": {
-                                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                          "catalog_entry_name": "Primary escalation",
-                                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                        },
-                                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                        "is_image_slack_icon": false,
                                         "label": "Lawrence Jones",
                                         "literal": "SEV123",
-                                        "reference": "incident.severity",
-                                        "sort_key": "000020",
-                                        "unavailable": false,
-                                        "value": "abc123"
+                                        "reference": "incident.severity"
                                       }
                                     ],
                                     "value": {
-                                      "catalog_entry": {
-                                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                        "catalog_entry_name": "Primary escalation",
-                                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                      },
-                                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                      "is_image_slack_icon": false,
                                       "label": "Lawrence Jones",
                                       "literal": "SEV123",
-                                      "reference": "incident.severity",
-                                      "sort_key": "000020",
-                                      "unavailable": false,
-                                      "value": "abc123"
+                                      "reference": "incident.severity"
                                     }
                                   }
                                 ],
@@ -24187,39 +24136,15 @@
                         "result": {
                           "array_value": [
                             {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           ],
                           "value": {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         }
                       }
@@ -24242,39 +24167,15 @@
                               {
                                 "array_value": [
                                   {
-                                    "catalog_entry": {
-                                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                      "catalog_entry_name": "Primary escalation",
-                                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                    },
-                                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                    "is_image_slack_icon": false,
                                     "label": "Lawrence Jones",
                                     "literal": "SEV123",
-                                    "reference": "incident.severity",
-                                    "sort_key": "000020",
-                                    "unavailable": false,
-                                    "value": "abc123"
+                                    "reference": "incident.severity"
                                   }
                                 ],
                                 "value": {
-                                  "catalog_entry": {
-                                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                    "catalog_entry_name": "Primary escalation",
-                                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                  },
-                                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                  "is_image_slack_icon": false,
                                   "label": "Lawrence Jones",
                                   "literal": "SEV123",
-                                  "reference": "incident.severity",
-                                  "sort_key": "000020",
-                                  "unavailable": false,
-                                  "value": "abc123"
+                                  "reference": "incident.severity"
                                 }
                               }
                             ],
@@ -24316,8 +24217,6 @@
           "folder": "My folder 01",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "include_private_incidents": true,
-          "include_retrospective_incidents": true,
-          "include_test_incidents": true,
           "managed_source_url": "https://github.com/my-company/incident-io-workflows",
           "name": "My workflow",
           "once_for": [
@@ -24329,6 +24228,10 @@
             }
           ],
           "runs_from": "2021-08-17T13:28:57.801578Z",
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
           "runs_on_incidents": "newly_created",
           "state": "active",
           "steps": [
@@ -24341,39 +24244,15 @@
                 {
                   "array_value": [
                     {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   ],
                   "value": {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                    "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "000020",
-                    "unavailable": false,
-                    "value": "abc123"
+                    "reference": "incident.severity"
                   }
                 }
               ]
@@ -24394,8 +24273,7 @@
           "condition_groups",
           "steps",
           "include_private_incidents",
-          "include_test_incidents",
-          "include_retrospective_incidents",
+          "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents",
           "once_for",
@@ -24447,39 +24325,15 @@
                       {
                         "array_value": [
                           {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         ],
                         "value": {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       }
                     ],
@@ -24512,39 +24366,15 @@
                   "result": {
                     "array_value": [
                       {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     ],
                     "value": {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   }
                 },
@@ -24567,39 +24397,15 @@
                                     {
                                       "array_value": [
                                         {
-                                          "catalog_entry": {
-                                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                            "catalog_entry_name": "Primary escalation",
-                                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                          },
-                                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                          "is_image_slack_icon": false,
                                           "label": "Lawrence Jones",
                                           "literal": "SEV123",
-                                          "reference": "incident.severity",
-                                          "sort_key": "000020",
-                                          "unavailable": false,
-                                          "value": "abc123"
+                                          "reference": "incident.severity"
                                         }
                                       ],
                                       "value": {
-                                        "catalog_entry": {
-                                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                          "catalog_entry_name": "Primary escalation",
-                                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                        },
-                                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                        "is_image_slack_icon": false,
                                         "label": "Lawrence Jones",
                                         "literal": "SEV123",
-                                        "reference": "incident.severity",
-                                        "sort_key": "000020",
-                                        "unavailable": false,
-                                        "value": "abc123"
+                                        "reference": "incident.severity"
                                       }
                                     }
                                   ],
@@ -24614,39 +24420,15 @@
                           "result": {
                             "array_value": [
                               {
-                                "catalog_entry": {
-                                  "archived_at": "2021-08-17T14:28:57.801578Z",
-                                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                  "catalog_entry_name": "Primary escalation",
-                                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                },
-                                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                "is_image_slack_icon": false,
                                 "label": "Lawrence Jones",
                                 "literal": "SEV123",
-                                "reference": "incident.severity",
-                                "sort_key": "000020",
-                                "unavailable": false,
-                                "value": "abc123"
+                                "reference": "incident.severity"
                               }
                             ],
                             "value": {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           }
                         }
@@ -24669,39 +24451,15 @@
                                 {
                                   "array_value": [
                                     {
-                                      "catalog_entry": {
-                                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                        "catalog_entry_name": "Primary escalation",
-                                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                      },
-                                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                      "is_image_slack_icon": false,
                                       "label": "Lawrence Jones",
                                       "literal": "SEV123",
-                                      "reference": "incident.severity",
-                                      "sort_key": "000020",
-                                      "unavailable": false,
-                                      "value": "abc123"
+                                      "reference": "incident.severity"
                                     }
                                   ],
                                   "value": {
-                                    "catalog_entry": {
-                                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                      "catalog_entry_name": "Primary escalation",
-                                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                    },
-                                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                    "is_image_slack_icon": false,
                                     "label": "Lawrence Jones",
                                     "literal": "SEV123",
-                                    "reference": "incident.severity",
-                                    "sort_key": "000020",
-                                    "unavailable": false,
-                                    "value": "abc123"
+                                    "reference": "incident.severity"
                                   }
                                 }
                               ],
@@ -24756,16 +24514,6 @@
             "description": "Whether to include private incidents",
             "example": true
           },
-          "include_retrospective_incidents": {
-            "type": "boolean",
-            "description": "Whether to include retrospective incidents",
-            "example": true
-          },
-          "include_test_incidents": {
-            "type": "boolean",
-            "description": "Whether to include test incidents",
-            "example": true
-          },
           "managed_source_url": {
             "type": "string",
             "description": "The url of the external repository where this workflow is managed",
@@ -24797,6 +24545,23 @@
             "example": "2021-08-17T13:28:57.801578Z",
             "format": "date-time"
           },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "test",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
           "runs_on_incidents": {
             "type": "string",
             "description": "Which incidents should the workflow be applied to?",
@@ -24813,7 +24578,6 @@
             "enum": [
               "active",
               "disabled",
-              "disabled_draft",
               "draft",
               "error"
             ]
@@ -24854,39 +24618,15 @@
                     {
                       "array_value": [
                         {
-                          "catalog_entry": {
-                            "archived_at": "2021-08-17T14:28:57.801578Z",
-                            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                            "catalog_entry_name": "Primary escalation",
-                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                          },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                          "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
-                          "reference": "incident.severity",
-                          "sort_key": "000020",
-                          "unavailable": false,
-                          "value": "abc123"
+                          "reference": "incident.severity"
                         }
                       ],
                       "value": {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                        "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "000020",
-                        "unavailable": false,
-                        "value": "abc123"
+                        "reference": "incident.severity"
                       }
                     }
                   ],
@@ -24909,39 +24649,15 @@
                 "result": {
                   "array_value": [
                     {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                      "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "000020",
-                      "unavailable": false,
-                      "value": "abc123"
+                      "reference": "incident.severity"
                     }
                   ],
                   "value": {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                    "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "000020",
-                    "unavailable": false,
-                    "value": "abc123"
+                    "reference": "incident.severity"
                   }
                 }
               },
@@ -24964,39 +24680,15 @@
                                   {
                                     "array_value": [
                                       {
-                                        "catalog_entry": {
-                                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                          "catalog_entry_name": "Primary escalation",
-                                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                        },
-                                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                        "is_image_slack_icon": false,
                                         "label": "Lawrence Jones",
                                         "literal": "SEV123",
-                                        "reference": "incident.severity",
-                                        "sort_key": "000020",
-                                        "unavailable": false,
-                                        "value": "abc123"
+                                        "reference": "incident.severity"
                                       }
                                     ],
                                     "value": {
-                                      "catalog_entry": {
-                                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                        "catalog_entry_name": "Primary escalation",
-                                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                      },
-                                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                      "is_image_slack_icon": false,
                                       "label": "Lawrence Jones",
                                       "literal": "SEV123",
-                                      "reference": "incident.severity",
-                                      "sort_key": "000020",
-                                      "unavailable": false,
-                                      "value": "abc123"
+                                      "reference": "incident.severity"
                                     }
                                   }
                                 ],
@@ -25011,39 +24703,15 @@
                         "result": {
                           "array_value": [
                             {
-                              "catalog_entry": {
-                                "archived_at": "2021-08-17T14:28:57.801578Z",
-                                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                "catalog_entry_name": "Primary escalation",
-                                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                              },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                              "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
-                              "reference": "incident.severity",
-                              "sort_key": "000020",
-                              "unavailable": false,
-                              "value": "abc123"
+                              "reference": "incident.severity"
                             }
                           ],
                           "value": {
-                            "catalog_entry": {
-                              "archived_at": "2021-08-17T14:28:57.801578Z",
-                              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                              "catalog_entry_name": "Primary escalation",
-                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                            },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                            "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
-                            "reference": "incident.severity",
-                            "sort_key": "000020",
-                            "unavailable": false,
-                            "value": "abc123"
+                            "reference": "incident.severity"
                           }
                         }
                       }
@@ -25066,39 +24734,15 @@
                               {
                                 "array_value": [
                                   {
-                                    "catalog_entry": {
-                                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                      "catalog_entry_name": "Primary escalation",
-                                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                    },
-                                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                    "is_image_slack_icon": false,
                                     "label": "Lawrence Jones",
                                     "literal": "SEV123",
-                                    "reference": "incident.severity",
-                                    "sort_key": "000020",
-                                    "unavailable": false,
-                                    "value": "abc123"
+                                    "reference": "incident.severity"
                                   }
                                 ],
                                 "value": {
-                                  "catalog_entry": {
-                                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                                    "catalog_entry_name": "Primary escalation",
-                                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                                  },
-                                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
-                                  "is_image_slack_icon": false,
                                   "label": "Lawrence Jones",
                                   "literal": "SEV123",
-                                  "reference": "incident.severity",
-                                  "sort_key": "000020",
-                                  "unavailable": false,
-                                  "value": "abc123"
+                                  "reference": "incident.severity"
                                 }
                               }
                             ],
@@ -25140,8 +24784,6 @@
           "folder": "My folder 01",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "include_private_incidents": true,
-          "include_retrospective_incidents": true,
-          "include_test_incidents": true,
           "managed_source_url": "https://github.com/my-company/incident-io-workflows",
           "name": "My workflow",
           "once_for": [
@@ -25153,6 +24795,10 @@
             }
           ],
           "runs_from": "2021-08-17T13:28:57.801578Z",
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
           "runs_on_incidents": "newly_created",
           "state": "active",
           "steps": [
@@ -25176,8 +24822,7 @@
           "condition_groups",
           "steps",
           "include_private_incidents",
-          "include_test_incidents",
-          "include_retrospective_incidents",
+          "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents",
           "once_for",
@@ -25278,6 +24923,10 @@
     {
       "name": "Webhooks",
       "description": "Webhooks can be used to receive notifications when certain events occur in incident.io. This might be useful for annotating graphs in a monitoring tool with incidents, or keeping track of follow-ups in another system. Our webhooks are powered by <a href=\"https://svix.com\" target=\"_blank\">Svix</a>.\n\n## Getting started with webhooks\n\nTo start using webhooks, you’ll need to create a webhook endpoint. You can do this in the same way that you’d create any other endpoint in your application. If you’d like to play around with our webhooks, we’d recommend using <a href=\"https://www.svix.com/play/\" target=\"_blank\">Svix play</a> which allows you to set up an endpoint and inspect the payloads via their web interface. There are also other services (e.g. <a href=\"https://ngrok.com/\" target=\"_blank\">ngrok</a>) which have great debugging tools to help getting started with webhooks.\n\nOnce you have a webhook endpoint set up, you can head to <a href=\"https://app.incident.io/settings/webhooks\" target=\"_blank\">Settings > Webhooks</a> to configure your endpoint. In here you'll be able to choose which types of events you'd like to recieve, send test events, see recent event deliveries, and retry any failed events.\n\n## Status codes, errors and retries\n\nWhen processing webhooks, please return a 2xx status code (e.g. `200 OK` or `204 No Content`). If the endpoint returns a non-2xx status code, we’ll try to resend the event with a backoff over the next 24 hours. If attempts to a specific endpoint repeatedly fail over a 5 day period, we’ll mark the endpoint as disabled and notify you via email. If you do miss some messages (e.g. due to unexpected downtime), Svix offer a number of options for [replaying messages](https://docs.svix.com/receiving/using-app-portal/replaying-messages) which you can access via <a href=\"https://app.incident.io/settings/webhooks\" target=\"_blank\">Settings > Webhooks</a>.\n\n## Verifying webhooks\n\nIt’s important to know whether a webhook has come from incident.io, or a third party that might be trying to exploit a vulnerability. To avoid this, we send a `signature` in the header of our webhooks, which you can verify using the `Signing secret` from the webhook endpoint settings page. The webhooks we send will have three headers that you’ll want to look at:\n\n```json\n{\n  \"webhook-id\": \"123\",\n  \"webhook-timestamp\": 1676033031,\n  \"webhook-signature\": \"v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE=\"\n}\n```\n\nThese are signed using a HMAC signature in the following format:\n\n```\n${webhook-id}.${webhook-timestamp}.${request_body}\n```\n\nYou can verify the signature either using the <a href=\"https://docs.svix.com/receiving/verifying-payloads/how\" target=\"_blank\">Svix client libraries</a>, or manually by following <a href=\"https://docs.svix.com/receiving/verifying-payloads/how-manual\" target=\"_blank\">these instructions</a>.\n\n## Keeping another system in-line with incident.io\n\nA common use-case for webhooks is to keep another system up-to-date with everything that’s happening in incident.io. As we deliver webhooks individually over HTTPS, we cannot guarantee that they’ll be delivered in the correct order. That means that, to keep the other system up-to-date, we’d recommend that you build an application which:\n\n- Receives a webhook about INC-123\n- Makes a request to our public API to get the latest state of INC-123\n- Save that state to your system\n\nThis means you aren’t relying on the order in which you receive webhooks to make sure your system remains up-to-date.\n\n## Webhooks on private incidents\n\nIn general, we try to send webhooks with all the relevant information in the payload (e.g. the name, summary, status etc.). However, private incidents are the exception. For private incidents, we only send the ID of the resource that’s been changed. If your integration needs to access the full data, you’ll need to <a href=\"https://help.incident.io/en/articles/6149651-our-api\" target=\"_blank\">create an API Key</a> that can view private incidents. You can then use that key to get the details about the specific incident or follow-up. This is to make sure we don’t leak information about private incidents to a system that shouldn’t have access to them.\n"
+    },
+    {
+      "name": "Workflows V2",
+      "description": "A draft version of the public API for workflows."
     },
     {
       "name": "Audit logs",

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -251,6 +251,27 @@ const (
 	CreateTypeRequestBodyIconUsers      CreateTypeRequestBodyIcon = "users"
 )
 
+// Defines values for CreateWorkflowRequestBodyRunsOnIncidentModes.
+const (
+	CreateWorkflowRequestBodyRunsOnIncidentModesRetrospective CreateWorkflowRequestBodyRunsOnIncidentModes = "retrospective"
+	CreateWorkflowRequestBodyRunsOnIncidentModesStandard      CreateWorkflowRequestBodyRunsOnIncidentModes = "standard"
+	CreateWorkflowRequestBodyRunsOnIncidentModesTest          CreateWorkflowRequestBodyRunsOnIncidentModes = "test"
+)
+
+// Defines values for CreateWorkflowRequestBodyRunsOnIncidents.
+const (
+	CreateWorkflowRequestBodyRunsOnIncidentsNewlyCreated          CreateWorkflowRequestBodyRunsOnIncidents = "newly_created"
+	CreateWorkflowRequestBodyRunsOnIncidentsNewlyCreatedAndActive CreateWorkflowRequestBodyRunsOnIncidents = "newly_created_and_active"
+)
+
+// Defines values for CreateWorkflowRequestBodyState.
+const (
+	CreateWorkflowRequestBodyStateActive   CreateWorkflowRequestBodyState = "active"
+	CreateWorkflowRequestBodyStateDisabled CreateWorkflowRequestBodyState = "disabled"
+	CreateWorkflowRequestBodyStateDraft    CreateWorkflowRequestBodyState = "draft"
+	CreateWorkflowRequestBodyStateError    CreateWorkflowRequestBodyState = "error"
+)
+
 // Defines values for CustomFieldTypeInfoV1FieldType.
 const (
 	CustomFieldTypeInfoV1FieldTypeLink         CustomFieldTypeInfoV1FieldType = "link"
@@ -290,6 +311,32 @@ const (
 	Numeric      CustomFieldV2FieldType = "numeric"
 	SingleSelect CustomFieldV2FieldType = "single_select"
 	Text         CustomFieldV2FieldType = "text"
+)
+
+// Defines values for ExpressionOperationPayloadV2OperationType.
+const (
+	ExpressionOperationPayloadV2OperationTypeBranches ExpressionOperationPayloadV2OperationType = "branches"
+	ExpressionOperationPayloadV2OperationTypeCount    ExpressionOperationPayloadV2OperationType = "count"
+	ExpressionOperationPayloadV2OperationTypeFilter   ExpressionOperationPayloadV2OperationType = "filter"
+	ExpressionOperationPayloadV2OperationTypeFirst    ExpressionOperationPayloadV2OperationType = "first"
+	ExpressionOperationPayloadV2OperationTypeMax      ExpressionOperationPayloadV2OperationType = "max"
+	ExpressionOperationPayloadV2OperationTypeMin      ExpressionOperationPayloadV2OperationType = "min"
+	ExpressionOperationPayloadV2OperationTypeNavigate ExpressionOperationPayloadV2OperationType = "navigate"
+	ExpressionOperationPayloadV2OperationTypeParse    ExpressionOperationPayloadV2OperationType = "parse"
+	ExpressionOperationPayloadV2OperationTypeRandom   ExpressionOperationPayloadV2OperationType = "random"
+)
+
+// Defines values for ExpressionOperationV2OperationType.
+const (
+	ExpressionOperationV2OperationTypeBranches ExpressionOperationV2OperationType = "branches"
+	ExpressionOperationV2OperationTypeCount    ExpressionOperationV2OperationType = "count"
+	ExpressionOperationV2OperationTypeFilter   ExpressionOperationV2OperationType = "filter"
+	ExpressionOperationV2OperationTypeFirst    ExpressionOperationV2OperationType = "first"
+	ExpressionOperationV2OperationTypeMax      ExpressionOperationV2OperationType = "max"
+	ExpressionOperationV2OperationTypeMin      ExpressionOperationV2OperationType = "min"
+	ExpressionOperationV2OperationTypeNavigate ExpressionOperationV2OperationType = "navigate"
+	ExpressionOperationV2OperationTypeParse    ExpressionOperationV2OperationType = "parse"
+	ExpressionOperationV2OperationTypeRandom   ExpressionOperationV2OperationType = "random"
 )
 
 // Defines values for ExternalIssueReferenceV1Provider.
@@ -507,6 +554,27 @@ const (
 	Users      UpdateTypeRequestBodyIcon = "users"
 )
 
+// Defines values for UpdateWorkflowRequestBodyRunsOnIncidentModes.
+const (
+	UpdateWorkflowRequestBodyRunsOnIncidentModesRetrospective UpdateWorkflowRequestBodyRunsOnIncidentModes = "retrospective"
+	UpdateWorkflowRequestBodyRunsOnIncidentModesStandard      UpdateWorkflowRequestBodyRunsOnIncidentModes = "standard"
+	UpdateWorkflowRequestBodyRunsOnIncidentModesTest          UpdateWorkflowRequestBodyRunsOnIncidentModes = "test"
+)
+
+// Defines values for UpdateWorkflowRequestBodyRunsOnIncidents.
+const (
+	UpdateWorkflowRequestBodyRunsOnIncidentsNewlyCreated          UpdateWorkflowRequestBodyRunsOnIncidents = "newly_created"
+	UpdateWorkflowRequestBodyRunsOnIncidentsNewlyCreatedAndActive UpdateWorkflowRequestBodyRunsOnIncidents = "newly_created_and_active"
+)
+
+// Defines values for UpdateWorkflowRequestBodyState.
+const (
+	UpdateWorkflowRequestBodyStateActive   UpdateWorkflowRequestBodyState = "active"
+	UpdateWorkflowRequestBodyStateDisabled UpdateWorkflowRequestBodyState = "disabled"
+	UpdateWorkflowRequestBodyStateDraft    UpdateWorkflowRequestBodyState = "draft"
+	UpdateWorkflowRequestBodyStateError    UpdateWorkflowRequestBodyState = "error"
+)
+
 // Defines values for UserV1Role.
 const (
 	UserV1RoleAdministrator UserV1Role = "administrator"
@@ -523,6 +591,48 @@ const (
 	Responder     UserWithRolesV2Role = "responder"
 	Unset         UserWithRolesV2Role = "unset"
 	Viewer        UserWithRolesV2Role = "viewer"
+)
+
+// Defines values for WorkflowRunsOnIncidentModes.
+const (
+	WorkflowRunsOnIncidentModesRetrospective WorkflowRunsOnIncidentModes = "retrospective"
+	WorkflowRunsOnIncidentModesStandard      WorkflowRunsOnIncidentModes = "standard"
+	WorkflowRunsOnIncidentModesTest          WorkflowRunsOnIncidentModes = "test"
+)
+
+// Defines values for WorkflowRunsOnIncidents.
+const (
+	WorkflowRunsOnIncidentsNewlyCreated          WorkflowRunsOnIncidents = "newly_created"
+	WorkflowRunsOnIncidentsNewlyCreatedAndActive WorkflowRunsOnIncidents = "newly_created_and_active"
+)
+
+// Defines values for WorkflowState.
+const (
+	WorkflowStateActive   WorkflowState = "active"
+	WorkflowStateDisabled WorkflowState = "disabled"
+	WorkflowStateDraft    WorkflowState = "draft"
+	WorkflowStateError    WorkflowState = "error"
+)
+
+// Defines values for WorkflowSlimRunsOnIncidentModes.
+const (
+	WorkflowSlimRunsOnIncidentModesRetrospective WorkflowSlimRunsOnIncidentModes = "retrospective"
+	WorkflowSlimRunsOnIncidentModesStandard      WorkflowSlimRunsOnIncidentModes = "standard"
+	WorkflowSlimRunsOnIncidentModesTest          WorkflowSlimRunsOnIncidentModes = "test"
+)
+
+// Defines values for WorkflowSlimRunsOnIncidents.
+const (
+	WorkflowSlimRunsOnIncidentsNewlyCreated          WorkflowSlimRunsOnIncidents = "newly_created"
+	WorkflowSlimRunsOnIncidentsNewlyCreatedAndActive WorkflowSlimRunsOnIncidents = "newly_created_and_active"
+)
+
+// Defines values for WorkflowSlimState.
+const (
+	WorkflowSlimStateActive   WorkflowSlimState = "active"
+	WorkflowSlimStateDisabled WorkflowSlimState = "disabled"
+	WorkflowSlimStateDraft    WorkflowSlimState = "draft"
+	WorkflowSlimStateError    WorkflowSlimState = "error"
 )
 
 // Defines values for ActionsV1ListParamsIncidentMode.
@@ -650,6 +760,45 @@ type AfterPaginationMetaResultV2 struct {
 	AfterUrl string `json:"after_url"`
 }
 
+// CatalogEntryEngineParamBindingV2 defines model for CatalogEntryEngineParamBindingV2.
+type CatalogEntryEngineParamBindingV2 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]CatalogEntryEngineParamBindingValueV2 `json:"array_value,omitempty"`
+	Value      *CatalogEntryEngineParamBindingValueV2   `json:"value,omitempty"`
+}
+
+// CatalogEntryEngineParamBindingValueV2 defines model for CatalogEntryEngineParamBindingValueV2.
+type CatalogEntryEngineParamBindingValueV2 struct {
+	CatalogEntry *CatalogEntryReferenceV2 `json:"catalog_entry,omitempty"`
+
+	// Helptext Gives a description of the option to the user
+	Helptext *string `json:"helptext,omitempty"`
+
+	// ImageUrl If appropriate, URL to an image that can be displayed alongside the option
+	ImageUrl *string `json:"image_url,omitempty"`
+
+	// IsImageSlackIcon If true, the image_url is a Slack icon and should be displayed as such
+	IsImageSlackIcon *bool `json:"is_image_slack_icon,omitempty"`
+
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+
+	// SortKey Gives an indication of how to sort the options when displayed to the user
+	SortKey string `json:"sort_key"`
+
+	// Unavailable Unavailable is true if we've failed to build the value for this binding
+	Unavailable *bool `json:"unavailable,omitempty"`
+
+	// Value Either the reference or the literal: this field is designed purely to make working with react-select easier
+	Value *string `json:"value,omitempty"`
+}
+
 // CatalogEntryReferenceV2 defines model for CatalogEntryReferenceV2.
 type CatalogEntryReferenceV2 struct {
 	// ArchivedAt When this entry was archived
@@ -674,7 +823,7 @@ type CatalogEntryV2 struct {
 	ArchivedAt *time.Time `json:"archived_at,omitempty"`
 
 	// AttributeValues Values of this entry
-	AttributeValues map[string]EngineParamBindingV2 `json:"attribute_values"`
+	AttributeValues map[string]CatalogEntryEngineParamBindingV2 `json:"attribute_values"`
 
 	// CatalogTypeId ID of this catalog type
 	CatalogTypeId string `json:"catalog_type_id"`
@@ -839,6 +988,57 @@ type CatalogTypeV2Color string
 
 // CatalogTypeV2Icon Sets the display icon of this type in the dashboard
 type CatalogTypeV2Icon string
+
+// ConditionGroupPayloadV2 defines model for ConditionGroupPayloadV2.
+type ConditionGroupPayloadV2 struct {
+	// Conditions List of conditions that should be AND-ed together
+	Conditions []ConditionPayloadV2 `json:"conditions"`
+}
+
+// ConditionGroupV2 defines model for ConditionGroupV2.
+type ConditionGroupV2 struct {
+	// Conditions List of conditions that should be AND-ed together
+	Conditions []ConditionV2 `json:"conditions"`
+}
+
+// ConditionOperationV2 defines model for ConditionOperationV2.
+type ConditionOperationV2 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Value Unique identifier for this option
+	Value string `json:"value"`
+}
+
+// ConditionPayloadV2 defines model for ConditionPayloadV2.
+type ConditionPayloadV2 struct {
+	// Operation The name of the operation on the subject
+	Operation string `json:"operation"`
+
+	// ParamBindings List of parameter bindings
+	ParamBindings []EngineParamBindingPayloadV2 `json:"param_bindings"`
+
+	// Subject The reference of the subject in the trigger scope
+	Subject string `json:"subject"`
+}
+
+// ConditionSubjectV2 defines model for ConditionSubjectV2.
+type ConditionSubjectV2 struct {
+	// Label Human readable identifier for the subject
+	Label string `json:"label"`
+
+	// Reference Reference into the scope for the value of the subject
+	Reference string `json:"reference"`
+}
+
+// ConditionV2 defines model for ConditionV2.
+type ConditionV2 struct {
+	Operation ConditionOperationV2 `json:"operation"`
+
+	// ParamBindings Bindings for the operation parameters
+	ParamBindings []EngineParamBindingV2 `json:"param_bindings"`
+	Subject       ConditionSubjectV2     `json:"subject"`
+}
 
 // CreateEntryRequestBody defines model for CreateEntryRequestBody.
 type CreateEntryRequestBody struct {
@@ -1215,6 +1415,61 @@ type CreateTypeResponseBody struct {
 	CatalogType CatalogTypeV2 `json:"catalog_type"`
 }
 
+// CreateWorkflowRequestBody defines model for CreateWorkflowRequestBody.
+type CreateWorkflowRequestBody struct {
+	// Annotations Annotations that track internal metadata about this workflow
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// ConditionGroups List of conditions to apply to the workflow
+	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
+
+	// ContinueOnStepError Whether to continue executing the workflow if a step fails
+	ContinueOnStepError bool           `json:"continue_on_step_error"`
+	Delay               *WorkflowDelay `json:"delay,omitempty"`
+
+	// Expressions The expressions used in the workflow
+	Expressions []ExpressionPayloadV2 `json:"expressions"`
+
+	// Folder Folder to display the workflow in
+	Folder *string `json:"folder,omitempty"`
+
+	// IncludePrivateIncidents Whether to include private incidents
+	IncludePrivateIncidents bool `json:"include_private_incidents"`
+
+	// ManagedSourceUrl The url of the external repository where this workflow is managed
+	ManagedSourceUrl *string `json:"managed_source_url,omitempty"`
+
+	// Name The human-readable name of the workflow
+	Name string `json:"name"`
+
+	// OnceFor Once For strategy to apply to this workflow
+	OnceFor []string `json:"once_for"`
+
+	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
+	RunsOnIncidentModes []CreateWorkflowRequestBodyRunsOnIncidentModes `json:"runs_on_incident_modes"`
+
+	// RunsOnIncidents Which incidents should the workflow be applied to?
+	RunsOnIncidents CreateWorkflowRequestBodyRunsOnIncidents `json:"runs_on_incidents"`
+
+	// State The state of the workflow (e.g. is it draft, or disabled)
+	State *CreateWorkflowRequestBodyState `json:"state,omitempty"`
+
+	// Steps List of step to execute as part of the workflow
+	Steps []StepConfigPayload `json:"steps"`
+
+	// Trigger Trigger to set on the workflow
+	Trigger string `json:"trigger"`
+}
+
+// CreateWorkflowRequestBodyRunsOnIncidentModes defines model for CreateWorkflowRequestBody.RunsOnIncidentModes.
+type CreateWorkflowRequestBodyRunsOnIncidentModes string
+
+// CreateWorkflowRequestBodyRunsOnIncidents Which incidents should the workflow be applied to?
+type CreateWorkflowRequestBodyRunsOnIncidents string
+
+// CreateWorkflowRequestBodyState The state of the workflow (e.g. is it draft, or disabled)
+type CreateWorkflowRequestBodyState string
+
 // CustomFieldEntryPayloadV1 defines model for CustomFieldEntryPayloadV1.
 type CustomFieldEntryPayloadV1 struct {
 	// CustomFieldId ID of the custom field this entry is linked against
@@ -1436,17 +1691,6 @@ type EngineParamBindingValuePayloadV2 struct {
 
 // EngineParamBindingValueV2 defines model for EngineParamBindingValueV2.
 type EngineParamBindingValueV2 struct {
-	CatalogEntry *CatalogEntryReferenceV2 `json:"catalog_entry,omitempty"`
-
-	// Helptext Gives a description of the option to the user
-	Helptext *string `json:"helptext,omitempty"`
-
-	// ImageUrl If appropriate, URL to an image that can be displayed alongside the option
-	ImageUrl *string `json:"image_url,omitempty"`
-
-	// IsImageSlackIcon If true, the image_url is a Slack icon and should be displayed as such
-	IsImageSlackIcon *bool `json:"is_image_slack_icon,omitempty"`
-
 	// Label Human readable label to be displayed for user to select
 	Label string `json:"label"`
 
@@ -1455,15 +1699,157 @@ type EngineParamBindingValueV2 struct {
 
 	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
 	Reference *string `json:"reference,omitempty"`
+}
 
-	// SortKey Gives an indication of how to sort the options when displayed to the user
-	SortKey string `json:"sort_key"`
+// EngineReferenceV2 defines model for EngineReferenceV2.
+type EngineReferenceV2 struct {
+	// Array If true, the reference can refer to 0 to many items
+	Array bool `json:"array"`
 
-	// Unavailable Unavailable is true if we've failed to build the value for this binding
-	Unavailable *bool `json:"unavailable,omitempty"`
+	// Key The key of the field this is a reference to
+	Key string `json:"key"`
 
-	// Value Either the reference or the literal: this field is designed purely to make working with react-select easier
-	Value *string `json:"value,omitempty"`
+	// Label Human readable label for the field (with context)
+	Label string `json:"label"`
+
+	// Type The type of this resource in the engine
+	Type string `json:"type"`
+}
+
+// ExpressionBranchPayloadV2 defines model for ExpressionBranchPayloadV2.
+type ExpressionBranchPayloadV2 struct {
+	// ConditionGroups When theses conditions are met, this branch will be evaluated
+	ConditionGroups []ConditionGroupPayloadV2   `json:"condition_groups"`
+	Result          EngineParamBindingPayloadV2 `json:"result"`
+}
+
+// ExpressionBranchV2 defines model for ExpressionBranchV2.
+type ExpressionBranchV2 struct {
+	// ConditionGroups When theses conditions are met, this branch will be evaluated
+	ConditionGroups []ConditionGroupV2   `json:"condition_groups"`
+	Result          EngineParamBindingV2 `json:"result"`
+}
+
+// ExpressionBranchesOptsPayloadV2 defines model for ExpressionBranchesOptsPayloadV2.
+type ExpressionBranchesOptsPayloadV2 struct {
+	// Branches The branches to apply for this operation
+	Branches []ExpressionBranchPayloadV2 `json:"branches"`
+	Returns  ReturnsMetaV2               `json:"returns"`
+}
+
+// ExpressionBranchesOptsV2 defines model for ExpressionBranchesOptsV2.
+type ExpressionBranchesOptsV2 struct {
+	// Branches The branches to apply for this operation
+	Branches []ExpressionBranchV2 `json:"branches"`
+	Returns  ReturnsMetaV2        `json:"returns"`
+}
+
+// ExpressionElseBranchPayloadV2 defines model for ExpressionElseBranchPayloadV2.
+type ExpressionElseBranchPayloadV2 struct {
+	Result EngineParamBindingPayloadV2 `json:"result"`
+}
+
+// ExpressionElseBranchV2 defines model for ExpressionElseBranchV2.
+type ExpressionElseBranchV2 struct {
+	Result EngineParamBindingV2 `json:"result"`
+}
+
+// ExpressionFilterOptsPayloadV2 defines model for ExpressionFilterOptsPayloadV2.
+type ExpressionFilterOptsPayloadV2 struct {
+	// ConditionGroups The conditions to apply to this filter
+	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
+}
+
+// ExpressionFilterOptsV2 defines model for ExpressionFilterOptsV2.
+type ExpressionFilterOptsV2 struct {
+	// ConditionGroups The conditions to apply to this filter
+	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
+}
+
+// ExpressionNavigateOptsPayloadV2 defines model for ExpressionNavigateOptsPayloadV2.
+type ExpressionNavigateOptsPayloadV2 struct {
+	// Reference The reference that you want to navigate to
+	Reference string `json:"reference"`
+}
+
+// ExpressionNavigateOptsV2 defines model for ExpressionNavigateOptsV2.
+type ExpressionNavigateOptsV2 struct {
+	// Reference The reference within the scope to navigate to
+	Reference string `json:"reference"`
+
+	// ReferenceLabel The name of the reference to navigate to
+	ReferenceLabel string `json:"reference_label"`
+}
+
+// ExpressionOperationPayloadV2 defines model for ExpressionOperationPayloadV2.
+type ExpressionOperationPayloadV2 struct {
+	Branches *ExpressionBranchesOptsPayloadV2 `json:"branches,omitempty"`
+	Filter   *ExpressionFilterOptsPayloadV2   `json:"filter,omitempty"`
+	Navigate *ExpressionNavigateOptsPayloadV2 `json:"navigate,omitempty"`
+
+	// OperationType The type of the operation
+	OperationType ExpressionOperationPayloadV2OperationType `json:"operation_type"`
+	Parse         *ExpressionParseOptsV2                    `json:"parse,omitempty"`
+}
+
+// ExpressionOperationPayloadV2OperationType The type of the operation
+type ExpressionOperationPayloadV2OperationType string
+
+// ExpressionOperationV2 defines model for ExpressionOperationV2.
+type ExpressionOperationV2 struct {
+	Branches *ExpressionBranchesOptsV2 `json:"branches,omitempty"`
+	Filter   *ExpressionFilterOptsV2   `json:"filter,omitempty"`
+	Navigate *ExpressionNavigateOptsV2 `json:"navigate,omitempty"`
+
+	// OperationType The type of the operation
+	OperationType ExpressionOperationV2OperationType `json:"operation_type"`
+	Parse         *ExpressionParseOptsV2             `json:"parse,omitempty"`
+	Returns       ReturnsMetaV2                      `json:"returns"`
+}
+
+// ExpressionOperationV2OperationType The type of the operation
+type ExpressionOperationV2OperationType string
+
+// ExpressionParseOptsV2 defines model for ExpressionParseOptsV2.
+type ExpressionParseOptsV2 struct {
+	Returns ReturnsMetaV2 `json:"returns"`
+
+	// Source Source expression that is evaluated to a result
+	Source string `json:"source"`
+}
+
+// ExpressionPayloadV2 defines model for ExpressionPayloadV2.
+type ExpressionPayloadV2 struct {
+	ElseBranch *ExpressionElseBranchPayloadV2 `json:"else_branch,omitempty"`
+
+	// Label The human readable label of the expression
+	Label      string                         `json:"label"`
+	Operations []ExpressionOperationPayloadV2 `json:"operations"`
+
+	// Reference A short ID that can be used to reference the expression
+	Reference string `json:"reference"`
+
+	// RootReference The root reference for this expression (i.e. where the expression starts)
+	RootReference string `json:"root_reference"`
+}
+
+// ExpressionV2 defines model for ExpressionV2.
+type ExpressionV2 struct {
+	ElseBranch *ExpressionElseBranchV2 `json:"else_branch,omitempty"`
+
+	// Id The ID of the expression
+	Id string `json:"id"`
+
+	// Label The human readable label of the expression
+	Label      string                  `json:"label"`
+	Operations []ExpressionOperationV2 `json:"operations"`
+
+	// Reference A short ID that can be used to reference the expression
+	Reference string        `json:"reference"`
+	Returns   ReturnsMetaV2 `json:"returns"`
+
+	// RootReference The root reference for this expression (i.e. where the expression starts)
+	RootReference string `json:"root_reference"`
 }
 
 // ExternalIssueReferenceV1 defines model for ExternalIssueReferenceV1.
@@ -2122,6 +2508,11 @@ type ListTypesResponseBody struct {
 	CatalogTypes []CatalogTypeV2 `json:"catalog_types"`
 }
 
+// ListWorkflowsResponseBody defines model for ListWorkflowsResponseBody.
+type ListWorkflowsResponseBody struct {
+	Workflows []WorkflowSlim `json:"workflows"`
+}
+
 // PaginationMetaResult defines model for PaginationMetaResult.
 type PaginationMetaResult struct {
 	// After If provided, pass this as the 'after' param to load the next page
@@ -2162,6 +2553,15 @@ type RBACRoleV2 struct {
 type RetrospectiveIncidentOptionsV2 struct {
 	// SlackChannelId If the incident mode is 'retrospective', pass the ID of a Slack channel in your workspace to attach the incident to an existing channel, rather than creating a new one
 	SlackChannelId *string `json:"slack_channel_id,omitempty"`
+}
+
+// ReturnsMetaV2 defines model for ReturnsMetaV2.
+type ReturnsMetaV2 struct {
+	// Array Whether the return value should be single or multi-value
+	Array bool `json:"array"`
+
+	// Type Expected return type of this expression (what to try casting the result to)
+	Type string `json:"type"`
 }
 
 // ScheduleConfigCreatePayloadV2 defines model for ScheduleConfigCreatePayloadV2.
@@ -2472,6 +2872,62 @@ type ShowResponseBody9 struct {
 	IncidentStatus IncidentStatusV1 `json:"incident_status"`
 }
 
+// ShowWorkflowResponseBody defines model for ShowWorkflowResponseBody.
+type ShowWorkflowResponseBody struct {
+	Workflow Workflow `json:"workflow"`
+}
+
+// StepConfig defines model for StepConfig.
+type StepConfig struct {
+	// ForEach Reference to the loop variable to run this step over
+	ForEach *string `json:"for_each,omitempty"`
+
+	// Id Unique ID of this step in a workflow
+	Id string `json:"id"`
+
+	// Label Human readable identifier for this step
+	Label string `json:"label"`
+
+	// Name Unique name of the step in the engine
+	Name string `json:"name"`
+
+	// ParamBindings Bindings for the step parameters
+	ParamBindings []EngineParamBindingV2 `json:"param_bindings"`
+}
+
+// StepConfigPayload defines model for StepConfigPayload.
+type StepConfigPayload struct {
+	// ForEach Reference to an expression that returns resources to run this step over
+	ForEach *string `json:"for_each,omitempty"`
+
+	// Id Unique ID of this step in a workflow
+	Id *string `json:"id,omitempty"`
+
+	// Name Unique name of the step in the engine
+	Name string `json:"name"`
+
+	// ParamBindings List of parameter bindings
+	ParamBindings []EngineParamBindingPayloadV2 `json:"param_bindings"`
+}
+
+// StepConfigSlim defines model for StepConfigSlim.
+type StepConfigSlim struct {
+	// Label Human readable identifier for this step
+	Label string `json:"label"`
+
+	// Name Unique name of the step in the engine
+	Name string `json:"name"`
+}
+
+// TriggerSlim defines model for TriggerSlim.
+type TriggerSlim struct {
+	// Label Human readable identifier for this trigger
+	Label string `json:"label"`
+
+	// Name Unique name of the trigger inside of the engine
+	Name string `json:"name"`
+}
+
 // UpdateEntryRequestBody defines model for UpdateEntryRequestBody.
 type UpdateEntryRequestBody struct {
 	// Aliases Optional aliases that can be used to reference this entry
@@ -2624,6 +3080,58 @@ type UpdateTypeSchemaRequestBody struct {
 	Version    int64                           `json:"version"`
 }
 
+// UpdateWorkflowRequestBody defines model for UpdateWorkflowRequestBody.
+type UpdateWorkflowRequestBody struct {
+	// Annotations Annotations that track internal metadata about this workflow
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// ConditionGroups List of conditions to apply to the workflow
+	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
+
+	// ContinueOnStepError Whether to continue executing the workflow if a step fails
+	ContinueOnStepError bool           `json:"continue_on_step_error"`
+	Delay               *WorkflowDelay `json:"delay,omitempty"`
+
+	// Expressions The expressions used in the workflow
+	Expressions []ExpressionPayloadV2 `json:"expressions"`
+
+	// Folder Folder to display the workflow in
+	Folder *string `json:"folder,omitempty"`
+
+	// IncludePrivateIncidents Whether to include private incidents
+	IncludePrivateIncidents bool `json:"include_private_incidents"`
+
+	// ManagedSourceUrl The url of the external repository where this workflow is managed
+	ManagedSourceUrl *string `json:"managed_source_url,omitempty"`
+
+	// Name The human-readable name of the workflow
+	Name string `json:"name"`
+
+	// OnceFor Once For strategy to apply to this workflow
+	OnceFor []string `json:"once_for"`
+
+	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
+	RunsOnIncidentModes []UpdateWorkflowRequestBodyRunsOnIncidentModes `json:"runs_on_incident_modes"`
+
+	// RunsOnIncidents Which incidents should the workflow be applied to?
+	RunsOnIncidents UpdateWorkflowRequestBodyRunsOnIncidents `json:"runs_on_incidents"`
+
+	// State The state of the workflow (e.g. is it draft, or disabled)
+	State *UpdateWorkflowRequestBodyState `json:"state,omitempty"`
+
+	// Steps List of step to execute as part of the workflow
+	Steps []StepConfigPayload `json:"steps"`
+}
+
+// UpdateWorkflowRequestBodyRunsOnIncidentModes defines model for UpdateWorkflowRequestBody.RunsOnIncidentModes.
+type UpdateWorkflowRequestBodyRunsOnIncidentModes string
+
+// UpdateWorkflowRequestBodyRunsOnIncidents Which incidents should the workflow be applied to?
+type UpdateWorkflowRequestBodyRunsOnIncidents string
+
+// UpdateWorkflowRequestBodyState The state of the workflow (e.g. is it draft, or disabled)
+type UpdateWorkflowRequestBodyState string
+
 // UserReferencePayloadV1 defines model for UserReferencePayloadV1.
 type UserReferencePayloadV1 struct {
 	// Email The user's email address, matching the email on their Slack account
@@ -2680,6 +3188,136 @@ type UserWithRolesV2 struct {
 
 // UserWithRolesV2Role DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.
 type UserWithRolesV2Role string
+
+// Workflow defines model for Workflow.
+type Workflow struct {
+	// Annotations Annotations that track internal metadata about this workflow
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// ConditionGroups Conditions that apply to the workflow trigger
+	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
+
+	// ContinueOnStepError Whether to continue executing the workflow if a step fails
+	ContinueOnStepError bool           `json:"continue_on_step_error"`
+	Delay               *WorkflowDelay `json:"delay,omitempty"`
+
+	// Expressions Expressions that make variables available in the scope
+	Expressions []ExpressionV2 `json:"expressions"`
+
+	// Folder Folder to display the workflow in
+	Folder *string `json:"folder,omitempty"`
+
+	// Id Unique identifier for the workflow
+	Id string `json:"id"`
+
+	// IncludePrivateIncidents Whether to include private incidents
+	IncludePrivateIncidents bool `json:"include_private_incidents"`
+
+	// ManagedSourceUrl The url of the external repository where this workflow is managed
+	ManagedSourceUrl *string `json:"managed_source_url,omitempty"`
+
+	// Name The human-readable name of the workflow
+	Name string `json:"name"`
+
+	// OnceFor This workflow will run 'once for' a list of references
+	OnceFor []EngineReferenceV2 `json:"once_for"`
+
+	// RunsFrom The time from which this workflow will run on incidents
+	RunsFrom *time.Time `json:"runs_from,omitempty"`
+
+	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
+	RunsOnIncidentModes []WorkflowRunsOnIncidentModes `json:"runs_on_incident_modes"`
+
+	// RunsOnIncidents Which incidents should the workflow be applied to?
+	RunsOnIncidents WorkflowRunsOnIncidents `json:"runs_on_incidents"`
+
+	// State The state of the workflow (e.g. is it draft, or disabled)
+	State WorkflowState `json:"state"`
+
+	// Steps Steps that are executed as part of the workflow
+	Steps   []StepConfig `json:"steps"`
+	Trigger TriggerSlim  `json:"trigger"`
+
+	// Version Revision of the workflow, uniquely identifying its version
+	Version int64 `json:"version"`
+}
+
+// WorkflowRunsOnIncidentModes defines model for Workflow.RunsOnIncidentModes.
+type WorkflowRunsOnIncidentModes string
+
+// WorkflowRunsOnIncidents Which incidents should the workflow be applied to?
+type WorkflowRunsOnIncidents string
+
+// WorkflowState The state of the workflow (e.g. is it draft, or disabled)
+type WorkflowState string
+
+// WorkflowDelay defines model for WorkflowDelay.
+type WorkflowDelay struct {
+	// ConditionsApplyOverDelay If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution
+	ConditionsApplyOverDelay bool `json:"conditions_apply_over_delay"`
+
+	// ForSeconds Delay in seconds between trigger firing and running the workflow
+	ForSeconds int64 `json:"for_seconds"`
+}
+
+// WorkflowSlim defines model for WorkflowSlim.
+type WorkflowSlim struct {
+	// ConditionGroups Conditions that apply to the workflow trigger
+	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
+
+	// ContinueOnStepError Whether to continue executing the workflow if a step fails
+	ContinueOnStepError bool           `json:"continue_on_step_error"`
+	Delay               *WorkflowDelay `json:"delay,omitempty"`
+
+	// Expressions Expressions that make variables available in the scope
+	Expressions []ExpressionV2 `json:"expressions"`
+
+	// Folder Folder to display the workflow in
+	Folder *string `json:"folder,omitempty"`
+
+	// Id Unique identifier for the workflow
+	Id string `json:"id"`
+
+	// IncludePrivateIncidents Whether to include private incidents
+	IncludePrivateIncidents bool `json:"include_private_incidents"`
+
+	// ManagedSourceUrl The url of the external repository where this workflow is managed
+	ManagedSourceUrl *string `json:"managed_source_url,omitempty"`
+
+	// Name The human-readable name of the workflow
+	Name string `json:"name"`
+
+	// OnceFor This workflow will run 'once for' a list of references
+	OnceFor []EngineReferenceV2 `json:"once_for"`
+
+	// RunsFrom The time from which this workflow will run on incidents
+	RunsFrom *time.Time `json:"runs_from,omitempty"`
+
+	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
+	RunsOnIncidentModes []WorkflowSlimRunsOnIncidentModes `json:"runs_on_incident_modes"`
+
+	// RunsOnIncidents Which incidents should the workflow be applied to?
+	RunsOnIncidents WorkflowSlimRunsOnIncidents `json:"runs_on_incidents"`
+
+	// State The state of the workflow (e.g. is it draft, or disabled)
+	State WorkflowSlimState `json:"state"`
+
+	// Steps Steps that are executed as part of the workflow
+	Steps   []StepConfigSlim `json:"steps"`
+	Trigger TriggerSlim      `json:"trigger"`
+
+	// Version Revision of the workflow, uniquely identifying its version
+	Version int64 `json:"version"`
+}
+
+// WorkflowSlimRunsOnIncidentModes defines model for WorkflowSlim.RunsOnIncidentModes.
+type WorkflowSlimRunsOnIncidentModes string
+
+// WorkflowSlimRunsOnIncidents Which incidents should the workflow be applied to?
+type WorkflowSlimRunsOnIncidents string
+
+// WorkflowSlimState The state of the workflow (e.g. is it draft, or disabled)
+type WorkflowSlimState string
 
 // ActionsV1ListParams defines parameters for ActionsV1List.
 type ActionsV1ListParams struct {
@@ -2938,6 +3576,12 @@ type SchedulesV2CreateJSONRequestBody = CreateRequestBody11
 
 // SchedulesV2UpdateJSONRequestBody defines body for SchedulesV2Update for application/json ContentType.
 type SchedulesV2UpdateJSONRequestBody = UpdateRequestBody7
+
+// WorkflowsV2CreateWorkflowJSONRequestBody defines body for WorkflowsV2CreateWorkflow for application/json ContentType.
+type WorkflowsV2CreateWorkflowJSONRequestBody = CreateWorkflowRequestBody
+
+// WorkflowsV2UpdateWorkflowJSONRequestBody defines body for WorkflowsV2UpdateWorkflow for application/json ContentType.
+type WorkflowsV2UpdateWorkflowJSONRequestBody = UpdateWorkflowRequestBody
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -3313,6 +3957,25 @@ type ClientInterface interface {
 
 	// UsersV2Show request
 	UsersV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// WorkflowsV2ListWorkflows request
+	WorkflowsV2ListWorkflows(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// WorkflowsV2CreateWorkflow request with any body
+	WorkflowsV2CreateWorkflowWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	WorkflowsV2CreateWorkflow(ctx context.Context, body WorkflowsV2CreateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// WorkflowsV2DestroyWorkflow request
+	WorkflowsV2DestroyWorkflow(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// WorkflowsV2ShowWorkflow request
+	WorkflowsV2ShowWorkflow(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// WorkflowsV2UpdateWorkflow request with any body
+	WorkflowsV2UpdateWorkflowWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	WorkflowsV2UpdateWorkflow(ctx context.Context, id string, body WorkflowsV2UpdateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) ActionsV1List(ctx context.Context, params *ActionsV1ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -4625,6 +5288,90 @@ func (c *Client) UsersV2List(ctx context.Context, params *UsersV2ListParams, req
 
 func (c *Client) UsersV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUsersV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkflowsV2ListWorkflows(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkflowsV2ListWorkflowsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkflowsV2CreateWorkflowWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkflowsV2CreateWorkflowRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkflowsV2CreateWorkflow(ctx context.Context, body WorkflowsV2CreateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkflowsV2CreateWorkflowRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkflowsV2DestroyWorkflow(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkflowsV2DestroyWorkflowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkflowsV2ShowWorkflow(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkflowsV2ShowWorkflowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkflowsV2UpdateWorkflowWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkflowsV2UpdateWorkflowRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WorkflowsV2UpdateWorkflow(ctx context.Context, id string, body WorkflowsV2UpdateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWorkflowsV2UpdateWorkflowRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -8203,6 +8950,188 @@ func NewUsersV2ShowRequest(server string, id string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewWorkflowsV2ListWorkflowsRequest generates requests for WorkflowsV2ListWorkflows
+func NewWorkflowsV2ListWorkflowsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/workflows")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewWorkflowsV2CreateWorkflowRequest calls the generic WorkflowsV2CreateWorkflow builder with application/json body
+func NewWorkflowsV2CreateWorkflowRequest(server string, body WorkflowsV2CreateWorkflowJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewWorkflowsV2CreateWorkflowRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewWorkflowsV2CreateWorkflowRequestWithBody generates requests for WorkflowsV2CreateWorkflow with any type of body
+func NewWorkflowsV2CreateWorkflowRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/workflows")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewWorkflowsV2DestroyWorkflowRequest generates requests for WorkflowsV2DestroyWorkflow
+func NewWorkflowsV2DestroyWorkflowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/workflows/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewWorkflowsV2ShowWorkflowRequest generates requests for WorkflowsV2ShowWorkflow
+func NewWorkflowsV2ShowWorkflowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/workflows/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewWorkflowsV2UpdateWorkflowRequest calls the generic WorkflowsV2UpdateWorkflow builder with application/json body
+func NewWorkflowsV2UpdateWorkflowRequest(server string, id string, body WorkflowsV2UpdateWorkflowJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewWorkflowsV2UpdateWorkflowRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewWorkflowsV2UpdateWorkflowRequestWithBody generates requests for WorkflowsV2UpdateWorkflow with any type of body
+func NewWorkflowsV2UpdateWorkflowRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/workflows/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -8547,6 +9476,25 @@ type ClientWithResponsesInterface interface {
 
 	// UsersV2Show request
 	UsersV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*UsersV2ShowResponse, error)
+
+	// WorkflowsV2ListWorkflows request
+	WorkflowsV2ListWorkflowsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*WorkflowsV2ListWorkflowsResponse, error)
+
+	// WorkflowsV2CreateWorkflow request with any body
+	WorkflowsV2CreateWorkflowWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*WorkflowsV2CreateWorkflowResponse, error)
+
+	WorkflowsV2CreateWorkflowWithResponse(ctx context.Context, body WorkflowsV2CreateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*WorkflowsV2CreateWorkflowResponse, error)
+
+	// WorkflowsV2DestroyWorkflow request
+	WorkflowsV2DestroyWorkflowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*WorkflowsV2DestroyWorkflowResponse, error)
+
+	// WorkflowsV2ShowWorkflow request
+	WorkflowsV2ShowWorkflowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*WorkflowsV2ShowWorkflowResponse, error)
+
+	// WorkflowsV2UpdateWorkflow request with any body
+	WorkflowsV2UpdateWorkflowWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*WorkflowsV2UpdateWorkflowResponse, error)
+
+	WorkflowsV2UpdateWorkflowWithResponse(ctx context.Context, id string, body WorkflowsV2UpdateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*WorkflowsV2UpdateWorkflowResponse, error)
 }
 
 type ActionsV1ListResponse struct {
@@ -10341,6 +11289,115 @@ func (r UsersV2ShowResponse) StatusCode() int {
 	return 0
 }
 
+type WorkflowsV2ListWorkflowsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListWorkflowsResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r WorkflowsV2ListWorkflowsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WorkflowsV2ListWorkflowsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type WorkflowsV2CreateWorkflowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ShowWorkflowResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r WorkflowsV2CreateWorkflowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WorkflowsV2CreateWorkflowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type WorkflowsV2DestroyWorkflowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r WorkflowsV2DestroyWorkflowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WorkflowsV2DestroyWorkflowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type WorkflowsV2ShowWorkflowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowWorkflowResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r WorkflowsV2ShowWorkflowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WorkflowsV2ShowWorkflowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type WorkflowsV2UpdateWorkflowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ShowWorkflowResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r WorkflowsV2UpdateWorkflowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WorkflowsV2UpdateWorkflowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 // ActionsV1ListWithResponse request returning *ActionsV1ListResponse
 func (c *ClientWithResponses) ActionsV1ListWithResponse(ctx context.Context, params *ActionsV1ListParams, reqEditors ...RequestEditorFn) (*ActionsV1ListResponse, error) {
 	rsp, err := c.ActionsV1List(ctx, params, reqEditors...)
@@ -11301,6 +12358,67 @@ func (c *ClientWithResponses) UsersV2ShowWithResponse(ctx context.Context, id st
 		return nil, err
 	}
 	return ParseUsersV2ShowResponse(rsp)
+}
+
+// WorkflowsV2ListWorkflowsWithResponse request returning *WorkflowsV2ListWorkflowsResponse
+func (c *ClientWithResponses) WorkflowsV2ListWorkflowsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*WorkflowsV2ListWorkflowsResponse, error) {
+	rsp, err := c.WorkflowsV2ListWorkflows(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkflowsV2ListWorkflowsResponse(rsp)
+}
+
+// WorkflowsV2CreateWorkflowWithBodyWithResponse request with arbitrary body returning *WorkflowsV2CreateWorkflowResponse
+func (c *ClientWithResponses) WorkflowsV2CreateWorkflowWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*WorkflowsV2CreateWorkflowResponse, error) {
+	rsp, err := c.WorkflowsV2CreateWorkflowWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkflowsV2CreateWorkflowResponse(rsp)
+}
+
+func (c *ClientWithResponses) WorkflowsV2CreateWorkflowWithResponse(ctx context.Context, body WorkflowsV2CreateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*WorkflowsV2CreateWorkflowResponse, error) {
+	rsp, err := c.WorkflowsV2CreateWorkflow(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkflowsV2CreateWorkflowResponse(rsp)
+}
+
+// WorkflowsV2DestroyWorkflowWithResponse request returning *WorkflowsV2DestroyWorkflowResponse
+func (c *ClientWithResponses) WorkflowsV2DestroyWorkflowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*WorkflowsV2DestroyWorkflowResponse, error) {
+	rsp, err := c.WorkflowsV2DestroyWorkflow(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkflowsV2DestroyWorkflowResponse(rsp)
+}
+
+// WorkflowsV2ShowWorkflowWithResponse request returning *WorkflowsV2ShowWorkflowResponse
+func (c *ClientWithResponses) WorkflowsV2ShowWorkflowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*WorkflowsV2ShowWorkflowResponse, error) {
+	rsp, err := c.WorkflowsV2ShowWorkflow(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkflowsV2ShowWorkflowResponse(rsp)
+}
+
+// WorkflowsV2UpdateWorkflowWithBodyWithResponse request with arbitrary body returning *WorkflowsV2UpdateWorkflowResponse
+func (c *ClientWithResponses) WorkflowsV2UpdateWorkflowWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*WorkflowsV2UpdateWorkflowResponse, error) {
+	rsp, err := c.WorkflowsV2UpdateWorkflowWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkflowsV2UpdateWorkflowResponse(rsp)
+}
+
+func (c *ClientWithResponses) WorkflowsV2UpdateWorkflowWithResponse(ctx context.Context, id string, body WorkflowsV2UpdateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*WorkflowsV2UpdateWorkflowResponse, error) {
+	rsp, err := c.WorkflowsV2UpdateWorkflow(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWorkflowsV2UpdateWorkflowResponse(rsp)
 }
 
 // ParseActionsV1ListResponse parses an HTTP response from a ActionsV1ListWithResponse call
@@ -13305,6 +14423,126 @@ func ParseUsersV2ShowResponse(rsp *http.Response) (*UsersV2ShowResponse, error) 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ShowResponseBody16
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWorkflowsV2ListWorkflowsResponse parses an HTTP response from a WorkflowsV2ListWorkflowsWithResponse call
+func ParseWorkflowsV2ListWorkflowsResponse(rsp *http.Response) (*WorkflowsV2ListWorkflowsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WorkflowsV2ListWorkflowsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListWorkflowsResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWorkflowsV2CreateWorkflowResponse parses an HTTP response from a WorkflowsV2CreateWorkflowWithResponse call
+func ParseWorkflowsV2CreateWorkflowResponse(rsp *http.Response) (*WorkflowsV2CreateWorkflowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WorkflowsV2CreateWorkflowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ShowWorkflowResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWorkflowsV2DestroyWorkflowResponse parses an HTTP response from a WorkflowsV2DestroyWorkflowWithResponse call
+func ParseWorkflowsV2DestroyWorkflowResponse(rsp *http.Response) (*WorkflowsV2DestroyWorkflowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WorkflowsV2DestroyWorkflowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseWorkflowsV2ShowWorkflowResponse parses an HTTP response from a WorkflowsV2ShowWorkflowWithResponse call
+func ParseWorkflowsV2ShowWorkflowResponse(rsp *http.Response) (*WorkflowsV2ShowWorkflowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WorkflowsV2ShowWorkflowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowWorkflowResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWorkflowsV2UpdateWorkflowResponse parses an HTTP response from a WorkflowsV2UpdateWorkflowWithResponse call
+func ParseWorkflowsV2UpdateWorkflowResponse(rsp *http.Response) (*WorkflowsV2UpdateWorkflowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WorkflowsV2UpdateWorkflowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ShowWorkflowResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/engine.go
+++ b/internal/provider/engine.go
@@ -29,13 +29,14 @@ type IncidentEngineParamBindingValue struct {
 	Reference types.String `tfsdk:"reference"`
 }
 
-type IncidentEngineExpressions map[string]IncidentEngineExpression
+type IncidentEngineExpressions []IncidentEngineExpression
 
 type IncidentEngineExpression struct {
 	ElseBranch    *IncidentEngineElseBranch           `tfsdk:"else_branch"`
 	ID            types.String                        `tfsdk:"id"`
 	Label         types.String                        `tfsdk:"label"`
 	Operations    []IncidentEngineExpressionOperation `tfsdk:"operations"`
+	Reference     types.String                        `tfsdk:"reference"`
 	RootReference types.String                        `tfsdk:"root_reference"`
 }
 
@@ -147,10 +148,22 @@ var returnsAttribute = schema.SingleNestedAttribute{
 	},
 }
 
-var expressionsAttribute = schema.MapNestedAttribute{
+var expressionsAttribute = schema.SetNestedAttribute{
 	Required: true,
 	NestedObject: schema.NestedAttributeObject{
 		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"label": schema.StringAttribute{
+				Required: true,
+			},
+			"reference": schema.StringAttribute{
+				Required: true,
+			},
+			"root_reference": schema.StringAttribute{
+				Required: true,
+			},
 			"else_branch": schema.SingleNestedAttribute{
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
@@ -159,12 +172,6 @@ var expressionsAttribute = schema.MapNestedAttribute{
 						Attributes: paramBindingAttributes,
 					},
 				},
-			},
-			"id": schema.StringAttribute{
-				Computed: true,
-			},
-			"label": schema.StringAttribute{
-				Required: true,
 			},
 			"operations": schema.ListNestedAttribute{
 				Required: true,
@@ -216,9 +223,6 @@ var expressionsAttribute = schema.MapNestedAttribute{
 						},
 					},
 				},
-			},
-			"root_reference": schema.StringAttribute{
-				Required: true,
 			},
 		},
 	},

--- a/internal/provider/engine.go
+++ b/internal/provider/engine.go
@@ -1,6 +1,11 @@
 package provider
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Types
 
 type IncidentEngineConditionGroups = []IncidentEngineConditionGroup
 
@@ -24,12 +29,13 @@ type IncidentEngineParamBindingValue struct {
 	Reference types.String `tfsdk:"reference"`
 }
 
+type IncidentEngineExpressions map[string]IncidentEngineExpression
+
 type IncidentEngineExpression struct {
 	ElseBranch    *IncidentEngineElseBranch           `tfsdk:"else_branch"`
 	ID            types.String                        `tfsdk:"id"`
 	Label         types.String                        `tfsdk:"label"`
 	Operations    []IncidentEngineExpressionOperation `tfsdk:"operations"`
-	Reference     types.String                        `tfsdk:"reference"`
 	RootReference types.String                        `tfsdk:"root_reference"`
 }
 
@@ -52,8 +58,8 @@ type IncidentEngineExpressionBranchesOpts struct {
 }
 
 type IncidentEngineBranch struct {
-	Conditions []IncidentEngineCondition  `tfsdk:"conditions"`
-	Result     IncidentEngineParamBinding `tfsdk:"result"`
+	ConditionGroups []IncidentEngineConditionGroup `tfsdk:"condition_groups"`
+	Result          IncidentEngineParamBinding     `tfsdk:"result"`
 }
 
 type IncidentEngineReturnsMeta struct {
@@ -62,7 +68,7 @@ type IncidentEngineReturnsMeta struct {
 }
 
 type IncidentEngineExpressionFilterOpts struct {
-	Conditions []IncidentEngineCondition `tfsdk:"conditions"`
+	ConditionGroups []IncidentEngineConditionGroup `tfsdk:"condition_groups"`
 }
 
 type IncidentEngineExpressionNavigateOpts struct {
@@ -72,4 +78,148 @@ type IncidentEngineExpressionNavigateOpts struct {
 type IncidentEngineExpressionParseOpts struct {
 	Returns IncidentEngineReturnsMeta `tfsdk:"returns"`
 	Source  types.String              `tfsdk:"source"`
+}
+
+// Attributes
+
+var paramBindingValueAttributes = map[string]schema.Attribute{
+	"literal": schema.StringAttribute{
+		Optional: true,
+	},
+	"reference": schema.StringAttribute{
+		Optional: true,
+	},
+}
+
+var paramBindingAttributes = map[string]schema.Attribute{
+	"array_value": schema.SetNestedAttribute{
+		Optional: true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: paramBindingValueAttributes,
+		},
+	},
+	"value": schema.SingleNestedAttribute{
+		Optional:   true,
+		Attributes: paramBindingValueAttributes,
+	},
+}
+
+var paramBindingsAttribute = schema.ListNestedAttribute{
+	Required: true,
+	NestedObject: schema.NestedAttributeObject{
+		Attributes: paramBindingAttributes,
+	},
+}
+
+var conditionsAttribute = schema.SetNestedAttribute{
+	Required: true,
+	NestedObject: schema.NestedAttributeObject{
+		Attributes: map[string]schema.Attribute{
+			"operation": schema.StringAttribute{
+				Required: true,
+			},
+			"param_bindings": paramBindingsAttribute,
+			"subject": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	},
+}
+
+var conditionGroupsAttribute = schema.SetNestedAttribute{
+	Required: true,
+	NestedObject: schema.NestedAttributeObject{
+		Attributes: map[string]schema.Attribute{
+			"conditions": conditionsAttribute,
+		},
+	},
+}
+
+var returnsAttribute = schema.SingleNestedAttribute{
+	Required: true,
+	Attributes: map[string]schema.Attribute{
+		"array": schema.BoolAttribute{
+			Required: true,
+		},
+		"type": schema.StringAttribute{
+			Required: true,
+		},
+	},
+}
+
+var expressionsAttribute = schema.MapNestedAttribute{
+	Required: true,
+	NestedObject: schema.NestedAttributeObject{
+		Attributes: map[string]schema.Attribute{
+			"else_branch": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"result": schema.SingleNestedAttribute{
+						Required:   true,
+						Attributes: paramBindingAttributes,
+					},
+				},
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"label": schema.StringAttribute{
+				Required: true,
+			},
+			"operations": schema.ListNestedAttribute{
+				Required: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"branches": schema.SingleNestedAttribute{
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"branches": schema.ListNestedAttribute{
+									Required: true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"condition_groups": conditionGroupsAttribute,
+											"result": schema.SingleNestedAttribute{
+												Required:   true,
+												Attributes: paramBindingAttributes,
+											},
+										},
+									},
+								},
+								"returns": returnsAttribute,
+							},
+						},
+						"filter": schema.SingleNestedAttribute{
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"condition_groups": conditionGroupsAttribute,
+							},
+						},
+						"navigate": schema.SingleNestedAttribute{
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"reference": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+						"operation_type": schema.StringAttribute{
+							Required: true,
+						},
+						"parse": schema.SingleNestedAttribute{
+							Optional: true,
+							Attributes: map[string]schema.Attribute{
+								"returns": returnsAttribute,
+								"source": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			"root_reference": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	},
 }

--- a/internal/provider/incident_catalog_entries_resource.go
+++ b/internal/provider/incident_catalog_entries_resource.go
@@ -522,7 +522,7 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 					for attributeID, value := range entry.AttributeValues {
 						current := client.EngineParamBindingPayloadV2{}
 						if value.ArrayValue != nil {
-							current.ArrayValue = lo.ToPtr(lo.Map(*value.ArrayValue, func(binding client.EngineParamBindingValueV2, _ int) client.EngineParamBindingValuePayloadV2 {
+							current.ArrayValue = lo.ToPtr(lo.Map(*value.ArrayValue, func(binding client.CatalogEntryEngineParamBindingValueV2, _ int) client.EngineParamBindingValuePayloadV2 {
 								return client.EngineParamBindingValuePayloadV2{
 									Literal: binding.Literal,
 								}

--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -295,7 +295,7 @@ func (r *IncidentCatalogEntryResource) buildModel(entry client.CatalogEntryV2) *
 		// state, so we paper over the issue by instantiating an empty array value if we think
 		// we're seeing the weirdness.
 		if binding.Value == nil && binding.ArrayValue == nil {
-			binding.ArrayValue = lo.ToPtr([]client.EngineParamBindingValueV2{})
+			binding.ArrayValue = lo.ToPtr([]client.CatalogEntryEngineParamBindingValueV2{})
 		}
 
 		if binding.Value != nil {

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -21,7 +21,8 @@ var (
 )
 
 type IncidentCatalogTypeResource struct {
-	client *client.ClientWithResponses
+	client           *client.ClientWithResponses
+	terraformVersion string
 }
 
 type IncidentCatalogTypeResourceModel struct {
@@ -91,6 +92,7 @@ func (r *IncidentCatalogTypeResource) Configure(ctx context.Context, req resourc
 	}
 
 	r.client = client.Client
+	r.terraformVersion = client.TerraformVersion
 }
 
 func (r *IncidentCatalogTypeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -103,6 +105,9 @@ func (r *IncidentCatalogTypeResource) Create(ctx context.Context, req resource.C
 	requestBody := client.CreateTypeRequestBody{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
+		Annotations: &map[string]string{
+			"incident.io/terraform/version": r.terraformVersion,
+		},
 	}
 	if typeName := data.TypeName.ValueString(); typeName != "" {
 		requestBody.TypeName = &typeName
@@ -156,6 +161,9 @@ func (r *IncidentCatalogTypeResource) Update(ctx context.Context, req resource.U
 		Name: data.Name.ValueString(),
 		// TypeName cannot be changed once set
 		Description: data.Description.ValueString(),
+		Annotations: &map[string]string{
+			"incident.io/terraform/version": r.terraformVersion,
+		},
 	}
 
 	if sourceRepoURL := data.SourceRepoURL.ValueString(); sourceRepoURL != "" {

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -49,9 +49,6 @@ type IncidentWorkflowResourceModel struct {
 	State                   types.String                  `tfsdk:"state"`
 }
 
-// 	IncludePrivateIncidents bool `json:"include_private_incidents"`
-// 	IncludeRetrospectiveIncidents bool `json:"include_retrospective_incidents"`
-
 type IncidentWorkflowStep struct {
 	ForEach       types.String                 `tfsdk:"for_each"`
 	ID            types.String                 `tfsdk:"id"`
@@ -455,6 +452,7 @@ func (r *IncidentWorkflowResource) buildExpressions(expressions []client.Express
 			ID:            types.StringValue(e.Id),
 			Label:         types.StringValue(e.Label),
 			Operations:    r.buildOperations(e.Operations),
+			Reference:     types.StringValue(e.Reference),
 			RootReference: types.StringValue(e.RootReference),
 		}
 		if e.ElseBranch != nil {
@@ -462,7 +460,7 @@ func (r *IncidentWorkflowResource) buildExpressions(expressions []client.Express
 				Result: r.buildParamBinding(e.ElseBranch.Result),
 			}
 		}
-		out[e.Reference] = expression
+		out = append(out, expression)
 	}
 
 	return out
@@ -603,11 +601,11 @@ func toPayloadParamBindingValue(v *IncidentEngineParamBindingValue) *client.Engi
 func toPayloadExpressions(expressions IncidentEngineExpressions) []client.ExpressionPayloadV2 {
 	out := []client.ExpressionPayloadV2{}
 
-	for ref, e := range expressions {
+	for _, e := range expressions {
 		expression := client.ExpressionPayloadV2{
 			Label:         e.Label.ValueString(),
 			Operations:    toPayloadOperations(e.Operations),
-			Reference:     ref,
+			Reference:     e.Reference.ValueString(),
 			RootReference: e.RootReference.ValueString(),
 		}
 		if e.ElseBranch != nil {

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
+	"github.com/samber/lo"
 )
 
 var (
@@ -21,7 +23,8 @@ var (
 )
 
 type IncidentWorkflowResource struct {
-	client *client.ClientWithResponses
+	client           *client.ClientWithResponses
+	terraformVersion string
 }
 
 func NewIncidentWorkflowResource() resource.Resource {
@@ -29,15 +32,25 @@ func NewIncidentWorkflowResource() resource.Resource {
 }
 
 type IncidentWorkflowResourceModel struct {
-	ID               types.String                  `tfsdk:"id"`
-	Name             types.String                  `tfsdk:"name"`
-	Folder           types.String                  `tfsdk:"folder"`
-	Trigger          types.String                  `tfsdk:"trigger"`
-	TerraformRepoURL types.String                  `tfsdk:"terraform_repo_url"`
-	ConditionGroups  IncidentEngineConditionGroups `tfsdk:"condition_groups"`
-	Steps            []IncidentWorkflowStep        `tfsdk:"steps"`
-	Expressions      []IncidentEngineExpression    `tfsdk:"expressions"`
+	ID                      types.String                  `tfsdk:"id"`
+	Name                    types.String                  `tfsdk:"name"`
+	Folder                  types.String                  `tfsdk:"folder"`
+	Trigger                 types.String                  `tfsdk:"trigger"`
+	ManagedSourceUrl        types.String                  `tfsdk:"managed_source_url"`
+	ConditionGroups         IncidentEngineConditionGroups `tfsdk:"condition_groups"`
+	Steps                   []IncidentWorkflowStep        `tfsdk:"steps"`
+	Expressions             IncidentEngineExpressions     `tfsdk:"expressions"`
+	OnceFor                 []types.String                `tfsdk:"once_for"`
+	IncludePrivateIncidents types.Bool                    `tfsdk:"include_private_incidents"`
+	ContinueOnStepError     types.Bool                    `tfsdk:"continue_on_step_error"`
+	Delay                   *IncidentWorkflowDelay        `tfsdk:"delay"`
+	RunsOnIncidents         types.String                  `tfsdk:"runs_on_incidents"`
+	RunsOnIncidentModes     []types.String                `tfsdk:"runs_on_incident_modes"`
+	State                   types.String                  `tfsdk:"state"`
 }
+
+// 	IncludePrivateIncidents bool `json:"include_private_incidents"`
+// 	IncludeRetrospectiveIncidents bool `json:"include_retrospective_incidents"`
 
 type IncidentWorkflowStep struct {
 	ForEach       types.String                 `tfsdk:"for_each"`
@@ -46,66 +59,16 @@ type IncidentWorkflowStep struct {
 	ParamBindings []IncidentEngineParamBinding `tfsdk:"param_bindings"`
 }
 
+type IncidentWorkflowDelay struct {
+	ConditionsApplyOverDelay types.Bool  `tfsdk:"conditions_apply_over_delay"`
+	ForSeconds               types.Int64 `tfsdk:"for_seconds"`
+}
+
 func (r *IncidentWorkflowResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_workflow"
 }
 
 func (r *IncidentWorkflowResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	paramBindingValueAttributes := map[string]schema.Attribute{
-		"literal": schema.StringAttribute{
-			Optional: true,
-		},
-		"reference": schema.StringAttribute{
-			Optional: true,
-		},
-	}
-
-	paramBindingAttributes := map[string]schema.Attribute{
-		"array_value": schema.SetNestedAttribute{
-			Optional: true,
-			NestedObject: schema.NestedAttributeObject{
-				Attributes: paramBindingValueAttributes,
-			},
-		},
-		"value": schema.SingleNestedAttribute{
-			Optional:   true,
-			Attributes: paramBindingValueAttributes,
-		},
-	}
-
-	paramBindingsAttribute := schema.ListNestedAttribute{
-		Required: true,
-		NestedObject: schema.NestedAttributeObject{
-			Attributes: paramBindingAttributes,
-		},
-	}
-
-	conditionsAttribute := schema.SetNestedAttribute{
-		Required: true,
-		NestedObject: schema.NestedAttributeObject{
-			Attributes: map[string]schema.Attribute{
-				"operation": schema.StringAttribute{
-					Required: true,
-				},
-				"param_bindings": paramBindingsAttribute,
-				"subject": schema.StringAttribute{
-					Required: true,
-				},
-			},
-		},
-	}
-
-	returnsAttribute := schema.SingleNestedAttribute{
-		Required: true,
-		Attributes: map[string]schema.Attribute{
-			"array": schema.BoolAttribute{
-				Required: true,
-			},
-			"type": schema.StringAttribute{
-				Required: true,
-			},
-		},
-	}
 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: apischema.TagDocstring("Workflows V2"),
@@ -125,17 +88,10 @@ func (r *IncidentWorkflowResource) Schema(ctx context.Context, req resource.Sche
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"terraform_repo_url": schema.StringAttribute{
-				Required: true,
+			"managed_source_url": schema.StringAttribute{
+				Optional: true,
 			},
-			"condition_groups": schema.SetNestedAttribute{
-				Required: true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"conditions": conditionsAttribute,
-					},
-				},
-			},
+			"condition_groups": conditionGroupsAttribute,
 			"steps": schema.ListNestedAttribute{
 				Required: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -153,84 +109,37 @@ func (r *IncidentWorkflowResource) Schema(ctx context.Context, req resource.Sche
 					},
 				},
 			},
-			"expressions": schema.ListNestedAttribute{
+			"expressions": expressionsAttribute,
+			"once_for": schema.ListAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+			},
+			"include_private_incidents": schema.BoolAttribute{
 				Required: true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"else_branch": schema.SingleNestedAttribute{
-							Optional: true,
-							Attributes: map[string]schema.Attribute{
-								"result": schema.SingleNestedAttribute{
-									Required:   true,
-									Attributes: paramBindingAttributes,
-								},
-							},
-						},
-						"id": schema.StringAttribute{
-							Computed: true,
-						},
-						"label": schema.StringAttribute{
-							Required: true,
-						},
-						"operations": schema.ListNestedAttribute{
-							Required: true,
-							NestedObject: schema.NestedAttributeObject{
-								Attributes: map[string]schema.Attribute{
-									"branches": schema.SingleNestedAttribute{
-										Optional: true,
-										Attributes: map[string]schema.Attribute{
-											"branches": schema.ListNestedAttribute{
-												Required: true,
-												NestedObject: schema.NestedAttributeObject{
-													Attributes: map[string]schema.Attribute{
-														"conditions": conditionsAttribute,
-														"result": schema.SingleNestedAttribute{
-															Required:   true,
-															Attributes: paramBindingAttributes,
-														},
-													},
-												},
-											},
-											"returns": returnsAttribute,
-										},
-									},
-									"filter": schema.SingleNestedAttribute{
-										Optional: true,
-										Attributes: map[string]schema.Attribute{
-											"conditions": conditionsAttribute,
-										},
-									},
-									"navigate": schema.SingleNestedAttribute{
-										Optional: true,
-										Attributes: map[string]schema.Attribute{
-											"reference": schema.StringAttribute{
-												Required: true,
-											},
-										},
-									},
-									"operation_type": schema.StringAttribute{
-										Required: true,
-									},
-									"parse": schema.SingleNestedAttribute{
-										Optional: true,
-										Attributes: map[string]schema.Attribute{
-											"returns": returnsAttribute,
-											"source": schema.StringAttribute{
-												Required: true,
-											},
-										},
-									},
-								},
-							},
-						},
-						"reference": schema.StringAttribute{
-							Required: true,
-						},
-						"root_reference": schema.StringAttribute{
-							Required: true,
-						},
+			},
+			"continue_on_step_error": schema.BoolAttribute{
+				Required: true,
+			},
+			"delay": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"conditions_apply_over_delay": schema.BoolAttribute{
+						Required: true,
+					},
+					"delay_for_seconds": schema.Int64Attribute{
+						Required: true,
 					},
 				},
+			},
+			"runs_on_incidents": schema.StringAttribute{
+				Required: true,
+			},
+			"runs_on_incident_modes": schema.ListAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+			},
+			"state": schema.StringAttribute{
+				Required: true,
 			},
 		},
 	}
@@ -243,21 +152,40 @@ func (r *IncidentWorkflowResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
+	onceFor := []string{}
+	for _, v := range data.OnceFor {
+		onceFor = append(onceFor, v.ValueString())
+	}
+
+	runsOnIncidentModes := []client.CreateWorkflowRequestBodyRunsOnIncidentModes{}
+	for _, v := range data.RunsOnIncidentModes {
+		runsOnIncidentModes = append(runsOnIncidentModes, client.CreateWorkflowRequestBodyRunsOnIncidentModes(v.ValueString()))
+	}
+
 	payload := client.CreateWorkflowRequestBody{
-		Trigger: data.Trigger.ValueString(),
-		Workflow: client.WorkflowPayload{
-			Name:             data.Name.ValueString(),
-			TerraformRepoUrl: data.TerraformRepoURL.ValueStringPointer(),
-			OnceFor:          []string{"incident.url"},
-			ConditionGroups:  toPayloadConditionGroups(data.ConditionGroups),
-			Steps:            toPayloadSteps(data.Steps),
-			Expressions:      toPayloadExpressions(data.Expressions),
-			RunsOnIncidents:  "newly_created",
-			IsDraft:          true,
+		Trigger:                 data.Trigger.ValueString(),
+		Name:                    data.Name.ValueString(),
+		ManagedSourceUrl:        data.ManagedSourceUrl.ValueStringPointer(),
+		OnceFor:                 onceFor,
+		ConditionGroups:         toPayloadConditionGroups(data.ConditionGroups),
+		Steps:                   toPayloadSteps(data.Steps),
+		Expressions:             toPayloadExpressions(data.Expressions),
+		RunsOnIncidents:         client.CreateWorkflowRequestBodyRunsOnIncidents(data.RunsOnIncidents.ValueString()),
+		RunsOnIncidentModes:     runsOnIncidentModes,
+		Folder:                  data.Folder.ValueStringPointer(),
+		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
+		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
+		State:                   lo.ToPtr(client.CreateWorkflowRequestBodyState(data.State.ValueString())),
+		Annotations: &map[string]string{
+			"incident.io/terraform/version": r.terraformVersion,
 		},
 	}
-	if folder := data.Folder.ValueString(); folder != "" {
-		payload.Folder = &folder
+
+	if data.Delay != nil {
+		payload.Delay = &client.WorkflowDelay{
+			ConditionsApplyOverDelay: data.Delay.ConditionsApplyOverDelay.ValueBool(),
+			ForSeconds:               data.Delay.ForSeconds.ValueInt64(),
+		}
 	}
 
 	result, err := r.client.WorkflowsV2CreateWorkflowWithResponse(ctx, payload)
@@ -287,17 +215,39 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
+	onceFor := []string{}
+	for _, v := range data.OnceFor {
+		onceFor = append(onceFor, v.ValueString())
+	}
+
+	runsOnIncidentModes := []client.UpdateWorkflowRequestBodyRunsOnIncidentModes{}
+	for _, v := range data.RunsOnIncidentModes {
+		runsOnIncidentModes = append(runsOnIncidentModes, client.UpdateWorkflowRequestBodyRunsOnIncidentModes(v.ValueString()))
+	}
+
 	payload := client.WorkflowsV2UpdateWorkflowJSONRequestBody{
-		Workflow: client.WorkflowPayload{
-			Name:             data.Name.ValueString(),
-			TerraformRepoUrl: data.TerraformRepoURL.ValueStringPointer(),
-			OnceFor:          []string{"incident.url"},
-			ConditionGroups:  toPayloadConditionGroups(data.ConditionGroups),
-			Steps:            toPayloadSteps(data.Steps),
-			Expressions:      toPayloadExpressions(data.Expressions),
-			RunsOnIncidents:  "newly_created",
-			IsDraft:          true,
+		Name:                    data.Name.ValueString(),
+		ManagedSourceUrl:        data.ManagedSourceUrl.ValueStringPointer(),
+		ConditionGroups:         toPayloadConditionGroups(data.ConditionGroups),
+		Steps:                   toPayloadSteps(data.Steps),
+		Expressions:             toPayloadExpressions(data.Expressions),
+		OnceFor:                 onceFor,
+		RunsOnIncidents:         client.UpdateWorkflowRequestBodyRunsOnIncidents(data.RunsOnIncidents.ValueString()),
+		RunsOnIncidentModes:     runsOnIncidentModes,
+		Folder:                  data.Folder.ValueStringPointer(),
+		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
+		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
+		State:                   lo.ToPtr(client.UpdateWorkflowRequestBodyState(data.State.ValueString())),
+		Annotations: &map[string]string{
+			"incident.io/terraform/version": r.terraformVersion,
 		},
+	}
+
+	if data.Delay != nil {
+		payload.Delay = &client.WorkflowDelay{
+			ConditionsApplyOverDelay: data.Delay.ConditionsApplyOverDelay.ValueBool(),
+			ForSeconds:               data.Delay.ForSeconds.ValueInt64(),
+		}
 	}
 
 	result, err := r.client.WorkflowsV2UpdateWorkflowWithResponse(ctx, state.ID.ValueString(), payload)
@@ -356,7 +306,7 @@ func (r *IncidentWorkflowResource) Configure(ctx context.Context, req resource.C
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.ClientWithResponses)
+	client, ok := req.ProviderData.(*IncidentProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
@@ -366,29 +316,62 @@ func (r *IncidentWorkflowResource) Configure(ctx context.Context, req resource.C
 		return
 	}
 
-	r.client = client
+	r.client = client.Client
+	r.terraformVersion = client.TerraformVersion
 }
 
 // buildModel converts from the response type to the terraform model/schema type.
 func (r *IncidentWorkflowResource) buildModel(workflow client.Workflow) *IncidentWorkflowResourceModel {
 	model := &IncidentWorkflowResourceModel{
-		ID:              types.StringValue(workflow.Id),
-		Name:            types.StringValue(workflow.Name),
-		Trigger:         types.StringValue(workflow.Trigger.Name),
-		ConditionGroups: r.buildConditionGroups(workflow.ConditionGroups),
-		Steps:           r.buildSteps(workflow.Steps),
-		Expressions:     r.buildExpressions(workflow.Expressions),
+		ID:                      types.StringValue(workflow.Id),
+		Name:                    types.StringValue(workflow.Name),
+		Trigger:                 types.StringValue(workflow.Trigger.Name),
+		ConditionGroups:         r.buildConditionGroups(workflow.ConditionGroups),
+		Steps:                   r.buildSteps(workflow.Steps),
+		Expressions:             r.buildExpressions(workflow.Expressions),
+		OnceFor:                 r.buildOnceFor(workflow.OnceFor),
+		RunsOnIncidentModes:     r.buildRunsOnIncidentModes(workflow.RunsOnIncidentModes),
+		IncludePrivateIncidents: types.BoolValue(workflow.IncludePrivateIncidents),
+		ContinueOnStepError:     types.BoolValue(workflow.ContinueOnStepError),
+		RunsOnIncidents:         types.StringValue(string(workflow.RunsOnIncidents)),
+		State:                   types.StringValue(string(workflow.State)),
 	}
 	if workflow.Folder != nil {
 		model.Folder = types.StringValue(*workflow.Folder)
 	}
-	if workflow.TerraformRepoUrl != nil {
-		model.TerraformRepoURL = types.StringValue(*workflow.TerraformRepoUrl)
+	if workflow.ManagedSourceUrl != nil {
+		model.ManagedSourceUrl = types.StringValue(*workflow.ManagedSourceUrl)
+	}
+	if workflow.Delay != nil {
+		model.Delay = &IncidentWorkflowDelay{
+			ConditionsApplyOverDelay: types.BoolValue(workflow.Delay.ConditionsApplyOverDelay),
+			ForSeconds:               types.Int64Value(workflow.Delay.ForSeconds),
+		}
 	}
 	return model
 }
 
-func (r *IncidentWorkflowResource) buildConditionGroups(groups []client.ExpressionFilterOptsV2) IncidentEngineConditionGroups {
+func (r *IncidentWorkflowResource) buildOnceFor(onceFor []client.EngineReferenceV2) []basetypes.StringValue {
+	out := []basetypes.StringValue{}
+
+	for _, ref := range onceFor {
+		out = append(out, types.StringValue(ref.Key))
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildRunsOnIncidentModes(modes []client.WorkflowRunsOnIncidentModes) []basetypes.StringValue {
+	out := []basetypes.StringValue{}
+
+	for _, mode := range modes {
+		out = append(out, types.StringValue(string(mode)))
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildConditionGroups(groups []client.ConditionGroupV2) IncidentEngineConditionGroups {
 	var out IncidentEngineConditionGroups
 
 	for _, g := range groups {
@@ -401,7 +384,7 @@ func (r *IncidentWorkflowResource) buildConditionGroups(groups []client.Expressi
 }
 
 func (r *IncidentWorkflowResource) buildConditions(conditions []client.ConditionV2) []IncidentEngineCondition {
-	var out []IncidentEngineCondition
+	out := []IncidentEngineCondition{}
 
 	for _, c := range conditions {
 		out = append(out, IncidentEngineCondition{
@@ -415,7 +398,7 @@ func (r *IncidentWorkflowResource) buildConditions(conditions []client.Condition
 }
 
 func (r *IncidentWorkflowResource) buildSteps(steps []client.StepConfig) []IncidentWorkflowStep {
-	var out []IncidentWorkflowStep
+	out := []IncidentWorkflowStep{}
 
 	for _, s := range steps {
 		out = append(out, IncidentWorkflowStep{
@@ -430,7 +413,7 @@ func (r *IncidentWorkflowResource) buildSteps(steps []client.StepConfig) []Incid
 }
 
 func (r *IncidentWorkflowResource) buildParamBindings(pbs []client.EngineParamBindingV2) []IncidentEngineParamBinding {
-	var out []IncidentEngineParamBinding
+	out := []IncidentEngineParamBinding{}
 
 	for _, pb := range pbs {
 		out = append(out, r.buildParamBinding(pb))
@@ -464,15 +447,14 @@ func (r *IncidentWorkflowResource) buildParamBinding(pb client.EngineParamBindin
 	}
 }
 
-func (r *IncidentWorkflowResource) buildExpressions(expressions []client.ExpressionV2) []IncidentEngineExpression {
-	var out []IncidentEngineExpression
+func (r *IncidentWorkflowResource) buildExpressions(expressions []client.ExpressionV2) IncidentEngineExpressions {
+	out := IncidentEngineExpressions{}
 
 	for _, e := range expressions {
 		expression := IncidentEngineExpression{
 			ID:            types.StringValue(e.Id),
 			Label:         types.StringValue(e.Label),
 			Operations:    r.buildOperations(e.Operations),
-			Reference:     types.StringValue(e.Reference),
 			RootReference: types.StringValue(e.RootReference),
 		}
 		if e.ElseBranch != nil {
@@ -480,14 +462,14 @@ func (r *IncidentWorkflowResource) buildExpressions(expressions []client.Express
 				Result: r.buildParamBinding(e.ElseBranch.Result),
 			}
 		}
-		out = append(out, expression)
+		out[e.Reference] = expression
 	}
 
 	return out
 }
 
 func (r *IncidentWorkflowResource) buildOperations(operations []client.ExpressionOperationV2) []IncidentEngineExpressionOperation {
-	var out []IncidentEngineExpressionOperation
+	out := []IncidentEngineExpressionOperation{}
 
 	for _, o := range operations {
 		operation := IncidentEngineExpressionOperation{
@@ -501,7 +483,7 @@ func (r *IncidentWorkflowResource) buildOperations(operations []client.Expressio
 		}
 		if o.Filter != nil {
 			operation.Filter = &IncidentEngineExpressionFilterOpts{
-				Conditions: r.buildConditions(o.Filter.Conditions),
+				ConditionGroups: r.buildConditionGroups(o.Filter.ConditionGroups),
 			}
 		}
 		if o.Navigate != nil {
@@ -522,12 +504,12 @@ func (r *IncidentWorkflowResource) buildOperations(operations []client.Expressio
 }
 
 func (r *IncidentWorkflowResource) buildBranches(branches []client.ExpressionBranchV2) []IncidentEngineBranch {
-	var out []IncidentEngineBranch
+	out := []IncidentEngineBranch{}
 
 	for _, b := range branches {
 		out = append(out, IncidentEngineBranch{
-			Conditions: r.buildConditions(b.Conditions),
-			Result:     r.buildParamBinding(b.Result),
+			ConditionGroups: r.buildConditionGroups(b.ConditionGroups),
+			Result:          r.buildParamBinding(b.Result),
 		})
 	}
 
@@ -543,11 +525,11 @@ func (r *IncidentWorkflowResource) buildReturns(returns client.ReturnsMetaV2) In
 
 // toPayloadConditionGroups converts from the terraform model to the http payload type.
 // The payload type is different from the response type, which includes more information such as labels.
-func toPayloadConditionGroups(groups IncidentEngineConditionGroups) []client.ExpressionFilterOptsPayloadV2 {
-	var payload []client.ExpressionFilterOptsPayloadV2
+func toPayloadConditionGroups(groups IncidentEngineConditionGroups) []client.ConditionGroupPayloadV2 {
+	var payload []client.ConditionGroupPayloadV2
 
 	for _, group := range groups {
-		payload = append(payload, client.ExpressionFilterOptsPayloadV2{
+		payload = append(payload, client.ConditionGroupPayloadV2{
 			Conditions: toPayloadConditions(group.Conditions),
 		})
 	}
@@ -556,7 +538,7 @@ func toPayloadConditionGroups(groups IncidentEngineConditionGroups) []client.Exp
 }
 
 func toPayloadConditions(conditions []IncidentEngineCondition) []client.ConditionPayloadV2 {
-	var out []client.ConditionPayloadV2
+	out := []client.ConditionPayloadV2{}
 
 	for _, c := range conditions {
 		out = append(out, client.ConditionPayloadV2{
@@ -570,7 +552,7 @@ func toPayloadConditions(conditions []IncidentEngineCondition) []client.Conditio
 }
 
 func toPayloadSteps(steps []IncidentWorkflowStep) []client.StepConfigPayload {
-	var out []client.StepConfigPayload
+	out := []client.StepConfigPayload{}
 
 	for _, step := range steps {
 		out = append(out, client.StepConfigPayload{
@@ -585,7 +567,7 @@ func toPayloadSteps(steps []IncidentWorkflowStep) []client.StepConfigPayload {
 }
 
 func toPayloadParamBindings(pbs []IncidentEngineParamBinding) []client.EngineParamBindingPayloadV2 {
-	var paramBindings []client.EngineParamBindingPayloadV2
+	paramBindings := []client.EngineParamBindingPayloadV2{}
 
 	for _, binding := range pbs {
 		paramBindings = append(paramBindings, toPayloadParamBinding(binding))
@@ -595,7 +577,7 @@ func toPayloadParamBindings(pbs []IncidentEngineParamBinding) []client.EnginePar
 }
 
 func toPayloadParamBinding(binding IncidentEngineParamBinding) client.EngineParamBindingPayloadV2 {
-	var arrayValue []client.EngineParamBindingValuePayloadV2
+	arrayValue := []client.EngineParamBindingValuePayloadV2{}
 	for _, v := range binding.ArrayValue {
 		arrayValue = append(arrayValue, *toPayloadParamBindingValue(&v))
 	}
@@ -618,14 +600,14 @@ func toPayloadParamBindingValue(v *IncidentEngineParamBindingValue) *client.Engi
 	}
 }
 
-func toPayloadExpressions(expressions []IncidentEngineExpression) []client.ExpressionPayloadV2 {
-	var out []client.ExpressionPayloadV2
+func toPayloadExpressions(expressions IncidentEngineExpressions) []client.ExpressionPayloadV2 {
+	out := []client.ExpressionPayloadV2{}
 
-	for _, e := range expressions {
+	for ref, e := range expressions {
 		expression := client.ExpressionPayloadV2{
 			Label:         e.Label.ValueString(),
 			Operations:    toPayloadOperations(e.Operations),
-			Reference:     e.Reference.ValueString(),
+			Reference:     ref,
 			RootReference: e.RootReference.ValueString(),
 		}
 		if e.ElseBranch != nil {
@@ -640,7 +622,7 @@ func toPayloadExpressions(expressions []IncidentEngineExpression) []client.Expre
 }
 
 func toPayloadOperations(operations []IncidentEngineExpressionOperation) []client.ExpressionOperationPayloadV2 {
-	var out []client.ExpressionOperationPayloadV2
+	out := []client.ExpressionOperationPayloadV2{}
 
 	for _, o := range operations {
 		operation := client.ExpressionOperationPayloadV2{
@@ -654,7 +636,7 @@ func toPayloadOperations(operations []IncidentEngineExpressionOperation) []clien
 		}
 		if o.Filter != nil {
 			operation.Filter = &client.ExpressionFilterOptsPayloadV2{
-				Conditions: toPayloadConditions(o.Filter.Conditions),
+				ConditionGroups: toPayloadConditionGroups(o.Filter.ConditionGroups),
 			}
 		}
 		if o.Navigate != nil {
@@ -675,12 +657,12 @@ func toPayloadOperations(operations []IncidentEngineExpressionOperation) []clien
 }
 
 func toPayloadBranches(branches []IncidentEngineBranch) []client.ExpressionBranchPayloadV2 {
-	var out []client.ExpressionBranchPayloadV2
+	out := []client.ExpressionBranchPayloadV2{}
 
 	for _, b := range branches {
 		out = append(out, client.ExpressionBranchPayloadV2{
-			Conditions: toPayloadConditions(b.Conditions),
-			Result:     toPayloadParamBinding(b.Result),
+			ConditionGroups: toPayloadConditionGroups(b.ConditionGroups),
+			Result:          toPayloadParamBinding(b.Result),
 		})
 	}
 


### PR DESCRIPTION
This updates to our latest openapi schema, and also implements all the 'other' fields that we hadn't touched yet.

It also changes expressions to be a map of `reference: expression` so that we don't get in trouble when the expressions don't come back in a consistent order.