### PR TITLE
Improve error handling 

### DIFF
--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -14,9 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
-	"github.com/samber/lo"
 )
 
 var (
@@ -221,6 +222,11 @@ func (r *IncidentCatalogEntryResource) Read(ctx context.Context, req resource.Re
 	if result.StatusCode() == 404 {
 		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read catalog entry, got status code: %d", result.StatusCode()))
 		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if result.StatusCode() >= 400 {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read catalog entry, got status code: %d", result.StatusCode()))
 		return
 	}
 

--- a/internal/provider/incident_custom_field_option_resource.go
+++ b/internal/provider/incident_custom_field_option_resource.go
@@ -11,9 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
-	"github.com/samber/lo"
 )
 
 var (
@@ -134,6 +135,11 @@ func (r *IncidentCustomFieldOptionResource) Read(ctx context.Context, req resour
 	if result.StatusCode() == 404 {
 		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read custom field option, got status code: %d", result.StatusCode()))
 		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if result.StatusCode() >= 400 {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read custom field option, got status code: %d", result.StatusCode()))
 		return
 	}
 

--- a/internal/provider/incident_custom_field_resource.go
+++ b/internal/provider/incident_custom_field_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
@@ -128,6 +129,11 @@ func (r *IncidentCustomFieldResource) Read(ctx context.Context, req resource.Rea
 	if result.StatusCode() == 404 {
 		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read custom field, got status code: %d", result.StatusCode()))
 		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if result.StatusCode() >= 400 {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read custom field, got status code: %d", result.StatusCode()))
 		return
 	}
 

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -12,10 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/incident-io/terraform-provider-incident/internal/apischema"
-	"github.com/incident-io/terraform-provider-incident/internal/client"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
+
+	"github.com/incident-io/terraform-provider-incident/internal/apischema"
+	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
 
 var (
@@ -292,6 +293,11 @@ func (r *IncidentEscalationPathResource) Read(ctx context.Context, req resource.
 	if result.StatusCode() == 404 {
 		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read escalation path, got status code: %d", result.StatusCode()))
 		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if result.StatusCode() >= 400 {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read escalation path, got status code: %d", result.StatusCode()))
 		return
 	}
 

--- a/internal/provider/incident_role_resource.go
+++ b/internal/provider/incident_role_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
@@ -125,6 +126,11 @@ func (r *IncidentRoleResource) Read(ctx context.Context, req resource.ReadReques
 	result, err := r.client.IncidentRolesV2ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read incident role, got error: %s", err))
+		return
+	}
+
+	if result.StatusCode() >= 400 {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read incident role, got status code: %d", result.StatusCode()))
 		return
 	}
 

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -13,9 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
-	"github.com/samber/lo"
 )
 
 var (
@@ -250,6 +251,11 @@ func (r *IncidentScheduleResource) Read(ctx context.Context, req resource.ReadRe
 	if result.StatusCode() == 404 {
 		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read schedule, got status code: %d", result.StatusCode()))
 		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if result.StatusCode() >= 400 {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read schedule, got status code: %d", result.StatusCode()))
 		return
 	}
 

--- a/internal/provider/incident_severity_resource.go
+++ b/internal/provider/incident_severity_resource.go
@@ -11,9 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
-	"github.com/samber/lo"
 )
 
 var (
@@ -130,6 +131,11 @@ func (r *IncidentSeverityResource) Read(ctx context.Context, req resource.ReadRe
 	if result.StatusCode() == 404 {
 		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read incident severity, got status code: %d", result.StatusCode()))
 		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if result.StatusCode() >= 400 {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read incident severity, got status code: %d", result.StatusCode()))
 		return
 	}
 

--- a/internal/provider/incident_status_resource.go
+++ b/internal/provider/incident_status_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
@@ -127,6 +128,11 @@ func (r *IncidentStatusResource) Read(ctx context.Context, req resource.ReadRequ
 	if result.StatusCode() == 404 {
 		resp.Diagnostics.AddWarning("Not Found", fmt.Sprintf("Unable to read incident status, got status code: %d", result.StatusCode()))
 		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if result.StatusCode() >= 400 {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read incident status, got status code: %d", result.StatusCode()))
 		return
 	}
 


### PR DESCRIPTION
If you've provisioned an API key incorrectly, or there are any other HTTP errors other than a 404 received, we're currently panicking in the provider. 

Instead, we should at least tell you the error code. E.g. if it's a 401, then you likely know something is up with your token. 

