### PR TITLE
Move release instructions to RELEASE.md for consistency

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -51,19 +51,6 @@ it's best to use a localhost endpoint for lower latency if possible.
 See the above for setting environment variables, otherwise configure your tests
 just as you would for a normal environment.
 
-## Releasing
-
-When you want to cut a new release, you can:
-
-1. Merge any of the changes you want in the release to master.
-2. Ensure that Terraform acceptance tests have passed.
-3. Create a new commit on master that adjusts the CHANGELOG so all unreleased
-   changes appear under the new version.
-4. Push that commit and tag it with whatever your release version should be.
-
-That will trigger the CI pipeline that will publish your provider version to the
-terraform registry.
-
 ## Running the provider locally
 
 There may be changes where you want to be running the provider itself, rather than

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+# Releasing
+
+When you want to cut a new release, you can:
+
+1. Merge any of the changes you want in the release to master.
+2. Ensure that Terraform acceptance tests have passed.
+3. Create a new commit on master that adjusts the CHANGELOG so all unreleased
+   changes appear under the new version.
+4. Push that commit and tag it with whatever your release version should be.
+
+That will trigger the CI pipeline that will publish your provider version to the
+terraform registry.


### PR DESCRIPTION
This will help us find these instructions across our multiple repos.