### PR TITLE
Fix two typos for version

### DIFF
--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -10,7 +10,7 @@ description: |-
 
 # incident_schedule (Resource)
 
-Beta: 
+Beta:
 View and manage schedules.
 Manage your full schedule of on-call rotations, including the users and rotation configuration.
 
@@ -72,7 +72,7 @@ resource "incident_schedule" "primary_on_call" {
         ]
       },
       {
-        # The date that a schedule rotation versin came into effect
+        # The date that a schedule rotation version came into effect
         # Expects an RFC3339 formatted string
         effective_from = "2024-05-14T12:54:13Z"
 
@@ -174,5 +174,3 @@ Required:
 - `day` (String)
 - `end` (String)
 - `start` (String)
-
-

--- a/examples/resources/incident_schedule/resource.tf
+++ b/examples/resources/incident_schedule/resource.tf
@@ -53,7 +53,7 @@ resource "incident_schedule" "primary_on_call" {
         ]
       },
       {
-        # The date that a schedule rotation versin came into effect
+        # The date that a schedule rotation version came into effect
         # Expects an RFC3339 formatted string
         effective_from = "2024-05-14T12:54:13Z"
 


### PR DESCRIPTION
Noticed two places where `versin` should be `version` in the examples/docs. My editor also cleaned up some trailing whitespace.

I'm not sure if your CLA is required for "obvious fixes" like typos; I know not all projects require CLAs for those kinds of things, but let me know if you need me to sign one.

Thanks!