### PR TITLE
fix typo in catalog type data source error message

### DIFF
--- a/internal/provider/incident_catalog_type_data_source.go
+++ b/internal/provider/incident_catalog_type_data_source.go
@@ -62,7 +62,7 @@ func (i *IncidentCatalogTypeDataSource) Configure(ctx context.Context, req datas
 	client, ok := req.ProviderData.(*IncidentProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source User",
+			"Unexpected Data Source Catalog Type",
 			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 


### PR DESCRIPTION
👋 This fixes a typos incorrectly referring to the "User" data source in a catalog type data source error message.

Thanks!