### PR TITLE
Remove expression IDs from the provider

### DIFF
--- a/internal/apischema/openapi3.json
+++ b/internal/apischema/openapi3.json
@@ -2517,7 +2517,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateHTTPResponseBody"
+                  "$ref": "#/components/schemas/AlertResult"
                 },
                 "example": {
                   "deduplication_key": "unique-key",
@@ -6417,7 +6417,6 @@
                               }
                             }
                           },
-                          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                           "label": "Team Slack channel",
                           "operations": [
                             {
@@ -6638,7 +6637,6 @@
                         }
                       }
                     },
-                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "label": "Team Slack channel",
                     "operations": [
                       {
@@ -6841,7 +6839,6 @@
                             }
                           }
                         },
-                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                         "label": "Team Slack channel",
                         "operations": [
                           {
@@ -7138,7 +7135,6 @@
                             }
                           }
                         },
-                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                         "label": "Team Slack channel",
                         "operations": [
                           {
@@ -7395,7 +7391,6 @@
                         }
                       }
                     },
-                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "label": "Team Slack channel",
                     "operations": [
                       {
@@ -7597,7 +7592,6 @@
                             }
                           }
                         },
-                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                         "label": "Team Slack channel",
                         "operations": [
                           {
@@ -8087,6 +8081,45 @@
         "required": [
           "after",
           "after_url"
+        ]
+      },
+      "AlertResult": {
+        "type": "object",
+        "properties": {
+          "deduplication_key": {
+            "type": "string",
+            "description": "The deduplication key that the event has been processed with",
+            "example": "unique-key",
+            "enum": [
+              "unique-key"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Human readable message giving detail about the event",
+            "example": "Event accepted for processing",
+            "enum": [
+              "Event accepted for processing"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the event",
+            "example": "success",
+            "enum": [
+              "success"
+            ]
+          }
+        },
+        "example": {
+          "deduplication_key": "unique-key",
+          "message": "Event accepted for processing",
+          "status": "success"
+        },
+        "required": [
+          "status",
+          "message",
+          "deduplication_key"
         ]
       },
       "AllResponseBody": {
@@ -10286,45 +10319,6 @@
           "status"
         ]
       },
-      "CreateHTTPResponseBody": {
-        "type": "object",
-        "properties": {
-          "deduplication_key": {
-            "type": "string",
-            "description": "The deduplication key that the event has been processed with",
-            "example": "unique-key",
-            "enum": [
-              "unique-key"
-            ]
-          },
-          "message": {
-            "type": "string",
-            "description": "Human readable message giving detail about the event",
-            "example": "Event accepted for processing",
-            "enum": [
-              "Event accepted for processing"
-            ]
-          },
-          "status": {
-            "type": "string",
-            "description": "Status of the event",
-            "example": "success",
-            "enum": [
-              "success"
-            ]
-          }
-        },
-        "example": {
-          "deduplication_key": "unique-key",
-          "message": "Event accepted for processing",
-          "status": "success"
-        },
-        "required": [
-          "status",
-          "message",
-          "deduplication_key"
-        ]
-      },
       "CreateManagedResourceRequestBody": {
         "type": "object",
         "properties": {
@@ -10341,12 +10335,12 @@
           },
           "resource_id": {
             "type": "string",
-            "description": "The ID of the resource that this relates to",
+            "description": "The ID of the related resource",
             "example": "abc123"
           },
           "resource_type": {
             "type": "string",
-            "description": "The type of resource that this is",
+            "description": "The type of the related resource",
             "example": "schedule",
             "enum": [
               "workflow",
@@ -11475,7 +11469,6 @@
                     }
                   }
                 },
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                 "label": "Team Slack channel",
                 "operations": [
                   {
@@ -11715,7 +11708,6 @@
                   }
                 }
               },
-              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "label": "Team Slack channel",
               "operations": [
                 {
@@ -13608,11 +13600,6 @@
           "else_branch": {
             "$ref": "#/components/schemas/ExpressionElseBranchPayloadV2"
           },
-          "id": {
-            "type": "string",
-            "description": "The ID of the expression. This must be a valid ULID.",
-            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
-          },
           "label": {
             "type": "string",
             "description": "The human readable label of the expression",
@@ -13737,7 +13724,6 @@
               }
             }
           },
-          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "label": "Team Slack channel",
           "operations": [
             {
@@ -13830,7 +13816,6 @@
           "root_reference": "incident.status"
         },
         "required": [
-          "id",
           "label",
           "reference",
           "root_reference",
@@ -13842,11 +13827,6 @@
         "properties": {
           "else_branch": {
             "$ref": "#/components/schemas/ExpressionElseBranchV2"
-          },
-          "id": {
-            "type": "string",
-            "description": "The ID of the expression",
-            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
           },
           "label": {
             "type": "string",
@@ -14000,7 +13980,6 @@
               }
             }
           },
-          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "label": "Team Slack channel",
           "operations": [
             {
@@ -14120,12 +14099,12 @@
           "root_reference": "incident.status"
         },
         "required": [
-          "id",
           "label",
           "reference",
           "returns",
           "root_reference",
-          "operations"
+          "operations",
+          "id"
         ]
       },
       "ExternalIssueReferenceV1": {
@@ -18223,7 +18202,6 @@
                         }
                       }
                     },
-                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "label": "Team Slack channel",
                     "operations": [
                       {
@@ -18435,7 +18413,6 @@
                       }
                     }
                   },
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                   "label": "Team Slack channel",
                   "operations": [
                     {
@@ -18618,12 +18595,12 @@
           },
           "resource_id": {
             "type": "string",
-            "description": "The ID of the resource that this relates to",
+            "description": "The ID of the related resource",
             "example": "abc123"
           },
           "resource_type": {
             "type": "string",
-            "description": "The type of resource that this is",
+            "description": "The type of the related resource",
             "example": "schedule",
             "enum": [
               "workflow",
@@ -19417,7 +19394,7 @@
             ]
           },
           "public_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/IncidentV2"
+            "$ref": "#/components/schemas/WebhookIncidentV2"
           }
         },
         "example": {
@@ -19551,6 +19528,9 @@
             "permalink": "https://app.incident.io/incidents/123",
             "postmortem_document_url": "https://docs.google.com/my_doc_id",
             "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
             "severity": {
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Issues with **low impact**.",
@@ -19807,7 +19787,7 @@
             ]
           },
           "public_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/IncidentV2"
+            "$ref": "#/components/schemas/WebhookIncidentV2"
           }
         },
         "example": {
@@ -19941,6 +19921,9 @@
             "permalink": "https://app.incident.io/incidents/123",
             "postmortem_document_url": "https://docs.google.com/my_doc_id",
             "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
             "severity": {
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Issues with **low impact**.",
@@ -22282,7 +22265,6 @@
                     }
                   }
                 },
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                 "label": "Team Slack channel",
                 "operations": [
                   {
@@ -23275,7 +23257,6 @@
                     }
                   }
                 },
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                 "label": "Team Slack channel",
                 "operations": [
                   {
@@ -23510,7 +23491,6 @@
                   }
                 }
               },
-              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "label": "Team Slack channel",
               "operations": [
                 {
@@ -24435,7 +24415,6 @@
                     }
                   }
                 },
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                 "label": "Team Slack channel",
                 "operations": [
                   {
@@ -24731,7 +24710,6 @@
                   }
                 }
               },
-              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "label": "Team Slack channel",
               "operations": [
                 {
@@ -25014,7 +24992,6 @@
                     }
                   }
                 },
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                 "label": "Team Slack channel",
                 "operations": [
                   {
@@ -25292,7 +25269,6 @@
                   }
                 }
               },
-              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "label": "Team Slack channel",
               "operations": [
                 {
@@ -26131,6 +26107,9 @@
                     "permalink": "https://app.incident.io/incidents/123",
                     "postmortem_document_url": "https://docs.google.com/my_doc_id",
                     "reference": "INC-123",
+                    "related_incidents": [
+                      "INC-237"
+                    ],
                     "severity": {
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Issues with **low impact**.",
@@ -26497,6 +26476,9 @@
                     "permalink": "https://app.incident.io/incidents/123",
                     "postmortem_document_url": "https://docs.google.com/my_doc_id",
                     "reference": "INC-123",
+                    "related_incidents": [
+                      "INC-237"
+                    ],
                     "severity": {
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Issues with **low impact**.",

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -34,6 +34,21 @@ const (
 	ActionV2StatusOutstanding ActionV2Status = "outstanding"
 )
 
+// Defines values for AlertResultDeduplicationKey.
+const (
+	UniqueKey AlertResultDeduplicationKey = "unique-key"
+)
+
+// Defines values for AlertResultMessage.
+const (
+	EventAcceptedForProcessing AlertResultMessage = "Event accepted for processing"
+)
+
+// Defines values for AlertResultStatus.
+const (
+	Success AlertResultStatus = "success"
+)
+
 // Defines values for CatalogResourceV2Category.
 const (
 	CatalogResourceV2CategoryCustom    CatalogResourceV2Category = "custom"
@@ -104,21 +119,6 @@ const (
 const (
 	Firing   CreateHTTPRequestBodyStatus = "firing"
 	Resolved CreateHTTPRequestBodyStatus = "resolved"
-)
-
-// Defines values for CreateHTTPResponseBodyDeduplicationKey.
-const (
-	UniqueKey CreateHTTPResponseBodyDeduplicationKey = "unique-key"
-)
-
-// Defines values for CreateHTTPResponseBodyMessage.
-const (
-	EventAcceptedForProcessing CreateHTTPResponseBodyMessage = "Event accepted for processing"
-)
-
-// Defines values for CreateHTTPResponseBodyStatus.
-const (
-	Success CreateHTTPResponseBodyStatus = "success"
 )
 
 // Defines values for CreateManagedResourceRequestBodyResourceType.
@@ -786,6 +786,27 @@ type AfterPaginationMetaResultV2 struct {
 	AfterUrl string `json:"after_url"`
 }
 
+// AlertResult defines model for AlertResult.
+type AlertResult struct {
+	// DeduplicationKey The deduplication key that the event has been processed with
+	DeduplicationKey AlertResultDeduplicationKey `json:"deduplication_key"`
+
+	// Message Human readable message giving detail about the event
+	Message AlertResultMessage `json:"message"`
+
+	// Status Status of the event
+	Status AlertResultStatus `json:"status"`
+}
+
+// AlertResultDeduplicationKey The deduplication key that the event has been processed with
+type AlertResultDeduplicationKey string
+
+// AlertResultMessage Human readable message giving detail about the event
+type AlertResultMessage string
+
+// AlertResultStatus Status of the event
+type AlertResultStatus string
+
 // CatalogEntryEngineParamBindingV2 defines model for CatalogEntryEngineParamBindingV2.
 type CatalogEntryEngineParamBindingV2 struct {
 	// ArrayValue If array_value is set, this helps render the values
@@ -1116,40 +1137,19 @@ type CreateHTTPRequestBody struct {
 // CreateHTTPRequestBodyStatus Current status of this alert
 type CreateHTTPRequestBodyStatus string
 
-// CreateHTTPResponseBody defines model for CreateHTTPResponseBody.
-type CreateHTTPResponseBody struct {
-	// DeduplicationKey The deduplication key that the event has been processed with
-	DeduplicationKey CreateHTTPResponseBodyDeduplicationKey `json:"deduplication_key"`
-
-	// Message Human readable message giving detail about the event
-	Message CreateHTTPResponseBodyMessage `json:"message"`
-
-	// Status Status of the event
-	Status CreateHTTPResponseBodyStatus `json:"status"`
-}
-
-// CreateHTTPResponseBodyDeduplicationKey The deduplication key that the event has been processed with
-type CreateHTTPResponseBodyDeduplicationKey string
-
-// CreateHTTPResponseBodyMessage Human readable message giving detail about the event
-type CreateHTTPResponseBodyMessage string
-
-// CreateHTTPResponseBodyStatus Status of the event
-type CreateHTTPResponseBodyStatus string
-
 // CreateManagedResourceRequestBody defines model for CreateManagedResourceRequestBody.
 type CreateManagedResourceRequestBody struct {
 	// Annotations Annotations that track metadata about this resource
 	Annotations map[string]string `json:"annotations"`
 
-	// ResourceId The ID of the resource that this relates to
+	// ResourceId The ID of the related resource
 	ResourceId string `json:"resource_id"`
 
-	// ResourceType The type of resource that this is
+	// ResourceType The type of the related resource
 	ResourceType CreateManagedResourceRequestBodyResourceType `json:"resource_type"`
 }
 
-// CreateManagedResourceRequestBodyResourceType The type of resource that this is
+// CreateManagedResourceRequestBodyResourceType The type of the related resource
 type CreateManagedResourceRequestBodyResourceType string
 
 // CreateManagedResourceResponseBody defines model for CreateManagedResourceResponseBody.
@@ -1865,9 +1865,6 @@ type ExpressionParseOptsV2 struct {
 type ExpressionPayloadV2 struct {
 	ElseBranch *ExpressionElseBranchPayloadV2 `json:"else_branch,omitempty"`
 
-	// Id The ID of the expression. This must be a valid ULID.
-	Id string `json:"id"`
-
 	// Label The human readable label of the expression
 	Label      string                         `json:"label"`
 	Operations []ExpressionOperationPayloadV2 `json:"operations"`
@@ -1882,9 +1879,6 @@ type ExpressionPayloadV2 struct {
 // ExpressionV2 defines model for ExpressionV2.
 type ExpressionV2 struct {
 	ElseBranch *ExpressionElseBranchV2 `json:"else_branch,omitempty"`
-
-	// Id The ID of the expression
-	Id string `json:"id"`
 
 	// Label The human readable label of the expression
 	Label      string                  `json:"label"`
@@ -2567,10 +2561,10 @@ type ManagedResourceV2 struct {
 	// ManagedBy How is this resource managed
 	ManagedBy ManagedResourceV2ManagedBy `json:"managed_by"`
 
-	// ResourceId The ID of the resource that this relates to
+	// ResourceId The ID of the related resource
 	ResourceId string `json:"resource_id"`
 
-	// ResourceType The type of resource that this is
+	// ResourceType The type of the related resource
 	ResourceType ManagedResourceV2ResourceType `json:"resource_type"`
 
 	// SourceUrl The url of the external repository where this resource is managed (if there is one)
@@ -2580,7 +2574,7 @@ type ManagedResourceV2 struct {
 // ManagedResourceV2ManagedBy How is this resource managed
 type ManagedResourceV2ManagedBy string
 
-// ManagedResourceV2ResourceType The type of resource that this is
+// ManagedResourceV2ResourceType The type of the related resource
 type ManagedResourceV2ResourceType string
 
 // ManagementMetaV2 defines model for ManagementMetaV2.
@@ -10568,7 +10562,7 @@ func (r ActionsV2ShowResponse) StatusCode() int {
 type AlertEventsV2CreateHTTPResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON202      *CreateHTTPResponseBody
+	JSON202      *AlertResult
 }
 
 // Status returns HTTPResponse.Status
@@ -13648,7 +13642,7 @@ func ParseAlertEventsV2CreateHTTPResponse(rsp *http.Response) (*AlertEventsV2Cre
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
-		var dest CreateHTTPResponseBody
+		var dest AlertResult
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/engine.go
+++ b/internal/provider/engine.go
@@ -34,7 +34,6 @@ type IncidentEngineExpressions []IncidentEngineExpression
 
 type IncidentEngineExpression struct {
 	ElseBranch    *IncidentEngineElseBranch           `tfsdk:"else_branch"`
-	ID            types.String                        `tfsdk:"id"`
 	Label         types.String                        `tfsdk:"label"`
 	Operations    []IncidentEngineExpressionOperation `tfsdk:"operations"`
 	Reference     types.String                        `tfsdk:"reference"`

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -457,7 +457,6 @@ func (r *IncidentWorkflowResource) buildExpressions(expressions []client.Express
 
 	for _, e := range expressions {
 		expression := IncidentEngineExpression{
-			ID:            types.StringValue(e.Id),
 			Label:         types.StringValue(e.Label),
 			Operations:    r.buildOperations(e.Operations),
 			Reference:     types.StringValue(e.Reference),
@@ -611,7 +610,6 @@ func toPayloadExpressions(expressions IncidentEngineExpressions) []client.Expres
 
 	for _, e := range expressions {
 		expression := client.ExpressionPayloadV2{
-			Id:            e.ID.ValueString(),
 			Label:         e.Label.ValueString(),
 			Operations:    toPayloadOperations(e.Operations),
 			Reference:     e.Reference.ValueString(),


### PR DESCRIPTION
We are no longer exposing this, as we'll create new expressions whenever you update a workflow (like workflow versions) to avoid changing history.