### PR TITLE
Add holidays_public_config to incident_schedule resource

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -121,3 +121,4 @@ TF_CLI_CONFIG_FILE=./dev.tfrc terraform plan
 
 TF_CLI_CONFIG_FILE=./dev.tfrc terraform apply
 ```
+

--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -108,6 +108,11 @@ resource "incident_schedule" "primary_on_call" {
       },
     ]
   }]
+
+  # If you want to show a country's public holidays on your schedule, use a list of alpha-2 country codes.
+  holidays_public_config = {
+    country_codes = ["GB", "FR"]
+  }
 }
 ```
 
@@ -119,6 +124,10 @@ resource "incident_schedule" "primary_on_call" {
 - `name` (String) Human readable name synced from external provider
 - `rotations` (Attributes List) (see [below for nested schema](#nestedatt--rotations))
 - `timezone` (String)
+
+### Optional
+
+- `holidays_public_config` (Attributes) (see [below for nested schema](#nestedatt--holidays_public_config))
 
 ### Read-Only
 
@@ -174,5 +183,15 @@ Required:
 - `day` (String)
 - `end` (String)
 - `start` (String)
+
+
+
+
+<a id="nestedatt--holidays_public_config"></a>
+### Nested Schema for `holidays_public_config`
+
+Required:
+
+- `country_codes` (List of String) ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for
 
 

--- a/examples/resources/incident_schedule/resource.tf
+++ b/examples/resources/incident_schedule/resource.tf
@@ -89,4 +89,9 @@ resource "incident_schedule" "primary_on_call" {
       },
     ]
   }]
+
+  # If you want to show a country's public holidays on your schedule, use a list of alpha-2 country codes.
+  holidays_public_config = {
+    country_codes = ["GB", "FR"]
+  }
 }

--- a/internal/apischema/openapi.json
+++ b/internal/apischema/openapi.json
@@ -811,11 +811,11 @@
             "schema": {
               "$ref": "#/definitions/IncidentRolesV1UpdateRequestBody",
               "required": [
-                "condition_groups",
                 "name",
+                "shortform",
                 "description",
                 "instructions",
-                "shortform",
+                "condition_groups",
                 "role_type",
                 "created_at",
                 "updated_at"
@@ -1561,6 +1561,151 @@
                 "deduplication_key"
               ]
             }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
+    "/v2/alert_routes": {
+      "post": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Create Alert Routes V2",
+        "description": "Create an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Create",
+        "parameters": [
+          {
+            "name": "CreateRequestBody",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AlertRoutesV2CreateRequestBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created response.",
+            "schema": {
+              "$ref": "#/definitions/AlertRoutesV2CreateResponseBody",
+              "required": [
+                "alert_route"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
+    "/v2/alert_routes/{id}": {
+      "get": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Show Alert Routes V2",
+        "description": "Show an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this alert route config",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/AlertRoutesV2ShowResponseBody",
+              "required": [
+                "alert_route"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      },
+      "put": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Update Alert Routes V2",
+        "description": "Updates an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this alert route config",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "UpdateRequestBody",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AlertRoutesV2UpdateRequestBody",
+              "required": [
+                "name",
+                "condition_groups",
+                "grouping_keys",
+                "grouping_window_seconds",
+                "defer_time_seconds",
+                "escalation_bindings",
+                "auto_decline_enabled",
+                "enabled",
+                "incident_enabled",
+                "incident_condition_groups",
+                "alert_source_ids",
+                "auto_cancel_escalations"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/AlertRoutesV2UpdateResponseBody",
+              "required": [
+                "alert_route"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Destroy Alert Routes V2",
+        "description": "Archives an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Destroy",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this alert route config",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
           }
         },
         "schemes": [
@@ -2515,11 +2660,11 @@
             "schema": {
               "$ref": "#/definitions/IncidentRolesV2UpdateRequestBody",
               "required": [
-                "condition_groups",
                 "name",
+                "shortform",
                 "description",
                 "instructions",
-                "shortform",
+                "condition_groups",
                 "role_type",
                 "created_at",
                 "updated_at"
@@ -4200,6 +4345,122 @@
             "description": "OK response.",
             "schema": {
               "$ref": "#/definitions/AuditLogsFollowUpPriorityUpdatedV1ResponseBody",
+              "required": [
+                "action",
+                "occurred_at",
+                "version",
+                "actor",
+                "targets",
+                "context"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
+    "/x-audit-logs/holiday_user_feed.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "HolidayUserFeedCreatedV1 Audit logs",
+        "description": "This entry is created whenever a holiday user feed is created",
+        "operationId": "Audit logs#HolidayUserFeedCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/AuditLogsHolidayUserFeedCreatedV1ResponseBody",
+              "required": [
+                "action",
+                "occurred_at",
+                "version",
+                "actor",
+                "targets",
+                "context"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
+    "/x-audit-logs/holiday_user_feed.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "HolidayUserFeedDeletedV1 Audit logs",
+        "description": "This entry is created whenever a holiday user feed is deleted",
+        "operationId": "Audit logs#HolidayUserFeedDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/AuditLogsHolidayUserFeedDeletedV1ResponseBody",
+              "required": [
+                "action",
+                "occurred_at",
+                "version",
+                "actor",
+                "targets",
+                "context"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
+    "/x-audit-logs/holiday_user_feed.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "HolidayUserFeedUpdatedV1 Audit logs",
+        "description": "This entry is created whenever a holiday user feed is updated",
+        "operationId": "Audit logs#HolidayUserFeedUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/AuditLogsHolidayUserFeedUpdatedV1ResponseBody",
+              "required": [
+                "action",
+                "occurred_at",
+                "version",
+                "actor",
+                "targets",
+                "context"
+              ]
+            }
+          }
+        },
+        "schemes": [
+          "https"
+        ]
+      }
+    },
+    "/x-audit-logs/incident_call_setting.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "IncidentCallSettingUpdatedV1 Audit logs",
+        "description": "This entry is created whenever an organisation's incident call settings are updated",
+        "operationId": "Audit logs#IncidentCallSettingUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "schema": {
+              "$ref": "#/definitions/AuditLogsIncidentCallSettingUpdatedV1ResponseBody",
               "required": [
                 "action",
                 "occurred_at",
@@ -6941,6 +7202,3029 @@
         "deduplication_key"
       ]
     },
+    "AlertRouteEscalationBindingPayloadV2RequestBody": {
+      "title": "AlertRouteEscalationBindingPayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "binding": {
+          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+        }
+      },
+      "example": {
+        "binding": {
+          "array_value": [
+            {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "required": [
+        "binding"
+      ]
+    },
+    "AlertRouteEscalationBindingV2ResponseBody": {
+      "title": "AlertRouteEscalationBindingV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "binding": {
+          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+        }
+      },
+      "example": {
+        "binding": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "required": [
+        "binding"
+      ]
+    },
+    "AlertRouteIncidentTemplatePayloadV2RequestBody": {
+      "title": "AlertRouteIncidentTemplatePayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "custom_field_priorities": {
+          "type": "object",
+          "description": "lookup of the priority options for each custom field in the template",
+          "example": {
+            "abc123": "abc123"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "example": "abc123"
+          }
+        },
+        "custom_fields": {
+          "type": "object",
+          "description": "Custom field keys mapped to values",
+          "example": {
+            "custom_field_10014": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          }
+        },
+        "incident_mode": {
+          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+        },
+        "incident_type": {
+          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+        },
+        "name": {
+          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+        },
+        "priority_severity": {
+          "type": "string",
+          "description": "option defining whether to cause subsequent alerts to increase the severity",
+          "example": "severity-first-wins",
+          "enum": [
+            "severity-first-wins",
+            "severity-max"
+          ]
+        },
+        "severity": {
+          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+        },
+        "summary": {
+          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+        },
+        "workspace": {
+          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+        }
+      },
+      "example": {
+        "custom_field_priorities": {
+          "abc123": "abc123"
+        },
+        "custom_fields": {
+          "custom_field_10014": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "incident_mode": {
+          "array_value": [
+            {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "incident_type": {
+          "array_value": [
+            {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "name": {
+          "array_value": [
+            {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "priority_severity": "severity-first-wins",
+        "severity": {
+          "array_value": [
+            {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "summary": {
+          "array_value": [
+            {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "workspace": {
+          "array_value": [
+            {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "required": [
+        "custom_field_priorities",
+        "priority_severity"
+      ]
+    },
+    "AlertRouteIncidentTemplateV2ResponseBody": {
+      "title": "AlertRouteIncidentTemplateV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "custom_field_priorities": {
+          "type": "object",
+          "description": "lookup of the priority options for each custom field in the template",
+          "example": {
+            "abc123": "first-wins"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "example": "first-wins",
+            "enum": [
+              "first-wins",
+              "last-wins",
+              "append"
+            ]
+          }
+        },
+        "custom_fields": {
+          "type": "object",
+          "description": "Custom field keys mapped to values",
+          "example": {
+            "custom_field_10014": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          }
+        },
+        "incident_mode": {
+          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+        },
+        "incident_type": {
+          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+        },
+        "name": {
+          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+        },
+        "priority_severity": {
+          "type": "string",
+          "description": "binding to use to resolve the workspace to create an incident in",
+          "example": "severity-first-wins",
+          "enum": [
+            "severity-first-wins",
+            "severity-max"
+          ]
+        },
+        "severity": {
+          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+        },
+        "summary": {
+          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+        },
+        "workspace": {
+          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+        }
+      },
+      "example": {
+        "custom_field_priorities": {
+          "abc123": "first-wins"
+        },
+        "custom_fields": {
+          "custom_field_10014": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "incident_mode": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "incident_type": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "name": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "priority_severity": "severity-first-wins",
+        "severity": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "summary": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        },
+        "workspace": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "required": [
+        "custom_field_priorities",
+        "priority_severity"
+      ]
+    },
+    "AlertRouteV2ResponseBody": {
+      "title": "AlertRouteV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "condition_groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConditionGroupV2ResponseBody"
+          },
+          "description": "What condition groups must be true for this alert route to fire?",
+          "example": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "defer_time_seconds": {
+          "type": "integer",
+          "description": "How long should the escalation defer time be?",
+          "example": 1,
+          "format": "int64"
+        },
+        "escalation_bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AlertRouteEscalationBindingV2ResponseBody"
+          },
+          "description": "Which escalation paths should this alert route escalate to?",
+          "example": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ]
+        },
+        "expressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressionV2ResponseBody"
+          },
+          "description": "The expressions used in this template",
+          "example": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ]
+        },
+        "grouping_keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupingKeyV2ResponseBody"
+          },
+          "description": "Which attributes should this alert route use to group alerts?",
+          "example": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ]
+        },
+        "grouping_window_seconds": {
+          "type": "integer",
+          "description": "How large should the grouping window be?",
+          "example": 1,
+          "format": "int64"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this alert route config",
+          "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of this alert route config, for the user's reference",
+          "example": "Production incidents"
+        },
+        "template": {
+          "$ref": "#/definitions/AlertRouteIncidentTemplateV2ResponseBody"
+        }
+      },
+      "example": {
+        "condition_groups": [
+          {
+            "conditions": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        ],
+        "defer_time_seconds": 1,
+        "escalation_bindings": [
+          {
+            "binding": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        ],
+        "expressions": [
+          {
+            "else_branch": {
+              "result": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "label": "Team Slack channel",
+            "operations": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": {
+                            "label": "Lawrence Jones",
+                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                          },
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": {
+                            "label": "Incident Severity",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "1235",
+                  "reference_label": "Teams"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                },
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              }
+            ],
+            "reference": "abc123",
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            },
+            "root_reference": "incident.status"
+          }
+        ],
+        "grouping_keys": [
+          {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "grouping_window_seconds": 1,
+        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+        "name": "Production incidents",
+        "template": {
+          "custom_field_priorities": {
+            "abc123": "first-wins"
+          },
+          "custom_fields": {
+            "custom_field_10014": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "incident_mode": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "incident_type": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "name": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "priority_severity": "severity-first-wins",
+          "severity": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "summary": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "workspace": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "condition_groups",
+        "grouping_keys",
+        "grouping_window_seconds",
+        "defer_time_seconds",
+        "escalation_bindings",
+        "auto_decline_enabled",
+        "enabled",
+        "incident_enabled",
+        "incident_condition_groups",
+        "alert_source_ids",
+        "auto_cancel_escalations"
+      ]
+    },
+    "AlertRoutesV2CreateRequestBody": {
+      "title": "AlertRoutesV2CreateRequestBody",
+      "type": "object",
+      "properties": {
+        "alert_source_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "abc123"
+          },
+          "description": "The alert sources that will match this alert route",
+          "example": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ]
+        },
+        "auto_decline_enabled": {
+          "type": "boolean",
+          "description": "Should triage incidents be declined when alerts are resolved?",
+          "example": false
+        },
+        "condition_groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+          },
+          "description": "What condition groups must be true for this alert route to fire?",
+          "example": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ]
+        },
+        "defer_time_seconds": {
+          "type": "integer",
+          "description": "How long should the escalation defer time be?",
+          "example": 1,
+          "format": "int64"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this alert route is enabled or not",
+          "example": false
+        },
+        "escalation_bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AlertRouteEscalationBindingPayloadV2RequestBody"
+          },
+          "description": "Which escalation paths should this alert route escalate to?",
+          "example": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ]
+        },
+        "expressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressionPayloadV2RequestBody"
+          },
+          "description": "The expressions used in this template",
+          "example": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ]
+        },
+        "grouping_keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupingKeyV2RequestBody"
+          },
+          "description": "Which attributes should this alert route use to group alerts?",
+          "example": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ]
+        },
+        "grouping_window_seconds": {
+          "type": "integer",
+          "description": "How large should the grouping window be?",
+          "example": 1,
+          "format": "int64"
+        },
+        "incident_condition_groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+          },
+          "description": "What condition groups must be true for this alert route to create an incident?",
+          "example": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ]
+        },
+        "incident_enabled": {
+          "type": "boolean",
+          "description": "Whether this alert route will create incidents or not",
+          "example": false
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of this alert route config, for the user's reference",
+          "example": "Production incidents"
+        },
+        "template": {
+          "$ref": "#/definitions/AlertRouteIncidentTemplatePayloadV2RequestBody"
+        }
+      },
+      "example": {
+        "alert_source_ids": [
+          "02FCNDV6P870EA6S7TK1DSYDG2"
+        ],
+        "auto_decline_enabled": false,
+        "condition_groups": [
+          {
+            "conditions": [
+              {
+                "operation": "one_of",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": "incident.severity"
+              }
+            ]
+          }
+        ],
+        "defer_time_seconds": 1,
+        "enabled": false,
+        "escalation_bindings": [
+          {
+            "binding": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        ],
+        "expressions": [
+          {
+            "else_branch": {
+              "result": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "label": "Team Slack channel",
+            "operations": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": "one_of",
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": "incident.severity"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                }
+              }
+            ],
+            "reference": "abc123",
+            "root_reference": "incident.status"
+          }
+        ],
+        "grouping_keys": [
+          {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "grouping_window_seconds": 1,
+        "incident_condition_groups": [
+          {
+            "conditions": [
+              {
+                "operation": "one_of",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": "incident.severity"
+              }
+            ]
+          }
+        ],
+        "incident_enabled": false,
+        "name": "Production incidents",
+        "template": {
+          "custom_field_priorities": {
+            "abc123": "abc123"
+          },
+          "custom_fields": {
+            "custom_field_10014": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "incident_mode": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "incident_type": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "name": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "priority_severity": "severity-first-wins",
+          "severity": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "summary": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "workspace": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        }
+      }
+    },
+    "AlertRoutesV2CreateResponseBody": {
+      "title": "AlertRoutesV2CreateResponseBody",
+      "type": "object",
+      "properties": {
+        "alert_route": {
+          "$ref": "#/definitions/AlertRouteV2ResponseBody"
+        }
+      },
+      "example": {
+        "alert_route": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "first-wins"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "alert_route"
+      ]
+    },
+    "AlertRoutesV2ShowResponseBody": {
+      "title": "AlertRoutesV2ShowResponseBody",
+      "type": "object",
+      "properties": {
+        "alert_route": {
+          "$ref": "#/definitions/AlertRouteV2ResponseBody"
+        }
+      },
+      "example": {
+        "alert_route": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "first-wins"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "alert_route"
+      ]
+    },
+    "AlertRoutesV2UpdateRequestBody": {
+      "title": "AlertRoutesV2UpdateRequestBody",
+      "type": "object",
+      "properties": {
+        "alert_source_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "abc123"
+          },
+          "description": "The alert sources that will match this alert route",
+          "example": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ]
+        },
+        "auto_decline_enabled": {
+          "type": "boolean",
+          "description": "Should triage incidents be declined when alerts are resolved?",
+          "example": false
+        },
+        "condition_groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+          },
+          "description": "What condition groups must be true for this alert route to fire?",
+          "example": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ]
+        },
+        "defer_time_seconds": {
+          "type": "integer",
+          "description": "How long should the escalation defer time be?",
+          "example": 1,
+          "format": "int64"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this alert route is enabled or not",
+          "example": false
+        },
+        "escalation_bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AlertRouteEscalationBindingPayloadV2RequestBody"
+          },
+          "description": "Which escalation paths should this alert route escalate to?",
+          "example": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ]
+        },
+        "expressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressionPayloadV2RequestBody"
+          },
+          "description": "The expressions used in this template",
+          "example": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ]
+        },
+        "grouping_keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupingKeyV2RequestBody"
+          },
+          "description": "Which attributes should this alert route use to group alerts?",
+          "example": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ]
+        },
+        "grouping_window_seconds": {
+          "type": "integer",
+          "description": "How large should the grouping window be?",
+          "example": 1,
+          "format": "int64"
+        },
+        "incident_condition_groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+          },
+          "description": "What condition groups must be true for this alert route to create an incident?",
+          "example": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ]
+        },
+        "incident_enabled": {
+          "type": "boolean",
+          "description": "Whether this alert route will create incidents or not",
+          "example": false
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of this alert route config, for the user's reference",
+          "example": "Production incidents"
+        },
+        "template": {
+          "$ref": "#/definitions/AlertRouteIncidentTemplatePayloadV2RequestBody"
+        }
+      },
+      "example": {
+        "alert_source_ids": [
+          "02FCNDV6P870EA6S7TK1DSYDG2"
+        ],
+        "auto_decline_enabled": false,
+        "condition_groups": [
+          {
+            "conditions": [
+              {
+                "operation": "one_of",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": "incident.severity"
+              }
+            ]
+          }
+        ],
+        "defer_time_seconds": 1,
+        "enabled": false,
+        "escalation_bindings": [
+          {
+            "binding": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        ],
+        "expressions": [
+          {
+            "else_branch": {
+              "result": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "label": "Team Slack channel",
+            "operations": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": "one_of",
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": "incident.severity"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                }
+              }
+            ],
+            "reference": "abc123",
+            "root_reference": "incident.status"
+          }
+        ],
+        "grouping_keys": [
+          {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "grouping_window_seconds": 1,
+        "incident_condition_groups": [
+          {
+            "conditions": [
+              {
+                "operation": "one_of",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": "incident.severity"
+              }
+            ]
+          }
+        ],
+        "incident_enabled": false,
+        "name": "Production incidents",
+        "template": {
+          "custom_field_priorities": {
+            "abc123": "abc123"
+          },
+          "custom_fields": {
+            "custom_field_10014": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "incident_mode": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "incident_type": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "name": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "priority_severity": "severity-first-wins",
+          "severity": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "summary": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "workspace": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        }
+      },
+      "required": [
+        "name",
+        "condition_groups",
+        "grouping_keys",
+        "grouping_window_seconds",
+        "defer_time_seconds",
+        "escalation_bindings",
+        "auto_decline_enabled",
+        "enabled",
+        "incident_enabled",
+        "incident_condition_groups",
+        "alert_source_ids",
+        "auto_cancel_escalations"
+      ]
+    },
+    "AlertRoutesV2UpdateResponseBody": {
+      "title": "AlertRoutesV2UpdateResponseBody",
+      "type": "object",
+      "properties": {
+        "alert_route": {
+          "$ref": "#/definitions/AlertRouteV2ResponseBody"
+        }
+      },
+      "example": {
+        "alert_route": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "first-wins"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "alert_route"
+      ]
+    },
     "AuditLogActorMetadataV2ResponseBody": {
       "title": "AuditLogActorMetadataV2ResponseBody",
       "type": "object",
@@ -7093,7 +10377,9 @@
             "debrief_invite_rule",
             "escalation_path",
             "follow_up_priority",
+            "holiday_user_feed",
             "incident",
+            "incident_call_setting",
             "incident_duration_metric",
             "incident_role",
             "incident_status",
@@ -9235,6 +12521,310 @@
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Low",
             "type": "follow_up_priority"
+          }
+        ],
+        "version": 1
+      },
+      "required": [
+        "action",
+        "occurred_at",
+        "version",
+        "actor",
+        "targets",
+        "context"
+      ]
+    },
+    "AuditLogsHolidayUserFeedCreatedV1ResponseBody": {
+      "title": "AuditLogsHolidayUserFeedCreatedV1ResponseBody",
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "description": "The type of log entry that this is",
+          "example": "holiday_user_feed.created"
+        },
+        "actor": {
+          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+        },
+        "context": {
+          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+        },
+        "occurred_at": {
+          "type": "string",
+          "description": "When the entry occurred",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+          },
+          "description": "The custom field that was created",
+          "example": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "US Team holidays",
+              "type": "holiday_user_feed"
+            }
+          ]
+        },
+        "version": {
+          "type": "integer",
+          "description": "Which version the event is",
+          "example": 1,
+          "format": "int64"
+        }
+      },
+      "example": {
+        "action": "holiday_user_feed.created",
+        "actor": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "metadata": {
+            "user_base_role_slug": "admin",
+            "user_custom_role_slugs": "engineering,security"
+          },
+          "name": "John Doe",
+          "type": "user"
+        },
+        "context": {
+          "location": "1.2.3.4",
+          "user_agent": "Chrome/91.0.4472.114"
+        },
+        "occurred_at": "2021-08-17T13:28:57.801578Z",
+        "targets": [
+          {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "US Team holidays",
+            "type": "holiday_user_feed"
+          }
+        ],
+        "version": 1
+      },
+      "required": [
+        "action",
+        "occurred_at",
+        "version",
+        "actor",
+        "targets",
+        "context"
+      ]
+    },
+    "AuditLogsHolidayUserFeedDeletedV1ResponseBody": {
+      "title": "AuditLogsHolidayUserFeedDeletedV1ResponseBody",
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "description": "The type of log entry that this is",
+          "example": "holiday_user_feed.deleted"
+        },
+        "actor": {
+          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+        },
+        "context": {
+          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+        },
+        "occurred_at": {
+          "type": "string",
+          "description": "When the entry occurred",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+          },
+          "description": "The custom field that was created",
+          "example": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "US Team holidays",
+              "type": "holiday_user_feed"
+            }
+          ]
+        },
+        "version": {
+          "type": "integer",
+          "description": "Which version the event is",
+          "example": 1,
+          "format": "int64"
+        }
+      },
+      "example": {
+        "action": "holiday_user_feed.deleted",
+        "actor": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "metadata": {
+            "user_base_role_slug": "admin",
+            "user_custom_role_slugs": "engineering,security"
+          },
+          "name": "John Doe",
+          "type": "user"
+        },
+        "context": {
+          "location": "1.2.3.4",
+          "user_agent": "Chrome/91.0.4472.114"
+        },
+        "occurred_at": "2021-08-17T13:28:57.801578Z",
+        "targets": [
+          {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "US Team holidays",
+            "type": "holiday_user_feed"
+          }
+        ],
+        "version": 1
+      },
+      "required": [
+        "action",
+        "occurred_at",
+        "version",
+        "actor",
+        "targets",
+        "context"
+      ]
+    },
+    "AuditLogsHolidayUserFeedUpdatedV1ResponseBody": {
+      "title": "AuditLogsHolidayUserFeedUpdatedV1ResponseBody",
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "description": "The type of log entry that this is",
+          "example": "holiday_user_feed.updated"
+        },
+        "actor": {
+          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+        },
+        "context": {
+          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+        },
+        "occurred_at": {
+          "type": "string",
+          "description": "When the entry occurred",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+          },
+          "description": "The custom field that was created",
+          "example": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "US Team holidays",
+              "type": "holiday_user_feed"
+            }
+          ]
+        },
+        "version": {
+          "type": "integer",
+          "description": "Which version the event is",
+          "example": 1,
+          "format": "int64"
+        }
+      },
+      "example": {
+        "action": "holiday_user_feed.updated",
+        "actor": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "metadata": {
+            "user_base_role_slug": "admin",
+            "user_custom_role_slugs": "engineering,security"
+          },
+          "name": "John Doe",
+          "type": "user"
+        },
+        "context": {
+          "location": "1.2.3.4",
+          "user_agent": "Chrome/91.0.4472.114"
+        },
+        "occurred_at": "2021-08-17T13:28:57.801578Z",
+        "targets": [
+          {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "US Team holidays",
+            "type": "holiday_user_feed"
+          }
+        ],
+        "version": 1
+      },
+      "required": [
+        "action",
+        "occurred_at",
+        "version",
+        "actor",
+        "targets",
+        "context"
+      ]
+    },
+    "AuditLogsIncidentCallSettingUpdatedV1ResponseBody": {
+      "title": "AuditLogsIncidentCallSettingUpdatedV1ResponseBody",
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "description": "The type of log entry that this is",
+          "example": "incident_call_setting.updated"
+        },
+        "actor": {
+          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+        },
+        "context": {
+          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+        },
+        "occurred_at": {
+          "type": "string",
+          "description": "When the entry occurred",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+          },
+          "description": "The custom field that was created",
+          "example": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Incident call settings",
+              "type": "incident_call_setting"
+            }
+          ]
+        },
+        "version": {
+          "type": "integer",
+          "description": "Which version the event is",
+          "example": 1,
+          "format": "int64"
+        }
+      },
+      "example": {
+        "action": "incident_call_setting.updated",
+        "actor": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "metadata": {
+            "user_base_role_slug": "admin",
+            "user_custom_role_slugs": "engineering,security"
+          },
+          "name": "John Doe",
+          "type": "user"
+        },
+        "context": {
+          "location": "1.2.3.4",
+          "user_agent": "Chrome/91.0.4472.114"
+        },
+        "occurred_at": "2021-08-17T13:28:57.801578Z",
+        "targets": [
+          {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Incident call settings",
+            "type": "incident_call_setting"
           }
         ],
         "version": 1
@@ -13873,13 +17463,13 @@
                 "catalog_entry_name": "Primary escalation",
                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
-              "helptext": "Collection of standalone automations like auto-closing incidents.",
-              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+              "helptext": "abc123",
+              "image_url": "abc123",
               "is_image_slack_icon": false,
               "label": "Lawrence Jones",
               "literal": "SEV123",
               "reference": "incident.severity",
-              "sort_key": "000020",
+              "sort_key": "abc123",
               "unavailable": false,
               "value": "abc123"
             }
@@ -13898,13 +17488,13 @@
               "catalog_entry_name": "Primary escalation",
               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
-            "helptext": "Collection of standalone automations like auto-closing incidents.",
-            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+            "helptext": "abc123",
+            "image_url": "abc123",
             "is_image_slack_icon": false,
             "label": "Lawrence Jones",
             "literal": "SEV123",
             "reference": "incident.severity",
-            "sort_key": "000020",
+            "sort_key": "abc123",
             "unavailable": false,
             "value": "abc123"
           }
@@ -13916,13 +17506,13 @@
             "catalog_entry_name": "Primary escalation",
             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
-          "helptext": "Collection of standalone automations like auto-closing incidents.",
-          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+          "helptext": "abc123",
+          "image_url": "abc123",
           "is_image_slack_icon": false,
           "label": "Lawrence Jones",
           "literal": "SEV123",
           "reference": "incident.severity",
-          "sort_key": "000020",
+          "sort_key": "abc123",
           "unavailable": false,
           "value": "abc123"
         }
@@ -13937,17 +17527,17 @@
         },
         "helptext": {
           "type": "string",
-          "description": "Gives a description of the option to the user",
-          "example": "Collection of standalone automations like auto-closing incidents."
+          "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
+          "example": "abc123"
         },
         "image_url": {
           "type": "string",
-          "description": "If appropriate, URL to an image that can be displayed alongside the option",
-          "example": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg"
+          "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
+          "example": "abc123"
         },
         "is_image_slack_icon": {
           "type": "boolean",
-          "description": "If true, the image_url is a Slack icon and should be displayed as such",
+          "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
           "example": false
         },
         "label": {
@@ -13962,22 +17552,22 @@
         },
         "reference": {
           "type": "string",
-          "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+          "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
           "example": "incident.severity"
         },
         "sort_key": {
           "type": "string",
-          "description": "Gives an indication of how to sort the options when displayed to the user",
-          "example": "000020"
+          "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
+          "example": "abc123"
         },
         "unavailable": {
           "type": "boolean",
-          "description": "Unavailable is true if we've failed to build the value for this binding",
+          "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
           "example": false
         },
         "value": {
           "type": "string",
-          "description": "Either the reference or the literal: this field is designed purely to make working with react-select easier",
+          "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
           "example": "abc123"
         }
       },
@@ -13988,13 +17578,13 @@
           "catalog_entry_name": "Primary escalation",
           "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
         },
-        "helptext": "Collection of standalone automations like auto-closing incidents.",
-        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+        "helptext": "abc123",
+        "image_url": "abc123",
         "is_image_slack_icon": false,
         "label": "Lawrence Jones",
         "literal": "SEV123",
         "reference": "incident.severity",
-        "sort_key": "000020",
+        "sort_key": "abc123",
         "unavailable": false,
         "value": "abc123"
       },
@@ -14076,13 +17666,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -14094,13 +17684,13 @@
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "helptext": "abc123",
+                "image_url": "abc123",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
                 "reference": "incident.severity",
-                "sort_key": "000020",
+                "sort_key": "abc123",
                 "unavailable": false,
                 "value": "abc123"
               }
@@ -14165,13 +17755,13 @@
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "helptext": "abc123",
+                "image_url": "abc123",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
                 "reference": "incident.severity",
-                "sort_key": "000020",
+                "sort_key": "abc123",
                 "unavailable": false,
                 "value": "abc123"
               }
@@ -14183,13 +17773,13 @@
                 "catalog_entry_name": "Primary escalation",
                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
-              "helptext": "Collection of standalone automations like auto-closing incidents.",
-              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+              "helptext": "abc123",
+              "image_url": "abc123",
               "is_image_slack_icon": false,
               "label": "Lawrence Jones",
               "literal": "SEV123",
               "reference": "incident.severity",
-              "sort_key": "000020",
+              "sort_key": "abc123",
               "unavailable": false,
               "value": "abc123"
             }
@@ -14593,8 +18183,9 @@
         "icon": {
           "type": "string",
           "description": "Sets the display icon of this type in the dashboard",
-          "example": "bolt",
+          "example": "alert",
           "enum": [
+            "alert",
             "bolt",
             "box",
             "briefcase",
@@ -14607,6 +18198,7 @@
             "database",
             "doc",
             "email",
+            "escalation-path",
             "files",
             "flag",
             "folder",
@@ -14614,6 +18206,7 @@
             "money",
             "server",
             "severity",
+            "status-page",
             "store",
             "star",
             "tag",
@@ -14700,7 +18293,7 @@
         "description": "Represents Kubernetes clusters that we run inside of GKE.",
         "dynamic_resource_parameter": "abc123",
         "estimated_count": 7,
-        "icon": "bolt",
+        "icon": "alert",
         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
         "is_editable": false,
         "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -14868,13 +18461,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -14886,13 +18479,13 @@
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "helptext": "abc123",
+                "image_url": "abc123",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
                 "reference": "incident.severity",
-                "sort_key": "000020",
+                "sort_key": "abc123",
                 "unavailable": false,
                 "value": "abc123"
               }
@@ -14968,8 +18561,9 @@
         "icon": {
           "type": "string",
           "description": "Sets the display icon of this type in the dashboard",
-          "example": "bolt",
+          "example": "alert",
           "enum": [
+            "alert",
             "bolt",
             "box",
             "briefcase",
@@ -14982,6 +18576,7 @@
             "database",
             "doc",
             "email",
+            "escalation-path",
             "files",
             "flag",
             "folder",
@@ -14989,6 +18584,7 @@
             "money",
             "server",
             "severity",
+            "status-page",
             "store",
             "star",
             "tag",
@@ -15026,7 +18622,7 @@
         ],
         "color": "yellow",
         "description": "Represents Kubernetes clusters that we run inside of GKE.",
-        "icon": "bolt",
+        "icon": "alert",
         "name": "Kubernetes Cluster",
         "ranked": true,
         "source_repo_url": "https://github.com/my-company/incident-io-catalog",
@@ -15058,7 +18654,7 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "icon": "bolt",
+          "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -15123,13 +18719,13 @@
                         "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                      "helptext": "abc123",
+                      "image_url": "abc123",
                       "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
                       "reference": "incident.severity",
-                      "sort_key": "000020",
+                      "sort_key": "abc123",
                       "unavailable": false,
                       "value": "abc123"
                     }
@@ -15141,13 +18737,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -15188,13 +18784,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -15206,13 +18802,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -15239,7 +18835,7 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "icon": "bolt",
+          "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -15341,7 +18937,7 @@
               "description": "Represents Kubernetes clusters that we run inside of GKE.",
               "dynamic_resource_parameter": "abc123",
               "estimated_count": 7,
-              "icon": "bolt",
+              "icon": "alert",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "is_editable": false,
               "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -15392,7 +18988,7 @@
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "icon": "bolt",
+            "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -15460,13 +19056,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -15478,13 +19074,13 @@
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "helptext": "abc123",
+                "image_url": "abc123",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
                 "reference": "incident.severity",
-                "sort_key": "000020",
+                "sort_key": "abc123",
                 "unavailable": false,
                 "value": "abc123"
               }
@@ -15510,7 +19106,7 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "icon": "bolt",
+          "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -15571,7 +19167,7 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "icon": "bolt",
+          "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -15720,13 +19316,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -15738,13 +19334,13 @@
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "helptext": "abc123",
+                "image_url": "abc123",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
                 "reference": "incident.severity",
-                "sort_key": "000020",
+                "sort_key": "abc123",
                 "unavailable": false,
                 "value": "abc123"
               }
@@ -15770,7 +19366,7 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "icon": "bolt",
+          "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -15867,8 +19463,9 @@
         "icon": {
           "type": "string",
           "description": "Sets the display icon of this type in the dashboard",
-          "example": "bolt",
+          "example": "alert",
           "enum": [
+            "alert",
             "bolt",
             "box",
             "briefcase",
@@ -15881,6 +19478,7 @@
             "database",
             "doc",
             "email",
+            "escalation-path",
             "files",
             "flag",
             "folder",
@@ -15888,6 +19486,7 @@
             "money",
             "server",
             "severity",
+            "status-page",
             "store",
             "star",
             "tag",
@@ -15920,7 +19519,7 @@
         ],
         "color": "yellow",
         "description": "Represents Kubernetes clusters that we run inside of GKE.",
-        "icon": "bolt",
+        "icon": "alert",
         "name": "Kubernetes Cluster",
         "ranked": true,
         "source_repo_url": "https://github.com/my-company/incident-io-catalog"
@@ -15951,7 +19550,7 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "icon": "bolt",
+          "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -16081,7 +19680,7 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "icon": "bolt",
+          "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -18157,8 +21756,7 @@
         "shortform": {
           "type": "string",
           "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-          "example": "lead",
-          "minLength": 1
+          "example": "lead"
         },
         "updated_at": {
           "type": "string",
@@ -18179,12 +21777,12 @@
         "updated_at": "2021-08-17T13:28:57.801578Z"
       },
       "required": [
-        "condition_groups",
-        "id",
         "name",
+        "shortform",
         "description",
         "instructions",
-        "shortform",
+        "condition_groups",
+        "id",
         "role_type",
         "created_at",
         "updated_at"
@@ -22206,6 +25804,40 @@
         "follow_up"
       ]
     },
+    "GroupingKeyV2RequestBody": {
+      "title": "GroupingKeyV2RequestBody",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the alert attribute the user wishes to group on",
+          "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+        }
+      },
+      "example": {
+        "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "GroupingKeyV2ResponseBody": {
+      "title": "GroupingKeyV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the alert attribute the user wishes to group on",
+          "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+        }
+      },
+      "example": {
+        "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+      },
+      "required": [
+        "id"
+      ]
+    },
     "IdentityV1ResponseBody": {
       "title": "IdentityV1ResponseBody",
       "type": "object",
@@ -22907,8 +26539,7 @@
         "shortform": {
           "type": "string",
           "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-          "example": "lead",
-          "minLength": 1
+          "example": "lead"
         },
         "updated_at": {
           "type": "string",
@@ -22929,12 +26560,12 @@
         "updated_at": "2021-08-17T13:28:57.801578Z"
       },
       "required": [
-        "condition_groups",
-        "id",
         "name",
+        "shortform",
         "description",
         "instructions",
-        "shortform",
+        "condition_groups",
+        "id",
         "role_type",
         "created_at",
         "updated_at"
@@ -22985,8 +26616,7 @@
         "shortform": {
           "type": "string",
           "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-          "example": "lead",
-          "minLength": 1
+          "example": "lead"
         },
         "updated_at": {
           "type": "string",
@@ -23006,12 +26636,12 @@
         "updated_at": "2021-08-17T13:28:57.801578Z"
       },
       "required": [
-        "condition_groups",
-        "id",
         "name",
+        "shortform",
         "description",
         "instructions",
-        "shortform",
+        "condition_groups",
+        "id",
         "role_type",
         "created_at",
         "updated_at"
@@ -23046,8 +26676,7 @@
         "shortform": {
           "type": "string",
           "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-          "example": "lead",
-          "minLength": 1
+          "example": "lead"
         }
       },
       "example": {
@@ -23192,8 +26821,7 @@
         "shortform": {
           "type": "string",
           "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-          "example": "lead",
-          "minLength": 1
+          "example": "lead"
         }
       },
       "example": {
@@ -23204,11 +26832,11 @@
         "shortform": "lead"
       },
       "required": [
-        "condition_groups",
         "name",
+        "shortform",
         "description",
         "instructions",
-        "shortform",
+        "condition_groups",
         "role_type",
         "created_at",
         "updated_at"
@@ -23263,8 +26891,7 @@
         "shortform": {
           "type": "string",
           "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-          "example": "lead",
-          "minLength": 1
+          "example": "lead"
         }
       },
       "example": {
@@ -23398,8 +27025,7 @@
         "shortform": {
           "type": "string",
           "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-          "example": "lead",
-          "minLength": 1
+          "example": "lead"
         }
       },
       "example": {
@@ -23409,11 +27035,11 @@
         "shortform": "lead"
       },
       "required": [
-        "condition_groups",
         "name",
+        "shortform",
         "description",
         "instructions",
-        "shortform",
+        "condition_groups",
         "role_type",
         "created_at",
         "updated_at"
@@ -27629,6 +31255,9 @@
         "config": {
           "$ref": "#/definitions/ScheduleConfigCreatePayloadV2RequestBody"
         },
+        "holidays_public_config": {
+          "$ref": "#/definitions/ScheduleHolidaysPublicConfigPayloadV2RequestBody"
+        },
         "name": {
           "type": "string",
           "description": "Name of the schedule",
@@ -27678,6 +31307,11 @@
                 }
               ]
             }
+          ]
+        },
+        "holidays_public_config": {
+          "country_codes": [
+            "abc123"
           ]
         },
         "name": "My Schedule",
@@ -27874,6 +31508,58 @@
         "external_user_id",
         "start_at",
         "end_at"
+      ]
+    },
+    "ScheduleHolidaysPublicConfigPayloadV2RequestBody": {
+      "title": "ScheduleHolidaysPublicConfigPayloadV2RequestBody",
+      "type": "object",
+      "properties": {
+        "country_codes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "abc123"
+          },
+          "description": "ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for",
+          "example": [
+            "abc123"
+          ]
+        }
+      },
+      "example": {
+        "country_codes": [
+          "abc123"
+        ]
+      },
+      "required": [
+        "country_codes"
+      ]
+    },
+    "ScheduleHolidaysPublicConfigV2ResponseBody": {
+      "title": "ScheduleHolidaysPublicConfigV2ResponseBody",
+      "type": "object",
+      "properties": {
+        "country_codes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "abc123"
+          },
+          "description": "ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for",
+          "example": [
+            "GB",
+            "FR"
+          ]
+        }
+      },
+      "example": {
+        "country_codes": [
+          "GB",
+          "FR"
+        ]
+      },
+      "required": [
+        "country_codes"
       ]
     },
     "ScheduleLayerCreatePayloadV2RequestBody": {
@@ -28464,6 +32150,9 @@
         "config": {
           "$ref": "#/definitions/ScheduleConfigUpdatePayloadV2RequestBody"
         },
+        "holidays_public_config": {
+          "$ref": "#/definitions/ScheduleHolidaysPublicConfigPayloadV2RequestBody"
+        },
         "name": {
           "type": "string",
           "description": "Name of the schedule",
@@ -28513,6 +32202,11 @@
                 }
               ]
             }
+          ]
+        },
+        "holidays_public_config": {
+          "country_codes": [
+            "abc123"
           ]
         },
         "name": "My Schedule",
@@ -28565,6 +32259,9 @@
               }
             }
           ]
+        },
+        "holidays_public_config": {
+          "$ref": "#/definitions/ScheduleHolidaysPublicConfigV2ResponseBody"
         },
         "id": {
           "type": "string",
@@ -28647,6 +32344,12 @@
             }
           }
         ],
+        "holidays_public_config": {
+          "country_codes": [
+            "GB",
+            "FR"
+          ]
+        },
         "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
         "name": "Primary On-Call Schedule",
         "timezone": "Europe/London",
@@ -28710,6 +32413,11 @@
                   }
                 ]
               }
+            ]
+          },
+          "holidays_public_config": {
+            "country_codes": [
+              "abc123"
             ]
           },
           "name": "My Schedule",
@@ -28789,6 +32497,12 @@
               }
             }
           ],
+          "holidays_public_config": {
+            "country_codes": [
+              "GB",
+              "FR"
+            ]
+          },
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "name": "Primary On-Call Schedule",
           "timezone": "Europe/London",
@@ -28872,6 +32586,12 @@
                   }
                 }
               ],
+              "holidays_public_config": {
+                "country_codes": [
+                  "GB",
+                  "FR"
+                ]
+              },
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "name": "Primary On-Call Schedule",
               "timezone": "Europe/London",
@@ -28947,6 +32667,12 @@
                 }
               }
             ],
+            "holidays_public_config": {
+              "country_codes": [
+                "GB",
+                "FR"
+              ]
+            },
             "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "name": "Primary On-Call Schedule",
             "timezone": "Europe/London",
@@ -29101,6 +32827,12 @@
               }
             }
           ],
+          "holidays_public_config": {
+            "country_codes": [
+              "GB",
+              "FR"
+            ]
+          },
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "name": "Primary On-Call Schedule",
           "timezone": "Europe/London",
@@ -29158,6 +32890,11 @@
                   }
                 ]
               }
+            ]
+          },
+          "holidays_public_config": {
+            "country_codes": [
+              "abc123"
             ]
           },
           "name": "My Schedule",
@@ -29244,6 +32981,12 @@
               }
             }
           ],
+          "holidays_public_config": {
+            "country_codes": [
+              "GB",
+              "FR"
+            ]
+          },
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "name": "Primary On-Call Schedule",
           "timezone": "Europe/London",
@@ -35771,6 +39514,10 @@
     {
       "name": "Actions V2",
       "description": "Manage incident actions.\n\nIncident actions are used during an incident, to track work such as 'restart the database' or 'contact the customer'.\n\nYou can manage actions in the incident Slack channel with <code>/incident actions</code>, or on\nthe incident homepage.\n"
+    },
+    {
+      "name": "Alert Routes V2",
+      "description": "Create and manage alert routes.\n\nAlert routes take alerts from alert sources, filter them according to conditions, apply\ngrouping on alert attributes, then finally create:\n\n1. Incidents\n2. Escalations\n\nThese are best configured in the incident.io dashboard and exported via the UI to\nTerraform, as the configuration is complex.\n"
     },
     {
       "name": "Audit logs",

--- a/internal/apischema/openapi.yaml
+++ b/internal/apischema/openapi.yaml
@@ -688,11 +688,11 @@ paths:
                   schema:
                     $ref: '#/definitions/IncidentRolesV1UpdateRequestBody'
                     required:
-                        - condition_groups
                         - name
+                        - shortform
                         - description
                         - instructions
-                        - shortform
+                        - condition_groups
                         - role_type
                         - created_at
                         - updated_at
@@ -1201,6 +1201,122 @@ paths:
                             - status
                             - message
                             - deduplication_key
+            schemes:
+                - https
+    /v2/alert_routes:
+        post:
+            tags:
+                - Alert Routes V2
+            summary: Create Alert Routes V2
+            description: |
+                Create an alert route.
+
+                We recommend you create alert routes in the incident.io dashboard where we allow
+                previewing filter and grouping rules.
+            operationId: Alert Routes V2#Create
+            parameters:
+                - name: CreateRequestBody
+                  in: body
+                  required: true
+                  schema:
+                    $ref: '#/definitions/AlertRoutesV2CreateRequestBody'
+            responses:
+                "201":
+                    description: Created response.
+                    schema:
+                        $ref: '#/definitions/AlertRoutesV2CreateResponseBody'
+                        required:
+                            - alert_route
+            schemes:
+                - https
+    /v2/alert_routes/{id}:
+        get:
+            tags:
+                - Alert Routes V2
+            summary: Show Alert Routes V2
+            description: |
+                Show an alert route.
+
+                We recommend you create alert routes in the incident.io dashboard where we allow
+                previewing filter and grouping rules.
+            operationId: Alert Routes V2#Show
+            parameters:
+                - name: id
+                  in: path
+                  description: Unique identifier for this alert route config
+                  required: true
+                  type: string
+            responses:
+                "200":
+                    description: OK response.
+                    schema:
+                        $ref: '#/definitions/AlertRoutesV2ShowResponseBody'
+                        required:
+                            - alert_route
+            schemes:
+                - https
+        put:
+            tags:
+                - Alert Routes V2
+            summary: Update Alert Routes V2
+            description: |
+                Updates an alert route.
+
+                We recommend you create alert routes in the incident.io dashboard where we allow
+                previewing filter and grouping rules.
+            operationId: Alert Routes V2#Update
+            parameters:
+                - name: id
+                  in: path
+                  description: Unique identifier for this alert route config
+                  required: true
+                  type: string
+                - name: UpdateRequestBody
+                  in: body
+                  required: true
+                  schema:
+                    $ref: '#/definitions/AlertRoutesV2UpdateRequestBody'
+                    required:
+                        - name
+                        - condition_groups
+                        - grouping_keys
+                        - grouping_window_seconds
+                        - defer_time_seconds
+                        - escalation_bindings
+                        - auto_decline_enabled
+                        - enabled
+                        - incident_enabled
+                        - incident_condition_groups
+                        - alert_source_ids
+                        - auto_cancel_escalations
+            responses:
+                "200":
+                    description: OK response.
+                    schema:
+                        $ref: '#/definitions/AlertRoutesV2UpdateResponseBody'
+                        required:
+                            - alert_route
+            schemes:
+                - https
+        delete:
+            tags:
+                - Alert Routes V2
+            summary: Destroy Alert Routes V2
+            description: |
+                Archives an alert route.
+
+                We recommend you create alert routes in the incident.io dashboard where we allow
+                previewing filter and grouping rules.
+            operationId: Alert Routes V2#Destroy
+            parameters:
+                - name: id
+                  in: path
+                  description: Unique identifier for this alert route config
+                  required: true
+                  type: string
+            responses:
+                "204":
+                    description: No Content response.
             schemes:
                 - https
     /v2/catalog_entries:
@@ -1889,11 +2005,11 @@ paths:
                   schema:
                     $ref: '#/definitions/IncidentRolesV2UpdateRequestBody'
                     required:
-                        - condition_groups
                         - name
+                        - shortform
                         - description
                         - instructions
-                        - shortform
+                        - condition_groups
                         - role_type
                         - created_at
                         - updated_at
@@ -3222,6 +3338,90 @@ paths:
                     description: OK response.
                     schema:
                         $ref: '#/definitions/AuditLogsFollowUpPriorityUpdatedV1ResponseBody'
+                        required:
+                            - action
+                            - occurred_at
+                            - version
+                            - actor
+                            - targets
+                            - context
+            schemes:
+                - https
+    /x-audit-logs/holiday_user_feed.created.1:
+        get:
+            tags:
+                - Audit logs
+            summary: HolidayUserFeedCreatedV1 Audit logs
+            description: This entry is created whenever a holiday user feed is created
+            operationId: Audit logs#HolidayUserFeedCreatedV1
+            responses:
+                "200":
+                    description: OK response.
+                    schema:
+                        $ref: '#/definitions/AuditLogsHolidayUserFeedCreatedV1ResponseBody'
+                        required:
+                            - action
+                            - occurred_at
+                            - version
+                            - actor
+                            - targets
+                            - context
+            schemes:
+                - https
+    /x-audit-logs/holiday_user_feed.deleted.1:
+        get:
+            tags:
+                - Audit logs
+            summary: HolidayUserFeedDeletedV1 Audit logs
+            description: This entry is created whenever a holiday user feed is deleted
+            operationId: Audit logs#HolidayUserFeedDeletedV1
+            responses:
+                "200":
+                    description: OK response.
+                    schema:
+                        $ref: '#/definitions/AuditLogsHolidayUserFeedDeletedV1ResponseBody'
+                        required:
+                            - action
+                            - occurred_at
+                            - version
+                            - actor
+                            - targets
+                            - context
+            schemes:
+                - https
+    /x-audit-logs/holiday_user_feed.updated.1:
+        get:
+            tags:
+                - Audit logs
+            summary: HolidayUserFeedUpdatedV1 Audit logs
+            description: This entry is created whenever a holiday user feed is updated
+            operationId: Audit logs#HolidayUserFeedUpdatedV1
+            responses:
+                "200":
+                    description: OK response.
+                    schema:
+                        $ref: '#/definitions/AuditLogsHolidayUserFeedUpdatedV1ResponseBody'
+                        required:
+                            - action
+                            - occurred_at
+                            - version
+                            - actor
+                            - targets
+                            - context
+            schemes:
+                - https
+    /x-audit-logs/incident_call_setting.updated.1:
+        get:
+            tags:
+                - Audit logs
+            summary: IncidentCallSettingUpdatedV1 Audit logs
+            description: This entry is created whenever an organisation's incident call settings are updated
+            operationId: Audit logs#IncidentCallSettingUpdatedV1
+            responses:
+                "200":
+                    description: OK response.
+                    schema:
+                        $ref: '#/definitions/AuditLogsIncidentCallSettingUpdatedV1ResponseBody'
                         required:
                             - action
                             - occurred_at
@@ -5214,6 +5414,1800 @@ definitions:
             - status
             - message
             - deduplication_key
+    AlertRouteEscalationBindingPayloadV2RequestBody:
+        title: AlertRouteEscalationBindingPayloadV2RequestBody
+        type: object
+        properties:
+            binding:
+                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+        example:
+            binding:
+                array_value:
+                    - literal: SEV123
+                      reference: incident.severity
+                value:
+                    literal: SEV123
+                    reference: incident.severity
+        required:
+            - binding
+    AlertRouteEscalationBindingV2ResponseBody:
+        title: AlertRouteEscalationBindingV2ResponseBody
+        type: object
+        properties:
+            binding:
+                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+        example:
+            binding:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        required:
+            - binding
+    AlertRouteIncidentTemplatePayloadV2RequestBody:
+        title: AlertRouteIncidentTemplatePayloadV2RequestBody
+        type: object
+        properties:
+            custom_field_priorities:
+                type: object
+                description: lookup of the priority options for each custom field in the template
+                example:
+                    abc123: abc123
+                additionalProperties:
+                    type: string
+                    example: abc123
+            custom_fields:
+                type: object
+                description: Custom field keys mapped to values
+                example:
+                    custom_field_10014:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                additionalProperties:
+                    $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+            incident_mode:
+                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+            incident_type:
+                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+            name:
+                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+            priority_severity:
+                type: string
+                description: option defining whether to cause subsequent alerts to increase the severity
+                example: severity-first-wins
+                enum:
+                    - severity-first-wins
+                    - severity-max
+            severity:
+                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+            summary:
+                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+            workspace:
+                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+        example:
+            custom_field_priorities:
+                abc123: abc123
+            custom_fields:
+                custom_field_10014:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+            incident_mode:
+                array_value:
+                    - literal: SEV123
+                      reference: incident.severity
+                value:
+                    literal: SEV123
+                    reference: incident.severity
+            incident_type:
+                array_value:
+                    - literal: SEV123
+                      reference: incident.severity
+                value:
+                    literal: SEV123
+                    reference: incident.severity
+            name:
+                array_value:
+                    - literal: SEV123
+                      reference: incident.severity
+                value:
+                    literal: SEV123
+                    reference: incident.severity
+            priority_severity: severity-first-wins
+            severity:
+                array_value:
+                    - literal: SEV123
+                      reference: incident.severity
+                value:
+                    literal: SEV123
+                    reference: incident.severity
+            summary:
+                array_value:
+                    - literal: SEV123
+                      reference: incident.severity
+                value:
+                    literal: SEV123
+                    reference: incident.severity
+            workspace:
+                array_value:
+                    - literal: SEV123
+                      reference: incident.severity
+                value:
+                    literal: SEV123
+                    reference: incident.severity
+        required:
+            - custom_field_priorities
+            - priority_severity
+    AlertRouteIncidentTemplateV2ResponseBody:
+        title: AlertRouteIncidentTemplateV2ResponseBody
+        type: object
+        properties:
+            custom_field_priorities:
+                type: object
+                description: lookup of the priority options for each custom field in the template
+                example:
+                    abc123: first-wins
+                additionalProperties:
+                    type: string
+                    example: first-wins
+                    enum:
+                        - first-wins
+                        - last-wins
+                        - append
+            custom_fields:
+                type: object
+                description: Custom field keys mapped to values
+                example:
+                    custom_field_10014:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                additionalProperties:
+                    $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+            incident_mode:
+                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+            incident_type:
+                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+            name:
+                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+            priority_severity:
+                type: string
+                description: binding to use to resolve the workspace to create an incident in
+                example: severity-first-wins
+                enum:
+                    - severity-first-wins
+                    - severity-max
+            severity:
+                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+            summary:
+                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+            workspace:
+                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+        example:
+            custom_field_priorities:
+                abc123: first-wins
+            custom_fields:
+                custom_field_10014:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+            incident_mode:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+            incident_type:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+            name:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+            priority_severity: severity-first-wins
+            severity:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+            summary:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+            workspace:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        required:
+            - custom_field_priorities
+            - priority_severity
+    AlertRouteV2ResponseBody:
+        title: AlertRouteV2ResponseBody
+        type: object
+        properties:
+            condition_groups:
+                type: array
+                items:
+                    $ref: '#/definitions/ConditionGroupV2ResponseBody'
+                description: What condition groups must be true for this alert route to fire?
+                example:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+            defer_time_seconds:
+                type: integer
+                description: How long should the escalation defer time be?
+                example: 1
+                format: int64
+            escalation_bindings:
+                type: array
+                items:
+                    $ref: '#/definitions/AlertRouteEscalationBindingV2ResponseBody'
+                description: Which escalation paths should this alert route escalate to?
+                example:
+                    - binding:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+            expressions:
+                type: array
+                items:
+                    $ref: '#/definitions/ExpressionV2ResponseBody'
+                description: The expressions used in this template
+                example:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                      reference: abc123
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                      root_reference: incident.status
+            grouping_keys:
+                type: array
+                items:
+                    $ref: '#/definitions/GroupingKeyV2ResponseBody'
+                description: Which attributes should this alert route use to group alerts?
+                example:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+            grouping_window_seconds:
+                type: integer
+                description: How large should the grouping window be?
+                example: 1
+                format: int64
+            id:
+                type: string
+                description: Unique identifier for this alert route config
+                example: 01FCNDV6P870EA6S7TK1DSYDG0
+            name:
+                type: string
+                description: The name of this alert route config, for the user's reference
+                example: Production incidents
+            template:
+                $ref: '#/definitions/AlertRouteIncidentTemplateV2ResponseBody'
+        example:
+            condition_groups:
+                - conditions:
+                    - operation:
+                        label: Lawrence Jones
+                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                      param_bindings:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                      subject:
+                        label: Incident Severity
+                        reference: incident.severity
+            defer_time_seconds: 1
+            escalation_bindings:
+                - binding:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+            expressions:
+                - else_branch:
+                    result:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                  label: Team Slack channel
+                  operations:
+                    - branches:
+                        branches:
+                            - condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                              result:
+                                array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                      filter:
+                        condition_groups:
+                            - conditions:
+                                - operation:
+                                    label: Lawrence Jones
+                                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                  param_bindings:
+                                    - array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject:
+                                    label: Incident Severity
+                                    reference: incident.severity
+                      navigate:
+                        reference: "1235"
+                        reference_label: Teams
+                      operation_type: navigate
+                      parse:
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                        source: metadata.annotations["github.com/repo"]
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                  reference: abc123
+                  returns:
+                    array: true
+                    type: IncidentStatus
+                  root_reference: incident.status
+            grouping_keys:
+                - id: 01FCNDV6P870EA6S7TK1DSYDG0
+            grouping_window_seconds: 1
+            id: 01FCNDV6P870EA6S7TK1DSYDG0
+            name: Production incidents
+            template:
+                custom_field_priorities:
+                    abc123: first-wins
+                custom_fields:
+                    custom_field_10014:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                incident_mode:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                incident_type:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                name:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                priority_severity: severity-first-wins
+                severity:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                summary:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                workspace:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+        required:
+            - id
+            - name
+            - condition_groups
+            - grouping_keys
+            - grouping_window_seconds
+            - defer_time_seconds
+            - escalation_bindings
+            - auto_decline_enabled
+            - enabled
+            - incident_enabled
+            - incident_condition_groups
+            - alert_source_ids
+            - auto_cancel_escalations
+    AlertRoutesV2CreateRequestBody:
+        title: AlertRoutesV2CreateRequestBody
+        type: object
+        properties:
+            alert_source_ids:
+                type: array
+                items:
+                    type: string
+                    example: abc123
+                description: The alert sources that will match this alert route
+                example:
+                    - 02FCNDV6P870EA6S7TK1DSYDG2
+            auto_decline_enabled:
+                type: boolean
+                description: Should triage incidents be declined when alerts are resolved?
+                example: false
+            condition_groups:
+                type: array
+                items:
+                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                description: What condition groups must be true for this alert route to fire?
+                example:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+            defer_time_seconds:
+                type: integer
+                description: How long should the escalation defer time be?
+                example: 1
+                format: int64
+            enabled:
+                type: boolean
+                description: Whether this alert route is enabled or not
+                example: false
+            escalation_bindings:
+                type: array
+                items:
+                    $ref: '#/definitions/AlertRouteEscalationBindingPayloadV2RequestBody'
+                description: Which escalation paths should this alert route escalate to?
+                example:
+                    - binding:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+            expressions:
+                type: array
+                items:
+                    $ref: '#/definitions/ExpressionPayloadV2RequestBody'
+                description: The expressions used in this template
+                example:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                                  result:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                          navigate:
+                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                      reference: abc123
+                      root_reference: incident.status
+            grouping_keys:
+                type: array
+                items:
+                    $ref: '#/definitions/GroupingKeyV2RequestBody'
+                description: Which attributes should this alert route use to group alerts?
+                example:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+            grouping_window_seconds:
+                type: integer
+                description: How large should the grouping window be?
+                example: 1
+                format: int64
+            incident_condition_groups:
+                type: array
+                items:
+                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                description: What condition groups must be true for this alert route to create an incident?
+                example:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+            incident_enabled:
+                type: boolean
+                description: Whether this alert route will create incidents or not
+                example: false
+            name:
+                type: string
+                description: The name of this alert route config, for the user's reference
+                example: Production incidents
+            template:
+                $ref: '#/definitions/AlertRouteIncidentTemplatePayloadV2RequestBody'
+        example:
+            alert_source_ids:
+                - 02FCNDV6P870EA6S7TK1DSYDG2
+            auto_decline_enabled: false
+            condition_groups:
+                - conditions:
+                    - operation: one_of
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+                      subject: incident.severity
+            defer_time_seconds: 1
+            enabled: false
+            escalation_bindings:
+                - binding:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+            expressions:
+                - else_branch:
+                    result:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                  label: Team Slack channel
+                  operations:
+                    - branches:
+                        branches:
+                            - condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                              result:
+                                array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                      filter:
+                        condition_groups:
+                            - conditions:
+                                - operation: one_of
+                                  param_bindings:
+                                    - array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject: incident.severity
+                      navigate:
+                        reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                      operation_type: navigate
+                      parse:
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                        source: metadata.annotations["github.com/repo"]
+                  reference: abc123
+                  root_reference: incident.status
+            grouping_keys:
+                - id: 01FCNDV6P870EA6S7TK1DSYDG0
+            grouping_window_seconds: 1
+            incident_condition_groups:
+                - conditions:
+                    - operation: one_of
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+                      subject: incident.severity
+            incident_enabled: false
+            name: Production incidents
+            template:
+                custom_field_priorities:
+                    abc123: abc123
+                custom_fields:
+                    custom_field_10014:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                incident_mode:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                incident_type:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                name:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                priority_severity: severity-first-wins
+                severity:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                summary:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                workspace:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+    AlertRoutesV2CreateResponseBody:
+        title: AlertRoutesV2CreateResponseBody
+        type: object
+        properties:
+            alert_route:
+                $ref: '#/definitions/AlertRouteV2ResponseBody'
+        example:
+            alert_route:
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+                defer_time_seconds: 1
+                escalation_bindings:
+                    - binding:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                      reference: abc123
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                      root_reference: incident.status
+                grouping_keys:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds: 1
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Production incidents
+                template:
+                    custom_field_priorities:
+                        abc123: first-wins
+                    custom_fields:
+                        custom_field_10014:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                    incident_mode:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    incident_type:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    name:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    priority_severity: severity-first-wins
+                    severity:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    summary:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    workspace:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+        required:
+            - alert_route
+    AlertRoutesV2ShowResponseBody:
+        title: AlertRoutesV2ShowResponseBody
+        type: object
+        properties:
+            alert_route:
+                $ref: '#/definitions/AlertRouteV2ResponseBody'
+        example:
+            alert_route:
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+                defer_time_seconds: 1
+                escalation_bindings:
+                    - binding:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                      reference: abc123
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                      root_reference: incident.status
+                grouping_keys:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds: 1
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Production incidents
+                template:
+                    custom_field_priorities:
+                        abc123: first-wins
+                    custom_fields:
+                        custom_field_10014:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                    incident_mode:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    incident_type:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    name:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    priority_severity: severity-first-wins
+                    severity:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    summary:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    workspace:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+        required:
+            - alert_route
+    AlertRoutesV2UpdateRequestBody:
+        title: AlertRoutesV2UpdateRequestBody
+        type: object
+        properties:
+            alert_source_ids:
+                type: array
+                items:
+                    type: string
+                    example: abc123
+                description: The alert sources that will match this alert route
+                example:
+                    - 02FCNDV6P870EA6S7TK1DSYDG2
+            auto_decline_enabled:
+                type: boolean
+                description: Should triage incidents be declined when alerts are resolved?
+                example: false
+            condition_groups:
+                type: array
+                items:
+                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                description: What condition groups must be true for this alert route to fire?
+                example:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+            defer_time_seconds:
+                type: integer
+                description: How long should the escalation defer time be?
+                example: 1
+                format: int64
+            enabled:
+                type: boolean
+                description: Whether this alert route is enabled or not
+                example: false
+            escalation_bindings:
+                type: array
+                items:
+                    $ref: '#/definitions/AlertRouteEscalationBindingPayloadV2RequestBody'
+                description: Which escalation paths should this alert route escalate to?
+                example:
+                    - binding:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+            expressions:
+                type: array
+                items:
+                    $ref: '#/definitions/ExpressionPayloadV2RequestBody'
+                description: The expressions used in this template
+                example:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                                  result:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                          navigate:
+                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                      reference: abc123
+                      root_reference: incident.status
+            grouping_keys:
+                type: array
+                items:
+                    $ref: '#/definitions/GroupingKeyV2RequestBody'
+                description: Which attributes should this alert route use to group alerts?
+                example:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+            grouping_window_seconds:
+                type: integer
+                description: How large should the grouping window be?
+                example: 1
+                format: int64
+            incident_condition_groups:
+                type: array
+                items:
+                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                description: What condition groups must be true for this alert route to create an incident?
+                example:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+            incident_enabled:
+                type: boolean
+                description: Whether this alert route will create incidents or not
+                example: false
+            name:
+                type: string
+                description: The name of this alert route config, for the user's reference
+                example: Production incidents
+            template:
+                $ref: '#/definitions/AlertRouteIncidentTemplatePayloadV2RequestBody'
+        example:
+            alert_source_ids:
+                - 02FCNDV6P870EA6S7TK1DSYDG2
+            auto_decline_enabled: false
+            condition_groups:
+                - conditions:
+                    - operation: one_of
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+                      subject: incident.severity
+            defer_time_seconds: 1
+            enabled: false
+            escalation_bindings:
+                - binding:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+            expressions:
+                - else_branch:
+                    result:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                  label: Team Slack channel
+                  operations:
+                    - branches:
+                        branches:
+                            - condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                              result:
+                                array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                      filter:
+                        condition_groups:
+                            - conditions:
+                                - operation: one_of
+                                  param_bindings:
+                                    - array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject: incident.severity
+                      navigate:
+                        reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                      operation_type: navigate
+                      parse:
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                        source: metadata.annotations["github.com/repo"]
+                  reference: abc123
+                  root_reference: incident.status
+            grouping_keys:
+                - id: 01FCNDV6P870EA6S7TK1DSYDG0
+            grouping_window_seconds: 1
+            incident_condition_groups:
+                - conditions:
+                    - operation: one_of
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+                      subject: incident.severity
+            incident_enabled: false
+            name: Production incidents
+            template:
+                custom_field_priorities:
+                    abc123: abc123
+                custom_fields:
+                    custom_field_10014:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                incident_mode:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                incident_type:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                name:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                priority_severity: severity-first-wins
+                severity:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                summary:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                workspace:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+        required:
+            - name
+            - condition_groups
+            - grouping_keys
+            - grouping_window_seconds
+            - defer_time_seconds
+            - escalation_bindings
+            - auto_decline_enabled
+            - enabled
+            - incident_enabled
+            - incident_condition_groups
+            - alert_source_ids
+            - auto_cancel_escalations
+    AlertRoutesV2UpdateResponseBody:
+        title: AlertRoutesV2UpdateResponseBody
+        type: object
+        properties:
+            alert_route:
+                $ref: '#/definitions/AlertRouteV2ResponseBody'
+        example:
+            alert_route:
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+                defer_time_seconds: 1
+                escalation_bindings:
+                    - binding:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                      reference: abc123
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                      root_reference: incident.status
+                grouping_keys:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds: 1
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Production incidents
+                template:
+                    custom_field_priorities:
+                        abc123: first-wins
+                    custom_fields:
+                        custom_field_10014:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                    incident_mode:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    incident_type:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    name:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    priority_severity: severity-first-wins
+                    severity:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    summary:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    workspace:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+        required:
+            - alert_route
     AuditLogActorMetadataV2ResponseBody:
         title: AuditLogActorMetadataV2ResponseBody
         type: object
@@ -5335,7 +7329,9 @@ definitions:
                     - debrief_invite_rule
                     - escalation_path
                     - follow_up_priority
+                    - holiday_user_feed
                     - incident
+                    - incident_call_setting
                     - incident_duration_metric
                     - incident_role
                     - incident_status
@@ -6921,6 +8917,230 @@ definitions:
                 - id: 01FCNDV6P870EA6S7TK1DSYDG0
                   name: Low
                   type: follow_up_priority
+            version: 1
+        required:
+            - action
+            - occurred_at
+            - version
+            - actor
+            - targets
+            - context
+    AuditLogsHolidayUserFeedCreatedV1ResponseBody:
+        title: AuditLogsHolidayUserFeedCreatedV1ResponseBody
+        type: object
+        properties:
+            action:
+                type: string
+                description: The type of log entry that this is
+                example: holiday_user_feed.created
+            actor:
+                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+            context:
+                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+            occurred_at:
+                type: string
+                description: When the entry occurred
+                example: "2021-08-17T13:28:57.801578Z"
+                format: date-time
+            targets:
+                type: array
+                items:
+                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                description: The custom field that was created
+                example:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      name: US Team holidays
+                      type: holiday_user_feed
+            version:
+                type: integer
+                description: Which version the event is
+                example: 1
+                format: int64
+        example:
+            action: holiday_user_feed.created
+            actor:
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                metadata:
+                    user_base_role_slug: admin
+                    user_custom_role_slugs: engineering,security
+                name: John Doe
+                type: user
+            context:
+                location: 1.2.3.4
+                user_agent: Chrome/91.0.4472.114
+            occurred_at: "2021-08-17T13:28:57.801578Z"
+            targets:
+                - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                  name: US Team holidays
+                  type: holiday_user_feed
+            version: 1
+        required:
+            - action
+            - occurred_at
+            - version
+            - actor
+            - targets
+            - context
+    AuditLogsHolidayUserFeedDeletedV1ResponseBody:
+        title: AuditLogsHolidayUserFeedDeletedV1ResponseBody
+        type: object
+        properties:
+            action:
+                type: string
+                description: The type of log entry that this is
+                example: holiday_user_feed.deleted
+            actor:
+                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+            context:
+                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+            occurred_at:
+                type: string
+                description: When the entry occurred
+                example: "2021-08-17T13:28:57.801578Z"
+                format: date-time
+            targets:
+                type: array
+                items:
+                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                description: The custom field that was created
+                example:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      name: US Team holidays
+                      type: holiday_user_feed
+            version:
+                type: integer
+                description: Which version the event is
+                example: 1
+                format: int64
+        example:
+            action: holiday_user_feed.deleted
+            actor:
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                metadata:
+                    user_base_role_slug: admin
+                    user_custom_role_slugs: engineering,security
+                name: John Doe
+                type: user
+            context:
+                location: 1.2.3.4
+                user_agent: Chrome/91.0.4472.114
+            occurred_at: "2021-08-17T13:28:57.801578Z"
+            targets:
+                - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                  name: US Team holidays
+                  type: holiday_user_feed
+            version: 1
+        required:
+            - action
+            - occurred_at
+            - version
+            - actor
+            - targets
+            - context
+    AuditLogsHolidayUserFeedUpdatedV1ResponseBody:
+        title: AuditLogsHolidayUserFeedUpdatedV1ResponseBody
+        type: object
+        properties:
+            action:
+                type: string
+                description: The type of log entry that this is
+                example: holiday_user_feed.updated
+            actor:
+                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+            context:
+                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+            occurred_at:
+                type: string
+                description: When the entry occurred
+                example: "2021-08-17T13:28:57.801578Z"
+                format: date-time
+            targets:
+                type: array
+                items:
+                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                description: The custom field that was created
+                example:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      name: US Team holidays
+                      type: holiday_user_feed
+            version:
+                type: integer
+                description: Which version the event is
+                example: 1
+                format: int64
+        example:
+            action: holiday_user_feed.updated
+            actor:
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                metadata:
+                    user_base_role_slug: admin
+                    user_custom_role_slugs: engineering,security
+                name: John Doe
+                type: user
+            context:
+                location: 1.2.3.4
+                user_agent: Chrome/91.0.4472.114
+            occurred_at: "2021-08-17T13:28:57.801578Z"
+            targets:
+                - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                  name: US Team holidays
+                  type: holiday_user_feed
+            version: 1
+        required:
+            - action
+            - occurred_at
+            - version
+            - actor
+            - targets
+            - context
+    AuditLogsIncidentCallSettingUpdatedV1ResponseBody:
+        title: AuditLogsIncidentCallSettingUpdatedV1ResponseBody
+        type: object
+        properties:
+            action:
+                type: string
+                description: The type of log entry that this is
+                example: incident_call_setting.updated
+            actor:
+                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+            context:
+                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+            occurred_at:
+                type: string
+                description: When the entry occurred
+                example: "2021-08-17T13:28:57.801578Z"
+                format: date-time
+            targets:
+                type: array
+                items:
+                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                description: The custom field that was created
+                example:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      name: Incident call settings
+                      type: incident_call_setting
+            version:
+                type: integer
+                description: Which version the event is
+                example: 1
+                format: int64
+        example:
+            action: incident_call_setting.updated
+            actor:
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                metadata:
+                    user_base_role_slug: admin
+                    user_custom_role_slugs: engineering,security
+                name: John Doe
+                type: user
+            context:
+                location: 1.2.3.4
+                user_agent: Chrome/91.0.4472.114
+            occurred_at: "2021-08-17T13:28:57.801578Z"
+            targets:
+                - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                  name: Incident call settings
+                  type: incident_call_setting
             version: 1
         required:
             - action
@@ -10337,13 +12557,13 @@ definitions:
                         catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                         catalog_entry_name: Primary escalation
                         catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      helptext: Collection of standalone automations like auto-closing incidents.
-                      image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                      helptext: abc123
+                      image_url: abc123
                       is_image_slack_icon: false
                       label: Lawrence Jones
                       literal: SEV123
                       reference: incident.severity
-                      sort_key: "000020"
+                      sort_key: abc123
                       unavailable: false
                       value: abc123
             value:
@@ -10355,13 +12575,13 @@ definitions:
                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                     catalog_entry_name: Primary escalation
                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                  helptext: Collection of standalone automations like auto-closing incidents.
-                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                  helptext: abc123
+                  image_url: abc123
                   is_image_slack_icon: false
                   label: Lawrence Jones
                   literal: SEV123
                   reference: incident.severity
-                  sort_key: "000020"
+                  sort_key: abc123
                   unavailable: false
                   value: abc123
             value:
@@ -10370,13 +12590,13 @@ definitions:
                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                     catalog_entry_name: Primary escalation
                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                helptext: Collection of standalone automations like auto-closing incidents.
-                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                helptext: abc123
+                image_url: abc123
                 is_image_slack_icon: false
                 label: Lawrence Jones
                 literal: SEV123
                 reference: incident.severity
-                sort_key: "000020"
+                sort_key: abc123
                 unavailable: false
                 value: abc123
     CatalogEntryEngineParamBindingValueV2ResponseBody:
@@ -10387,15 +12607,15 @@ definitions:
                 $ref: '#/definitions/CatalogEntryReferenceV2ResponseBody'
             helptext:
                 type: string
-                description: Gives a description of the option to the user
-                example: Collection of standalone automations like auto-closing incidents.
+                description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
+                example: abc123
             image_url:
                 type: string
-                description: If appropriate, URL to an image that can be displayed alongside the option
-                example: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
+                example: abc123
             is_image_slack_icon:
                 type: boolean
-                description: If true, the image_url is a Slack icon and should be displayed as such
+                description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
                 example: false
             label:
                 type: string
@@ -10407,19 +12627,19 @@ definitions:
                 example: SEV123
             reference:
                 type: string
-                description: If set, this is the reference into the trigger scope that is the value of this parameter
+                description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
                 example: incident.severity
             sort_key:
                 type: string
-                description: Gives an indication of how to sort the options when displayed to the user
-                example: "000020"
+                description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
+                example: abc123
             unavailable:
                 type: boolean
-                description: Unavailable is true if we've failed to build the value for this binding
+                description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
                 example: false
             value:
                 type: string
-                description: 'Either the reference or the literal: this field is designed purely to make working with react-select easier'
+                description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
                 example: abc123
         example:
             catalog_entry:
@@ -10427,13 +12647,13 @@ definitions:
                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                 catalog_entry_name: Primary escalation
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-            helptext: Collection of standalone automations like auto-closing incidents.
-            image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+            helptext: abc123
+            image_url: abc123
             is_image_slack_icon: false
             label: Lawrence Jones
             literal: SEV123
             reference: incident.severity
-            sort_key: "000020"
+            sort_key: abc123
             unavailable: false
             value: abc123
         required:
@@ -10498,13 +12718,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              helptext: Collection of standalone automations like auto-closing incidents.
-                              image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                              helptext: abc123
+                              image_url: abc123
                               is_image_slack_icon: false
                               label: Lawrence Jones
                               literal: SEV123
                               reference: incident.severity
-                              sort_key: "000020"
+                              sort_key: abc123
                               unavailable: false
                               value: abc123
                         value:
@@ -10513,13 +12733,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                            helptext: Collection of standalone automations like auto-closing incidents.
-                            image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                            helptext: abc123
+                            image_url: abc123
                             is_image_slack_icon: false
                             label: Lawrence Jones
                             literal: SEV123
                             reference: incident.severity
-                            sort_key: "000020"
+                            sort_key: abc123
                             unavailable: false
                             value: abc123
                 additionalProperties:
@@ -10568,13 +12788,13 @@ definitions:
                             catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                             catalog_entry_name: Primary escalation
                             catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          helptext: Collection of standalone automations like auto-closing incidents.
-                          image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                          helptext: abc123
+                          image_url: abc123
                           is_image_slack_icon: false
                           label: Lawrence Jones
                           literal: SEV123
                           reference: incident.severity
-                          sort_key: "000020"
+                          sort_key: abc123
                           unavailable: false
                           value: abc123
                     value:
@@ -10583,13 +12803,13 @@ definitions:
                             catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                             catalog_entry_name: Primary escalation
                             catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                        helptext: Collection of standalone automations like auto-closing incidents.
-                        image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                        helptext: abc123
+                        image_url: abc123
                         is_image_slack_icon: false
                         label: Lawrence Jones
                         literal: SEV123
                         reference: incident.severity
-                        sort_key: "000020"
+                        sort_key: abc123
                         unavailable: false
                         value: abc123
             catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10896,8 +13116,9 @@ definitions:
             icon:
                 type: string
                 description: Sets the display icon of this type in the dashboard
-                example: bolt
+                example: alert
                 enum:
+                    - alert
                     - bolt
                     - box
                     - briefcase
@@ -10910,6 +13131,7 @@ definitions:
                     - database
                     - doc
                     - email
+                    - escalation-path
                     - files
                     - flag
                     - folder
@@ -10917,6 +13139,7 @@ definitions:
                     - money
                     - server
                     - severity
+                    - status-page
                     - store
                     - star
                     - tag
@@ -10984,7 +13207,7 @@ definitions:
             description: Represents Kubernetes clusters that we run inside of GKE.
             dynamic_resource_parameter: abc123
             estimated_count: 7
-            icon: bolt
+            icon: alert
             id: 01FCNDV6P870EA6S7TK1DSYDG0
             is_editable: false
             last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -11110,13 +13333,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              helptext: Collection of standalone automations like auto-closing incidents.
-                              image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                              helptext: abc123
+                              image_url: abc123
                               is_image_slack_icon: false
                               label: Lawrence Jones
                               literal: SEV123
                               reference: incident.severity
-                              sort_key: "000020"
+                              sort_key: abc123
                               unavailable: false
                               value: abc123
                         value:
@@ -11125,13 +13348,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                            helptext: Collection of standalone automations like auto-closing incidents.
-                            image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                            helptext: abc123
+                            image_url: abc123
                             is_image_slack_icon: false
                             label: Lawrence Jones
                             literal: SEV123
                             reference: incident.severity
-                            sort_key: "000020"
+                            sort_key: abc123
                             unavailable: false
                             value: abc123
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11190,8 +13413,9 @@ definitions:
             icon:
                 type: string
                 description: Sets the display icon of this type in the dashboard
-                example: bolt
+                example: alert
                 enum:
+                    - alert
                     - bolt
                     - box
                     - briefcase
@@ -11204,6 +13428,7 @@ definitions:
                     - database
                     - doc
                     - email
+                    - escalation-path
                     - files
                     - flag
                     - folder
@@ -11211,6 +13436,7 @@ definitions:
                     - money
                     - server
                     - severity
+                    - status-page
                     - store
                     - star
                     - tag
@@ -11239,7 +13465,7 @@ definitions:
                 - issue-tracker
             color: yellow
             description: Represents Kubernetes clusters that we run inside of GKE.
-            icon: bolt
+            icon: alert
             name: Kubernetes Cluster
             ranked: true
             source_repo_url: https://github.com/my-company/incident-io-catalog
@@ -11264,7 +13490,7 @@ definitions:
                 description: Represents Kubernetes clusters that we run inside of GKE.
                 dynamic_resource_parameter: abc123
                 estimated_count: 7
-                icon: bolt
+                icon: alert
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
                 is_editable: false
                 last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -11312,13 +13538,13 @@ definitions:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                  helptext: Collection of standalone automations like auto-closing incidents.
-                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                  helptext: abc123
+                                  image_url: abc123
                                   is_image_slack_icon: false
                                   label: Lawrence Jones
                                   literal: SEV123
                                   reference: incident.severity
-                                  sort_key: "000020"
+                                  sort_key: abc123
                                   unavailable: false
                                   value: abc123
                             value:
@@ -11327,13 +13553,13 @@ definitions:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                helptext: Collection of standalone automations like auto-closing incidents.
-                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                helptext: abc123
+                                image_url: abc123
                                 is_image_slack_icon: false
                                 label: Lawrence Jones
                                 literal: SEV123
                                 reference: incident.severity
-                                sort_key: "000020"
+                                sort_key: abc123
                                 unavailable: false
                                 value: abc123
                       catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11361,13 +13587,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              helptext: Collection of standalone automations like auto-closing incidents.
-                              image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                              helptext: abc123
+                              image_url: abc123
                               is_image_slack_icon: false
                               label: Lawrence Jones
                               literal: SEV123
                               reference: incident.severity
-                              sort_key: "000020"
+                              sort_key: abc123
                               unavailable: false
                               value: abc123
                         value:
@@ -11376,13 +13602,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                            helptext: Collection of standalone automations like auto-closing incidents.
-                            image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                            helptext: abc123
+                            image_url: abc123
                             is_image_slack_icon: false
                             label: Lawrence Jones
                             literal: SEV123
                             reference: incident.severity
-                            sort_key: "000020"
+                            sort_key: abc123
                             unavailable: false
                             value: abc123
                   catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11402,7 +13628,7 @@ definitions:
                 description: Represents Kubernetes clusters that we run inside of GKE.
                 dynamic_resource_parameter: abc123
                 estimated_count: 7
-                icon: bolt
+                icon: alert
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
                 is_editable: false
                 last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -11475,7 +13701,7 @@ definitions:
                       description: Represents Kubernetes clusters that we run inside of GKE.
                       dynamic_resource_parameter: abc123
                       estimated_count: 7
-                      icon: bolt
+                      icon: alert
                       id: 01FCNDV6P870EA6S7TK1DSYDG0
                       is_editable: false
                       last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -11511,7 +13737,7 @@ definitions:
                   description: Represents Kubernetes clusters that we run inside of GKE.
                   dynamic_resource_parameter: abc123
                   estimated_count: 7
-                  icon: bolt
+                  icon: alert
                   id: 01FCNDV6P870EA6S7TK1DSYDG0
                   is_editable: false
                   last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -11560,13 +13786,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              helptext: Collection of standalone automations like auto-closing incidents.
-                              image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                              helptext: abc123
+                              image_url: abc123
                               is_image_slack_icon: false
                               label: Lawrence Jones
                               literal: SEV123
                               reference: incident.severity
-                              sort_key: "000020"
+                              sort_key: abc123
                               unavailable: false
                               value: abc123
                         value:
@@ -11575,13 +13801,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                            helptext: Collection of standalone automations like auto-closing incidents.
-                            image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                            helptext: abc123
+                            image_url: abc123
                             is_image_slack_icon: false
                             label: Lawrence Jones
                             literal: SEV123
                             reference: incident.severity
-                            sort_key: "000020"
+                            sort_key: abc123
                             unavailable: false
                             value: abc123
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11601,7 +13827,7 @@ definitions:
                 description: Represents Kubernetes clusters that we run inside of GKE.
                 dynamic_resource_parameter: abc123
                 estimated_count: 7
-                icon: bolt
+                icon: alert
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
                 is_editable: false
                 last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -11646,7 +13872,7 @@ definitions:
                 description: Represents Kubernetes clusters that we run inside of GKE.
                 dynamic_resource_parameter: abc123
                 estimated_count: 7
-                icon: bolt
+                icon: alert
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
                 is_editable: false
                 last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -11752,13 +13978,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              helptext: Collection of standalone automations like auto-closing incidents.
-                              image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                              helptext: abc123
+                              image_url: abc123
                               is_image_slack_icon: false
                               label: Lawrence Jones
                               literal: SEV123
                               reference: incident.severity
-                              sort_key: "000020"
+                              sort_key: abc123
                               unavailable: false
                               value: abc123
                         value:
@@ -11767,13 +13993,13 @@ definitions:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                            helptext: Collection of standalone automations like auto-closing incidents.
-                            image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                            helptext: abc123
+                            image_url: abc123
                             is_image_slack_icon: false
                             label: Lawrence Jones
                             literal: SEV123
                             reference: incident.severity
-                            sort_key: "000020"
+                            sort_key: abc123
                             unavailable: false
                             value: abc123
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11793,7 +14019,7 @@ definitions:
                 description: Represents Kubernetes clusters that we run inside of GKE.
                 dynamic_resource_parameter: abc123
                 estimated_count: 7
-                icon: bolt
+                icon: alert
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
                 is_editable: false
                 last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -11868,8 +14094,9 @@ definitions:
             icon:
                 type: string
                 description: Sets the display icon of this type in the dashboard
-                example: bolt
+                example: alert
                 enum:
+                    - alert
                     - bolt
                     - box
                     - briefcase
@@ -11882,6 +14109,7 @@ definitions:
                     - database
                     - doc
                     - email
+                    - escalation-path
                     - files
                     - flag
                     - folder
@@ -11889,6 +14117,7 @@ definitions:
                     - money
                     - server
                     - severity
+                    - status-page
                     - store
                     - star
                     - tag
@@ -11913,7 +14142,7 @@ definitions:
                 - issue-tracker
             color: yellow
             description: Represents Kubernetes clusters that we run inside of GKE.
-            icon: bolt
+            icon: alert
             name: Kubernetes Cluster
             ranked: true
             source_repo_url: https://github.com/my-company/incident-io-catalog
@@ -11937,7 +14166,7 @@ definitions:
                 description: Represents Kubernetes clusters that we run inside of GKE.
                 dynamic_resource_parameter: abc123
                 estimated_count: 7
-                icon: bolt
+                icon: alert
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
                 is_editable: false
                 last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -12032,7 +14261,7 @@ definitions:
                 description: Represents Kubernetes clusters that we run inside of GKE.
                 dynamic_resource_parameter: abc123
                 estimated_count: 7
-                icon: bolt
+                icon: alert
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
                 is_editable: false
                 last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -13585,7 +15814,6 @@ definitions:
                 type: string
                 description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                 example: lead
-                minLength: 1
             updated_at:
                 type: string
                 description: When the role was last updated
@@ -13602,12 +15830,12 @@ definitions:
             shortform: lead
             updated_at: "2021-08-17T13:28:57.801578Z"
         required:
-            - condition_groups
-            - id
             - name
+            - shortform
             - description
             - instructions
-            - shortform
+            - condition_groups
+            - id
             - role_type
             - created_at
             - updated_at
@@ -16186,6 +18414,30 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - follow_up
+    GroupingKeyV2RequestBody:
+        title: GroupingKeyV2RequestBody
+        type: object
+        properties:
+            id:
+                type: string
+                description: Unique identifier of the alert attribute the user wishes to group on
+                example: 01FCNDV6P870EA6S7TK1DSYDG0
+        example:
+            id: 01FCNDV6P870EA6S7TK1DSYDG0
+        required:
+            - id
+    GroupingKeyV2ResponseBody:
+        title: GroupingKeyV2ResponseBody
+        type: object
+        properties:
+            id:
+                type: string
+                description: Unique identifier of the alert attribute the user wishes to group on
+                example: 01FCNDV6P870EA6S7TK1DSYDG0
+        example:
+            id: 01FCNDV6P870EA6S7TK1DSYDG0
+        required:
+            - id
     IdentityV1ResponseBody:
         title: IdentityV1ResponseBody
         type: object
@@ -16714,7 +18966,6 @@ definitions:
                 type: string
                 description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                 example: lead
-                minLength: 1
             updated_at:
                 type: string
                 description: When the role was last updated
@@ -16731,12 +18982,12 @@ definitions:
             shortform: lead
             updated_at: "2021-08-17T13:28:57.801578Z"
         required:
-            - condition_groups
-            - id
             - name
+            - shortform
             - description
             - instructions
-            - shortform
+            - condition_groups
+            - id
             - role_type
             - created_at
             - updated_at
@@ -16779,7 +19030,6 @@ definitions:
                 type: string
                 description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                 example: lead
-                minLength: 1
             updated_at:
                 type: string
                 description: When the role was last updated
@@ -16795,12 +19045,12 @@ definitions:
             shortform: lead
             updated_at: "2021-08-17T13:28:57.801578Z"
         required:
-            - condition_groups
-            - id
             - name
+            - shortform
             - description
             - instructions
-            - shortform
+            - condition_groups
+            - id
             - role_type
             - created_at
             - updated_at
@@ -16830,7 +19080,6 @@ definitions:
                 type: string
                 description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                 example: lead
-                minLength: 1
         example:
             description: The person currently coordinating the incident
             instructions: Take point on the incident; Make sure people are clear on responsibilities
@@ -16943,7 +19192,6 @@ definitions:
                 type: string
                 description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                 example: lead
-                minLength: 1
         example:
             description: The person currently coordinating the incident
             instructions: Take point on the incident; Make sure people are clear on responsibilities
@@ -16951,11 +19199,11 @@ definitions:
             required: false
             shortform: lead
         required:
-            - condition_groups
             - name
+            - shortform
             - description
             - instructions
-            - shortform
+            - condition_groups
             - role_type
             - created_at
             - updated_at
@@ -17000,7 +19248,6 @@ definitions:
                 type: string
                 description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                 example: lead
-                minLength: 1
         example:
             description: The person currently coordinating the incident
             instructions: Take point on the incident; Make sure people are clear on responsibilities
@@ -17103,18 +19350,17 @@ definitions:
                 type: string
                 description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                 example: lead
-                minLength: 1
         example:
             description: The person currently coordinating the incident
             instructions: Take point on the incident; Make sure people are clear on responsibilities
             name: Incident Lead
             shortform: lead
         required:
-            - condition_groups
             - name
+            - shortform
             - description
             - instructions
-            - shortform
+            - condition_groups
             - role_type
             - created_at
             - updated_at
@@ -20263,6 +22509,8 @@ definitions:
                     example: abc123
             config:
                 $ref: '#/definitions/ScheduleConfigCreatePayloadV2RequestBody'
+            holidays_public_config:
+                $ref: '#/definitions/ScheduleHolidaysPublicConfigPayloadV2RequestBody'
             name:
                 type: string
                 description: Name of the schedule
@@ -20294,6 +22542,9 @@ definitions:
                         - end_time: "17:00"
                           start_time: "09:00"
                           weekday: tuesday
+            holidays_public_config:
+                country_codes:
+                    - abc123
             name: My Schedule
             timezone: America/Los_Angeles
     ScheduleEntriesListPayloadV2ResponseBody:
@@ -20442,6 +22693,42 @@ definitions:
             - external_user_id
             - start_at
             - end_at
+    ScheduleHolidaysPublicConfigPayloadV2RequestBody:
+        title: ScheduleHolidaysPublicConfigPayloadV2RequestBody
+        type: object
+        properties:
+            country_codes:
+                type: array
+                items:
+                    type: string
+                    example: abc123
+                description: ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for
+                example:
+                    - abc123
+        example:
+            country_codes:
+                - abc123
+        required:
+            - country_codes
+    ScheduleHolidaysPublicConfigV2ResponseBody:
+        title: ScheduleHolidaysPublicConfigV2ResponseBody
+        type: object
+        properties:
+            country_codes:
+                type: array
+                items:
+                    type: string
+                    example: abc123
+                description: ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for
+                example:
+                    - GB
+                    - FR
+        example:
+            country_codes:
+                - GB
+                - FR
+        required:
+            - country_codes
     ScheduleLayerCreatePayloadV2RequestBody:
         title: ScheduleLayerCreatePayloadV2RequestBody
         type: object
@@ -20856,6 +23143,8 @@ definitions:
                     example: abc123
             config:
                 $ref: '#/definitions/ScheduleConfigUpdatePayloadV2RequestBody'
+            holidays_public_config:
+                $ref: '#/definitions/ScheduleHolidaysPublicConfigPayloadV2RequestBody'
             name:
                 type: string
                 description: Name of the schedule
@@ -20887,6 +23176,9 @@ definitions:
                         - end_time: "17:00"
                           start_time: "09:00"
                           weekday: tuesday
+            holidays_public_config:
+                country_codes:
+                    - abc123
             name: My Schedule
             timezone: America/Los_Angeles
     ScheduleV2ResponseBody:
@@ -20925,6 +23217,8 @@ definitions:
                         name: Lisa Karlin Curtis
                         role: viewer
                         slack_user_id: U02AYNF2XJM
+            holidays_public_config:
+                $ref: '#/definitions/ScheduleHolidaysPublicConfigV2ResponseBody'
             id:
                 type: string
                 description: Unique internal ID of the schedule
@@ -20980,6 +23274,10 @@ definitions:
                     name: Lisa Karlin Curtis
                     role: viewer
                     slack_user_id: U02AYNF2XJM
+            holidays_public_config:
+                country_codes:
+                    - GB
+                    - FR
             id: 01G0J1EXE7AXZ2C93K61WBPYEH
             name: Primary On-Call Schedule
             timezone: Europe/London
@@ -21023,6 +23321,9 @@ definitions:
                             - end_time: "17:00"
                               start_time: "09:00"
                               weekday: tuesday
+                holidays_public_config:
+                    country_codes:
+                        - abc123
                 name: My Schedule
                 timezone: America/Los_Angeles
         required:
@@ -21073,6 +23374,10 @@ definitions:
                         name: Lisa Karlin Curtis
                         role: viewer
                         slack_user_id: U02AYNF2XJM
+                holidays_public_config:
+                    country_codes:
+                        - GB
+                        - FR
                 id: 01G0J1EXE7AXZ2C93K61WBPYEH
                 name: Primary On-Call Schedule
                 timezone: Europe/London
@@ -21128,6 +23433,10 @@ definitions:
                             name: Lisa Karlin Curtis
                             role: viewer
                             slack_user_id: U02AYNF2XJM
+                      holidays_public_config:
+                        country_codes:
+                            - GB
+                            - FR
                       id: 01G0J1EXE7AXZ2C93K61WBPYEH
                       name: Primary On-Call Schedule
                       timezone: Europe/London
@@ -21176,6 +23485,10 @@ definitions:
                         name: Lisa Karlin Curtis
                         role: viewer
                         slack_user_id: U02AYNF2XJM
+                  holidays_public_config:
+                    country_codes:
+                        - GB
+                        - FR
                   id: 01G0J1EXE7AXZ2C93K61WBPYEH
                   name: Primary On-Call Schedule
                   timezone: Europe/London
@@ -21282,6 +23595,10 @@ definitions:
                         name: Lisa Karlin Curtis
                         role: viewer
                         slack_user_id: U02AYNF2XJM
+                holidays_public_config:
+                    country_codes:
+                        - GB
+                        - FR
                 id: 01G0J1EXE7AXZ2C93K61WBPYEH
                 name: Primary On-Call Schedule
                 timezone: Europe/London
@@ -21318,6 +23635,9 @@ definitions:
                             - end_time: "17:00"
                               start_time: "09:00"
                               weekday: tuesday
+                holidays_public_config:
+                    country_codes:
+                        - abc123
                 name: My Schedule
                 timezone: America/Los_Angeles
         required:
@@ -21375,6 +23695,10 @@ definitions:
                         name: Lisa Karlin Curtis
                         role: viewer
                         slack_user_id: U02AYNF2XJM
+                holidays_public_config:
+                    country_codes:
+                        - GB
+                        - FR
                 id: 01G0J1EXE7AXZ2C93K61WBPYEH
                 name: Primary On-Call Schedule
                 timezone: Europe/London

--- a/internal/apischema/openapi3-secret.json
+++ b/internal/apischema/openapi3-secret.json
@@ -257,7 +257,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody"
+                "$ref": "#/components/schemas/CreateRequestBody2"
               },
               "example": {
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -385,7 +385,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody"
+                "$ref": "#/components/schemas/UpdateRequestBody2"
               },
               "example": {
                 "sort_key": 10,
@@ -483,7 +483,7 @@
                 "show_in_announcement_post": true
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody2"
+                "$ref": "#/components/schemas/CreateRequestBody3"
               }
             }
           },
@@ -653,7 +653,7 @@
                 "show_in_announcement_post": true
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody2"
+                "$ref": "#/components/schemas/UpdateRequestBody3"
               }
             }
           },
@@ -838,7 +838,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody4"
+                "$ref": "#/components/schemas/CreateRequestBody5"
               },
               "example": {
                 "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
@@ -856,7 +856,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody"
+                  "$ref": "#/components/schemas/CreateResponseBody2"
                 },
                 "example": {
                   "incident_attachment": {
@@ -918,7 +918,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/CreateRequestBody6"
               },
               "example": {
                 "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
@@ -933,7 +933,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody2"
+                  "$ref": "#/components/schemas/CreateResponseBody3"
                 },
                 "example": {
                   "incident_membership": {
@@ -969,7 +969,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/CreateRequestBody6"
               },
               "example": {
                 "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
@@ -1036,7 +1036,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/CreateRequestBody7"
               }
             }
           },
@@ -1179,7 +1179,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody4"
+                "$ref": "#/components/schemas/UpdateRequestBody5"
               }
             }
           },
@@ -1263,7 +1263,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody8"
+                "$ref": "#/components/schemas/CreateRequestBody9"
               },
               "example": {
                 "category": "live",
@@ -1397,7 +1397,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody6"
+                "$ref": "#/components/schemas/UpdateRequestBody7"
               },
               "example": {
                 "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
@@ -1762,7 +1762,7 @@
                 "visibility": "public"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody9"
+                "$ref": "#/components/schemas/CreateRequestBody10"
               }
             }
           },
@@ -2155,7 +2155,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody12"
+                "$ref": "#/components/schemas/CreateRequestBody13"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2287,7 +2287,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody12"
+                "$ref": "#/components/schemas/CreateRequestBody13"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2531,6 +2531,1623 @@
         }
       }
     },
+    "/v2/alert_routes": {
+      "post": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Create Alert Routes V2",
+        "description": "Create an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRequestBody"
+              },
+              "example": {
+                "alert_source_ids": [
+                  "02FCNDV6P870EA6S7TK1DSYDG2"
+                ],
+                "auto_decline_enabled": false,
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "defer_time_seconds": 1,
+                "enabled": false,
+                "escalation_bindings": [
+                  {
+                    "binding": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "expressions": [
+                  {
+                    "else_branch": {
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    },
+                    "label": "Team Slack channel",
+                    "operations": [
+                      {
+                        "branches": {
+                          "branches": [
+                            {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": "one_of",
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": "incident.severity"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "result": {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            }
+                          ],
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
+                        "filter": {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "navigate": {
+                          "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                        },
+                        "operation_type": "navigate",
+                        "parse": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          },
+                          "source": "metadata.annotations[\"github.com/repo\"]"
+                        }
+                      }
+                    ],
+                    "reference": "abc123",
+                    "root_reference": "incident.status"
+                  }
+                ],
+                "grouping_keys": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  }
+                ],
+                "grouping_window_seconds": 1,
+                "incident_condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "incident_enabled": false,
+                "name": "Production incidents",
+                "template": {
+                  "custom_field_priorities": {
+                    "abc123": "abc123"
+                  },
+                  "custom_fields": {
+                    "custom_field_10014": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  },
+                  "incident_mode": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "incident_type": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "name": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "priority_severity": "severity-first-wins",
+                  "severity": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "summary": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "workspace": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateResponseBody"
+                },
+                "example": {
+                  "alert_route": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "defer_time_seconds": 1,
+                    "escalation_bindings": [
+                      {
+                        "binding": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "expressions": [
+                      {
+                        "else_branch": {
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "label": "Team Slack channel",
+                        "operations": [
+                          {
+                            "branches": {
+                              "branches": [
+                                {
+                                  "condition_groups": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "operation": {
+                                            "label": "Lawrence Jones",
+                                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                          },
+                                          "param_bindings": [
+                                            {
+                                              "array_value": [
+                                                {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              ],
+                                              "value": {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            }
+                                          ],
+                                          "subject": {
+                                            "label": "Incident Severity",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "result": {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                }
+                              ],
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            },
+                            "filter": {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "navigate": {
+                              "reference": "1235",
+                              "reference_label": "Teams"
+                            },
+                            "operation_type": "navigate",
+                            "parse": {
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              },
+                              "source": "metadata.annotations[\"github.com/repo\"]"
+                            },
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          }
+                        ],
+                        "reference": "abc123",
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "root_reference": "incident.status"
+                      }
+                    ],
+                    "grouping_keys": [
+                      {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                      }
+                    ],
+                    "grouping_window_seconds": 1,
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Production incidents",
+                    "template": {
+                      "custom_field_priorities": {
+                        "abc123": "first-wins"
+                      },
+                      "custom_fields": {
+                        "custom_field_10014": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
+                      "incident_mode": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "incident_type": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "name": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "priority_severity": "severity-first-wins",
+                      "severity": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "summary": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "workspace": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/alert_routes/{id}": {
+      "delete": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Destroy Alert Routes V2",
+        "description": "Archives an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Destroy",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this alert route config",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for this alert route config",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Show Alert Routes V2",
+        "description": "Show an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this alert route config",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for this alert route config",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateResponseBody"
+                },
+                "example": {
+                  "alert_route": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "defer_time_seconds": 1,
+                    "escalation_bindings": [
+                      {
+                        "binding": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "expressions": [
+                      {
+                        "else_branch": {
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "label": "Team Slack channel",
+                        "operations": [
+                          {
+                            "branches": {
+                              "branches": [
+                                {
+                                  "condition_groups": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "operation": {
+                                            "label": "Lawrence Jones",
+                                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                          },
+                                          "param_bindings": [
+                                            {
+                                              "array_value": [
+                                                {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              ],
+                                              "value": {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            }
+                                          ],
+                                          "subject": {
+                                            "label": "Incident Severity",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "result": {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                }
+                              ],
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            },
+                            "filter": {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "navigate": {
+                              "reference": "1235",
+                              "reference_label": "Teams"
+                            },
+                            "operation_type": "navigate",
+                            "parse": {
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              },
+                              "source": "metadata.annotations[\"github.com/repo\"]"
+                            },
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          }
+                        ],
+                        "reference": "abc123",
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "root_reference": "incident.status"
+                      }
+                    ],
+                    "grouping_keys": [
+                      {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                      }
+                    ],
+                    "grouping_window_seconds": 1,
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Production incidents",
+                    "template": {
+                      "custom_field_priorities": {
+                        "abc123": "first-wins"
+                      },
+                      "custom_fields": {
+                        "custom_field_10014": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
+                      "incident_mode": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "incident_type": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "name": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "priority_severity": "severity-first-wins",
+                      "severity": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "summary": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "workspace": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Update Alert Routes V2",
+        "description": "Updates an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this alert route config",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for this alert route config",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRequestBody"
+              },
+              "example": {
+                "alert_source_ids": [
+                  "02FCNDV6P870EA6S7TK1DSYDG2"
+                ],
+                "auto_decline_enabled": false,
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "defer_time_seconds": 1,
+                "enabled": false,
+                "escalation_bindings": [
+                  {
+                    "binding": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "expressions": [
+                  {
+                    "else_branch": {
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    },
+                    "label": "Team Slack channel",
+                    "operations": [
+                      {
+                        "branches": {
+                          "branches": [
+                            {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": "one_of",
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": "incident.severity"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "result": {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            }
+                          ],
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
+                        "filter": {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "navigate": {
+                          "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                        },
+                        "operation_type": "navigate",
+                        "parse": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          },
+                          "source": "metadata.annotations[\"github.com/repo\"]"
+                        }
+                      }
+                    ],
+                    "reference": "abc123",
+                    "root_reference": "incident.status"
+                  }
+                ],
+                "grouping_keys": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  }
+                ],
+                "grouping_window_seconds": 1,
+                "incident_condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "incident_enabled": false,
+                "name": "Production incidents",
+                "template": {
+                  "custom_field_priorities": {
+                    "abc123": "abc123"
+                  },
+                  "custom_fields": {
+                    "custom_field_10014": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  },
+                  "incident_mode": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "incident_type": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "name": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "priority_severity": "severity-first-wins",
+                  "severity": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "summary": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "workspace": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateResponseBody"
+                },
+                "example": {
+                  "alert_route": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "defer_time_seconds": 1,
+                    "escalation_bindings": [
+                      {
+                        "binding": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "expressions": [
+                      {
+                        "else_branch": {
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "label": "Team Slack channel",
+                        "operations": [
+                          {
+                            "branches": {
+                              "branches": [
+                                {
+                                  "condition_groups": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "operation": {
+                                            "label": "Lawrence Jones",
+                                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                          },
+                                          "param_bindings": [
+                                            {
+                                              "array_value": [
+                                                {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              ],
+                                              "value": {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            }
+                                          ],
+                                          "subject": {
+                                            "label": "Incident Severity",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "result": {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                }
+                              ],
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            },
+                            "filter": {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "navigate": {
+                              "reference": "1235",
+                              "reference_label": "Teams"
+                            },
+                            "operation_type": "navigate",
+                            "parse": {
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              },
+                              "source": "metadata.annotations[\"github.com/repo\"]"
+                            },
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          }
+                        ],
+                        "reference": "abc123",
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "root_reference": "incident.status"
+                      }
+                    ],
+                    "grouping_keys": [
+                      {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                      }
+                    ],
+                    "grouping_window_seconds": 1,
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Production incidents",
+                    "template": {
+                      "custom_field_priorities": {
+                        "abc123": "first-wins"
+                      },
+                      "custom_fields": {
+                        "custom_field_10014": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
+                      "incident_mode": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "incident_type": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "name": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "priority_severity": "severity-first-wins",
+                      "severity": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "summary": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "workspace": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/catalog_entries": {
       "get": {
         "tags": [
@@ -2607,13 +4224,13 @@
                                 "catalog_entry_name": "Primary escalation",
                                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                               },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                              "helptext": "abc123",
+                              "image_url": "abc123",
                               "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
                               "reference": "incident.severity",
-                              "sort_key": "000020",
+                              "sort_key": "abc123",
                               "unavailable": false,
                               "value": "abc123"
                             }
@@ -2625,13 +4242,13 @@
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                            "helptext": "abc123",
+                            "image_url": "abc123",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
                             "reference": "incident.severity",
-                            "sort_key": "000020",
+                            "sort_key": "abc123",
                             "unavailable": false,
                             "value": "abc123"
                           }
@@ -2658,7 +4275,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -2768,13 +4385,13 @@
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                            "helptext": "abc123",
+                            "image_url": "abc123",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
                             "reference": "incident.severity",
-                            "sort_key": "000020",
+                            "sort_key": "abc123",
                             "unavailable": false,
                             "value": "abc123"
                           }
@@ -2786,13 +4403,13 @@
                             "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                          "helptext": "abc123",
+                          "image_url": "abc123",
                           "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
                           "reference": "incident.severity",
-                          "sort_key": "000020",
+                          "sort_key": "abc123",
                           "unavailable": false,
                           "value": "abc123"
                         }
@@ -2887,13 +4504,13 @@
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                            "helptext": "abc123",
+                            "image_url": "abc123",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
                             "reference": "incident.severity",
-                            "sort_key": "000020",
+                            "sort_key": "abc123",
                             "unavailable": false,
                             "value": "abc123"
                           }
@@ -2905,13 +4522,13 @@
                             "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                          "helptext": "abc123",
+                          "image_url": "abc123",
                           "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
                           "reference": "incident.severity",
-                          "sort_key": "000020",
+                          "sort_key": "abc123",
                           "unavailable": false,
                           "value": "abc123"
                         }
@@ -2937,7 +4554,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3056,13 +4673,13 @@
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                            "helptext": "abc123",
+                            "image_url": "abc123",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
                             "reference": "incident.severity",
-                            "sort_key": "000020",
+                            "sort_key": "abc123",
                             "unavailable": false,
                             "value": "abc123"
                           }
@@ -3074,13 +4691,13 @@
                             "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                          "helptext": "abc123",
+                          "image_url": "abc123",
                           "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
                           "reference": "incident.severity",
-                          "sort_key": "000020",
+                          "sort_key": "abc123",
                           "unavailable": false,
                           "value": "abc123"
                         }
@@ -3106,7 +4723,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3210,7 +4827,7 @@
                       "description": "Represents Kubernetes clusters that we run inside of GKE.",
                       "dynamic_resource_parameter": "abc123",
                       "estimated_count": 7,
-                      "icon": "bolt",
+                      "icon": "alert",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "is_editable": false,
                       "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3274,7 +4891,7 @@
                 ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
-                "icon": "bolt",
+                "icon": "alert",
                 "name": "Kubernetes Cluster",
                 "ranked": true,
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog",
@@ -3304,7 +4921,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3415,7 +5032,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3492,7 +5109,7 @@
                 ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
-                "icon": "bolt",
+                "icon": "alert",
                 "name": "Kubernetes Cluster",
                 "ranked": true,
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog"
@@ -3521,7 +5138,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3633,7 +5250,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3720,7 +5337,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody3"
+                "$ref": "#/components/schemas/CreateRequestBody4"
               },
               "example": {
                 "description": "Which team is impacted by this issue",
@@ -3854,7 +5471,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody3"
+                "$ref": "#/components/schemas/UpdateRequestBody4"
               },
               "example": {
                 "description": "Which team is impacted by this issue",
@@ -4620,7 +6237,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody7"
+                "$ref": "#/components/schemas/CreateRequestBody8"
               },
               "example": {
                 "description": "The person currently coordinating the incident",
@@ -4757,7 +6374,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody5"
+                "$ref": "#/components/schemas/UpdateRequestBody6"
               },
               "example": {
                 "description": "The person currently coordinating the incident",
@@ -5492,7 +7109,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody10"
+                "$ref": "#/components/schemas/CreateRequestBody11"
               },
               "example": {
                 "custom_field_entries": [
@@ -6418,6 +8035,12 @@
                           }
                         }
                       ],
+                      "holidays_public_config": {
+                        "country_codes": [
+                          "GB",
+                          "FR"
+                        ]
+                      },
                       "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                       "name": "Primary On-Call Schedule",
                       "timezone": "Europe/London",
@@ -6442,7 +8065,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody11"
+                "$ref": "#/components/schemas/CreateRequestBody12"
               },
               "example": {
                 "schedule": {
@@ -6483,6 +8106,11 @@
                           }
                         ]
                       }
+                    ]
+                  },
+                  "holidays_public_config": {
+                    "country_codes": [
+                      "abc123"
                     ]
                   },
                   "name": "My Schedule",
@@ -6561,6 +8189,12 @@
                         }
                       }
                     ],
+                    "holidays_public_config": {
+                      "country_codes": [
+                        "GB",
+                        "FR"
+                      ]
+                    },
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "name": "Primary On-Call Schedule",
                     "timezone": "Europe/London",
@@ -6691,6 +8325,12 @@
                         }
                       }
                     ],
+                    "holidays_public_config": {
+                      "country_codes": [
+                        "GB",
+                        "FR"
+                      ]
+                    },
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "name": "Primary On-Call Schedule",
                     "timezone": "Europe/London",
@@ -6728,7 +8368,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody7"
+                "$ref": "#/components/schemas/UpdateRequestBody8"
               },
               "example": {
                 "schedule": {
@@ -6769,6 +8409,11 @@
                           }
                         ]
                       }
+                    ]
+                  },
+                  "holidays_public_config": {
+                    "country_codes": [
+                      "abc123"
                     ]
                   },
                   "name": "My Schedule",
@@ -6847,6 +8492,12 @@
                         }
                       }
                     ],
+                    "holidays_public_config": {
+                      "country_codes": [
+                        "GB",
+                        "FR"
+                      ]
+                    },
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "name": "Primary On-Call Schedule",
                     "timezone": "Europe/London",
@@ -8801,6 +10452,968 @@
           "deduplication_key"
         ]
       },
+      "AlertRouteEscalationBindingPayloadV2": {
+        "type": "object",
+        "properties": {
+          "binding": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          }
+        },
+        "example": {
+          "binding": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "binding"
+        ]
+      },
+      "AlertRouteEscalationBindingV2": {
+        "type": "object",
+        "properties": {
+          "binding": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          }
+        },
+        "example": {
+          "binding": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "binding"
+        ]
+      },
+      "AlertRouteIncidentTemplatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "custom_field_priorities": {
+            "type": "object",
+            "description": "lookup of the priority options for each custom field in the template",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "custom_fields": {
+            "type": "object",
+            "description": "Custom field keys mapped to values",
+            "example": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+            }
+          },
+          "incident_mode": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "incident_type": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "name": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "priority_severity": {
+            "type": "string",
+            "description": "option defining whether to cause subsequent alerts to increase the severity",
+            "example": "severity-first-wins",
+            "enum": [
+              "severity-first-wins",
+              "severity-max"
+            ]
+          },
+          "severity": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "workspace": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          }
+        },
+        "example": {
+          "custom_field_priorities": {
+            "abc123": "abc123"
+          },
+          "custom_fields": {
+            "custom_field_10014": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "incident_mode": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "incident_type": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "name": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "priority_severity": "severity-first-wins",
+          "severity": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "summary": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "workspace": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "custom_field_priorities",
+          "priority_severity"
+        ]
+      },
+      "AlertRouteIncidentTemplateV2": {
+        "type": "object",
+        "properties": {
+          "custom_field_priorities": {
+            "type": "object",
+            "description": "lookup of the priority options for each custom field in the template",
+            "example": {
+              "abc123": "first-wins"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "first-wins",
+              "enum": [
+                "first-wins",
+                "last-wins",
+                "append"
+              ]
+            }
+          },
+          "custom_fields": {
+            "type": "object",
+            "description": "Custom field keys mapped to values",
+            "example": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EngineParamBindingV2"
+            }
+          },
+          "incident_mode": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "incident_type": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "name": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "priority_severity": {
+            "type": "string",
+            "description": "binding to use to resolve the workspace to create an incident in",
+            "example": "severity-first-wins",
+            "enum": [
+              "severity-first-wins",
+              "severity-max"
+            ]
+          },
+          "severity": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "workspace": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          }
+        },
+        "example": {
+          "custom_field_priorities": {
+            "abc123": "first-wins"
+          },
+          "custom_fields": {
+            "custom_field_10014": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "incident_mode": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "incident_type": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "name": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "priority_severity": "severity-first-wins",
+          "severity": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "summary": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "workspace": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "custom_field_priorities",
+          "priority_severity"
+        ]
+      },
+      "AlertRouteV2": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
+            "type": "integer",
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this alert route config",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplateV2"
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "first-wins"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "condition_groups",
+          "grouping_keys",
+          "grouping_window_seconds",
+          "defer_time_seconds",
+          "escalation_bindings",
+          "auto_decline_enabled",
+          "enabled",
+          "incident_enabled",
+          "incident_condition_groups",
+          "alert_source_ids",
+          "auto_cancel_escalations"
+        ]
+      },
       "AllResponseBody": {
         "type": "object",
         "properties": {
@@ -8827,22 +11440,22 @@
             ]
           },
           "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.membership_granted_v1": {
             "$ref": "#/components/schemas/WebhookIncidentUserV2"
@@ -9612,7 +12225,9 @@
               "debrief_invite_rule",
               "escalation_path",
               "follow_up_priority",
+              "holiday_user_feed",
               "incident",
+              "incident_call_setting",
               "incident_duration_metric",
               "incident_role",
               "incident_status",
@@ -9730,13 +12345,13 @@
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "helptext": "abc123",
+                "image_url": "abc123",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
                 "reference": "incident.severity",
-                "sort_key": "000020",
+                "sort_key": "abc123",
                 "unavailable": false,
                 "value": "abc123"
               }
@@ -9755,13 +12370,13 @@
                 "catalog_entry_name": "Primary escalation",
                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
-              "helptext": "Collection of standalone automations like auto-closing incidents.",
-              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+              "helptext": "abc123",
+              "image_url": "abc123",
               "is_image_slack_icon": false,
               "label": "Lawrence Jones",
               "literal": "SEV123",
               "reference": "incident.severity",
-              "sort_key": "000020",
+              "sort_key": "abc123",
               "unavailable": false,
               "value": "abc123"
             }
@@ -9773,13 +12388,13 @@
               "catalog_entry_name": "Primary escalation",
               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
-            "helptext": "Collection of standalone automations like auto-closing incidents.",
-            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+            "helptext": "abc123",
+            "image_url": "abc123",
             "is_image_slack_icon": false,
             "label": "Lawrence Jones",
             "literal": "SEV123",
             "reference": "incident.severity",
-            "sort_key": "000020",
+            "sort_key": "abc123",
             "unavailable": false,
             "value": "abc123"
           }
@@ -9793,17 +12408,17 @@
           },
           "helptext": {
             "type": "string",
-            "description": "Gives a description of the option to the user",
-            "example": "Collection of standalone automations like auto-closing incidents."
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
+            "example": "abc123"
           },
           "image_url": {
             "type": "string",
-            "description": "If appropriate, URL to an image that can be displayed alongside the option",
-            "example": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg"
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
+            "example": "abc123"
           },
           "is_image_slack_icon": {
             "type": "boolean",
-            "description": "If true, the image_url is a Slack icon and should be displayed as such",
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
             "example": false
           },
           "label": {
@@ -9818,22 +12433,22 @@
           },
           "reference": {
             "type": "string",
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
             "example": "incident.severity"
           },
           "sort_key": {
             "type": "string",
-            "description": "Gives an indication of how to sort the options when displayed to the user",
-            "example": "000020"
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
+            "example": "abc123"
           },
           "unavailable": {
             "type": "boolean",
-            "description": "Unavailable is true if we've failed to build the value for this binding",
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
             "example": false
           },
           "value": {
             "type": "string",
-            "description": "Either the reference or the literal: this field is designed purely to make working with react-select easier",
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
             "example": "abc123"
           }
         },
@@ -9844,13 +12459,13 @@
             "catalog_entry_name": "Primary escalation",
             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
-          "helptext": "Collection of standalone automations like auto-closing incidents.",
-          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+          "helptext": "abc123",
+          "image_url": "abc123",
           "is_image_slack_icon": false,
           "label": "Lawrence Jones",
           "literal": "SEV123",
           "reference": "incident.severity",
-          "sort_key": "000020",
+          "sort_key": "abc123",
           "unavailable": false,
           "value": "abc123"
         },
@@ -9930,13 +12545,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -9948,13 +12563,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -10019,13 +12634,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -10037,13 +12652,13 @@
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "helptext": "abc123",
+                "image_url": "abc123",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
                 "reference": "incident.severity",
-                "sort_key": "000020",
+                "sort_key": "abc123",
                 "unavailable": false,
                 "value": "abc123"
               }
@@ -10440,8 +13055,9 @@
           "icon": {
             "type": "string",
             "description": "Sets the display icon of this type in the dashboard",
-            "example": "bolt",
+            "example": "alert",
             "enum": [
+              "alert",
               "bolt",
               "box",
               "briefcase",
@@ -10454,6 +13070,7 @@
               "database",
               "doc",
               "email",
+              "escalation-path",
               "files",
               "flag",
               "folder",
@@ -10461,6 +13078,7 @@
               "money",
               "server",
               "severity",
+              "status-page",
               "store",
               "star",
               "tag",
@@ -10547,7 +13165,7 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "icon": "bolt",
+          "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -10659,6 +13277,79 @@
         ]
       },
       "ConditionGroupV2": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV2"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV3": {
         "type": "object",
         "properties": {
           "conditions": {
@@ -11127,13 +13818,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -11145,13 +13836,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -11563,35 +14254,706 @@
       "CreateRequestBody": {
         "type": "object",
         "properties": {
-          "custom_field_id": {
-            "type": "string",
-            "description": "ID of the custom field this option belongs to",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          "alert_source_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "The alert sources that will match this alert route",
+            "example": [
+              "02FCNDV6P870EA6S7TK1DSYDG2"
+            ]
           },
-          "sort_key": {
+          "auto_decline_enabled": {
+            "type": "boolean",
+            "description": "Should triage incidents be declined when alerts are resolved?",
+            "example": false
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
             "type": "integer",
-            "description": "Sort key used to order the custom field options correctly",
-            "default": 1000,
-            "example": 10,
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
             "format": "int64"
           },
-          "value": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route is enabled or not",
+            "example": false
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "incident_condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to create an incident?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "incident_enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route will create incidents or not",
+            "example": false
+          },
+          "name": {
             "type": "string",
-            "description": "Human readable name for the custom field option",
-            "example": "Product"
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
           }
         },
         "example": {
-          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "sort_key": 10,
-          "value": "Product"
-        },
-        "required": [
-          "custom_field_id",
-          "value"
-        ]
+          "alert_source_ids": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ],
+          "auto_decline_enabled": false,
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "enabled": false,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "incident_condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "incident_enabled": false,
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "abc123"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        }
       },
       "CreateRequestBody10": {
+        "type": "object",
+        "properties": {
+          "custom_field_entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+            },
+            "description": "Set the incident's custom fields to these values",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ]
+          },
+          "idempotency_key": {
+            "type": "string",
+            "description": "Unique string used to de-duplicate incident create requests",
+            "example": "alert-uuid"
+          },
+          "incident_role_assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
+            },
+            "description": "Assign incident roles to these people",
+            "example": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ]
+          },
+          "incident_type_id": {
+            "type": "string",
+            "description": "Incident type to create this incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Whether the incident is real or test",
+            "example": "real",
+            "enum": [
+              "real",
+              "test"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Explanation of the incident",
+            "example": "Our database is sad"
+          },
+          "severity_id": {
+            "type": "string",
+            "description": "Severity to create incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "slack_team_id": {
+            "type": "string",
+            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
+            "example": "T02A1FSLE8J"
+          },
+          "source_message_channel_id": {
+            "type": "string",
+            "description": "Channel ID of the source message, if this incident was created from one",
+            "example": "C02AW36C1M5"
+          },
+          "source_message_timestamp": {
+            "type": "string",
+            "description": "Timestamp of the source message, if this incident was created from one",
+            "example": "1653650280.526509"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the incident",
+            "example": "triage",
+            "enum": [
+              "triage",
+              "investigating",
+              "fixing",
+              "monitoring",
+              "closed",
+              "declined"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "description": "Detailed description of the incident",
+            "example": "Our database is really really sad, and we don't know why yet."
+          },
+          "visibility": {
+            "type": "string",
+            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+            "example": "public",
+            "enum": [
+              "public",
+              "private"
+            ]
+          }
+        },
+        "example": {
+          "custom_field_entries": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ],
+          "idempotency_key": "alert-uuid",
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ],
+          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "mode": "real",
+          "name": "Our database is sad",
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "slack_team_id": "T02A1FSLE8J",
+          "source_message_channel_id": "C02AW36C1M5",
+          "source_message_timestamp": "1653650280.526509",
+          "status": "triage",
+          "summary": "Our database is really really sad, and we don't know why yet.",
+          "visibility": "public"
+        },
+        "required": [
+          "idempotency_key",
+          "visibility"
+        ]
+      },
+      "CreateRequestBody11": {
         "type": "object",
         "properties": {
           "custom_field_entries": {
@@ -11770,7 +15132,7 @@
           "visibility"
         ]
       },
-      "CreateRequestBody11": {
+      "CreateRequestBody12": {
         "type": "object",
         "properties": {
           "schedule": {
@@ -11818,6 +15180,11 @@
                 }
               ]
             },
+            "holidays_public_config": {
+              "country_codes": [
+                "abc123"
+              ]
+            },
             "name": "My Schedule",
             "timezone": "America/Los_Angeles"
           }
@@ -11826,7 +15193,7 @@
           "schedule"
         ]
       },
-      "CreateRequestBody12": {
+      "CreateRequestBody13": {
         "type": "object",
         "properties": {
           "description": {
@@ -11858,6 +15225,37 @@
         ]
       },
       "CreateRequestBody2": {
+        "type": "object",
+        "properties": {
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
+          }
+        },
+        "example": {
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        },
+        "required": [
+          "custom_field_id",
+          "value"
+        ]
+      },
+      "CreateRequestBody3": {
         "type": "object",
         "properties": {
           "description": {
@@ -11948,7 +15346,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody3": {
+      "CreateRequestBody4": {
         "type": "object",
         "properties": {
           "description": {
@@ -11990,7 +15388,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody4": {
+      "CreateRequestBody5": {
         "type": "object",
         "properties": {
           "incident_id": {
@@ -12054,7 +15452,7 @@
           "resource"
         ]
       },
-      "CreateRequestBody5": {
+      "CreateRequestBody6": {
         "type": "object",
         "properties": {
           "incident_id": {
@@ -12075,7 +15473,7 @@
           "incident_id"
         ]
       },
-      "CreateRequestBody6": {
+      "CreateRequestBody7": {
         "type": "object",
         "properties": {
           "description": {
@@ -12103,8 +15501,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           }
         },
         "example": {
@@ -12127,7 +15524,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody7": {
+      "CreateRequestBody8": {
         "type": "object",
         "properties": {
           "description": {
@@ -12150,8 +15547,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           }
         },
         "example": {
@@ -12172,7 +15568,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody8": {
+      "CreateRequestBody9": {
         "type": "object",
         "properties": {
           "category": {
@@ -12211,166 +15607,324 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody9": {
+      "CreateResponseBody": {
         "type": "object",
         "properties": {
-          "custom_field_entries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
-            },
-            "description": "Set the incident's custom fields to these values",
-            "example": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "values": [
-                  {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_text": "This is my text field, I hope you like it",
-                    "value_timestamp": ""
-                  }
-                ]
-              }
-            ]
-          },
-          "idempotency_key": {
-            "type": "string",
-            "description": "Unique string used to de-duplicate incident create requests",
-            "example": "alert-uuid"
-          },
-          "incident_role_assignments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
-            },
-            "description": "Assign incident roles to these people",
-            "example": [
-              {
-                "assignee": {
-                  "email": "bob@example.com",
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "slack_user_id": "USER123"
-                },
-                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-              }
-            ]
-          },
-          "incident_type_id": {
-            "type": "string",
-            "description": "Incident type to create this incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "mode": {
-            "type": "string",
-            "description": "Whether the incident is real or test",
-            "example": "real",
-            "enum": [
-              "real",
-              "test"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Explanation of the incident",
-            "example": "Our database is sad"
-          },
-          "severity_id": {
-            "type": "string",
-            "description": "Severity to create incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "slack_team_id": {
-            "type": "string",
-            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
-            "example": "T02A1FSLE8J"
-          },
-          "source_message_channel_id": {
-            "type": "string",
-            "description": "Channel ID of the source message, if this incident was created from one",
-            "example": "C02AW36C1M5"
-          },
-          "source_message_timestamp": {
-            "type": "string",
-            "description": "Timestamp of the source message, if this incident was created from one",
-            "example": "1653650280.526509"
-          },
-          "status": {
-            "type": "string",
-            "description": "Current status of the incident",
-            "example": "triage",
-            "enum": [
-              "triage",
-              "investigating",
-              "fixing",
-              "monitoring",
-              "closed",
-              "declined"
-            ]
-          },
-          "summary": {
-            "type": "string",
-            "description": "Detailed description of the incident",
-            "example": "Our database is really really sad, and we don't know why yet."
-          },
-          "visibility": {
-            "type": "string",
-            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-            "example": "public",
-            "enum": [
-              "public",
-              "private"
-            ]
+          "alert_route": {
+            "$ref": "#/components/schemas/AlertRouteV2"
           }
         },
         "example": {
-          "custom_field_entries": [
-            {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "values": [
-                {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_text": "This is my text field, I hope you like it",
-                  "value_timestamp": ""
+          "alert_route": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defer_time_seconds": 1,
+            "escalation_bindings": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
                 }
-              ]
-            }
-          ],
-          "idempotency_key": "alert-uuid",
-          "incident_role_assignments": [
-            {
-              "assignee": {
-                "email": "bob@example.com",
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                "slack_user_id": "USER123"
+              }
+            ],
+            "expressions": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ],
+            "grouping_keys": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ],
+            "grouping_window_seconds": 1,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Production incidents",
+            "template": {
+              "custom_field_priorities": {
+                "abc123": "first-wins"
               },
-              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              "custom_fields": {
+                "custom_field_10014": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "incident_mode": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "incident_type": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "name": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "priority_severity": "severity-first-wins",
+              "severity": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "summary": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "workspace": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
             }
-          ],
-          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "mode": "real",
-          "name": "Our database is sad",
-          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "slack_team_id": "T02A1FSLE8J",
-          "source_message_channel_id": "C02AW36C1M5",
-          "source_message_timestamp": "1653650280.526509",
-          "status": "triage",
-          "summary": "Our database is really really sad, and we don't know why yet.",
-          "visibility": "public"
+          }
         },
         "required": [
-          "idempotency_key",
-          "visibility"
+          "alert_route"
         ]
       },
-      "CreateResponseBody": {
+      "CreateResponseBody2": {
         "type": "object",
         "properties": {
           "incident_attachment": {
@@ -12393,7 +15947,7 @@
           "incident_attachment"
         ]
       },
-      "CreateResponseBody2": {
+      "CreateResponseBody3": {
         "type": "object",
         "properties": {
           "incident_membership": {
@@ -12475,8 +16029,9 @@
           "icon": {
             "type": "string",
             "description": "Sets the display icon of this type in the dashboard",
-            "example": "bolt",
+            "example": "alert",
             "enum": [
+              "alert",
               "bolt",
               "box",
               "briefcase",
@@ -12489,6 +16044,7 @@
               "database",
               "doc",
               "email",
+              "escalation-path",
               "files",
               "flag",
               "folder",
@@ -12496,6 +16052,7 @@
               "money",
               "server",
               "severity",
+              "status-page",
               "store",
               "star",
               "tag",
@@ -12533,7 +16090,7 @@
           ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
-          "icon": "bolt",
+          "icon": "alert",
           "name": "Kubernetes Cluster",
           "ranked": true,
           "source_repo_url": "https://github.com/my-company/incident-io-catalog",
@@ -12564,7 +16121,7 @@
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "icon": "bolt",
+            "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -15222,6 +18779,105 @@
             ]
           },
           "result": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "result": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "condition_groups",
+          "result"
+        ]
+      },
+      "ExpressionBranchV3": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV3"
+            },
+            "description": "When one of these condition groups are satisfied, this branch will be evaluated",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "result": {
             "$ref": "#/components/schemas/EngineParamBindingV3"
           }
         },
@@ -15508,6 +19164,131 @@
           "returns"
         ]
       },
+      "ExpressionBranchesOptsV3": {
+        "type": "object",
+        "properties": {
+          "branches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionBranchV3"
+            },
+            "description": "The branches to apply for this operation",
+            "example": [
+              {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          }
+        },
+        "example": {
+          "branches": [
+            {
+              "condition_groups": [
+                {
+                  "conditions": [
+                    {
+                      "operation": {
+                        "label": "Lawrence Jones",
+                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                      },
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": {
+                        "label": "Incident Severity",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "result": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "required": [
+          "branches",
+          "returns"
+        ]
+      },
       "ExpressionElseBranchPayloadV2": {
         "type": "object",
         "properties": {
@@ -15534,6 +19315,33 @@
         ]
       },
       "ExpressionElseBranchV2": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          }
+        },
+        "example": {
+          "result": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "ExpressionElseBranchV3": {
         "type": "object",
         "properties": {
           "result": {
@@ -15706,6 +19514,87 @@
           "condition_groups"
         ]
       },
+      "ExpressionFilterOptsV3": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV3"
+            },
+            "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "condition_groups"
+        ]
+      },
       "ExpressionNavigateOptsPayloadV2": {
         "type": "object",
         "properties": {
@@ -15774,7 +19663,7 @@
             ]
           },
           "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsV2"
+            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
           }
         },
         "example": {
@@ -15896,7 +19785,7 @@
             ]
           },
           "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsV2"
+            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
           },
           "returns": {
             "$ref": "#/components/schemas/ReturnsMetaV2"
@@ -16015,7 +19904,155 @@
           "returns"
         ]
       },
-      "ExpressionParseOptsV2": {
+      "ExpressionOperationV3": {
+        "type": "object",
+        "properties": {
+          "branches": {
+            "$ref": "#/components/schemas/ExpressionBranchesOptsV3"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/ExpressionFilterOptsV3"
+          },
+          "navigate": {
+            "$ref": "#/components/schemas/ExpressionNavigateOptsV2"
+          },
+          "operation_type": {
+            "type": "string",
+            "description": "The type of the operation",
+            "example": "navigate",
+            "enum": [
+              "navigate",
+              "filter",
+              "count",
+              "min",
+              "max",
+              "random",
+              "first",
+              "parse",
+              "branches"
+            ]
+          },
+          "parse": {
+            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          }
+        },
+        "example": {
+          "branches": {
+            "branches": [
+              {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ],
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            }
+          },
+          "filter": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "navigate": {
+            "reference": "1235",
+            "reference_label": "Teams"
+          },
+          "operation_type": "navigate",
+          "parse": {
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            },
+            "source": "metadata.annotations[\"github.com/repo\"]"
+          },
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "required": [
+          "operation_type",
+          "returns"
+        ]
+      },
+      "ExpressionParseOptsPayloadV2": {
         "type": "object",
         "properties": {
           "returns": {
@@ -16282,6 +20319,291 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExpressionOperationV2"
+            },
+            "example": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": {
+                            "label": "Lawrence Jones",
+                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                          },
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": {
+                            "label": "Incident Severity",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "1235",
+                  "reference_label": "Teams"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                },
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              }
+            ]
+          },
+          "reference": {
+            "type": "string",
+            "description": "A short ID that can be used to reference the expression",
+            "example": "abc123"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          },
+          "root_reference": {
+            "type": "string",
+            "description": "The root reference for this expression (i.e. where the expression starts)",
+            "example": "incident.status"
+          }
+        },
+        "example": {
+          "else_branch": {
+            "result": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "label": "Team Slack channel",
+          "operations": [
+            {
+              "branches": {
+                "branches": [
+                  {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "result": {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              },
+              "filter": {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "navigate": {
+                "reference": "1235",
+                "reference_label": "Teams"
+              },
+              "operation_type": "navigate",
+              "parse": {
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "source": "metadata.annotations[\"github.com/repo\"]"
+              },
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              }
+            }
+          ],
+          "reference": "abc123",
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          },
+          "root_reference": "incident.status"
+        },
+        "required": [
+          "label",
+          "reference",
+          "returns",
+          "root_reference",
+          "operations",
+          "id"
+        ]
+      },
+      "ExpressionV3": {
+        "type": "object",
+        "properties": {
+          "else_branch": {
+            "$ref": "#/components/schemas/ExpressionElseBranchV3"
+          },
+          "label": {
+            "type": "string",
+            "description": "The human readable label of the expression",
+            "example": "Team Slack channel"
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionOperationV3"
             },
             "example": [
               {
@@ -16820,6 +21142,22 @@
           "updated_at"
         ]
       },
+      "GroupingKeyV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the alert attribute the user wishes to group on",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        },
+        "example": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "required": [
+          "id"
+        ]
+      },
       "IdentityResponseBody": {
         "type": "object",
         "properties": {
@@ -17294,8 +21632,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           },
           "updated_at": {
             "type": "string",
@@ -17316,12 +21653,12 @@
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "required": [
-          "condition_groups",
-          "id",
           "name",
+          "shortform",
           "description",
           "instructions",
-          "shortform",
+          "condition_groups",
+          "id",
           "role_type",
           "created_at",
           "updated_at"
@@ -17371,8 +21708,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           },
           "updated_at": {
             "type": "string",
@@ -17392,12 +21728,12 @@
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "required": [
-          "condition_groups",
-          "id",
           "name",
+          "shortform",
           "description",
           "instructions",
-          "shortform",
+          "condition_groups",
+          "id",
           "role_type",
           "created_at",
           "updated_at"
@@ -18721,13 +23057,13 @@
                           "catalog_entry_name": "Primary escalation",
                           "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                         },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                        "helptext": "abc123",
+                        "image_url": "abc123",
                         "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
                         "reference": "incident.severity",
-                        "sort_key": "000020",
+                        "sort_key": "abc123",
                         "unavailable": false,
                         "value": "abc123"
                       }
@@ -18739,13 +23075,13 @@
                         "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                      "helptext": "abc123",
+                      "image_url": "abc123",
                       "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
                       "reference": "incident.severity",
-                      "sort_key": "000020",
+                      "sort_key": "abc123",
                       "unavailable": false,
                       "value": "abc123"
                     }
@@ -18786,13 +23122,13 @@
                         "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                      "helptext": "abc123",
+                      "image_url": "abc123",
                       "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
                       "reference": "incident.severity",
-                      "sort_key": "000020",
+                      "sort_key": "abc123",
                       "unavailable": false,
                       "value": "abc123"
                     }
@@ -18804,13 +23140,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -18837,7 +23173,7 @@
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "icon": "bolt",
+            "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -19845,6 +24181,12 @@
                     }
                   }
                 ],
+                "holidays_public_config": {
+                  "country_codes": [
+                    "GB",
+                    "FR"
+                  ]
+                },
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                 "name": "Primary On-Call Schedule",
                 "timezone": "Europe/London",
@@ -19920,6 +24262,12 @@
                   }
                 }
               ],
+              "holidays_public_config": {
+                "country_codes": [
+                  "GB",
+                  "FR"
+                ]
+              },
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "name": "Primary On-Call Schedule",
               "timezone": "Europe/London",
@@ -20525,7 +24873,7 @@
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
                 "dynamic_resource_parameter": "abc123",
                 "estimated_count": 7,
-                "icon": "bolt",
+                "icon": "alert",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "is_editable": false,
                 "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -20576,7 +24924,7 @@
               "description": "Represents Kubernetes clusters that we run inside of GKE.",
               "dynamic_resource_parameter": "abc123",
               "estimated_count": 7,
-              "icon": "bolt",
+              "icon": "alert",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "is_editable": false,
               "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -21313,7 +25661,7 @@
             ]
           },
           "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21353,7 +25701,7 @@
             ]
           },
           "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21393,7 +25741,7 @@
             ]
           },
           "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21433,7 +25781,7 @@
             ]
           },
           "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21473,7 +25821,7 @@
             ]
           },
           "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21513,7 +25861,7 @@
             ]
           },
           "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -22775,6 +27123,9 @@
           "config": {
             "$ref": "#/components/schemas/ScheduleConfigCreatePayloadV2"
           },
+          "holidays_public_config": {
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
+          },
           "name": {
             "type": "string",
             "description": "Name of the schedule",
@@ -22824,6 +27175,11 @@
                   }
                 ]
               }
+            ]
+          },
+          "holidays_public_config": {
+            "country_codes": [
+              "abc123"
             ]
           },
           "name": "My Schedule",
@@ -23018,6 +27374,32 @@
           "external_user_id",
           "start_at",
           "end_at"
+        ]
+      },
+      "ScheduleHolidaysPublicConfigV2": {
+        "type": "object",
+        "properties": {
+          "country_codes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for",
+            "example": [
+              "GB",
+              "FR"
+            ]
+          }
+        },
+        "example": {
+          "country_codes": [
+            "GB",
+            "FR"
+          ]
+        },
+        "required": [
+          "country_codes"
         ]
       },
       "ScheduleLayerCreatePayloadV2": {
@@ -23476,6 +27858,9 @@
           "config": {
             "$ref": "#/components/schemas/ScheduleConfigUpdatePayloadV2"
           },
+          "holidays_public_config": {
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
+          },
           "name": {
             "type": "string",
             "description": "Name of the schedule",
@@ -23527,6 +27912,11 @@
               }
             ]
           },
+          "holidays_public_config": {
+            "country_codes": [
+              "abc123"
+            ]
+          },
           "name": "My Schedule",
           "timezone": "America/Los_Angeles"
         }
@@ -23576,6 +27966,9 @@
                 }
               }
             ]
+          },
+          "holidays_public_config": {
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
           },
           "id": {
             "type": "string",
@@ -23658,6 +28051,12 @@
               }
             }
           ],
+          "holidays_public_config": {
+            "country_codes": [
+              "GB",
+              "FR"
+            ]
+          },
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "name": "Primary On-Call Schedule",
           "timezone": "Europe/London",
@@ -23841,13 +28240,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -23859,13 +28258,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -23891,7 +28290,7 @@
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "icon": "bolt",
+            "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -24365,6 +28764,12 @@
                 }
               }
             ],
+            "holidays_public_config": {
+              "country_codes": [
+                "GB",
+                "FR"
+              ]
+            },
             "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "name": "Primary On-Call Schedule",
             "timezone": "Europe/London",
@@ -25172,6 +29577,563 @@
       "UpdateRequestBody": {
         "type": "object",
         "properties": {
+          "alert_source_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "The alert sources that will match this alert route",
+            "example": [
+              "02FCNDV6P870EA6S7TK1DSYDG2"
+            ]
+          },
+          "auto_decline_enabled": {
+            "type": "boolean",
+            "description": "Should triage incidents be declined when alerts are resolved?",
+            "example": false
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
+            "type": "integer",
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route is enabled or not",
+            "example": false
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "incident_condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to create an incident?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "incident_enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route will create incidents or not",
+            "example": false
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
+          }
+        },
+        "example": {
+          "alert_source_ids": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ],
+          "auto_decline_enabled": false,
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "enabled": false,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "incident_condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "incident_enabled": false,
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "abc123"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        },
+        "required": [
+          "name",
+          "condition_groups",
+          "grouping_keys",
+          "grouping_window_seconds",
+          "defer_time_seconds",
+          "escalation_bindings",
+          "auto_decline_enabled",
+          "enabled",
+          "incident_enabled",
+          "incident_condition_groups",
+          "alert_source_ids",
+          "auto_cancel_escalations"
+        ]
+      },
+      "UpdateRequestBody2": {
+        "type": "object",
+        "properties": {
           "sort_key": {
             "type": "integer",
             "description": "Sort key used to order the custom field options correctly",
@@ -25195,7 +30157,7 @@
           "sort_key"
         ]
       },
-      "UpdateRequestBody2": {
+      "UpdateRequestBody3": {
         "type": "object",
         "properties": {
           "description": {
@@ -25272,7 +30234,7 @@
           "updated_at"
         ]
       },
-      "UpdateRequestBody3": {
+      "UpdateRequestBody4": {
         "type": "object",
         "properties": {
           "description": {
@@ -25300,7 +30262,7 @@
           "updated_at"
         ]
       },
-      "UpdateRequestBody4": {
+      "UpdateRequestBody5": {
         "type": "object",
         "properties": {
           "description": {
@@ -25328,8 +30290,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           }
         },
         "example": {
@@ -25340,17 +30301,17 @@
           "shortform": "lead"
         },
         "required": [
-          "condition_groups",
           "name",
+          "shortform",
           "description",
           "instructions",
-          "shortform",
+          "condition_groups",
           "role_type",
           "created_at",
           "updated_at"
         ]
       },
-      "UpdateRequestBody5": {
+      "UpdateRequestBody6": {
         "type": "object",
         "properties": {
           "description": {
@@ -25373,8 +30334,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           }
         },
         "example": {
@@ -25384,17 +30344,17 @@
           "shortform": "lead"
         },
         "required": [
-          "condition_groups",
           "name",
+          "shortform",
           "description",
           "instructions",
-          "shortform",
+          "condition_groups",
           "role_type",
           "created_at",
           "updated_at"
         ]
       },
-      "UpdateRequestBody6": {
+      "UpdateRequestBody7": {
         "type": "object",
         "properties": {
           "description": {
@@ -25421,7 +30381,7 @@
           "updated_at"
         ]
       },
-      "UpdateRequestBody7": {
+      "UpdateRequestBody8": {
         "type": "object",
         "properties": {
           "schedule": {
@@ -25467,6 +30427,11 @@
                     }
                   ]
                 }
+              ]
+            },
+            "holidays_public_config": {
+              "country_codes": [
+                "abc123"
               ]
             },
             "name": "My Schedule",
@@ -25540,8 +30505,9 @@
           "icon": {
             "type": "string",
             "description": "Sets the display icon of this type in the dashboard",
-            "example": "bolt",
+            "example": "alert",
             "enum": [
+              "alert",
               "bolt",
               "box",
               "briefcase",
@@ -25554,6 +30520,7 @@
               "database",
               "doc",
               "email",
+              "escalation-path",
               "files",
               "flag",
               "folder",
@@ -25561,6 +30528,7 @@
               "money",
               "server",
               "severity",
+              "status-page",
               "store",
               "star",
               "tag",
@@ -25593,7 +30561,7 @@
           ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
-          "icon": "bolt",
+          "icon": "alert",
           "name": "Kubernetes Cluster",
           "ranked": true,
           "source_repo_url": "https://github.com/my-company/incident-io-catalog"
@@ -26815,22 +31783,6 @@
           "reported_at"
         ]
       },
-      "WebhookPrivateResourceV2": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The ID of the resource",
-            "example": "abc123"
-          }
-        },
-        "example": {
-          "id": "abc123"
-        },
-        "required": [
-          "id"
-        ]
-      },
       "WeekdayIntervalConfigV2": {
         "type": "object",
         "properties": {
@@ -26918,7 +31870,7 @@
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV2"
+              "$ref": "#/components/schemas/ConditionGroupV3"
             },
             "description": "Conditions that apply to the workflow trigger",
             "example": [
@@ -26965,7 +31917,7 @@
           "expressions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ExpressionV2"
+              "$ref": "#/components/schemas/ExpressionV3"
             },
             "description": "Expressions that make variables available in the scope",
             "example": [
@@ -27495,7 +32447,7 @@
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV2"
+              "$ref": "#/components/schemas/ConditionGroupV3"
             },
             "description": "Conditions that apply to the workflow trigger",
             "example": [
@@ -27542,7 +32494,7 @@
           "expressions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ExpressionV2"
+              "$ref": "#/components/schemas/ExpressionV3"
             },
             "description": "Expressions that make variables available in the scope",
             "example": [
@@ -28016,6 +32968,10 @@
     {
       "name": "Actions V2",
       "description": "Manage incident actions.\n\nIncident actions are used during an incident, to track work such as 'restart the database' or 'contact the customer'.\n\nYou can manage actions in the incident Slack channel with <code>/incident actions</code>, or on\nthe incident homepage.\n"
+    },
+    {
+      "name": "Alert Routes V2",
+      "description": "Create and manage alert routes.\n\nAlert routes take alerts from alert sources, filter them according to conditions, apply\ngrouping on alert attributes, then finally create:\n\n1. Incidents\n2. Escalations\n\nThese are best configured in the incident.io dashboard and exported via the UI to\nTerraform, as the configuration is complex.\n"
     },
     {
       "name": "Alert Events V2",
@@ -30339,6 +35295,194 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Low",
                       "type": "follow_up_priority"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/holiday_user_feed.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "HolidayUserFeedCreatedV1",
+        "description": "This entry is created whenever a holiday user feed is created",
+        "operationId": "Audit logs#HolidayUserFeedCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "holiday_user_feed.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "US Team holidays",
+                      "type": "holiday_user_feed"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/holiday_user_feed.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "HolidayUserFeedDeletedV1",
+        "description": "This entry is created whenever a holiday user feed is deleted",
+        "operationId": "Audit logs#HolidayUserFeedDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "holiday_user_feed.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "US Team holidays",
+                      "type": "holiday_user_feed"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/holiday_user_feed.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "HolidayUserFeedUpdatedV1",
+        "description": "This entry is created whenever a holiday user feed is updated",
+        "operationId": "Audit logs#HolidayUserFeedUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "holiday_user_feed.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "US Team holidays",
+                      "type": "holiday_user_feed"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/incident_call_setting.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "IncidentCallSettingUpdatedV1",
+        "description": "This entry is created whenever an organisation's incident call settings are updated",
+        "operationId": "Audit logs#IncidentCallSettingUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "incident_call_setting.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Incident call settings",
+                      "type": "incident_call_setting"
                     }
                   ],
                   "version": 1

--- a/internal/apischema/openapi3.json
+++ b/internal/apischema/openapi3.json
@@ -257,7 +257,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody"
+                "$ref": "#/components/schemas/CreateRequestBody2"
               },
               "example": {
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -385,7 +385,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody"
+                "$ref": "#/components/schemas/UpdateRequestBody2"
               },
               "example": {
                 "sort_key": 10,
@@ -483,7 +483,7 @@
                 "show_in_announcement_post": true
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody2"
+                "$ref": "#/components/schemas/CreateRequestBody3"
               }
             }
           },
@@ -653,7 +653,7 @@
                 "show_in_announcement_post": true
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody2"
+                "$ref": "#/components/schemas/UpdateRequestBody3"
               }
             }
           },
@@ -838,7 +838,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody4"
+                "$ref": "#/components/schemas/CreateRequestBody5"
               },
               "example": {
                 "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
@@ -856,7 +856,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody"
+                  "$ref": "#/components/schemas/CreateResponseBody2"
                 },
                 "example": {
                   "incident_attachment": {
@@ -918,7 +918,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/CreateRequestBody6"
               },
               "example": {
                 "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
@@ -933,7 +933,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody2"
+                  "$ref": "#/components/schemas/CreateResponseBody3"
                 },
                 "example": {
                   "incident_membership": {
@@ -969,7 +969,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/CreateRequestBody6"
               },
               "example": {
                 "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
@@ -1036,7 +1036,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/CreateRequestBody7"
               }
             }
           },
@@ -1179,7 +1179,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody4"
+                "$ref": "#/components/schemas/UpdateRequestBody5"
               }
             }
           },
@@ -1263,7 +1263,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody8"
+                "$ref": "#/components/schemas/CreateRequestBody9"
               },
               "example": {
                 "category": "live",
@@ -1397,7 +1397,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody6"
+                "$ref": "#/components/schemas/UpdateRequestBody7"
               },
               "example": {
                 "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
@@ -1762,7 +1762,7 @@
                 "visibility": "public"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody9"
+                "$ref": "#/components/schemas/CreateRequestBody10"
               }
             }
           },
@@ -2155,7 +2155,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody12"
+                "$ref": "#/components/schemas/CreateRequestBody13"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2287,7 +2287,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody12"
+                "$ref": "#/components/schemas/CreateRequestBody13"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2531,6 +2531,1623 @@
         }
       }
     },
+    "/v2/alert_routes": {
+      "post": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Create Alert Routes V2",
+        "description": "Create an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRequestBody"
+              },
+              "example": {
+                "alert_source_ids": [
+                  "02FCNDV6P870EA6S7TK1DSYDG2"
+                ],
+                "auto_decline_enabled": false,
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "defer_time_seconds": 1,
+                "enabled": false,
+                "escalation_bindings": [
+                  {
+                    "binding": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "expressions": [
+                  {
+                    "else_branch": {
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    },
+                    "label": "Team Slack channel",
+                    "operations": [
+                      {
+                        "branches": {
+                          "branches": [
+                            {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": "one_of",
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": "incident.severity"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "result": {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            }
+                          ],
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
+                        "filter": {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "navigate": {
+                          "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                        },
+                        "operation_type": "navigate",
+                        "parse": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          },
+                          "source": "metadata.annotations[\"github.com/repo\"]"
+                        }
+                      }
+                    ],
+                    "reference": "abc123",
+                    "root_reference": "incident.status"
+                  }
+                ],
+                "grouping_keys": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  }
+                ],
+                "grouping_window_seconds": 1,
+                "incident_condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "incident_enabled": false,
+                "name": "Production incidents",
+                "template": {
+                  "custom_field_priorities": {
+                    "abc123": "abc123"
+                  },
+                  "custom_fields": {
+                    "custom_field_10014": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  },
+                  "incident_mode": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "incident_type": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "name": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "priority_severity": "severity-first-wins",
+                  "severity": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "summary": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "workspace": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateResponseBody"
+                },
+                "example": {
+                  "alert_route": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "defer_time_seconds": 1,
+                    "escalation_bindings": [
+                      {
+                        "binding": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "expressions": [
+                      {
+                        "else_branch": {
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "label": "Team Slack channel",
+                        "operations": [
+                          {
+                            "branches": {
+                              "branches": [
+                                {
+                                  "condition_groups": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "operation": {
+                                            "label": "Lawrence Jones",
+                                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                          },
+                                          "param_bindings": [
+                                            {
+                                              "array_value": [
+                                                {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              ],
+                                              "value": {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            }
+                                          ],
+                                          "subject": {
+                                            "label": "Incident Severity",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "result": {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                }
+                              ],
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            },
+                            "filter": {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "navigate": {
+                              "reference": "1235",
+                              "reference_label": "Teams"
+                            },
+                            "operation_type": "navigate",
+                            "parse": {
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              },
+                              "source": "metadata.annotations[\"github.com/repo\"]"
+                            },
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          }
+                        ],
+                        "reference": "abc123",
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "root_reference": "incident.status"
+                      }
+                    ],
+                    "grouping_keys": [
+                      {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                      }
+                    ],
+                    "grouping_window_seconds": 1,
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Production incidents",
+                    "template": {
+                      "custom_field_priorities": {
+                        "abc123": "first-wins"
+                      },
+                      "custom_fields": {
+                        "custom_field_10014": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
+                      "incident_mode": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "incident_type": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "name": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "priority_severity": "severity-first-wins",
+                      "severity": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "summary": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "workspace": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/alert_routes/{id}": {
+      "delete": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Destroy Alert Routes V2",
+        "description": "Archives an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Destroy",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this alert route config",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for this alert route config",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Show Alert Routes V2",
+        "description": "Show an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Show",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this alert route config",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for this alert route config",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateResponseBody"
+                },
+                "example": {
+                  "alert_route": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "defer_time_seconds": 1,
+                    "escalation_bindings": [
+                      {
+                        "binding": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "expressions": [
+                      {
+                        "else_branch": {
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "label": "Team Slack channel",
+                        "operations": [
+                          {
+                            "branches": {
+                              "branches": [
+                                {
+                                  "condition_groups": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "operation": {
+                                            "label": "Lawrence Jones",
+                                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                          },
+                                          "param_bindings": [
+                                            {
+                                              "array_value": [
+                                                {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              ],
+                                              "value": {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            }
+                                          ],
+                                          "subject": {
+                                            "label": "Incident Severity",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "result": {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                }
+                              ],
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            },
+                            "filter": {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "navigate": {
+                              "reference": "1235",
+                              "reference_label": "Teams"
+                            },
+                            "operation_type": "navigate",
+                            "parse": {
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              },
+                              "source": "metadata.annotations[\"github.com/repo\"]"
+                            },
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          }
+                        ],
+                        "reference": "abc123",
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "root_reference": "incident.status"
+                      }
+                    ],
+                    "grouping_keys": [
+                      {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                      }
+                    ],
+                    "grouping_window_seconds": 1,
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Production incidents",
+                    "template": {
+                      "custom_field_priorities": {
+                        "abc123": "first-wins"
+                      },
+                      "custom_fields": {
+                        "custom_field_10014": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
+                      "incident_mode": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "incident_type": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "name": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "priority_severity": "severity-first-wins",
+                      "severity": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "summary": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "workspace": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Alert Routes V2"
+        ],
+        "summary": "Update Alert Routes V2",
+        "description": "Updates an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
+        "operationId": "Alert Routes V2#Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Unique identifier for this alert route config",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Unique identifier for this alert route config",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRequestBody"
+              },
+              "example": {
+                "alert_source_ids": [
+                  "02FCNDV6P870EA6S7TK1DSYDG2"
+                ],
+                "auto_decline_enabled": false,
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "defer_time_seconds": 1,
+                "enabled": false,
+                "escalation_bindings": [
+                  {
+                    "binding": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "expressions": [
+                  {
+                    "else_branch": {
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    },
+                    "label": "Team Slack channel",
+                    "operations": [
+                      {
+                        "branches": {
+                          "branches": [
+                            {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": "one_of",
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": "incident.severity"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "result": {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            }
+                          ],
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
+                        "filter": {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "navigate": {
+                          "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                        },
+                        "operation_type": "navigate",
+                        "parse": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          },
+                          "source": "metadata.annotations[\"github.com/repo\"]"
+                        }
+                      }
+                    ],
+                    "reference": "abc123",
+                    "root_reference": "incident.status"
+                  }
+                ],
+                "grouping_keys": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  }
+                ],
+                "grouping_window_seconds": 1,
+                "incident_condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ],
+                "incident_enabled": false,
+                "name": "Production incidents",
+                "template": {
+                  "custom_field_priorities": {
+                    "abc123": "abc123"
+                  },
+                  "custom_fields": {
+                    "custom_field_10014": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  },
+                  "incident_mode": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "incident_type": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "name": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "priority_severity": "severity-first-wins",
+                  "severity": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "summary": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  },
+                  "workspace": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateResponseBody"
+                },
+                "example": {
+                  "alert_route": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "defer_time_seconds": 1,
+                    "escalation_bindings": [
+                      {
+                        "binding": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "expressions": [
+                      {
+                        "else_branch": {
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "label": "Team Slack channel",
+                        "operations": [
+                          {
+                            "branches": {
+                              "branches": [
+                                {
+                                  "condition_groups": [
+                                    {
+                                      "conditions": [
+                                        {
+                                          "operation": {
+                                            "label": "Lawrence Jones",
+                                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                          },
+                                          "param_bindings": [
+                                            {
+                                              "array_value": [
+                                                {
+                                                  "label": "Lawrence Jones",
+                                                  "literal": "SEV123",
+                                                  "reference": "incident.severity"
+                                                }
+                                              ],
+                                              "value": {
+                                                "label": "Lawrence Jones",
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            }
+                                          ],
+                                          "subject": {
+                                            "label": "Incident Severity",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "result": {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                }
+                              ],
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              }
+                            },
+                            "filter": {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "navigate": {
+                              "reference": "1235",
+                              "reference_label": "Teams"
+                            },
+                            "operation_type": "navigate",
+                            "parse": {
+                              "returns": {
+                                "array": true,
+                                "type": "IncidentStatus"
+                              },
+                              "source": "metadata.annotations[\"github.com/repo\"]"
+                            },
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          }
+                        ],
+                        "reference": "abc123",
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "root_reference": "incident.status"
+                      }
+                    ],
+                    "grouping_keys": [
+                      {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                      }
+                    ],
+                    "grouping_window_seconds": 1,
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Production incidents",
+                    "template": {
+                      "custom_field_priorities": {
+                        "abc123": "first-wins"
+                      },
+                      "custom_fields": {
+                        "custom_field_10014": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
+                      "incident_mode": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "incident_type": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "name": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "priority_severity": "severity-first-wins",
+                      "severity": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "summary": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      },
+                      "workspace": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/catalog_entries": {
       "get": {
         "tags": [
@@ -2607,13 +4224,13 @@
                                 "catalog_entry_name": "Primary escalation",
                                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                               },
-                              "helptext": "Collection of standalone automations like auto-closing incidents.",
-                              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                              "helptext": "abc123",
+                              "image_url": "abc123",
                               "is_image_slack_icon": false,
                               "label": "Lawrence Jones",
                               "literal": "SEV123",
                               "reference": "incident.severity",
-                              "sort_key": "000020",
+                              "sort_key": "abc123",
                               "unavailable": false,
                               "value": "abc123"
                             }
@@ -2625,13 +4242,13 @@
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                            "helptext": "abc123",
+                            "image_url": "abc123",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
                             "reference": "incident.severity",
-                            "sort_key": "000020",
+                            "sort_key": "abc123",
                             "unavailable": false,
                             "value": "abc123"
                           }
@@ -2658,7 +4275,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -2768,13 +4385,13 @@
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                            "helptext": "abc123",
+                            "image_url": "abc123",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
                             "reference": "incident.severity",
-                            "sort_key": "000020",
+                            "sort_key": "abc123",
                             "unavailable": false,
                             "value": "abc123"
                           }
@@ -2786,13 +4403,13 @@
                             "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                          "helptext": "abc123",
+                          "image_url": "abc123",
                           "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
                           "reference": "incident.severity",
-                          "sort_key": "000020",
+                          "sort_key": "abc123",
                           "unavailable": false,
                           "value": "abc123"
                         }
@@ -2887,13 +4504,13 @@
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                            "helptext": "abc123",
+                            "image_url": "abc123",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
                             "reference": "incident.severity",
-                            "sort_key": "000020",
+                            "sort_key": "abc123",
                             "unavailable": false,
                             "value": "abc123"
                           }
@@ -2905,13 +4522,13 @@
                             "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                          "helptext": "abc123",
+                          "image_url": "abc123",
                           "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
                           "reference": "incident.severity",
-                          "sort_key": "000020",
+                          "sort_key": "abc123",
                           "unavailable": false,
                           "value": "abc123"
                         }
@@ -2937,7 +4554,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3056,13 +4673,13 @@
                               "catalog_entry_name": "Primary escalation",
                               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                             },
-                            "helptext": "Collection of standalone automations like auto-closing incidents.",
-                            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                            "helptext": "abc123",
+                            "image_url": "abc123",
                             "is_image_slack_icon": false,
                             "label": "Lawrence Jones",
                             "literal": "SEV123",
                             "reference": "incident.severity",
-                            "sort_key": "000020",
+                            "sort_key": "abc123",
                             "unavailable": false,
                             "value": "abc123"
                           }
@@ -3074,13 +4691,13 @@
                             "catalog_entry_name": "Primary escalation",
                             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                           },
-                          "helptext": "Collection of standalone automations like auto-closing incidents.",
-                          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                          "helptext": "abc123",
+                          "image_url": "abc123",
                           "is_image_slack_icon": false,
                           "label": "Lawrence Jones",
                           "literal": "SEV123",
                           "reference": "incident.severity",
-                          "sort_key": "000020",
+                          "sort_key": "abc123",
                           "unavailable": false,
                           "value": "abc123"
                         }
@@ -3106,7 +4723,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3210,7 +4827,7 @@
                       "description": "Represents Kubernetes clusters that we run inside of GKE.",
                       "dynamic_resource_parameter": "abc123",
                       "estimated_count": 7,
-                      "icon": "bolt",
+                      "icon": "alert",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "is_editable": false,
                       "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3274,7 +4891,7 @@
                 ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
-                "icon": "bolt",
+                "icon": "alert",
                 "name": "Kubernetes Cluster",
                 "ranked": true,
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog",
@@ -3304,7 +4921,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3415,7 +5032,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3492,7 +5109,7 @@
                 ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
-                "icon": "bolt",
+                "icon": "alert",
                 "name": "Kubernetes Cluster",
                 "ranked": true,
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog"
@@ -3521,7 +5138,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3633,7 +5250,7 @@
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
                     "estimated_count": 7,
-                    "icon": "bolt",
+                    "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_editable": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -3720,7 +5337,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody3"
+                "$ref": "#/components/schemas/CreateRequestBody4"
               },
               "example": {
                 "description": "Which team is impacted by this issue",
@@ -3854,7 +5471,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody3"
+                "$ref": "#/components/schemas/UpdateRequestBody4"
               },
               "example": {
                 "description": "Which team is impacted by this issue",
@@ -4620,7 +6237,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody7"
+                "$ref": "#/components/schemas/CreateRequestBody8"
               },
               "example": {
                 "description": "The person currently coordinating the incident",
@@ -4757,7 +6374,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody5"
+                "$ref": "#/components/schemas/UpdateRequestBody6"
               },
               "example": {
                 "description": "The person currently coordinating the incident",
@@ -5492,7 +7109,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody10"
+                "$ref": "#/components/schemas/CreateRequestBody11"
               },
               "example": {
                 "custom_field_entries": [
@@ -6368,6 +7985,12 @@
                           }
                         }
                       ],
+                      "holidays_public_config": {
+                        "country_codes": [
+                          "GB",
+                          "FR"
+                        ]
+                      },
                       "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                       "name": "Primary On-Call Schedule",
                       "timezone": "Europe/London",
@@ -6392,7 +8015,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody11"
+                "$ref": "#/components/schemas/CreateRequestBody12"
               },
               "example": {
                 "schedule": {
@@ -6433,6 +8056,11 @@
                           }
                         ]
                       }
+                    ]
+                  },
+                  "holidays_public_config": {
+                    "country_codes": [
+                      "abc123"
                     ]
                   },
                   "name": "My Schedule",
@@ -6511,6 +8139,12 @@
                         }
                       }
                     ],
+                    "holidays_public_config": {
+                      "country_codes": [
+                        "GB",
+                        "FR"
+                      ]
+                    },
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "name": "Primary On-Call Schedule",
                     "timezone": "Europe/London",
@@ -6641,6 +8275,12 @@
                         }
                       }
                     ],
+                    "holidays_public_config": {
+                      "country_codes": [
+                        "GB",
+                        "FR"
+                      ]
+                    },
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "name": "Primary On-Call Schedule",
                     "timezone": "Europe/London",
@@ -6678,7 +8318,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody7"
+                "$ref": "#/components/schemas/UpdateRequestBody8"
               },
               "example": {
                 "schedule": {
@@ -6719,6 +8359,11 @@
                           }
                         ]
                       }
+                    ]
+                  },
+                  "holidays_public_config": {
+                    "country_codes": [
+                      "abc123"
                     ]
                   },
                   "name": "My Schedule",
@@ -6797,6 +8442,12 @@
                         }
                       }
                     ],
+                    "holidays_public_config": {
+                      "country_codes": [
+                        "GB",
+                        "FR"
+                      ]
+                    },
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "name": "Primary On-Call Schedule",
                     "timezone": "Europe/London",
@@ -8751,6 +10402,968 @@
           "deduplication_key"
         ]
       },
+      "AlertRouteEscalationBindingPayloadV2": {
+        "type": "object",
+        "properties": {
+          "binding": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          }
+        },
+        "example": {
+          "binding": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "binding"
+        ]
+      },
+      "AlertRouteEscalationBindingV2": {
+        "type": "object",
+        "properties": {
+          "binding": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          }
+        },
+        "example": {
+          "binding": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "binding"
+        ]
+      },
+      "AlertRouteIncidentTemplatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "custom_field_priorities": {
+            "type": "object",
+            "description": "lookup of the priority options for each custom field in the template",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "custom_fields": {
+            "type": "object",
+            "description": "Custom field keys mapped to values",
+            "example": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+            }
+          },
+          "incident_mode": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "incident_type": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "name": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "priority_severity": {
+            "type": "string",
+            "description": "option defining whether to cause subsequent alerts to increase the severity",
+            "example": "severity-first-wins",
+            "enum": [
+              "severity-first-wins",
+              "severity-max"
+            ]
+          },
+          "severity": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          },
+          "workspace": {
+            "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+          }
+        },
+        "example": {
+          "custom_field_priorities": {
+            "abc123": "abc123"
+          },
+          "custom_fields": {
+            "custom_field_10014": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "incident_mode": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "incident_type": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "name": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "priority_severity": "severity-first-wins",
+          "severity": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "summary": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "workspace": {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "custom_field_priorities",
+          "priority_severity"
+        ]
+      },
+      "AlertRouteIncidentTemplateV2": {
+        "type": "object",
+        "properties": {
+          "custom_field_priorities": {
+            "type": "object",
+            "description": "lookup of the priority options for each custom field in the template",
+            "example": {
+              "abc123": "first-wins"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "first-wins",
+              "enum": [
+                "first-wins",
+                "last-wins",
+                "append"
+              ]
+            }
+          },
+          "custom_fields": {
+            "type": "object",
+            "description": "Custom field keys mapped to values",
+            "example": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EngineParamBindingV2"
+            }
+          },
+          "incident_mode": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "incident_type": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "name": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "priority_severity": {
+            "type": "string",
+            "description": "binding to use to resolve the workspace to create an incident in",
+            "example": "severity-first-wins",
+            "enum": [
+              "severity-first-wins",
+              "severity-max"
+            ]
+          },
+          "severity": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "workspace": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          }
+        },
+        "example": {
+          "custom_field_priorities": {
+            "abc123": "first-wins"
+          },
+          "custom_fields": {
+            "custom_field_10014": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "incident_mode": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "incident_type": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "name": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "priority_severity": "severity-first-wins",
+          "severity": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "summary": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "workspace": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "custom_field_priorities",
+          "priority_severity"
+        ]
+      },
+      "AlertRouteV2": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
+            "type": "integer",
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this alert route config",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplateV2"
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "first-wins"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "condition_groups",
+          "grouping_keys",
+          "grouping_window_seconds",
+          "defer_time_seconds",
+          "escalation_bindings",
+          "auto_decline_enabled",
+          "enabled",
+          "incident_enabled",
+          "incident_condition_groups",
+          "alert_source_ids",
+          "auto_cancel_escalations"
+        ]
+      },
       "AllResponseBody": {
         "type": "object",
         "properties": {
@@ -8777,22 +11390,22 @@
             ]
           },
           "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           },
           "private_incident.membership_granted_v1": {
             "$ref": "#/components/schemas/WebhookIncidentUserV2"
@@ -9562,7 +12175,9 @@
               "debrief_invite_rule",
               "escalation_path",
               "follow_up_priority",
+              "holiday_user_feed",
               "incident",
+              "incident_call_setting",
               "incident_duration_metric",
               "incident_role",
               "incident_status",
@@ -9680,13 +12295,13 @@
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "helptext": "abc123",
+                "image_url": "abc123",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
                 "reference": "incident.severity",
-                "sort_key": "000020",
+                "sort_key": "abc123",
                 "unavailable": false,
                 "value": "abc123"
               }
@@ -9705,13 +12320,13 @@
                 "catalog_entry_name": "Primary escalation",
                 "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
               },
-              "helptext": "Collection of standalone automations like auto-closing incidents.",
-              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+              "helptext": "abc123",
+              "image_url": "abc123",
               "is_image_slack_icon": false,
               "label": "Lawrence Jones",
               "literal": "SEV123",
               "reference": "incident.severity",
-              "sort_key": "000020",
+              "sort_key": "abc123",
               "unavailable": false,
               "value": "abc123"
             }
@@ -9723,13 +12338,13 @@
               "catalog_entry_name": "Primary escalation",
               "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
             },
-            "helptext": "Collection of standalone automations like auto-closing incidents.",
-            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+            "helptext": "abc123",
+            "image_url": "abc123",
             "is_image_slack_icon": false,
             "label": "Lawrence Jones",
             "literal": "SEV123",
             "reference": "incident.severity",
-            "sort_key": "000020",
+            "sort_key": "abc123",
             "unavailable": false,
             "value": "abc123"
           }
@@ -9743,17 +12358,17 @@
           },
           "helptext": {
             "type": "string",
-            "description": "Gives a description of the option to the user",
-            "example": "Collection of standalone automations like auto-closing incidents."
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
+            "example": "abc123"
           },
           "image_url": {
             "type": "string",
-            "description": "If appropriate, URL to an image that can be displayed alongside the option",
-            "example": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg"
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
+            "example": "abc123"
           },
           "is_image_slack_icon": {
             "type": "boolean",
-            "description": "If true, the image_url is a Slack icon and should be displayed as such",
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
             "example": false
           },
           "label": {
@@ -9768,22 +12383,22 @@
           },
           "reference": {
             "type": "string",
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
             "example": "incident.severity"
           },
           "sort_key": {
             "type": "string",
-            "description": "Gives an indication of how to sort the options when displayed to the user",
-            "example": "000020"
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
+            "example": "abc123"
           },
           "unavailable": {
             "type": "boolean",
-            "description": "Unavailable is true if we've failed to build the value for this binding",
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
             "example": false
           },
           "value": {
             "type": "string",
-            "description": "Either the reference or the literal: this field is designed purely to make working with react-select easier",
+            "description": "This field is deprecated. It will not be present in any responses, and will be removed in a future version",
             "example": "abc123"
           }
         },
@@ -9794,13 +12409,13 @@
             "catalog_entry_name": "Primary escalation",
             "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
-          "helptext": "Collection of standalone automations like auto-closing incidents.",
-          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+          "helptext": "abc123",
+          "image_url": "abc123",
           "is_image_slack_icon": false,
           "label": "Lawrence Jones",
           "literal": "SEV123",
           "reference": "incident.severity",
-          "sort_key": "000020",
+          "sort_key": "abc123",
           "unavailable": false,
           "value": "abc123"
         },
@@ -9880,13 +12495,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -9898,13 +12513,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -9969,13 +12584,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -9987,13 +12602,13 @@
                   "catalog_entry_name": "Primary escalation",
                   "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                 },
-                "helptext": "Collection of standalone automations like auto-closing incidents.",
-                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "helptext": "abc123",
+                "image_url": "abc123",
                 "is_image_slack_icon": false,
                 "label": "Lawrence Jones",
                 "literal": "SEV123",
                 "reference": "incident.severity",
-                "sort_key": "000020",
+                "sort_key": "abc123",
                 "unavailable": false,
                 "value": "abc123"
               }
@@ -10390,8 +13005,9 @@
           "icon": {
             "type": "string",
             "description": "Sets the display icon of this type in the dashboard",
-            "example": "bolt",
+            "example": "alert",
             "enum": [
+              "alert",
               "bolt",
               "box",
               "briefcase",
@@ -10404,6 +13020,7 @@
               "database",
               "doc",
               "email",
+              "escalation-path",
               "files",
               "flag",
               "folder",
@@ -10411,6 +13028,7 @@
               "money",
               "server",
               "severity",
+              "status-page",
               "store",
               "star",
               "tag",
@@ -10497,7 +13115,7 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
           "estimated_count": 7,
-          "icon": "bolt",
+          "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_editable": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -10609,6 +13227,79 @@
         ]
       },
       "ConditionGroupV2": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV2"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV3": {
         "type": "object",
         "properties": {
           "conditions": {
@@ -11077,13 +13768,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -11095,13 +13786,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -11513,35 +14204,706 @@
       "CreateRequestBody": {
         "type": "object",
         "properties": {
-          "custom_field_id": {
-            "type": "string",
-            "description": "ID of the custom field this option belongs to",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          "alert_source_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "The alert sources that will match this alert route",
+            "example": [
+              "02FCNDV6P870EA6S7TK1DSYDG2"
+            ]
           },
-          "sort_key": {
+          "auto_decline_enabled": {
+            "type": "boolean",
+            "description": "Should triage incidents be declined when alerts are resolved?",
+            "example": false
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
             "type": "integer",
-            "description": "Sort key used to order the custom field options correctly",
-            "default": 1000,
-            "example": 10,
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
             "format": "int64"
           },
-          "value": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route is enabled or not",
+            "example": false
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "incident_condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to create an incident?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "incident_enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route will create incidents or not",
+            "example": false
+          },
+          "name": {
             "type": "string",
-            "description": "Human readable name for the custom field option",
-            "example": "Product"
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
           }
         },
         "example": {
-          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "sort_key": 10,
-          "value": "Product"
-        },
-        "required": [
-          "custom_field_id",
-          "value"
-        ]
+          "alert_source_ids": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ],
+          "auto_decline_enabled": false,
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "enabled": false,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "incident_condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "incident_enabled": false,
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "abc123"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        }
       },
       "CreateRequestBody10": {
+        "type": "object",
+        "properties": {
+          "custom_field_entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+            },
+            "description": "Set the incident's custom fields to these values",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ]
+          },
+          "idempotency_key": {
+            "type": "string",
+            "description": "Unique string used to de-duplicate incident create requests",
+            "example": "alert-uuid"
+          },
+          "incident_role_assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
+            },
+            "description": "Assign incident roles to these people",
+            "example": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ]
+          },
+          "incident_type_id": {
+            "type": "string",
+            "description": "Incident type to create this incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Whether the incident is real or test",
+            "example": "real",
+            "enum": [
+              "real",
+              "test"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Explanation of the incident",
+            "example": "Our database is sad"
+          },
+          "severity_id": {
+            "type": "string",
+            "description": "Severity to create incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "slack_team_id": {
+            "type": "string",
+            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
+            "example": "T02A1FSLE8J"
+          },
+          "source_message_channel_id": {
+            "type": "string",
+            "description": "Channel ID of the source message, if this incident was created from one",
+            "example": "C02AW36C1M5"
+          },
+          "source_message_timestamp": {
+            "type": "string",
+            "description": "Timestamp of the source message, if this incident was created from one",
+            "example": "1653650280.526509"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the incident",
+            "example": "triage",
+            "enum": [
+              "triage",
+              "investigating",
+              "fixing",
+              "monitoring",
+              "closed",
+              "declined"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "description": "Detailed description of the incident",
+            "example": "Our database is really really sad, and we don't know why yet."
+          },
+          "visibility": {
+            "type": "string",
+            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+            "example": "public",
+            "enum": [
+              "public",
+              "private"
+            ]
+          }
+        },
+        "example": {
+          "custom_field_entries": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ],
+          "idempotency_key": "alert-uuid",
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ],
+          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "mode": "real",
+          "name": "Our database is sad",
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "slack_team_id": "T02A1FSLE8J",
+          "source_message_channel_id": "C02AW36C1M5",
+          "source_message_timestamp": "1653650280.526509",
+          "status": "triage",
+          "summary": "Our database is really really sad, and we don't know why yet.",
+          "visibility": "public"
+        },
+        "required": [
+          "idempotency_key",
+          "visibility"
+        ]
+      },
+      "CreateRequestBody11": {
         "type": "object",
         "properties": {
           "custom_field_entries": {
@@ -11720,7 +15082,7 @@
           "visibility"
         ]
       },
-      "CreateRequestBody11": {
+      "CreateRequestBody12": {
         "type": "object",
         "properties": {
           "schedule": {
@@ -11768,6 +15130,11 @@
                 }
               ]
             },
+            "holidays_public_config": {
+              "country_codes": [
+                "abc123"
+              ]
+            },
             "name": "My Schedule",
             "timezone": "America/Los_Angeles"
           }
@@ -11776,7 +15143,7 @@
           "schedule"
         ]
       },
-      "CreateRequestBody12": {
+      "CreateRequestBody13": {
         "type": "object",
         "properties": {
           "description": {
@@ -11808,6 +15175,37 @@
         ]
       },
       "CreateRequestBody2": {
+        "type": "object",
+        "properties": {
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
+          }
+        },
+        "example": {
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        },
+        "required": [
+          "custom_field_id",
+          "value"
+        ]
+      },
+      "CreateRequestBody3": {
         "type": "object",
         "properties": {
           "description": {
@@ -11898,7 +15296,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody3": {
+      "CreateRequestBody4": {
         "type": "object",
         "properties": {
           "description": {
@@ -11940,7 +15338,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody4": {
+      "CreateRequestBody5": {
         "type": "object",
         "properties": {
           "incident_id": {
@@ -12004,7 +15402,7 @@
           "resource"
         ]
       },
-      "CreateRequestBody5": {
+      "CreateRequestBody6": {
         "type": "object",
         "properties": {
           "incident_id": {
@@ -12025,7 +15423,7 @@
           "incident_id"
         ]
       },
-      "CreateRequestBody6": {
+      "CreateRequestBody7": {
         "type": "object",
         "properties": {
           "description": {
@@ -12053,8 +15451,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           }
         },
         "example": {
@@ -12077,7 +15474,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody7": {
+      "CreateRequestBody8": {
         "type": "object",
         "properties": {
           "description": {
@@ -12100,8 +15497,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           }
         },
         "example": {
@@ -12122,7 +15518,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody8": {
+      "CreateRequestBody9": {
         "type": "object",
         "properties": {
           "category": {
@@ -12161,166 +15557,324 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody9": {
+      "CreateResponseBody": {
         "type": "object",
         "properties": {
-          "custom_field_entries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
-            },
-            "description": "Set the incident's custom fields to these values",
-            "example": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "values": [
-                  {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_text": "This is my text field, I hope you like it",
-                    "value_timestamp": ""
-                  }
-                ]
-              }
-            ]
-          },
-          "idempotency_key": {
-            "type": "string",
-            "description": "Unique string used to de-duplicate incident create requests",
-            "example": "alert-uuid"
-          },
-          "incident_role_assignments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
-            },
-            "description": "Assign incident roles to these people",
-            "example": [
-              {
-                "assignee": {
-                  "email": "bob@example.com",
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "slack_user_id": "USER123"
-                },
-                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-              }
-            ]
-          },
-          "incident_type_id": {
-            "type": "string",
-            "description": "Incident type to create this incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "mode": {
-            "type": "string",
-            "description": "Whether the incident is real or test",
-            "example": "real",
-            "enum": [
-              "real",
-              "test"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Explanation of the incident",
-            "example": "Our database is sad"
-          },
-          "severity_id": {
-            "type": "string",
-            "description": "Severity to create incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "slack_team_id": {
-            "type": "string",
-            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
-            "example": "T02A1FSLE8J"
-          },
-          "source_message_channel_id": {
-            "type": "string",
-            "description": "Channel ID of the source message, if this incident was created from one",
-            "example": "C02AW36C1M5"
-          },
-          "source_message_timestamp": {
-            "type": "string",
-            "description": "Timestamp of the source message, if this incident was created from one",
-            "example": "1653650280.526509"
-          },
-          "status": {
-            "type": "string",
-            "description": "Current status of the incident",
-            "example": "triage",
-            "enum": [
-              "triage",
-              "investigating",
-              "fixing",
-              "monitoring",
-              "closed",
-              "declined"
-            ]
-          },
-          "summary": {
-            "type": "string",
-            "description": "Detailed description of the incident",
-            "example": "Our database is really really sad, and we don't know why yet."
-          },
-          "visibility": {
-            "type": "string",
-            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-            "example": "public",
-            "enum": [
-              "public",
-              "private"
-            ]
+          "alert_route": {
+            "$ref": "#/components/schemas/AlertRouteV2"
           }
         },
         "example": {
-          "custom_field_entries": [
-            {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "values": [
-                {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_text": "This is my text field, I hope you like it",
-                  "value_timestamp": ""
+          "alert_route": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defer_time_seconds": 1,
+            "escalation_bindings": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
                 }
-              ]
-            }
-          ],
-          "idempotency_key": "alert-uuid",
-          "incident_role_assignments": [
-            {
-              "assignee": {
-                "email": "bob@example.com",
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                "slack_user_id": "USER123"
+              }
+            ],
+            "expressions": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ],
+            "grouping_keys": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ],
+            "grouping_window_seconds": 1,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Production incidents",
+            "template": {
+              "custom_field_priorities": {
+                "abc123": "first-wins"
               },
-              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              "custom_fields": {
+                "custom_field_10014": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "incident_mode": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "incident_type": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "name": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "priority_severity": "severity-first-wins",
+              "severity": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "summary": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "workspace": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
             }
-          ],
-          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "mode": "real",
-          "name": "Our database is sad",
-          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "slack_team_id": "T02A1FSLE8J",
-          "source_message_channel_id": "C02AW36C1M5",
-          "source_message_timestamp": "1653650280.526509",
-          "status": "triage",
-          "summary": "Our database is really really sad, and we don't know why yet.",
-          "visibility": "public"
+          }
         },
         "required": [
-          "idempotency_key",
-          "visibility"
+          "alert_route"
         ]
       },
-      "CreateResponseBody": {
+      "CreateResponseBody2": {
         "type": "object",
         "properties": {
           "incident_attachment": {
@@ -12343,7 +15897,7 @@
           "incident_attachment"
         ]
       },
-      "CreateResponseBody2": {
+      "CreateResponseBody3": {
         "type": "object",
         "properties": {
           "incident_membership": {
@@ -12425,8 +15979,9 @@
           "icon": {
             "type": "string",
             "description": "Sets the display icon of this type in the dashboard",
-            "example": "bolt",
+            "example": "alert",
             "enum": [
+              "alert",
               "bolt",
               "box",
               "briefcase",
@@ -12439,6 +15994,7 @@
               "database",
               "doc",
               "email",
+              "escalation-path",
               "files",
               "flag",
               "folder",
@@ -12446,6 +16002,7 @@
               "money",
               "server",
               "severity",
+              "status-page",
               "store",
               "star",
               "tag",
@@ -12483,7 +16040,7 @@
           ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
-          "icon": "bolt",
+          "icon": "alert",
           "name": "Kubernetes Cluster",
           "ranked": true,
           "source_repo_url": "https://github.com/my-company/incident-io-catalog",
@@ -12514,7 +16071,7 @@
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "icon": "bolt",
+            "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -15172,6 +18729,105 @@
             ]
           },
           "result": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "result": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "condition_groups",
+          "result"
+        ]
+      },
+      "ExpressionBranchV3": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV3"
+            },
+            "description": "When one of these condition groups are satisfied, this branch will be evaluated",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "result": {
             "$ref": "#/components/schemas/EngineParamBindingV3"
           }
         },
@@ -15458,6 +19114,131 @@
           "returns"
         ]
       },
+      "ExpressionBranchesOptsV3": {
+        "type": "object",
+        "properties": {
+          "branches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionBranchV3"
+            },
+            "description": "The branches to apply for this operation",
+            "example": [
+              {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          }
+        },
+        "example": {
+          "branches": [
+            {
+              "condition_groups": [
+                {
+                  "conditions": [
+                    {
+                      "operation": {
+                        "label": "Lawrence Jones",
+                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                      },
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": {
+                        "label": "Incident Severity",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "result": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "required": [
+          "branches",
+          "returns"
+        ]
+      },
       "ExpressionElseBranchPayloadV2": {
         "type": "object",
         "properties": {
@@ -15484,6 +19265,33 @@
         ]
       },
       "ExpressionElseBranchV2": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          }
+        },
+        "example": {
+          "result": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "ExpressionElseBranchV3": {
         "type": "object",
         "properties": {
           "result": {
@@ -15656,6 +19464,87 @@
           "condition_groups"
         ]
       },
+      "ExpressionFilterOptsV3": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV3"
+            },
+            "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "condition_groups"
+        ]
+      },
       "ExpressionNavigateOptsPayloadV2": {
         "type": "object",
         "properties": {
@@ -15724,7 +19613,7 @@
             ]
           },
           "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsV2"
+            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
           }
         },
         "example": {
@@ -15846,7 +19735,7 @@
             ]
           },
           "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsV2"
+            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
           },
           "returns": {
             "$ref": "#/components/schemas/ReturnsMetaV2"
@@ -15965,7 +19854,155 @@
           "returns"
         ]
       },
-      "ExpressionParseOptsV2": {
+      "ExpressionOperationV3": {
+        "type": "object",
+        "properties": {
+          "branches": {
+            "$ref": "#/components/schemas/ExpressionBranchesOptsV3"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/ExpressionFilterOptsV3"
+          },
+          "navigate": {
+            "$ref": "#/components/schemas/ExpressionNavigateOptsV2"
+          },
+          "operation_type": {
+            "type": "string",
+            "description": "The type of the operation",
+            "example": "navigate",
+            "enum": [
+              "navigate",
+              "filter",
+              "count",
+              "min",
+              "max",
+              "random",
+              "first",
+              "parse",
+              "branches"
+            ]
+          },
+          "parse": {
+            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          }
+        },
+        "example": {
+          "branches": {
+            "branches": [
+              {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ],
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            }
+          },
+          "filter": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "navigate": {
+            "reference": "1235",
+            "reference_label": "Teams"
+          },
+          "operation_type": "navigate",
+          "parse": {
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            },
+            "source": "metadata.annotations[\"github.com/repo\"]"
+          },
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "required": [
+          "operation_type",
+          "returns"
+        ]
+      },
+      "ExpressionParseOptsPayloadV2": {
         "type": "object",
         "properties": {
           "returns": {
@@ -16232,6 +20269,291 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExpressionOperationV2"
+            },
+            "example": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": {
+                            "label": "Lawrence Jones",
+                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                          },
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": {
+                            "label": "Incident Severity",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "1235",
+                  "reference_label": "Teams"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                },
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              }
+            ]
+          },
+          "reference": {
+            "type": "string",
+            "description": "A short ID that can be used to reference the expression",
+            "example": "abc123"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          },
+          "root_reference": {
+            "type": "string",
+            "description": "The root reference for this expression (i.e. where the expression starts)",
+            "example": "incident.status"
+          }
+        },
+        "example": {
+          "else_branch": {
+            "result": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "label": "Team Slack channel",
+          "operations": [
+            {
+              "branches": {
+                "branches": [
+                  {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "result": {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              },
+              "filter": {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "navigate": {
+                "reference": "1235",
+                "reference_label": "Teams"
+              },
+              "operation_type": "navigate",
+              "parse": {
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "source": "metadata.annotations[\"github.com/repo\"]"
+              },
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              }
+            }
+          ],
+          "reference": "abc123",
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          },
+          "root_reference": "incident.status"
+        },
+        "required": [
+          "label",
+          "reference",
+          "returns",
+          "root_reference",
+          "operations",
+          "id"
+        ]
+      },
+      "ExpressionV3": {
+        "type": "object",
+        "properties": {
+          "else_branch": {
+            "$ref": "#/components/schemas/ExpressionElseBranchV3"
+          },
+          "label": {
+            "type": "string",
+            "description": "The human readable label of the expression",
+            "example": "Team Slack channel"
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionOperationV3"
             },
             "example": [
               {
@@ -16770,6 +21092,22 @@
           "updated_at"
         ]
       },
+      "GroupingKeyV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the alert attribute the user wishes to group on",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        },
+        "example": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "required": [
+          "id"
+        ]
+      },
       "IdentityResponseBody": {
         "type": "object",
         "properties": {
@@ -17244,8 +21582,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           },
           "updated_at": {
             "type": "string",
@@ -17266,12 +21603,12 @@
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "required": [
-          "condition_groups",
-          "id",
           "name",
+          "shortform",
           "description",
           "instructions",
-          "shortform",
+          "condition_groups",
+          "id",
           "role_type",
           "created_at",
           "updated_at"
@@ -17321,8 +21658,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           },
           "updated_at": {
             "type": "string",
@@ -17342,12 +21678,12 @@
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "required": [
-          "condition_groups",
-          "id",
           "name",
+          "shortform",
           "description",
           "instructions",
-          "shortform",
+          "condition_groups",
+          "id",
           "role_type",
           "created_at",
           "updated_at"
@@ -18671,13 +23007,13 @@
                           "catalog_entry_name": "Primary escalation",
                           "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                         },
-                        "helptext": "Collection of standalone automations like auto-closing incidents.",
-                        "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                        "helptext": "abc123",
+                        "image_url": "abc123",
                         "is_image_slack_icon": false,
                         "label": "Lawrence Jones",
                         "literal": "SEV123",
                         "reference": "incident.severity",
-                        "sort_key": "000020",
+                        "sort_key": "abc123",
                         "unavailable": false,
                         "value": "abc123"
                       }
@@ -18689,13 +23025,13 @@
                         "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                      "helptext": "abc123",
+                      "image_url": "abc123",
                       "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
                       "reference": "incident.severity",
-                      "sort_key": "000020",
+                      "sort_key": "abc123",
                       "unavailable": false,
                       "value": "abc123"
                     }
@@ -18736,13 +23072,13 @@
                         "catalog_entry_name": "Primary escalation",
                         "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                       },
-                      "helptext": "Collection of standalone automations like auto-closing incidents.",
-                      "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                      "helptext": "abc123",
+                      "image_url": "abc123",
                       "is_image_slack_icon": false,
                       "label": "Lawrence Jones",
                       "literal": "SEV123",
                       "reference": "incident.severity",
-                      "sort_key": "000020",
+                      "sort_key": "abc123",
                       "unavailable": false,
                       "value": "abc123"
                     }
@@ -18754,13 +23090,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -18787,7 +23123,7 @@
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "icon": "bolt",
+            "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -19795,6 +24131,12 @@
                     }
                   }
                 ],
+                "holidays_public_config": {
+                  "country_codes": [
+                    "GB",
+                    "FR"
+                  ]
+                },
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                 "name": "Primary On-Call Schedule",
                 "timezone": "Europe/London",
@@ -19870,6 +24212,12 @@
                   }
                 }
               ],
+              "holidays_public_config": {
+                "country_codes": [
+                  "GB",
+                  "FR"
+                ]
+              },
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "name": "Primary On-Call Schedule",
               "timezone": "Europe/London",
@@ -20475,7 +24823,7 @@
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
                 "dynamic_resource_parameter": "abc123",
                 "estimated_count": 7,
-                "icon": "bolt",
+                "icon": "alert",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "is_editable": false,
                 "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -20526,7 +24874,7 @@
               "description": "Represents Kubernetes clusters that we run inside of GKE.",
               "dynamic_resource_parameter": "abc123",
               "estimated_count": 7,
-              "icon": "bolt",
+              "icon": "alert",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "is_editable": false,
               "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -21263,7 +25611,7 @@
             ]
           },
           "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21303,7 +25651,7 @@
             ]
           },
           "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21343,7 +25691,7 @@
             ]
           },
           "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21383,7 +25731,7 @@
             ]
           },
           "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21423,7 +25771,7 @@
             ]
           },
           "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -21463,7 +25811,7 @@
             ]
           },
           "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+            "$ref": "#/components/schemas/GroupingKeyV2"
           }
         },
         "example": {
@@ -22725,6 +27073,9 @@
           "config": {
             "$ref": "#/components/schemas/ScheduleConfigCreatePayloadV2"
           },
+          "holidays_public_config": {
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
+          },
           "name": {
             "type": "string",
             "description": "Name of the schedule",
@@ -22774,6 +27125,11 @@
                   }
                 ]
               }
+            ]
+          },
+          "holidays_public_config": {
+            "country_codes": [
+              "abc123"
             ]
           },
           "name": "My Schedule",
@@ -22968,6 +27324,32 @@
           "external_user_id",
           "start_at",
           "end_at"
+        ]
+      },
+      "ScheduleHolidaysPublicConfigV2": {
+        "type": "object",
+        "properties": {
+          "country_codes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for",
+            "example": [
+              "GB",
+              "FR"
+            ]
+          }
+        },
+        "example": {
+          "country_codes": [
+            "GB",
+            "FR"
+          ]
+        },
+        "required": [
+          "country_codes"
         ]
       },
       "ScheduleLayerCreatePayloadV2": {
@@ -23426,6 +27808,9 @@
           "config": {
             "$ref": "#/components/schemas/ScheduleConfigUpdatePayloadV2"
           },
+          "holidays_public_config": {
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
+          },
           "name": {
             "type": "string",
             "description": "Name of the schedule",
@@ -23477,6 +27862,11 @@
               }
             ]
           },
+          "holidays_public_config": {
+            "country_codes": [
+              "abc123"
+            ]
+          },
           "name": "My Schedule",
           "timezone": "America/Los_Angeles"
         }
@@ -23526,6 +27916,9 @@
                 }
               }
             ]
+          },
+          "holidays_public_config": {
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
           },
           "id": {
             "type": "string",
@@ -23608,6 +28001,12 @@
               }
             }
           ],
+          "holidays_public_config": {
+            "country_codes": [
+              "GB",
+              "FR"
+            ]
+          },
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "name": "Primary On-Call Schedule",
           "timezone": "Europe/London",
@@ -23791,13 +28190,13 @@
                       "catalog_entry_name": "Primary escalation",
                       "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                     },
-                    "helptext": "Collection of standalone automations like auto-closing incidents.",
-                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "helptext": "abc123",
+                    "image_url": "abc123",
                     "is_image_slack_icon": false,
                     "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity",
-                    "sort_key": "000020",
+                    "sort_key": "abc123",
                     "unavailable": false,
                     "value": "abc123"
                   }
@@ -23809,13 +28208,13 @@
                     "catalog_entry_name": "Primary escalation",
                     "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
                   },
-                  "helptext": "Collection of standalone automations like auto-closing incidents.",
-                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "helptext": "abc123",
+                  "image_url": "abc123",
                   "is_image_slack_icon": false,
                   "label": "Lawrence Jones",
                   "literal": "SEV123",
                   "reference": "incident.severity",
-                  "sort_key": "000020",
+                  "sort_key": "abc123",
                   "unavailable": false,
                   "value": "abc123"
                 }
@@ -23841,7 +28240,7 @@
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
             "estimated_count": 7,
-            "icon": "bolt",
+            "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_editable": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
@@ -24315,6 +28714,12 @@
                 }
               }
             ],
+            "holidays_public_config": {
+              "country_codes": [
+                "GB",
+                "FR"
+              ]
+            },
             "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "name": "Primary On-Call Schedule",
             "timezone": "Europe/London",
@@ -25122,6 +29527,563 @@
       "UpdateRequestBody": {
         "type": "object",
         "properties": {
+          "alert_source_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "The alert sources that will match this alert route",
+            "example": [
+              "02FCNDV6P870EA6S7TK1DSYDG2"
+            ]
+          },
+          "auto_decline_enabled": {
+            "type": "boolean",
+            "description": "Should triage incidents be declined when alerts are resolved?",
+            "example": false
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
+            "type": "integer",
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route is enabled or not",
+            "example": false
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "incident_condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to create an incident?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "incident_enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route will create incidents or not",
+            "example": false
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
+          }
+        },
+        "example": {
+          "alert_source_ids": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ],
+          "auto_decline_enabled": false,
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "enabled": false,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "incident_condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "incident_enabled": false,
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "abc123"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        },
+        "required": [
+          "name",
+          "condition_groups",
+          "grouping_keys",
+          "grouping_window_seconds",
+          "defer_time_seconds",
+          "escalation_bindings",
+          "auto_decline_enabled",
+          "enabled",
+          "incident_enabled",
+          "incident_condition_groups",
+          "alert_source_ids",
+          "auto_cancel_escalations"
+        ]
+      },
+      "UpdateRequestBody2": {
+        "type": "object",
+        "properties": {
           "sort_key": {
             "type": "integer",
             "description": "Sort key used to order the custom field options correctly",
@@ -25145,7 +30107,7 @@
           "sort_key"
         ]
       },
-      "UpdateRequestBody2": {
+      "UpdateRequestBody3": {
         "type": "object",
         "properties": {
           "description": {
@@ -25222,7 +30184,7 @@
           "updated_at"
         ]
       },
-      "UpdateRequestBody3": {
+      "UpdateRequestBody4": {
         "type": "object",
         "properties": {
           "description": {
@@ -25250,7 +30212,7 @@
           "updated_at"
         ]
       },
-      "UpdateRequestBody4": {
+      "UpdateRequestBody5": {
         "type": "object",
         "properties": {
           "description": {
@@ -25278,8 +30240,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           }
         },
         "example": {
@@ -25290,17 +30251,17 @@
           "shortform": "lead"
         },
         "required": [
-          "condition_groups",
           "name",
+          "shortform",
           "description",
           "instructions",
-          "shortform",
+          "condition_groups",
           "role_type",
           "created_at",
           "updated_at"
         ]
       },
-      "UpdateRequestBody5": {
+      "UpdateRequestBody6": {
         "type": "object",
         "properties": {
           "description": {
@@ -25323,8 +30284,7 @@
           "shortform": {
             "type": "string",
             "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "minLength": 1
+            "example": "lead"
           }
         },
         "example": {
@@ -25334,17 +30294,17 @@
           "shortform": "lead"
         },
         "required": [
-          "condition_groups",
           "name",
+          "shortform",
           "description",
           "instructions",
-          "shortform",
+          "condition_groups",
           "role_type",
           "created_at",
           "updated_at"
         ]
       },
-      "UpdateRequestBody6": {
+      "UpdateRequestBody7": {
         "type": "object",
         "properties": {
           "description": {
@@ -25371,7 +30331,7 @@
           "updated_at"
         ]
       },
-      "UpdateRequestBody7": {
+      "UpdateRequestBody8": {
         "type": "object",
         "properties": {
           "schedule": {
@@ -25417,6 +30377,11 @@
                     }
                   ]
                 }
+              ]
+            },
+            "holidays_public_config": {
+              "country_codes": [
+                "abc123"
               ]
             },
             "name": "My Schedule",
@@ -25490,8 +30455,9 @@
           "icon": {
             "type": "string",
             "description": "Sets the display icon of this type in the dashboard",
-            "example": "bolt",
+            "example": "alert",
             "enum": [
+              "alert",
               "bolt",
               "box",
               "briefcase",
@@ -25504,6 +30470,7 @@
               "database",
               "doc",
               "email",
+              "escalation-path",
               "files",
               "flag",
               "folder",
@@ -25511,6 +30478,7 @@
               "money",
               "server",
               "severity",
+              "status-page",
               "store",
               "star",
               "tag",
@@ -25543,7 +30511,7 @@
           ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
-          "icon": "bolt",
+          "icon": "alert",
           "name": "Kubernetes Cluster",
           "ranked": true,
           "source_repo_url": "https://github.com/my-company/incident-io-catalog"
@@ -26765,22 +31733,6 @@
           "reported_at"
         ]
       },
-      "WebhookPrivateResourceV2": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The ID of the resource",
-            "example": "abc123"
-          }
-        },
-        "example": {
-          "id": "abc123"
-        },
-        "required": [
-          "id"
-        ]
-      },
       "WeekdayIntervalConfigV2": {
         "type": "object",
         "properties": {
@@ -26868,7 +31820,7 @@
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV2"
+              "$ref": "#/components/schemas/ConditionGroupV3"
             },
             "description": "Conditions that apply to the workflow trigger",
             "example": [
@@ -26915,7 +31867,7 @@
           "expressions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ExpressionV2"
+              "$ref": "#/components/schemas/ExpressionV3"
             },
             "description": "Expressions that make variables available in the scope",
             "example": [
@@ -27445,7 +32397,7 @@
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV2"
+              "$ref": "#/components/schemas/ConditionGroupV3"
             },
             "description": "Conditions that apply to the workflow trigger",
             "example": [
@@ -27492,7 +32444,7 @@
           "expressions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ExpressionV2"
+              "$ref": "#/components/schemas/ExpressionV3"
             },
             "description": "Expressions that make variables available in the scope",
             "example": [
@@ -27968,6 +32920,10 @@
       "description": "Manage incident actions.\n\nIncident actions are used during an incident, to track work such as 'restart the database' or 'contact the customer'.\n\nYou can manage actions in the incident Slack channel with <code>/incident actions</code>, or on\nthe incident homepage.\n"
     },
     {
+      "name": "Alert Routes V2",
+      "description": "Create and manage alert routes.\n\nAlert routes take alerts from alert sources, filter them according to conditions, apply\ngrouping on alert attributes, then finally create:\n\n1. Incidents\n2. Escalations\n\nThese are best configured in the incident.io dashboard and exported via the UI to\nTerraform, as the configuration is complex.\n"
+    },
+    {
       "name": "Alert Events V2",
       "description": "Create alerts within incident.io.\n\nThe alerts API allows you to create alerts within incident.io by posting alert events. You\ncan use alerts to automatically trigger incidents.\n\nTo create an alert, you must first configure an alert source in the incident.io dashboard.\n"
     },
@@ -28034,10 +32990,6 @@
     {
       "name": "Incidents V2",
       "description": "Create and read incidents.\n\nIncidents are a core resource, on which many other resources (actions, etc) are created.\n\nCare should be taken around these endpoints, as automation that creates duplicate\nincidents can be distracting, and impact reporting.\n"
-    },
-    {
-      "name": "Managed Resources V2",
-      "description": "Manage how resources are managed.\n\nAllows callers to set whether a resource is being managed externally, and where the source configuration is.\n"
     },
     {
       "name": "Schedules V2",
@@ -30289,6 +35241,194 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Low",
                       "type": "follow_up_priority"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/holiday_user_feed.created.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "HolidayUserFeedCreatedV1",
+        "description": "This entry is created whenever a holiday user feed is created",
+        "operationId": "Audit logs#HolidayUserFeedCreatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "holiday_user_feed.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "US Team holidays",
+                      "type": "holiday_user_feed"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/holiday_user_feed.deleted.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "HolidayUserFeedDeletedV1",
+        "description": "This entry is created whenever a holiday user feed is deleted",
+        "operationId": "Audit logs#HolidayUserFeedDeletedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "holiday_user_feed.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "US Team holidays",
+                      "type": "holiday_user_feed"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/holiday_user_feed.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "HolidayUserFeedUpdatedV1",
+        "description": "This entry is created whenever a holiday user feed is updated",
+        "operationId": "Audit logs#HolidayUserFeedUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "holiday_user_feed.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "US Team holidays",
+                      "type": "holiday_user_feed"
+                    }
+                  ],
+                  "version": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-audit-logs/incident_call_setting.updated.1": {
+      "get": {
+        "tags": [
+          "Audit logs"
+        ],
+        "summary": "IncidentCallSettingUpdatedV1",
+        "description": "This entry is created whenever an organisation's incident call settings are updated",
+        "operationId": "Audit logs#IncidentCallSettingUpdatedV1",
+        "responses": {
+          "200": {
+            "description": "OK response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                },
+                "example": {
+                  "action": "incident_call_setting.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Incident call settings",
+                      "type": "incident_call_setting"
                     }
                   ],
                   "version": 1

--- a/internal/apischema/openapi3.yaml
+++ b/internal/apischema/openapi3.yaml
@@ -309,7 +309,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody'
+                            $ref: '#/components/schemas/CreateRequestBody2'
                         example:
                             custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
                             sort_key: 10
@@ -397,7 +397,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/UpdateRequestBody'
+                            $ref: '#/components/schemas/UpdateRequestBody2'
                         example:
                             sort_key: 10
                             value: Product
@@ -466,7 +466,7 @@ paths:
                             show_before_update: true
                             show_in_announcement_post: true
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody2'
+                            $ref: '#/components/schemas/CreateRequestBody3'
                 required: true
             responses:
                 "201":
@@ -590,7 +590,7 @@ paths:
                             show_before_update: true
                             show_in_announcement_post: true
                         schema:
-                            $ref: '#/components/schemas/UpdateRequestBody2'
+                            $ref: '#/components/schemas/UpdateRequestBody3'
                 required: true
             responses:
                 "200":
@@ -721,7 +721,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody4'
+                            $ref: '#/components/schemas/CreateRequestBody5'
                         example:
                             incident_id: 01FDAG4SAP5TYPT98WGR2N7W91
                             resource:
@@ -733,7 +733,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/CreateResponseBody'
+                                $ref: '#/components/schemas/CreateResponseBody2'
                             example:
                                 incident_attachment:
                                     id: 01FCNDV6P870EA6S7TK1DSYD5H
@@ -775,7 +775,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody5'
+                            $ref: '#/components/schemas/CreateRequestBody6'
                         example:
                             incident_id: 01ET65M7ZADYFCKD4K1AE2QNMC
                             user_id: 01FCQSP07Z74QMMYPDDGQB9FTG
@@ -785,7 +785,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/CreateResponseBody2'
+                                $ref: '#/components/schemas/CreateResponseBody3'
                             example:
                                 incident_membership:
                                     created_at: "2021-08-17T13:28:57.801578Z"
@@ -810,7 +810,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody5'
+                            $ref: '#/components/schemas/CreateRequestBody6'
                         example:
                             incident_id: 01FCNDV6P870EA6S7TK1DSYD5H
                             user_id: 01FCQSP07Z74QMMYPDDGQB9FTG
@@ -856,7 +856,7 @@ paths:
                             required: false
                             shortform: lead
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody6'
+                            $ref: '#/components/schemas/CreateRequestBody7'
                 required: true
             responses:
                 "201":
@@ -959,7 +959,7 @@ paths:
                             required: false
                             shortform: lead
                         schema:
-                            $ref: '#/components/schemas/UpdateRequestBody4'
+                            $ref: '#/components/schemas/UpdateRequestBody5'
                 required: true
             responses:
                 "200":
@@ -1017,7 +1017,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody8'
+                            $ref: '#/components/schemas/CreateRequestBody9'
                         example:
                             category: live
                             description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
@@ -1111,7 +1111,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/UpdateRequestBody6'
+                            $ref: '#/components/schemas/UpdateRequestBody7'
                         example:
                             description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
                             name: Closed
@@ -1372,7 +1372,7 @@ paths:
                             summary: Our database is really really sad, and we don't know why yet.
                             visibility: public
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody9'
+                            $ref: '#/components/schemas/CreateRequestBody10'
                 required: true
             responses:
                 "200":
@@ -1657,7 +1657,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody12'
+                            $ref: '#/components/schemas/CreateRequestBody13'
                         example:
                             description: Issues with **low impact**.
                             name: Minor
@@ -1749,7 +1749,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody12'
+                            $ref: '#/components/schemas/CreateRequestBody13'
                         example:
                             description: Issues with **low impact**.
                             name: Minor
@@ -1918,6 +1918,962 @@ paths:
                                 deduplication_key: unique-key
                                 message: Event accepted for processing
                                 status: success
+    /v2/alert_routes:
+        post:
+            tags:
+                - Alert Routes V2
+            summary: Create Alert Routes V2
+            description: |
+                Create an alert route.
+
+                We recommend you create alert routes in the incident.io dashboard where we allow
+                previewing filter and grouping rules.
+            operationId: Alert Routes V2#Create
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/CreateRequestBody'
+                        example:
+                            alert_source_ids:
+                                - 02FCNDV6P870EA6S7TK1DSYDG2
+                            auto_decline_enabled: false
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                            defer_time_seconds: 1
+                            enabled: false
+                            escalation_bindings:
+                                - binding:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            expressions:
+                                - else_branch:
+                                    result:
+                                        array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                  label: Team Slack channel
+                                  operations:
+                                    - branches:
+                                        branches:
+                                            - condition_groups:
+                                                - conditions:
+                                                    - operation: one_of
+                                                      param_bindings:
+                                                        - array_value:
+                                                            - literal: SEV123
+                                                              reference: incident.severity
+                                                          value:
+                                                            literal: SEV123
+                                                            reference: incident.severity
+                                                      subject: incident.severity
+                                              result:
+                                                array_value:
+                                                    - literal: SEV123
+                                                      reference: incident.severity
+                                                value:
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                        returns:
+                                            array: true
+                                            type: IncidentStatus
+                                      filter:
+                                        condition_groups:
+                                            - conditions:
+                                                - operation: one_of
+                                                  param_bindings:
+                                                    - array_value:
+                                                        - literal: SEV123
+                                                          reference: incident.severity
+                                                      value:
+                                                        literal: SEV123
+                                                        reference: incident.severity
+                                                  subject: incident.severity
+                                      navigate:
+                                        reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                                      operation_type: navigate
+                                      parse:
+                                        returns:
+                                            array: true
+                                            type: IncidentStatus
+                                        source: metadata.annotations["github.com/repo"]
+                                  reference: abc123
+                                  root_reference: incident.status
+                            grouping_keys:
+                                - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            grouping_window_seconds: 1
+                            incident_condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                            incident_enabled: false
+                            name: Production incidents
+                            template:
+                                custom_field_priorities:
+                                    abc123: abc123
+                                custom_fields:
+                                    custom_field_10014:
+                                        array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                incident_mode:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                incident_type:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                name:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                priority_severity: severity-first-wins
+                                severity:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                summary:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                workspace:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+            responses:
+                "201":
+                    description: Created response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/CreateResponseBody'
+                            example:
+                                alert_route:
+                                    condition_groups:
+                                        - conditions:
+                                            - operation:
+                                                label: Lawrence Jones
+                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                              param_bindings:
+                                                - array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject:
+                                                label: Incident Severity
+                                                reference: incident.severity
+                                    defer_time_seconds: 1
+                                    escalation_bindings:
+                                        - binding:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                    expressions:
+                                        - else_branch:
+                                            result:
+                                                array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                          label: Team Slack channel
+                                          operations:
+                                            - branches:
+                                                branches:
+                                                    - condition_groups:
+                                                        - conditions:
+                                                            - operation:
+                                                                label: Lawrence Jones
+                                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                                              param_bindings:
+                                                                - array_value:
+                                                                    - label: Lawrence Jones
+                                                                      literal: SEV123
+                                                                      reference: incident.severity
+                                                                  value:
+                                                                    label: Lawrence Jones
+                                                                    literal: SEV123
+                                                                    reference: incident.severity
+                                                              subject:
+                                                                label: Incident Severity
+                                                                reference: incident.severity
+                                                      result:
+                                                        array_value:
+                                                            - label: Lawrence Jones
+                                                              literal: SEV123
+                                                              reference: incident.severity
+                                                        value:
+                                                            label: Lawrence Jones
+                                                            literal: SEV123
+                                                            reference: incident.severity
+                                                returns:
+                                                    array: true
+                                                    type: IncidentStatus
+                                              filter:
+                                                condition_groups:
+                                                    - conditions:
+                                                        - operation:
+                                                            label: Lawrence Jones
+                                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                                          param_bindings:
+                                                            - array_value:
+                                                                - label: Lawrence Jones
+                                                                  literal: SEV123
+                                                                  reference: incident.severity
+                                                              value:
+                                                                label: Lawrence Jones
+                                                                literal: SEV123
+                                                                reference: incident.severity
+                                                          subject:
+                                                            label: Incident Severity
+                                                            reference: incident.severity
+                                              navigate:
+                                                reference: "1235"
+                                                reference_label: Teams
+                                              operation_type: navigate
+                                              parse:
+                                                returns:
+                                                    array: true
+                                                    type: IncidentStatus
+                                                source: metadata.annotations["github.com/repo"]
+                                              returns:
+                                                array: true
+                                                type: IncidentStatus
+                                          reference: abc123
+                                          returns:
+                                            array: true
+                                            type: IncidentStatus
+                                          root_reference: incident.status
+                                    grouping_keys:
+                                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    grouping_window_seconds: 1
+                                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    name: Production incidents
+                                    template:
+                                        custom_field_priorities:
+                                            abc123: first-wins
+                                        custom_fields:
+                                            custom_field_10014:
+                                                array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                        incident_mode:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        incident_type:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        name:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        priority_severity: severity-first-wins
+                                        severity:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        summary:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        workspace:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+    /v2/alert_routes/{id}:
+        delete:
+            tags:
+                - Alert Routes V2
+            summary: Destroy Alert Routes V2
+            description: |
+                Archives an alert route.
+
+                We recommend you create alert routes in the incident.io dashboard where we allow
+                previewing filter and grouping rules.
+            operationId: Alert Routes V2#Destroy
+            parameters:
+                - name: id
+                  in: path
+                  description: Unique identifier for this alert route config
+                  required: true
+                  schema:
+                    type: string
+                    description: Unique identifier for this alert route config
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                  example: 01FCNDV6P870EA6S7TK1DSYDG0
+            responses:
+                "204":
+                    description: No Content response.
+        get:
+            tags:
+                - Alert Routes V2
+            summary: Show Alert Routes V2
+            description: |
+                Show an alert route.
+
+                We recommend you create alert routes in the incident.io dashboard where we allow
+                previewing filter and grouping rules.
+            operationId: Alert Routes V2#Show
+            parameters:
+                - name: id
+                  in: path
+                  description: Unique identifier for this alert route config
+                  required: true
+                  schema:
+                    type: string
+                    description: Unique identifier for this alert route config
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                  example: 01FCNDV6P870EA6S7TK1DSYDG0
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/CreateResponseBody'
+                            example:
+                                alert_route:
+                                    condition_groups:
+                                        - conditions:
+                                            - operation:
+                                                label: Lawrence Jones
+                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                              param_bindings:
+                                                - array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject:
+                                                label: Incident Severity
+                                                reference: incident.severity
+                                    defer_time_seconds: 1
+                                    escalation_bindings:
+                                        - binding:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                    expressions:
+                                        - else_branch:
+                                            result:
+                                                array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                          label: Team Slack channel
+                                          operations:
+                                            - branches:
+                                                branches:
+                                                    - condition_groups:
+                                                        - conditions:
+                                                            - operation:
+                                                                label: Lawrence Jones
+                                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                                              param_bindings:
+                                                                - array_value:
+                                                                    - label: Lawrence Jones
+                                                                      literal: SEV123
+                                                                      reference: incident.severity
+                                                                  value:
+                                                                    label: Lawrence Jones
+                                                                    literal: SEV123
+                                                                    reference: incident.severity
+                                                              subject:
+                                                                label: Incident Severity
+                                                                reference: incident.severity
+                                                      result:
+                                                        array_value:
+                                                            - label: Lawrence Jones
+                                                              literal: SEV123
+                                                              reference: incident.severity
+                                                        value:
+                                                            label: Lawrence Jones
+                                                            literal: SEV123
+                                                            reference: incident.severity
+                                                returns:
+                                                    array: true
+                                                    type: IncidentStatus
+                                              filter:
+                                                condition_groups:
+                                                    - conditions:
+                                                        - operation:
+                                                            label: Lawrence Jones
+                                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                                          param_bindings:
+                                                            - array_value:
+                                                                - label: Lawrence Jones
+                                                                  literal: SEV123
+                                                                  reference: incident.severity
+                                                              value:
+                                                                label: Lawrence Jones
+                                                                literal: SEV123
+                                                                reference: incident.severity
+                                                          subject:
+                                                            label: Incident Severity
+                                                            reference: incident.severity
+                                              navigate:
+                                                reference: "1235"
+                                                reference_label: Teams
+                                              operation_type: navigate
+                                              parse:
+                                                returns:
+                                                    array: true
+                                                    type: IncidentStatus
+                                                source: metadata.annotations["github.com/repo"]
+                                              returns:
+                                                array: true
+                                                type: IncidentStatus
+                                          reference: abc123
+                                          returns:
+                                            array: true
+                                            type: IncidentStatus
+                                          root_reference: incident.status
+                                    grouping_keys:
+                                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    grouping_window_seconds: 1
+                                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    name: Production incidents
+                                    template:
+                                        custom_field_priorities:
+                                            abc123: first-wins
+                                        custom_fields:
+                                            custom_field_10014:
+                                                array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                        incident_mode:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        incident_type:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        name:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        priority_severity: severity-first-wins
+                                        severity:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        summary:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        workspace:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+        put:
+            tags:
+                - Alert Routes V2
+            summary: Update Alert Routes V2
+            description: |
+                Updates an alert route.
+
+                We recommend you create alert routes in the incident.io dashboard where we allow
+                previewing filter and grouping rules.
+            operationId: Alert Routes V2#Update
+            parameters:
+                - name: id
+                  in: path
+                  description: Unique identifier for this alert route config
+                  required: true
+                  schema:
+                    type: string
+                    description: Unique identifier for this alert route config
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                  example: 01FCNDV6P870EA6S7TK1DSYDG0
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/UpdateRequestBody'
+                        example:
+                            alert_source_ids:
+                                - 02FCNDV6P870EA6S7TK1DSYDG2
+                            auto_decline_enabled: false
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                            defer_time_seconds: 1
+                            enabled: false
+                            escalation_bindings:
+                                - binding:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            expressions:
+                                - else_branch:
+                                    result:
+                                        array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                  label: Team Slack channel
+                                  operations:
+                                    - branches:
+                                        branches:
+                                            - condition_groups:
+                                                - conditions:
+                                                    - operation: one_of
+                                                      param_bindings:
+                                                        - array_value:
+                                                            - literal: SEV123
+                                                              reference: incident.severity
+                                                          value:
+                                                            literal: SEV123
+                                                            reference: incident.severity
+                                                      subject: incident.severity
+                                              result:
+                                                array_value:
+                                                    - literal: SEV123
+                                                      reference: incident.severity
+                                                value:
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                        returns:
+                                            array: true
+                                            type: IncidentStatus
+                                      filter:
+                                        condition_groups:
+                                            - conditions:
+                                                - operation: one_of
+                                                  param_bindings:
+                                                    - array_value:
+                                                        - literal: SEV123
+                                                          reference: incident.severity
+                                                      value:
+                                                        literal: SEV123
+                                                        reference: incident.severity
+                                                  subject: incident.severity
+                                      navigate:
+                                        reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                                      operation_type: navigate
+                                      parse:
+                                        returns:
+                                            array: true
+                                            type: IncidentStatus
+                                        source: metadata.annotations["github.com/repo"]
+                                  reference: abc123
+                                  root_reference: incident.status
+                            grouping_keys:
+                                - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            grouping_window_seconds: 1
+                            incident_condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                            incident_enabled: false
+                            name: Production incidents
+                            template:
+                                custom_field_priorities:
+                                    abc123: abc123
+                                custom_fields:
+                                    custom_field_10014:
+                                        array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                incident_mode:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                incident_type:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                name:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                priority_severity: severity-first-wins
+                                severity:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                summary:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                workspace:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/CreateResponseBody'
+                            example:
+                                alert_route:
+                                    condition_groups:
+                                        - conditions:
+                                            - operation:
+                                                label: Lawrence Jones
+                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                              param_bindings:
+                                                - array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject:
+                                                label: Incident Severity
+                                                reference: incident.severity
+                                    defer_time_seconds: 1
+                                    escalation_bindings:
+                                        - binding:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                    expressions:
+                                        - else_branch:
+                                            result:
+                                                array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                          label: Team Slack channel
+                                          operations:
+                                            - branches:
+                                                branches:
+                                                    - condition_groups:
+                                                        - conditions:
+                                                            - operation:
+                                                                label: Lawrence Jones
+                                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                                              param_bindings:
+                                                                - array_value:
+                                                                    - label: Lawrence Jones
+                                                                      literal: SEV123
+                                                                      reference: incident.severity
+                                                                  value:
+                                                                    label: Lawrence Jones
+                                                                    literal: SEV123
+                                                                    reference: incident.severity
+                                                              subject:
+                                                                label: Incident Severity
+                                                                reference: incident.severity
+                                                      result:
+                                                        array_value:
+                                                            - label: Lawrence Jones
+                                                              literal: SEV123
+                                                              reference: incident.severity
+                                                        value:
+                                                            label: Lawrence Jones
+                                                            literal: SEV123
+                                                            reference: incident.severity
+                                                returns:
+                                                    array: true
+                                                    type: IncidentStatus
+                                              filter:
+                                                condition_groups:
+                                                    - conditions:
+                                                        - operation:
+                                                            label: Lawrence Jones
+                                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                                          param_bindings:
+                                                            - array_value:
+                                                                - label: Lawrence Jones
+                                                                  literal: SEV123
+                                                                  reference: incident.severity
+                                                              value:
+                                                                label: Lawrence Jones
+                                                                literal: SEV123
+                                                                reference: incident.severity
+                                                          subject:
+                                                            label: Incident Severity
+                                                            reference: incident.severity
+                                              navigate:
+                                                reference: "1235"
+                                                reference_label: Teams
+                                              operation_type: navigate
+                                              parse:
+                                                returns:
+                                                    array: true
+                                                    type: IncidentStatus
+                                                source: metadata.annotations["github.com/repo"]
+                                              returns:
+                                                array: true
+                                                type: IncidentStatus
+                                          reference: abc123
+                                          returns:
+                                            array: true
+                                            type: IncidentStatus
+                                          root_reference: incident.status
+                                    grouping_keys:
+                                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    grouping_window_seconds: 1
+                                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    name: Production incidents
+                                    template:
+                                        custom_field_priorities:
+                                            abc123: first-wins
+                                        custom_fields:
+                                            custom_field_10014:
+                                                array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                        incident_mode:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        incident_type:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        name:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        priority_severity: severity-first-wins
+                                        severity:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        summary:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                        workspace:
+                                            array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                            value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
     /v2/catalog_entries:
         get:
             tags:
@@ -1978,13 +2934,13 @@ paths:
                                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                                     catalog_entry_name: Primary escalation
                                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                                  helptext: Collection of standalone automations like auto-closing incidents.
-                                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                                  helptext: abc123
+                                                  image_url: abc123
                                                   is_image_slack_icon: false
                                                   label: Lawrence Jones
                                                   literal: SEV123
                                                   reference: incident.severity
-                                                  sort_key: "000020"
+                                                  sort_key: abc123
                                                   unavailable: false
                                                   value: abc123
                                             value:
@@ -1993,13 +2949,13 @@ paths:
                                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                                     catalog_entry_name: Primary escalation
                                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                                helptext: Collection of standalone automations like auto-closing incidents.
-                                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                                helptext: abc123
+                                                image_url: abc123
                                                 is_image_slack_icon: false
                                                 label: Lawrence Jones
                                                 literal: SEV123
                                                 reference: incident.severity
-                                                sort_key: "000020"
+                                                sort_key: abc123
                                                 unavailable: false
                                                 value: abc123
                                       catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -2019,7 +2975,7 @@ paths:
                                     description: Represents Kubernetes clusters that we run inside of GKE.
                                     dynamic_resource_parameter: abc123
                                     estimated_count: 7
-                                    icon: bolt
+                                    icon: alert
                                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     is_editable: false
                                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -2096,13 +3052,13 @@ paths:
                                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                                     catalog_entry_name: Primary escalation
                                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                                  helptext: Collection of standalone automations like auto-closing incidents.
-                                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                                  helptext: abc123
+                                                  image_url: abc123
                                                   is_image_slack_icon: false
                                                   label: Lawrence Jones
                                                   literal: SEV123
                                                   reference: incident.severity
-                                                  sort_key: "000020"
+                                                  sort_key: abc123
                                                   unavailable: false
                                                   value: abc123
                                             value:
@@ -2111,13 +3067,13 @@ paths:
                                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                                     catalog_entry_name: Primary escalation
                                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                                helptext: Collection of standalone automations like auto-closing incidents.
-                                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                                helptext: abc123
+                                                image_url: abc123
                                                 is_image_slack_icon: false
                                                 label: Lawrence Jones
                                                 literal: SEV123
                                                 reference: incident.severity
-                                                sort_key: "000020"
+                                                sort_key: abc123
                                                 unavailable: false
                                                 value: abc123
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -2184,13 +3140,13 @@ paths:
                                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                                     catalog_entry_name: Primary escalation
                                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                                  helptext: Collection of standalone automations like auto-closing incidents.
-                                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                                  helptext: abc123
+                                                  image_url: abc123
                                                   is_image_slack_icon: false
                                                   label: Lawrence Jones
                                                   literal: SEV123
                                                   reference: incident.severity
-                                                  sort_key: "000020"
+                                                  sort_key: abc123
                                                   unavailable: false
                                                   value: abc123
                                             value:
@@ -2199,13 +3155,13 @@ paths:
                                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                                     catalog_entry_name: Primary escalation
                                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                                helptext: Collection of standalone automations like auto-closing incidents.
-                                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                                helptext: abc123
+                                                image_url: abc123
                                                 is_image_slack_icon: false
                                                 label: Lawrence Jones
                                                 literal: SEV123
                                                 reference: incident.severity
-                                                sort_key: "000020"
+                                                sort_key: abc123
                                                 unavailable: false
                                                 value: abc123
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -2225,7 +3181,7 @@ paths:
                                     description: Represents Kubernetes clusters that we run inside of GKE.
                                     dynamic_resource_parameter: abc123
                                     estimated_count: 7
-                                    icon: bolt
+                                    icon: alert
                                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     is_editable: false
                                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -2308,13 +3264,13 @@ paths:
                                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                                     catalog_entry_name: Primary escalation
                                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                                  helptext: Collection of standalone automations like auto-closing incidents.
-                                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                                  helptext: abc123
+                                                  image_url: abc123
                                                   is_image_slack_icon: false
                                                   label: Lawrence Jones
                                                   literal: SEV123
                                                   reference: incident.severity
-                                                  sort_key: "000020"
+                                                  sort_key: abc123
                                                   unavailable: false
                                                   value: abc123
                                             value:
@@ -2323,13 +3279,13 @@ paths:
                                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                                     catalog_entry_name: Primary escalation
                                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                                helptext: Collection of standalone automations like auto-closing incidents.
-                                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                                helptext: abc123
+                                                image_url: abc123
                                                 is_image_slack_icon: false
                                                 label: Lawrence Jones
                                                 literal: SEV123
                                                 reference: incident.severity
-                                                sort_key: "000020"
+                                                sort_key: abc123
                                                 unavailable: false
                                                 value: abc123
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -2349,7 +3305,7 @@ paths:
                                     description: Represents Kubernetes clusters that we run inside of GKE.
                                     dynamic_resource_parameter: abc123
                                     estimated_count: 7
-                                    icon: bolt
+                                    icon: alert
                                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     is_editable: false
                                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -2425,7 +3381,7 @@ paths:
                                       description: Represents Kubernetes clusters that we run inside of GKE.
                                       dynamic_resource_parameter: abc123
                                       estimated_count: 7
-                                      icon: bolt
+                                      icon: alert
                                       id: 01FCNDV6P870EA6S7TK1DSYDG0
                                       is_editable: false
                                       last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -2469,7 +3425,7 @@ paths:
                                 - issue-tracker
                             color: yellow
                             description: Represents Kubernetes clusters that we run inside of GKE.
-                            icon: bolt
+                            icon: alert
                             name: Kubernetes Cluster
                             ranked: true
                             source_repo_url: https://github.com/my-company/incident-io-catalog
@@ -2492,7 +3448,7 @@ paths:
                                     description: Represents Kubernetes clusters that we run inside of GKE.
                                     dynamic_resource_parameter: abc123
                                     estimated_count: 7
-                                    icon: bolt
+                                    icon: alert
                                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     is_editable: false
                                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -2571,7 +3527,7 @@ paths:
                                     description: Represents Kubernetes clusters that we run inside of GKE.
                                     dynamic_resource_parameter: abc123
                                     estimated_count: 7
-                                    icon: bolt
+                                    icon: alert
                                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     is_editable: false
                                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -2625,7 +3581,7 @@ paths:
                                 - issue-tracker
                             color: yellow
                             description: Represents Kubernetes clusters that we run inside of GKE.
-                            icon: bolt
+                            icon: alert
                             name: Kubernetes Cluster
                             ranked: true
                             source_repo_url: https://github.com/my-company/incident-io-catalog
@@ -2647,7 +3603,7 @@ paths:
                                     description: Represents Kubernetes clusters that we run inside of GKE.
                                     dynamic_resource_parameter: abc123
                                     estimated_count: 7
-                                    icon: bolt
+                                    icon: alert
                                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     is_editable: false
                                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -2732,7 +3688,7 @@ paths:
                                     description: Represents Kubernetes clusters that we run inside of GKE.
                                     dynamic_resource_parameter: abc123
                                     estimated_count: 7
-                                    icon: bolt
+                                    icon: alert
                                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     is_editable: false
                                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -2791,7 +3747,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody3'
+                            $ref: '#/components/schemas/CreateRequestBody4'
                         example:
                             description: Which team is impacted by this issue
                             field_type: single_select
@@ -2885,7 +3841,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/UpdateRequestBody3'
+                            $ref: '#/components/schemas/UpdateRequestBody4'
                         example:
                             description: Which team is impacted by this issue
                             name: Affected Team
@@ -3404,7 +4360,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody7'
+                            $ref: '#/components/schemas/CreateRequestBody8'
                         example:
                             description: The person currently coordinating the incident
                             instructions: Take point on the incident; Make sure people are clear on responsibilities
@@ -3501,7 +4457,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/UpdateRequestBody5'
+                            $ref: '#/components/schemas/UpdateRequestBody6'
                         example:
                             description: The person currently coordinating the incident
                             instructions: Take point on the incident; Make sure people are clear on responsibilities
@@ -4147,7 +5103,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody10'
+                            $ref: '#/components/schemas/CreateRequestBody11'
                         example:
                             custom_field_entries:
                                 - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -4827,6 +5783,10 @@ paths:
                                             name: Lisa Karlin Curtis
                                             role: viewer
                                             slack_user_id: U02AYNF2XJM
+                                      holidays_public_config:
+                                        country_codes:
+                                            - GB
+                                            - FR
                                       id: 01G0J1EXE7AXZ2C93K61WBPYEH
                                       name: Primary On-Call Schedule
                                       timezone: Europe/London
@@ -4842,7 +5802,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody11'
+                            $ref: '#/components/schemas/CreateRequestBody12'
                         example:
                             schedule:
                                 annotations:
@@ -4867,6 +5827,9 @@ paths:
                                             - end_time: "17:00"
                                               start_time: "09:00"
                                               weekday: tuesday
+                                holidays_public_config:
+                                    country_codes:
+                                        - abc123
                                 name: My Schedule
                                 timezone: America/Los_Angeles
             responses:
@@ -4916,6 +5879,10 @@ paths:
                                             name: Lisa Karlin Curtis
                                             role: viewer
                                             slack_user_id: U02AYNF2XJM
+                                    holidays_public_config:
+                                        country_codes:
+                                            - GB
+                                            - FR
                                     id: 01G0J1EXE7AXZ2C93K61WBPYEH
                                     name: Primary On-Call Schedule
                                     timezone: Europe/London
@@ -5003,6 +5970,10 @@ paths:
                                             name: Lisa Karlin Curtis
                                             role: viewer
                                             slack_user_id: U02AYNF2XJM
+                                    holidays_public_config:
+                                        country_codes:
+                                            - GB
+                                            - FR
                                     id: 01G0J1EXE7AXZ2C93K61WBPYEH
                                     name: Primary On-Call Schedule
                                     timezone: Europe/London
@@ -5028,7 +5999,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/UpdateRequestBody7'
+                            $ref: '#/components/schemas/UpdateRequestBody8'
                         example:
                             schedule:
                                 annotations:
@@ -5053,6 +6024,9 @@ paths:
                                             - end_time: "17:00"
                                               start_time: "09:00"
                                               weekday: tuesday
+                                holidays_public_config:
+                                    country_codes:
+                                        - abc123
                                 name: My Schedule
                                 timezone: America/Los_Angeles
             responses:
@@ -5102,6 +6076,10 @@ paths:
                                             name: Lisa Karlin Curtis
                                             role: viewer
                                             slack_user_id: U02AYNF2XJM
+                                    holidays_public_config:
+                                        country_codes:
+                                            - GB
+                                            - FR
                                     id: 01G0J1EXE7AXZ2C93K61WBPYEH
                                     name: Primary On-Call Schedule
                                     timezone: Europe/London
@@ -6927,6 +7905,134 @@ paths:
                                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
                                       name: Low
                                       type: follow_up_priority
+                                version: 1
+    /x-audit-logs/holiday_user_feed.created.1:
+        get:
+            tags:
+                - Audit logs
+            summary: HolidayUserFeedCreatedV1 Audit logs
+            description: This entry is created whenever a holiday user feed is created
+            operationId: Audit logs#HolidayUserFeedCreatedV1
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                            example:
+                                action: holiday_user_feed.created
+                                actor:
+                                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    metadata:
+                                        user_base_role_slug: admin
+                                        user_custom_role_slugs: engineering,security
+                                    name: John Doe
+                                    type: user
+                                context:
+                                    location: 1.2.3.4
+                                    user_agent: Chrome/91.0.4472.114
+                                occurred_at: "2021-08-17T13:28:57.801578Z"
+                                targets:
+                                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                      name: US Team holidays
+                                      type: holiday_user_feed
+                                version: 1
+    /x-audit-logs/holiday_user_feed.deleted.1:
+        get:
+            tags:
+                - Audit logs
+            summary: HolidayUserFeedDeletedV1 Audit logs
+            description: This entry is created whenever a holiday user feed is deleted
+            operationId: Audit logs#HolidayUserFeedDeletedV1
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                            example:
+                                action: holiday_user_feed.deleted
+                                actor:
+                                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    metadata:
+                                        user_base_role_slug: admin
+                                        user_custom_role_slugs: engineering,security
+                                    name: John Doe
+                                    type: user
+                                context:
+                                    location: 1.2.3.4
+                                    user_agent: Chrome/91.0.4472.114
+                                occurred_at: "2021-08-17T13:28:57.801578Z"
+                                targets:
+                                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                      name: US Team holidays
+                                      type: holiday_user_feed
+                                version: 1
+    /x-audit-logs/holiday_user_feed.updated.1:
+        get:
+            tags:
+                - Audit logs
+            summary: HolidayUserFeedUpdatedV1 Audit logs
+            description: This entry is created whenever a holiday user feed is updated
+            operationId: Audit logs#HolidayUserFeedUpdatedV1
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                            example:
+                                action: holiday_user_feed.updated
+                                actor:
+                                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    metadata:
+                                        user_base_role_slug: admin
+                                        user_custom_role_slugs: engineering,security
+                                    name: John Doe
+                                    type: user
+                                context:
+                                    location: 1.2.3.4
+                                    user_agent: Chrome/91.0.4472.114
+                                occurred_at: "2021-08-17T13:28:57.801578Z"
+                                targets:
+                                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                      name: US Team holidays
+                                      type: holiday_user_feed
+                                version: 1
+    /x-audit-logs/incident_call_setting.updated.1:
+        get:
+            tags:
+                - Audit logs
+            summary: IncidentCallSettingUpdatedV1 Audit logs
+            description: This entry is created whenever an organisation's incident call settings are updated
+            operationId: Audit logs#IncidentCallSettingUpdatedV1
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                            example:
+                                action: incident_call_setting.updated
+                                actor:
+                                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    metadata:
+                                        user_base_role_slug: admin
+                                        user_custom_role_slugs: engineering,security
+                                    name: John Doe
+                                    type: user
+                                context:
+                                    location: 1.2.3.4
+                                    user_agent: Chrome/91.0.4472.114
+                                occurred_at: "2021-08-17T13:28:57.801578Z"
+                                targets:
+                                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                      name: Incident call settings
+                                      type: incident_call_setting
                                 version: 1
     /x-audit-logs/incident_duration_metric.created.1:
         get:
@@ -10308,6 +11414,604 @@ components:
                 - status
                 - message
                 - deduplication_key
+        AlertRouteEscalationBindingPayloadV2:
+            type: object
+            properties:
+                binding:
+                    $ref: '#/components/schemas/EngineParamBindingPayloadV2'
+            example:
+                binding:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+            required:
+                - binding
+        AlertRouteEscalationBindingV2:
+            type: object
+            properties:
+                binding:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+            example:
+                binding:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+            required:
+                - binding
+        AlertRouteIncidentTemplatePayloadV2:
+            type: object
+            properties:
+                custom_field_priorities:
+                    type: object
+                    description: lookup of the priority options for each custom field in the template
+                    example:
+                        abc123: abc123
+                    additionalProperties:
+                        type: string
+                        example: abc123
+                custom_fields:
+                    type: object
+                    description: Custom field keys mapped to values
+                    example:
+                        custom_field_10014:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                    additionalProperties:
+                        $ref: '#/components/schemas/EngineParamBindingPayloadV2'
+                incident_mode:
+                    $ref: '#/components/schemas/EngineParamBindingPayloadV2'
+                incident_type:
+                    $ref: '#/components/schemas/EngineParamBindingPayloadV2'
+                name:
+                    $ref: '#/components/schemas/EngineParamBindingPayloadV2'
+                priority_severity:
+                    type: string
+                    description: option defining whether to cause subsequent alerts to increase the severity
+                    example: severity-first-wins
+                    enum:
+                        - severity-first-wins
+                        - severity-max
+                severity:
+                    $ref: '#/components/schemas/EngineParamBindingPayloadV2'
+                summary:
+                    $ref: '#/components/schemas/EngineParamBindingPayloadV2'
+                workspace:
+                    $ref: '#/components/schemas/EngineParamBindingPayloadV2'
+            example:
+                custom_field_priorities:
+                    abc123: abc123
+                custom_fields:
+                    custom_field_10014:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                incident_mode:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                incident_type:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                name:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                priority_severity: severity-first-wins
+                severity:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                summary:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+                workspace:
+                    array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                    value:
+                        literal: SEV123
+                        reference: incident.severity
+            required:
+                - custom_field_priorities
+                - priority_severity
+        AlertRouteIncidentTemplateV2:
+            type: object
+            properties:
+                custom_field_priorities:
+                    type: object
+                    description: lookup of the priority options for each custom field in the template
+                    example:
+                        abc123: first-wins
+                    additionalProperties:
+                        type: string
+                        example: first-wins
+                        enum:
+                            - first-wins
+                            - last-wins
+                            - append
+                custom_fields:
+                    type: object
+                    description: Custom field keys mapped to values
+                    example:
+                        custom_field_10014:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                    additionalProperties:
+                        $ref: '#/components/schemas/EngineParamBindingV2'
+                incident_mode:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+                incident_type:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+                name:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+                priority_severity:
+                    type: string
+                    description: binding to use to resolve the workspace to create an incident in
+                    example: severity-first-wins
+                    enum:
+                        - severity-first-wins
+                        - severity-max
+                severity:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+                summary:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+                workspace:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+            example:
+                custom_field_priorities:
+                    abc123: first-wins
+                custom_fields:
+                    custom_field_10014:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                incident_mode:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                incident_type:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                name:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                priority_severity: severity-first-wins
+                severity:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                summary:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                workspace:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+            required:
+                - custom_field_priorities
+                - priority_severity
+        AlertRouteV2:
+            type: object
+            properties:
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupV2'
+                    description: What condition groups must be true for this alert route to fire?
+                    example:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                defer_time_seconds:
+                    type: integer
+                    description: How long should the escalation defer time be?
+                    example: 1
+                    format: int64
+                escalation_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AlertRouteEscalationBindingV2'
+                    description: Which escalation paths should this alert route escalate to?
+                    example:
+                        - binding:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                expressions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionV2'
+                    description: The expressions used in this template
+                    example:
+                        - else_branch:
+                            result:
+                                array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                          label: Team Slack channel
+                          operations:
+                            - branches:
+                                branches:
+                                    - condition_groups:
+                                        - conditions:
+                                            - operation:
+                                                label: Lawrence Jones
+                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                              param_bindings:
+                                                - array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject:
+                                                label: Incident Severity
+                                                reference: incident.severity
+                                      result:
+                                        array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                              filter:
+                                condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                              navigate:
+                                reference: "1235"
+                                reference_label: Teams
+                              operation_type: navigate
+                              parse:
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                                source: metadata.annotations["github.com/repo"]
+                              returns:
+                                array: true
+                                type: IncidentStatus
+                          reference: abc123
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                          root_reference: incident.status
+                grouping_keys:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GroupingKeyV2'
+                    description: Which attributes should this alert route use to group alerts?
+                    example:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds:
+                    type: integer
+                    description: How large should the grouping window be?
+                    example: 1
+                    format: int64
+                id:
+                    type: string
+                    description: Unique identifier for this alert route config
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                name:
+                    type: string
+                    description: The name of this alert route config, for the user's reference
+                    example: Production incidents
+                template:
+                    $ref: '#/components/schemas/AlertRouteIncidentTemplateV2'
+            example:
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+                defer_time_seconds: 1
+                escalation_bindings:
+                    - binding:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                      reference: abc123
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                      root_reference: incident.status
+                grouping_keys:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds: 1
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Production incidents
+                template:
+                    custom_field_priorities:
+                        abc123: first-wins
+                    custom_fields:
+                        custom_field_10014:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                    incident_mode:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    incident_type:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    name:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    priority_severity: severity-first-wins
+                    severity:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    summary:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    workspace:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+            required:
+                - id
+                - name
+                - condition_groups
+                - grouping_keys
+                - grouping_window_seconds
+                - defer_time_seconds
+                - escalation_bindings
+                - auto_decline_enabled
+                - enabled
+                - incident_enabled
+                - incident_condition_groups
+                - alert_source_ids
+                - auto_cancel_escalations
         AllResponseBody:
             type: object
             properties:
@@ -10332,17 +12036,17 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.action_created_v1:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
                 private_incident.action_updated_v1:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
                 private_incident.follow_up_created_v1:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
                 private_incident.follow_up_updated_v1:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
                 private_incident.incident_created_v2:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
                 private_incident.incident_updated_v2:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
                 private_incident.membership_granted_v1:
                     $ref: '#/components/schemas/WebhookIncidentUserV2'
                 private_incident.membership_revoked_v1:
@@ -10937,7 +12641,9 @@ components:
                         - debrief_invite_rule
                         - escalation_path
                         - follow_up_priority
+                        - holiday_user_feed
                         - incident
+                        - incident_call_setting
                         - incident_duration_metric
                         - incident_role
                         - incident_status
@@ -11031,13 +12737,13 @@ components:
                             catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                             catalog_entry_name: Primary escalation
                             catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          helptext: Collection of standalone automations like auto-closing incidents.
-                          image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                          helptext: abc123
+                          image_url: abc123
                           is_image_slack_icon: false
                           label: Lawrence Jones
                           literal: SEV123
                           reference: incident.severity
-                          sort_key: "000020"
+                          sort_key: abc123
                           unavailable: false
                           value: abc123
                 value:
@@ -11049,13 +12755,13 @@ components:
                         catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                         catalog_entry_name: Primary escalation
                         catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      helptext: Collection of standalone automations like auto-closing incidents.
-                      image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                      helptext: abc123
+                      image_url: abc123
                       is_image_slack_icon: false
                       label: Lawrence Jones
                       literal: SEV123
                       reference: incident.severity
-                      sort_key: "000020"
+                      sort_key: abc123
                       unavailable: false
                       value: abc123
                 value:
@@ -11064,13 +12770,13 @@ components:
                         catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                         catalog_entry_name: Primary escalation
                         catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                    helptext: Collection of standalone automations like auto-closing incidents.
-                    image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                    helptext: abc123
+                    image_url: abc123
                     is_image_slack_icon: false
                     label: Lawrence Jones
                     literal: SEV123
                     reference: incident.severity
-                    sort_key: "000020"
+                    sort_key: abc123
                     unavailable: false
                     value: abc123
         CatalogEntryEngineParamBindingValueV2:
@@ -11080,15 +12786,15 @@ components:
                     $ref: '#/components/schemas/CatalogEntryReferenceV2'
                 helptext:
                     type: string
-                    description: Gives a description of the option to the user
-                    example: Collection of standalone automations like auto-closing incidents.
+                    description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
+                    example: abc123
                 image_url:
                     type: string
-                    description: If appropriate, URL to an image that can be displayed alongside the option
-                    example: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                    description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
+                    example: abc123
                 is_image_slack_icon:
                     type: boolean
-                    description: If true, the image_url is a Slack icon and should be displayed as such
+                    description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
                     example: false
                 label:
                     type: string
@@ -11100,19 +12806,19 @@ components:
                     example: SEV123
                 reference:
                     type: string
-                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
                     example: incident.severity
                 sort_key:
                     type: string
-                    description: Gives an indication of how to sort the options when displayed to the user
-                    example: "000020"
+                    description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
+                    example: abc123
                 unavailable:
                     type: boolean
-                    description: Unavailable is true if we've failed to build the value for this binding
+                    description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
                     example: false
                 value:
                     type: string
-                    description: 'Either the reference or the literal: this field is designed purely to make working with react-select easier'
+                    description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
                     example: abc123
             example:
                 catalog_entry:
@@ -11120,13 +12826,13 @@ components:
                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                     catalog_entry_name: Primary escalation
                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                helptext: Collection of standalone automations like auto-closing incidents.
-                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                helptext: abc123
+                image_url: abc123
                 is_image_slack_icon: false
                 label: Lawrence Jones
                 literal: SEV123
                 reference: incident.severity
-                sort_key: "000020"
+                sort_key: abc123
                 unavailable: false
                 value: abc123
             required:
@@ -11189,13 +12895,13 @@ components:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                  helptext: Collection of standalone automations like auto-closing incidents.
-                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                  helptext: abc123
+                                  image_url: abc123
                                   is_image_slack_icon: false
                                   label: Lawrence Jones
                                   literal: SEV123
                                   reference: incident.severity
-                                  sort_key: "000020"
+                                  sort_key: abc123
                                   unavailable: false
                                   value: abc123
                             value:
@@ -11204,13 +12910,13 @@ components:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                helptext: Collection of standalone automations like auto-closing incidents.
-                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                helptext: abc123
+                                image_url: abc123
                                 is_image_slack_icon: false
                                 label: Lawrence Jones
                                 literal: SEV123
                                 reference: incident.severity
-                                sort_key: "000020"
+                                sort_key: abc123
                                 unavailable: false
                                 value: abc123
                     additionalProperties:
@@ -11259,13 +12965,13 @@ components:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              helptext: Collection of standalone automations like auto-closing incidents.
-                              image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                              helptext: abc123
+                              image_url: abc123
                               is_image_slack_icon: false
                               label: Lawrence Jones
                               literal: SEV123
                               reference: incident.severity
-                              sort_key: "000020"
+                              sort_key: abc123
                               unavailable: false
                               value: abc123
                         value:
@@ -11274,13 +12980,13 @@ components:
                                 catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                 catalog_entry_name: Primary escalation
                                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                            helptext: Collection of standalone automations like auto-closing incidents.
-                            image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                            helptext: abc123
+                            image_url: abc123
                             is_image_slack_icon: false
                             label: Lawrence Jones
                             literal: SEV123
                             reference: incident.severity
-                            sort_key: "000020"
+                            sort_key: abc123
                             unavailable: false
                             value: abc123
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11580,8 +13286,9 @@ components:
                 icon:
                     type: string
                     description: Sets the display icon of this type in the dashboard
-                    example: bolt
+                    example: alert
                     enum:
+                        - alert
                         - bolt
                         - box
                         - briefcase
@@ -11594,6 +13301,7 @@ components:
                         - database
                         - doc
                         - email
+                        - escalation-path
                         - files
                         - flag
                         - folder
@@ -11601,6 +13309,7 @@ components:
                         - money
                         - server
                         - severity
+                        - status-page
                         - store
                         - star
                         - tag
@@ -11668,7 +13377,7 @@ components:
                 description: Represents Kubernetes clusters that we run inside of GKE.
                 dynamic_resource_parameter: abc123
                 estimated_count: 7
-                icon: bolt
+                icon: alert
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
                 is_editable: false
                 last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -11743,6 +13452,49 @@ components:
             required:
                 - conditions
         ConditionGroupV2:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionV2'
+                    description: All conditions in this list must be satisfied for the group to be satisfied
+                    example:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+            example:
+                conditions:
+                    - operation:
+                        label: Lawrence Jones
+                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                      param_bindings:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                      subject:
+                        label: Incident Severity
+                        reference: incident.severity
+            required:
+                - conditions
+        ConditionGroupV3:
             type: object
             properties:
                 conditions:
@@ -12056,13 +13808,13 @@ components:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                  helptext: Collection of standalone automations like auto-closing incidents.
-                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                  helptext: abc123
+                                  image_url: abc123
                                   is_image_slack_icon: false
                                   label: Lawrence Jones
                                   literal: SEV123
                                   reference: incident.severity
-                                  sort_key: "000020"
+                                  sort_key: abc123
                                   unavailable: false
                                   value: abc123
                             value:
@@ -12071,13 +13823,13 @@ components:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                helptext: Collection of standalone automations like auto-closing incidents.
-                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                helptext: abc123
+                                image_url: abc123
                                 is_image_slack_icon: false
                                 label: Lawrence Jones
                                 literal: SEV123
                                 reference: incident.severity
-                                sort_key: "000020"
+                                sort_key: abc123
                                 unavailable: false
                                 value: abc123
                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12348,6 +14100,309 @@ components:
         CreateRequestBody:
             type: object
             properties:
+                alert_source_ids:
+                    type: array
+                    items:
+                        type: string
+                        example: abc123
+                    description: The alert sources that will match this alert route
+                    example:
+                        - 02FCNDV6P870EA6S7TK1DSYDG2
+                auto_decline_enabled:
+                    type: boolean
+                    description: Should triage incidents be declined when alerts are resolved?
+                    example: false
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
+                    description: What condition groups must be true for this alert route to fire?
+                    example:
+                        - conditions:
+                            - operation: one_of
+                              param_bindings:
+                                - array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject: incident.severity
+                defer_time_seconds:
+                    type: integer
+                    description: How long should the escalation defer time be?
+                    example: 1
+                    format: int64
+                enabled:
+                    type: boolean
+                    description: Whether this alert route is enabled or not
+                    example: false
+                escalation_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AlertRouteEscalationBindingPayloadV2'
+                    description: Which escalation paths should this alert route escalate to?
+                    example:
+                        - binding:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                expressions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionPayloadV2'
+                    description: The expressions used in this template
+                    example:
+                        - else_branch:
+                            result:
+                                array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                          label: Team Slack channel
+                          operations:
+                            - branches:
+                                branches:
+                                    - condition_groups:
+                                        - conditions:
+                                            - operation: one_of
+                                              param_bindings:
+                                                - array_value:
+                                                    - literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject: incident.severity
+                                      result:
+                                        array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                              filter:
+                                condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                              navigate:
+                                reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                              operation_type: navigate
+                              parse:
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                                source: metadata.annotations["github.com/repo"]
+                          reference: abc123
+                          root_reference: incident.status
+                grouping_keys:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GroupingKeyV2'
+                    description: Which attributes should this alert route use to group alerts?
+                    example:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds:
+                    type: integer
+                    description: How large should the grouping window be?
+                    example: 1
+                    format: int64
+                incident_condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
+                    description: What condition groups must be true for this alert route to create an incident?
+                    example:
+                        - conditions:
+                            - operation: one_of
+                              param_bindings:
+                                - array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject: incident.severity
+                incident_enabled:
+                    type: boolean
+                    description: Whether this alert route will create incidents or not
+                    example: false
+                name:
+                    type: string
+                    description: The name of this alert route config, for the user's reference
+                    example: Production incidents
+                template:
+                    $ref: '#/components/schemas/AlertRouteIncidentTemplatePayloadV2'
+            example:
+                alert_source_ids:
+                    - 02FCNDV6P870EA6S7TK1DSYDG2
+                auto_decline_enabled: false
+                condition_groups:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+                defer_time_seconds: 1
+                enabled: false
+                escalation_bindings:
+                    - binding:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                                  result:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                          navigate:
+                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                      reference: abc123
+                      root_reference: incident.status
+                grouping_keys:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds: 1
+                incident_condition_groups:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+                incident_enabled: false
+                name: Production incidents
+                template:
+                    custom_field_priorities:
+                        abc123: abc123
+                    custom_fields:
+                        custom_field_10014:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                    incident_mode:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    incident_type:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    name:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    priority_severity: severity-first-wins
+                    severity:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    summary:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    workspace:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+        CreateRequestBody2:
+            type: object
+            properties:
                 custom_field_id:
                     type: string
                     description: ID of the custom field this option belongs to
@@ -12369,7 +14424,7 @@ components:
             required:
                 - custom_field_id
                 - value
-        CreateRequestBody2:
+        CreateRequestBody3:
             type: object
             properties:
                 description:
@@ -12444,7 +14499,7 @@ components:
                 - options
                 - created_at
                 - updated_at
-        CreateRequestBody3:
+        CreateRequestBody4:
             type: object
             properties:
                 description:
@@ -12478,7 +14533,7 @@ components:
                 - cannot_be_unset
                 - created_at
                 - updated_at
-        CreateRequestBody4:
+        CreateRequestBody5:
             type: object
             properties:
                 incident_id:
@@ -12529,7 +14584,7 @@ components:
             required:
                 - incident_id
                 - resource
-        CreateRequestBody5:
+        CreateRequestBody6:
             type: object
             properties:
                 incident_id:
@@ -12544,7 +14599,7 @@ components:
             required:
                 - user_id
                 - incident_id
-        CreateRequestBody6:
+        CreateRequestBody7:
             type: object
             properties:
                 description:
@@ -12569,7 +14624,6 @@ components:
                     type: string
                     description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                     example: lead
-                    minLength: 1
             example:
                 description: The person currently coordinating the incident
                 instructions: Take point on the incident; Make sure people are clear on responsibilities
@@ -12587,7 +14641,7 @@ components:
                 - role_type
                 - created_at
                 - updated_at
-        CreateRequestBody7:
+        CreateRequestBody8:
             type: object
             properties:
                 description:
@@ -12608,7 +14662,6 @@ components:
                     type: string
                     description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                     example: lead
-                    minLength: 1
             example:
                 description: The person currently coordinating the incident
                 instructions: Take point on the incident; Make sure people are clear on responsibilities
@@ -12624,7 +14677,7 @@ components:
                 - role_type
                 - created_at
                 - updated_at
-        CreateRequestBody8:
+        CreateRequestBody9:
             type: object
             properties:
                 category:
@@ -12655,7 +14708,7 @@ components:
                 - rank
                 - created_at
                 - updated_at
-        CreateRequestBody9:
+        CreateRequestBody10:
             type: object
             properties:
                 custom_field_entries:
@@ -12772,7 +14825,7 @@ components:
             required:
                 - idempotency_key
                 - visibility
-        CreateRequestBody10:
+        CreateRequestBody11:
             type: object
             properties:
                 custom_field_entries:
@@ -12900,7 +14953,7 @@ components:
             required:
                 - idempotency_key
                 - visibility
-        CreateRequestBody11:
+        CreateRequestBody12:
             type: object
             properties:
                 schedule:
@@ -12929,11 +14982,14 @@ components:
                                 - end_time: "17:00"
                                   start_time: "09:00"
                                   weekday: tuesday
+                    holidays_public_config:
+                        country_codes:
+                            - abc123
                     name: My Schedule
                     timezone: America/Los_Angeles
             required:
                 - schedule
-        CreateRequestBody12:
+        CreateRequestBody13:
             type: object
             properties:
                 description:
@@ -12960,6 +15016,195 @@ components:
         CreateResponseBody:
             type: object
             properties:
+                alert_route:
+                    $ref: '#/components/schemas/AlertRouteV2'
+            example:
+                alert_route:
+                    condition_groups:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                    defer_time_seconds: 1
+                    escalation_bindings:
+                        - binding:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                    expressions:
+                        - else_branch:
+                            result:
+                                array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                          label: Team Slack channel
+                          operations:
+                            - branches:
+                                branches:
+                                    - condition_groups:
+                                        - conditions:
+                                            - operation:
+                                                label: Lawrence Jones
+                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                              param_bindings:
+                                                - array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject:
+                                                label: Incident Severity
+                                                reference: incident.severity
+                                      result:
+                                        array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                              filter:
+                                condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                              navigate:
+                                reference: "1235"
+                                reference_label: Teams
+                              operation_type: navigate
+                              parse:
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                                source: metadata.annotations["github.com/repo"]
+                              returns:
+                                array: true
+                                type: IncidentStatus
+                          reference: abc123
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                          root_reference: incident.status
+                    grouping_keys:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    grouping_window_seconds: 1
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: Production incidents
+                    template:
+                        custom_field_priorities:
+                            abc123: first-wins
+                        custom_fields:
+                            custom_field_10014:
+                                array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                        incident_mode:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                        incident_type:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                        name:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                        priority_severity: severity-first-wins
+                        severity:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                        summary:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                        workspace:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+            required:
+                - alert_route
+        CreateResponseBody2:
+            type: object
+            properties:
                 incident_attachment:
                     $ref: '#/components/schemas/IncidentAttachmentV1'
             example:
@@ -12973,7 +15218,7 @@ components:
                         title: The database has gone down
             required:
                 - incident_attachment
-        CreateResponseBody2:
+        CreateResponseBody3:
             type: object
             properties:
                 incident_membership:
@@ -13038,8 +15283,9 @@ components:
                 icon:
                     type: string
                     description: Sets the display icon of this type in the dashboard
-                    example: bolt
+                    example: alert
                     enum:
+                        - alert
                         - bolt
                         - box
                         - briefcase
@@ -13052,6 +15298,7 @@ components:
                         - database
                         - doc
                         - email
+                        - escalation-path
                         - files
                         - flag
                         - folder
@@ -13059,6 +15306,7 @@ components:
                         - money
                         - server
                         - severity
+                        - status-page
                         - store
                         - star
                         - tag
@@ -13087,7 +15335,7 @@ components:
                     - issue-tracker
                 color: yellow
                 description: Represents Kubernetes clusters that we run inside of GKE.
-                icon: bolt
+                icon: alert
                 name: Kubernetes Cluster
                 ranked: true
                 source_repo_url: https://github.com/my-company/incident-io-catalog
@@ -13111,7 +15359,7 @@ components:
                     description: Represents Kubernetes clusters that we run inside of GKE.
                     dynamic_resource_parameter: abc123
                     estimated_count: 7
-                    icon: bolt
+                    icon: alert
                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                     is_editable: false
                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -14880,6 +17128,63 @@ components:
                                 label: Incident Severity
                                 reference: incident.severity
                 result:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+            example:
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+                result:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+            required:
+                - condition_groups
+                - result
+        ExpressionBranchV3:
+            type: object
+            properties:
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupV3'
+                    description: When one of these condition groups are satisfied, this branch will be evaluated
+                    example:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                result:
                     $ref: '#/components/schemas/EngineParamBindingV3'
             example:
                 condition_groups:
@@ -15037,6 +17342,77 @@ components:
             required:
                 - branches
                 - returns
+        ExpressionBranchesOptsV3:
+            type: object
+            properties:
+                branches:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionBranchV3'
+                    description: The branches to apply for this operation
+                    example:
+                        - condition_groups:
+                            - conditions:
+                                - operation:
+                                    label: Lawrence Jones
+                                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                  param_bindings:
+                                    - array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject:
+                                    label: Incident Severity
+                                    reference: incident.severity
+                          result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                returns:
+                    $ref: '#/components/schemas/ReturnsMetaV2'
+            example:
+                branches:
+                    - condition_groups:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                      result:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                returns:
+                    array: true
+                    type: IncidentStatus
+            required:
+                - branches
+                - returns
         ExpressionElseBranchPayloadV2:
             type: object
             properties:
@@ -15053,6 +17429,23 @@ components:
             required:
                 - result
         ExpressionElseBranchV2:
+            type: object
+            properties:
+                result:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+            example:
+                result:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+            required:
+                - result
+        ExpressionElseBranchV3:
             type: object
             properties:
                 result:
@@ -15147,6 +17540,51 @@ components:
                             reference: incident.severity
             required:
                 - condition_groups
+        ExpressionFilterOptsV3:
+            type: object
+            properties:
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupV3'
+                    description: The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
+                    example:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+            example:
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+            required:
+                - condition_groups
         ExpressionNavigateOptsPayloadV2:
             type: object
             properties:
@@ -15199,7 +17637,7 @@ components:
                         - parse
                         - branches
                 parse:
-                    $ref: '#/components/schemas/ExpressionParseOptsV2'
+                    $ref: '#/components/schemas/ExpressionParseOptsPayloadV2'
             example:
                 branches:
                     branches:
@@ -15271,7 +17709,7 @@ components:
                         - parse
                         - branches
                 parse:
-                    $ref: '#/components/schemas/ExpressionParseOptsV2'
+                    $ref: '#/components/schemas/ExpressionParseOptsPayloadV2'
                 returns:
                     $ref: '#/components/schemas/ReturnsMetaV2'
             example:
@@ -15339,7 +17777,99 @@ components:
             required:
                 - operation_type
                 - returns
-        ExpressionParseOptsV2:
+        ExpressionOperationV3:
+            type: object
+            properties:
+                branches:
+                    $ref: '#/components/schemas/ExpressionBranchesOptsV3'
+                filter:
+                    $ref: '#/components/schemas/ExpressionFilterOptsV3'
+                navigate:
+                    $ref: '#/components/schemas/ExpressionNavigateOptsV2'
+                operation_type:
+                    type: string
+                    description: The type of the operation
+                    example: navigate
+                    enum:
+                        - navigate
+                        - filter
+                        - count
+                        - min
+                        - max
+                        - random
+                        - first
+                        - parse
+                        - branches
+                parse:
+                    $ref: '#/components/schemas/ExpressionParseOptsPayloadV2'
+                returns:
+                    $ref: '#/components/schemas/ReturnsMetaV2'
+            example:
+                branches:
+                    branches:
+                        - condition_groups:
+                            - conditions:
+                                - operation:
+                                    label: Lawrence Jones
+                                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                  param_bindings:
+                                    - array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject:
+                                    label: Incident Severity
+                                    reference: incident.severity
+                          result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                    returns:
+                        array: true
+                        type: IncidentStatus
+                filter:
+                    condition_groups:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                navigate:
+                    reference: "1235"
+                    reference_label: Teams
+                operation_type: navigate
+                parse:
+                    returns:
+                        array: true
+                        type: IncidentStatus
+                    source: metadata.annotations["github.com/repo"]
+                returns:
+                    array: true
+                    type: IncidentStatus
+            required:
+                - operation_type
+                - returns
+        ExpressionParseOptsPayloadV2:
             type: object
             properties:
                 returns:
@@ -15495,6 +18025,177 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/ExpressionOperationV2'
+                    example:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                reference:
+                    type: string
+                    description: A short ID that can be used to reference the expression
+                    example: abc123
+                returns:
+                    $ref: '#/components/schemas/ReturnsMetaV2'
+                root_reference:
+                    type: string
+                    description: The root reference for this expression (i.e. where the expression starts)
+                    example: incident.status
+            example:
+                else_branch:
+                    result:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                label: Team Slack channel
+                operations:
+                    - branches:
+                        branches:
+                            - condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                              result:
+                                array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                      filter:
+                        condition_groups:
+                            - conditions:
+                                - operation:
+                                    label: Lawrence Jones
+                                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                  param_bindings:
+                                    - array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject:
+                                    label: Incident Severity
+                                    reference: incident.severity
+                      navigate:
+                        reference: "1235"
+                        reference_label: Teams
+                      operation_type: navigate
+                      parse:
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                        source: metadata.annotations["github.com/repo"]
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                reference: abc123
+                returns:
+                    array: true
+                    type: IncidentStatus
+                root_reference: incident.status
+            required:
+                - label
+                - reference
+                - returns
+                - root_reference
+                - operations
+                - id
+        ExpressionV3:
+            type: object
+            properties:
+                else_branch:
+                    $ref: '#/components/schemas/ExpressionElseBranchV3'
+                label:
+                    type: string
+                    description: The human readable label of the expression
+                    example: Team Slack channel
+                operations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionOperationV3'
                     example:
                         - branches:
                             branches:
@@ -15870,6 +18571,17 @@ components:
                 - status
                 - created_at
                 - updated_at
+        GroupingKeyV2:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Unique identifier of the alert attribute the user wishes to group on
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+            example:
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+            required:
+                - id
         IdentityResponseBody:
             type: object
             properties:
@@ -16225,7 +18937,6 @@ components:
                     type: string
                     description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                     example: lead
-                    minLength: 1
                 updated_at:
                     type: string
                     description: When the role was last updated
@@ -16242,12 +18953,12 @@ components:
                 shortform: lead
                 updated_at: "2021-08-17T13:28:57.801578Z"
             required:
-                - condition_groups
-                - id
                 - name
+                - shortform
                 - description
                 - instructions
-                - shortform
+                - condition_groups
+                - id
                 - role_type
                 - created_at
                 - updated_at
@@ -16289,7 +19000,6 @@ components:
                     type: string
                     description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                     example: lead
-                    minLength: 1
                 updated_at:
                     type: string
                     description: When the role was last updated
@@ -16305,12 +19015,12 @@ components:
                 shortform: lead
                 updated_at: "2021-08-17T13:28:57.801578Z"
             required:
-                - condition_groups
-                - id
                 - name
+                - shortform
                 - description
                 - instructions
-                - shortform
+                - condition_groups
+                - id
                 - role_type
                 - created_at
                 - updated_at
@@ -17333,13 +20043,13 @@ components:
                                         catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                         catalog_entry_name: Primary escalation
                                         catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                      helptext: Collection of standalone automations like auto-closing incidents.
-                                      image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                      helptext: abc123
+                                      image_url: abc123
                                       is_image_slack_icon: false
                                       label: Lawrence Jones
                                       literal: SEV123
                                       reference: incident.severity
-                                      sort_key: "000020"
+                                      sort_key: abc123
                                       unavailable: false
                                       value: abc123
                                 value:
@@ -17348,13 +20058,13 @@ components:
                                         catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                         catalog_entry_name: Primary escalation
                                         catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                    helptext: Collection of standalone automations like auto-closing incidents.
-                                    image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                    helptext: abc123
+                                    image_url: abc123
                                     is_image_slack_icon: false
                                     label: Lawrence Jones
                                     literal: SEV123
                                     reference: incident.severity
-                                    sort_key: "000020"
+                                    sort_key: abc123
                                     unavailable: false
                                     value: abc123
                           catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -17382,13 +20092,13 @@ components:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                  helptext: Collection of standalone automations like auto-closing incidents.
-                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                  helptext: abc123
+                                  image_url: abc123
                                   is_image_slack_icon: false
                                   label: Lawrence Jones
                                   literal: SEV123
                                   reference: incident.severity
-                                  sort_key: "000020"
+                                  sort_key: abc123
                                   unavailable: false
                                   value: abc123
                             value:
@@ -17397,13 +20107,13 @@ components:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                helptext: Collection of standalone automations like auto-closing incidents.
-                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                helptext: abc123
+                                image_url: abc123
                                 is_image_slack_icon: false
                                 label: Lawrence Jones
                                 literal: SEV123
                                 reference: incident.severity
-                                sort_key: "000020"
+                                sort_key: abc123
                                 unavailable: false
                                 value: abc123
                       catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -17423,7 +20133,7 @@ components:
                     description: Represents Kubernetes clusters that we run inside of GKE.
                     dynamic_resource_parameter: abc123
                     estimated_count: 7
-                    icon: bolt
+                    icon: alert
                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                     is_editable: false
                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -18438,6 +21148,10 @@ components:
                                 name: Lisa Karlin Curtis
                                 role: viewer
                                 slack_user_id: U02AYNF2XJM
+                          holidays_public_config:
+                            country_codes:
+                                - GB
+                                - FR
                           id: 01G0J1EXE7AXZ2C93K61WBPYEH
                           name: Primary On-Call Schedule
                           timezone: Europe/London
@@ -18486,6 +21200,10 @@ components:
                             name: Lisa Karlin Curtis
                             role: viewer
                             slack_user_id: U02AYNF2XJM
+                      holidays_public_config:
+                        country_codes:
+                            - GB
+                            - FR
                       id: 01G0J1EXE7AXZ2C93K61WBPYEH
                       name: Primary On-Call Schedule
                       timezone: Europe/London
@@ -18634,7 +21352,7 @@ components:
                           description: Represents Kubernetes clusters that we run inside of GKE.
                           dynamic_resource_parameter: abc123
                           estimated_count: 7
-                          icon: bolt
+                          icon: alert
                           id: 01FCNDV6P870EA6S7TK1DSYDG0
                           is_editable: false
                           last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -18670,7 +21388,7 @@ components:
                       description: Represents Kubernetes clusters that we run inside of GKE.
                       dynamic_resource_parameter: abc123
                       estimated_count: 7
-                      icon: bolt
+                      icon: alert
                       id: 01FCNDV6P870EA6S7TK1DSYDG0
                       is_editable: false
                       last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -19156,7 +21874,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.action_created_v1:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
             example:
                 event_type: private_incident.action_created_v1
                 private_incident.action_created_v1:
@@ -19188,7 +21906,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.action_updated_v1:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
             example:
                 event_type: private_incident.action_updated_v1
                 private_incident.action_updated_v1:
@@ -19220,7 +21938,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.follow_up_created_v1:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
             example:
                 event_type: private_incident.follow_up_created_v1
                 private_incident.follow_up_created_v1:
@@ -19252,7 +21970,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.follow_up_updated_v1:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
             example:
                 event_type: private_incident.follow_up_updated_v1
                 private_incident.follow_up_updated_v1:
@@ -19284,7 +22002,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.incident_created_v2:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
             example:
                 event_type: private_incident.incident_created_v2
                 private_incident.incident_created_v2:
@@ -19316,7 +22034,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.incident_updated_v2:
-                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                    $ref: '#/components/schemas/GroupingKeyV2'
             example:
                 event_type: private_incident.incident_updated_v2
                 private_incident.incident_updated_v2:
@@ -20256,6 +22974,8 @@ components:
                         example: abc123
                 config:
                     $ref: '#/components/schemas/ScheduleConfigCreatePayloadV2'
+                holidays_public_config:
+                    $ref: '#/components/schemas/ScheduleHolidaysPublicConfigV2'
                 name:
                     type: string
                     description: Name of the schedule
@@ -20287,6 +23007,9 @@ components:
                             - end_time: "17:00"
                               start_time: "09:00"
                               weekday: tuesday
+                holidays_public_config:
+                    country_codes:
+                        - abc123
                 name: My Schedule
                 timezone: America/Los_Angeles
         ScheduleEntriesListPayloadV2:
@@ -20433,6 +23156,24 @@ components:
                 - external_user_id
                 - start_at
                 - end_at
+        ScheduleHolidaysPublicConfigV2:
+            type: object
+            properties:
+                country_codes:
+                    type: array
+                    items:
+                        type: string
+                        example: abc123
+                    description: ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for
+                    example:
+                        - GB
+                        - FR
+            example:
+                country_codes:
+                    - GB
+                    - FR
+            required:
+                - country_codes
         ScheduleLayerCreatePayloadV2:
             type: object
             properties:
@@ -20742,6 +23483,8 @@ components:
                         example: abc123
                 config:
                     $ref: '#/components/schemas/ScheduleConfigUpdatePayloadV2'
+                holidays_public_config:
+                    $ref: '#/components/schemas/ScheduleHolidaysPublicConfigV2'
                 name:
                     type: string
                     description: Name of the schedule
@@ -20773,6 +23516,9 @@ components:
                             - end_time: "17:00"
                               start_time: "09:00"
                               weekday: tuesday
+                holidays_public_config:
+                    country_codes:
+                        - abc123
                 name: My Schedule
                 timezone: America/Los_Angeles
         ScheduleV2:
@@ -20810,6 +23556,8 @@ components:
                             name: Lisa Karlin Curtis
                             role: viewer
                             slack_user_id: U02AYNF2XJM
+                holidays_public_config:
+                    $ref: '#/components/schemas/ScheduleHolidaysPublicConfigV2'
                 id:
                     type: string
                     description: Unique internal ID of the schedule
@@ -20865,6 +23613,10 @@ components:
                         name: Lisa Karlin Curtis
                         role: viewer
                         slack_user_id: U02AYNF2XJM
+                holidays_public_config:
+                    country_codes:
+                        - GB
+                        - FR
                 id: 01G0J1EXE7AXZ2C93K61WBPYEH
                 name: Primary On-Call Schedule
                 timezone: Europe/London
@@ -21007,13 +23759,13 @@ components:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                  helptext: Collection of standalone automations like auto-closing incidents.
-                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                  helptext: abc123
+                                  image_url: abc123
                                   is_image_slack_icon: false
                                   label: Lawrence Jones
                                   literal: SEV123
                                   reference: incident.severity
-                                  sort_key: "000020"
+                                  sort_key: abc123
                                   unavailable: false
                                   value: abc123
                             value:
@@ -21022,13 +23774,13 @@ components:
                                     catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
                                     catalog_entry_name: Primary escalation
                                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                                helptext: Collection of standalone automations like auto-closing incidents.
-                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                helptext: abc123
+                                image_url: abc123
                                 is_image_slack_icon: false
                                 label: Lawrence Jones
                                 literal: SEV123
                                 reference: incident.severity
-                                sort_key: "000020"
+                                sort_key: abc123
                                 unavailable: false
                                 value: abc123
                     catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -21048,7 +23800,7 @@ components:
                     description: Represents Kubernetes clusters that we run inside of GKE.
                     dynamic_resource_parameter: abc123
                     estimated_count: 7
-                    icon: bolt
+                    icon: alert
                     id: 01FCNDV6P870EA6S7TK1DSYDG0
                     is_editable: false
                     last_synced_at: "2021-08-17T13:28:57.801578Z"
@@ -21556,6 +24308,10 @@ components:
                             name: Lisa Karlin Curtis
                             role: viewer
                             slack_user_id: U02AYNF2XJM
+                    holidays_public_config:
+                        country_codes:
+                            - GB
+                            - FR
                     id: 01G0J1EXE7AXZ2C93K61WBPYEH
                     name: Primary On-Call Schedule
                     timezone: Europe/London
@@ -21945,6 +24701,322 @@ components:
         UpdateRequestBody:
             type: object
             properties:
+                alert_source_ids:
+                    type: array
+                    items:
+                        type: string
+                        example: abc123
+                    description: The alert sources that will match this alert route
+                    example:
+                        - 02FCNDV6P870EA6S7TK1DSYDG2
+                auto_decline_enabled:
+                    type: boolean
+                    description: Should triage incidents be declined when alerts are resolved?
+                    example: false
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
+                    description: What condition groups must be true for this alert route to fire?
+                    example:
+                        - conditions:
+                            - operation: one_of
+                              param_bindings:
+                                - array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject: incident.severity
+                defer_time_seconds:
+                    type: integer
+                    description: How long should the escalation defer time be?
+                    example: 1
+                    format: int64
+                enabled:
+                    type: boolean
+                    description: Whether this alert route is enabled or not
+                    example: false
+                escalation_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AlertRouteEscalationBindingPayloadV2'
+                    description: Which escalation paths should this alert route escalate to?
+                    example:
+                        - binding:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                expressions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionPayloadV2'
+                    description: The expressions used in this template
+                    example:
+                        - else_branch:
+                            result:
+                                array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                          label: Team Slack channel
+                          operations:
+                            - branches:
+                                branches:
+                                    - condition_groups:
+                                        - conditions:
+                                            - operation: one_of
+                                              param_bindings:
+                                                - array_value:
+                                                    - literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject: incident.severity
+                                      result:
+                                        array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                              filter:
+                                condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                              navigate:
+                                reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                              operation_type: navigate
+                              parse:
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                                source: metadata.annotations["github.com/repo"]
+                          reference: abc123
+                          root_reference: incident.status
+                grouping_keys:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GroupingKeyV2'
+                    description: Which attributes should this alert route use to group alerts?
+                    example:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds:
+                    type: integer
+                    description: How large should the grouping window be?
+                    example: 1
+                    format: int64
+                incident_condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
+                    description: What condition groups must be true for this alert route to create an incident?
+                    example:
+                        - conditions:
+                            - operation: one_of
+                              param_bindings:
+                                - array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject: incident.severity
+                incident_enabled:
+                    type: boolean
+                    description: Whether this alert route will create incidents or not
+                    example: false
+                name:
+                    type: string
+                    description: The name of this alert route config, for the user's reference
+                    example: Production incidents
+                template:
+                    $ref: '#/components/schemas/AlertRouteIncidentTemplatePayloadV2'
+            example:
+                alert_source_ids:
+                    - 02FCNDV6P870EA6S7TK1DSYDG2
+                auto_decline_enabled: false
+                condition_groups:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+                defer_time_seconds: 1
+                enabled: false
+                escalation_bindings:
+                    - binding:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                                  result:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                          navigate:
+                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                      reference: abc123
+                      root_reference: incident.status
+                grouping_keys:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds: 1
+                incident_condition_groups:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+                incident_enabled: false
+                name: Production incidents
+                template:
+                    custom_field_priorities:
+                        abc123: abc123
+                    custom_fields:
+                        custom_field_10014:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                    incident_mode:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    incident_type:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    name:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    priority_severity: severity-first-wins
+                    severity:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    summary:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    workspace:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+            required:
+                - name
+                - condition_groups
+                - grouping_keys
+                - grouping_window_seconds
+                - defer_time_seconds
+                - escalation_bindings
+                - auto_decline_enabled
+                - enabled
+                - incident_enabled
+                - incident_condition_groups
+                - alert_source_ids
+                - auto_cancel_escalations
+        UpdateRequestBody2:
+            type: object
+            properties:
                 sort_key:
                     type: integer
                     description: Sort key used to order the custom field options correctly
@@ -21962,7 +25034,7 @@ components:
                 - value
                 - custom_field_id
                 - sort_key
-        UpdateRequestBody2:
+        UpdateRequestBody3:
             type: object
             properties:
                 description:
@@ -22025,7 +25097,7 @@ components:
                 - options
                 - created_at
                 - updated_at
-        UpdateRequestBody3:
+        UpdateRequestBody4:
             type: object
             properties:
                 description:
@@ -22047,7 +25119,7 @@ components:
                 - cannot_be_unset
                 - created_at
                 - updated_at
-        UpdateRequestBody4:
+        UpdateRequestBody5:
             type: object
             properties:
                 description:
@@ -22072,7 +25144,6 @@ components:
                     type: string
                     description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                     example: lead
-                    minLength: 1
             example:
                 description: The person currently coordinating the incident
                 instructions: Take point on the incident; Make sure people are clear on responsibilities
@@ -22080,15 +25151,15 @@ components:
                 required: false
                 shortform: lead
             required:
-                - condition_groups
                 - name
+                - shortform
                 - description
                 - instructions
-                - shortform
+                - condition_groups
                 - role_type
                 - created_at
                 - updated_at
-        UpdateRequestBody5:
+        UpdateRequestBody6:
             type: object
             properties:
                 description:
@@ -22109,22 +25180,21 @@ components:
                     type: string
                     description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
                     example: lead
-                    minLength: 1
             example:
                 description: The person currently coordinating the incident
                 instructions: Take point on the incident; Make sure people are clear on responsibilities
                 name: Incident Lead
                 shortform: lead
             required:
-                - condition_groups
                 - name
+                - shortform
                 - description
                 - instructions
-                - shortform
+                - condition_groups
                 - role_type
                 - created_at
                 - updated_at
-        UpdateRequestBody6:
+        UpdateRequestBody7:
             type: object
             properties:
                 description:
@@ -22145,7 +25215,7 @@ components:
                 - category
                 - created_at
                 - updated_at
-        UpdateRequestBody7:
+        UpdateRequestBody8:
             type: object
             properties:
                 schedule:
@@ -22174,6 +25244,9 @@ components:
                                 - end_time: "17:00"
                                   start_time: "09:00"
                                   weekday: tuesday
+                    holidays_public_config:
+                        country_codes:
+                            - abc123
                     name: My Schedule
                     timezone: America/Los_Angeles
             required:
@@ -22231,8 +25304,9 @@ components:
                 icon:
                     type: string
                     description: Sets the display icon of this type in the dashboard
-                    example: bolt
+                    example: alert
                     enum:
+                        - alert
                         - bolt
                         - box
                         - briefcase
@@ -22245,6 +25319,7 @@ components:
                         - database
                         - doc
                         - email
+                        - escalation-path
                         - files
                         - flag
                         - folder
@@ -22252,6 +25327,7 @@ components:
                         - money
                         - server
                         - severity
+                        - status-page
                         - store
                         - star
                         - tag
@@ -22276,7 +25352,7 @@ components:
                     - issue-tracker
                 color: yellow
                 description: Represents Kubernetes clusters that we run inside of GKE.
-                icon: bolt
+                icon: alert
                 name: Kubernetes Cluster
                 ranked: true
                 source_repo_url: https://github.com/my-company/incident-io-catalog
@@ -23126,17 +26202,6 @@ components:
                 - created_at
                 - updated_at
                 - reported_at
-        WebhookPrivateResourceV2:
-            type: object
-            properties:
-                id:
-                    type: string
-                    description: The ID of the resource
-                    example: abc123
-            example:
-                id: abc123
-            required:
-                - id
         WeekdayIntervalConfigV2:
             type: object
             properties:
@@ -23202,7 +26267,7 @@ components:
                 condition_groups:
                     type: array
                     items:
-                        $ref: '#/components/schemas/ConditionGroupV2'
+                        $ref: '#/components/schemas/ConditionGroupV3'
                     description: Conditions that apply to the workflow trigger
                     example:
                         - conditions:
@@ -23230,7 +26295,7 @@ components:
                 expressions:
                     type: array
                     items:
-                        $ref: '#/components/schemas/ExpressionV2'
+                        $ref: '#/components/schemas/ExpressionV3'
                     description: Expressions that make variables available in the scope
                     example:
                         - else_branch:
@@ -23569,7 +26634,7 @@ components:
                 condition_groups:
                     type: array
                     items:
-                        $ref: '#/components/schemas/ConditionGroupV2'
+                        $ref: '#/components/schemas/ConditionGroupV3'
                     description: Conditions that apply to the workflow trigger
                     example:
                         - conditions:
@@ -23597,7 +26662,7 @@ components:
                 expressions:
                     type: array
                     items:
-                        $ref: '#/components/schemas/ExpressionV2'
+                        $ref: '#/components/schemas/ExpressionV3'
                     description: Expressions that make variables available in the scope
                     example:
                         - else_branch:
@@ -23916,6 +26981,18 @@ tags:
 
         You can manage actions in the incident Slack channel with <code>/incident actions</code>, or on
         the incident homepage.
+    - name: Alert Routes V2
+      description: |
+        Create and manage alert routes.
+
+        Alert routes take alerts from alert sources, filter them according to conditions, apply
+        grouping on alert attributes, then finally create:
+
+        1. Incidents
+        2. Escalations
+
+        These are best configured in the incident.io dashboard and exported via the UI to
+        Terraform, as the configuration is complex.
     - name: Audit logs
       description: |
         To give you visibility over the changes that are made within your incident.io account, we use an audit log. Our audit log is powered by <a href="https://workos.com" target="_blank">WorkOS</a>. The log is available for customers on our [Enterprise plan](https://incident.io/pricing).

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -49,6 +49,25 @@ const (
 	Success AlertResultStatus = "success"
 )
 
+// Defines values for AlertRouteIncidentTemplatePayloadV2PrioritySeverity.
+const (
+	AlertRouteIncidentTemplatePayloadV2PrioritySeveritySeverityFirstWins AlertRouteIncidentTemplatePayloadV2PrioritySeverity = "severity-first-wins"
+	AlertRouteIncidentTemplatePayloadV2PrioritySeveritySeverityMax       AlertRouteIncidentTemplatePayloadV2PrioritySeverity = "severity-max"
+)
+
+// Defines values for AlertRouteIncidentTemplateV2CustomFieldPriorities.
+const (
+	Append    AlertRouteIncidentTemplateV2CustomFieldPriorities = "append"
+	FirstWins AlertRouteIncidentTemplateV2CustomFieldPriorities = "first-wins"
+	LastWins  AlertRouteIncidentTemplateV2CustomFieldPriorities = "last-wins"
+)
+
+// Defines values for AlertRouteIncidentTemplateV2PrioritySeverity.
+const (
+	AlertRouteIncidentTemplateV2PrioritySeveritySeverityFirstWins AlertRouteIncidentTemplateV2PrioritySeverity = "severity-first-wins"
+	AlertRouteIncidentTemplateV2PrioritySeveritySeverityMax       AlertRouteIncidentTemplateV2PrioritySeverity = "severity-max"
+)
+
 // Defines values for CatalogResourceV2Category.
 const (
 	CatalogResourceV2CategoryCustom    CatalogResourceV2Category = "custom"
@@ -102,30 +121,33 @@ const (
 
 // Defines values for CatalogTypeV2Icon.
 const (
-	CatalogTypeV2IconBolt       CatalogTypeV2Icon = "bolt"
-	CatalogTypeV2IconBox        CatalogTypeV2Icon = "box"
-	CatalogTypeV2IconBriefcase  CatalogTypeV2Icon = "briefcase"
-	CatalogTypeV2IconBrowser    CatalogTypeV2Icon = "browser"
-	CatalogTypeV2IconBulb       CatalogTypeV2Icon = "bulb"
-	CatalogTypeV2IconCalendar   CatalogTypeV2Icon = "calendar"
-	CatalogTypeV2IconClock      CatalogTypeV2Icon = "clock"
-	CatalogTypeV2IconCog        CatalogTypeV2Icon = "cog"
-	CatalogTypeV2IconComponents CatalogTypeV2Icon = "components"
-	CatalogTypeV2IconDatabase   CatalogTypeV2Icon = "database"
-	CatalogTypeV2IconDoc        CatalogTypeV2Icon = "doc"
-	CatalogTypeV2IconEmail      CatalogTypeV2Icon = "email"
-	CatalogTypeV2IconFiles      CatalogTypeV2Icon = "files"
-	CatalogTypeV2IconFlag       CatalogTypeV2Icon = "flag"
-	CatalogTypeV2IconFolder     CatalogTypeV2Icon = "folder"
-	CatalogTypeV2IconGlobe      CatalogTypeV2Icon = "globe"
-	CatalogTypeV2IconMoney      CatalogTypeV2Icon = "money"
-	CatalogTypeV2IconServer     CatalogTypeV2Icon = "server"
-	CatalogTypeV2IconSeverity   CatalogTypeV2Icon = "severity"
-	CatalogTypeV2IconStar       CatalogTypeV2Icon = "star"
-	CatalogTypeV2IconStore      CatalogTypeV2Icon = "store"
-	CatalogTypeV2IconTag        CatalogTypeV2Icon = "tag"
-	CatalogTypeV2IconUser       CatalogTypeV2Icon = "user"
-	CatalogTypeV2IconUsers      CatalogTypeV2Icon = "users"
+	CatalogTypeV2IconAlert          CatalogTypeV2Icon = "alert"
+	CatalogTypeV2IconBolt           CatalogTypeV2Icon = "bolt"
+	CatalogTypeV2IconBox            CatalogTypeV2Icon = "box"
+	CatalogTypeV2IconBriefcase      CatalogTypeV2Icon = "briefcase"
+	CatalogTypeV2IconBrowser        CatalogTypeV2Icon = "browser"
+	CatalogTypeV2IconBulb           CatalogTypeV2Icon = "bulb"
+	CatalogTypeV2IconCalendar       CatalogTypeV2Icon = "calendar"
+	CatalogTypeV2IconClock          CatalogTypeV2Icon = "clock"
+	CatalogTypeV2IconCog            CatalogTypeV2Icon = "cog"
+	CatalogTypeV2IconComponents     CatalogTypeV2Icon = "components"
+	CatalogTypeV2IconDatabase       CatalogTypeV2Icon = "database"
+	CatalogTypeV2IconDoc            CatalogTypeV2Icon = "doc"
+	CatalogTypeV2IconEmail          CatalogTypeV2Icon = "email"
+	CatalogTypeV2IconEscalationPath CatalogTypeV2Icon = "escalation-path"
+	CatalogTypeV2IconFiles          CatalogTypeV2Icon = "files"
+	CatalogTypeV2IconFlag           CatalogTypeV2Icon = "flag"
+	CatalogTypeV2IconFolder         CatalogTypeV2Icon = "folder"
+	CatalogTypeV2IconGlobe          CatalogTypeV2Icon = "globe"
+	CatalogTypeV2IconMoney          CatalogTypeV2Icon = "money"
+	CatalogTypeV2IconServer         CatalogTypeV2Icon = "server"
+	CatalogTypeV2IconSeverity       CatalogTypeV2Icon = "severity"
+	CatalogTypeV2IconStar           CatalogTypeV2Icon = "star"
+	CatalogTypeV2IconStatusPage     CatalogTypeV2Icon = "status-page"
+	CatalogTypeV2IconStore          CatalogTypeV2Icon = "store"
+	CatalogTypeV2IconTag            CatalogTypeV2Icon = "tag"
+	CatalogTypeV2IconUser           CatalogTypeV2Icon = "user"
+	CatalogTypeV2IconUsers          CatalogTypeV2Icon = "users"
 )
 
 // Defines values for CreateHTTPRequestBodyStatus.
@@ -142,10 +164,18 @@ const (
 
 // Defines values for CreateRequestBody10Mode.
 const (
-	CreateRequestBody10ModeRetrospective CreateRequestBody10Mode = "retrospective"
-	CreateRequestBody10ModeStandard      CreateRequestBody10Mode = "standard"
-	CreateRequestBody10ModeTest          CreateRequestBody10Mode = "test"
-	CreateRequestBody10ModeTutorial      CreateRequestBody10Mode = "tutorial"
+	CreateRequestBody10ModeReal CreateRequestBody10Mode = "real"
+	CreateRequestBody10ModeTest CreateRequestBody10Mode = "test"
+)
+
+// Defines values for CreateRequestBody10Status.
+const (
+	CreateRequestBody10StatusClosed        CreateRequestBody10Status = "closed"
+	CreateRequestBody10StatusDeclined      CreateRequestBody10Status = "declined"
+	CreateRequestBody10StatusFixing        CreateRequestBody10Status = "fixing"
+	CreateRequestBody10StatusInvestigating CreateRequestBody10Status = "investigating"
+	CreateRequestBody10StatusMonitoring    CreateRequestBody10Status = "monitoring"
+	CreateRequestBody10StatusTriage        CreateRequestBody10Status = "triage"
 )
 
 // Defines values for CreateRequestBody10Visibility.
@@ -154,27 +184,18 @@ const (
 	CreateRequestBody10VisibilityPublic  CreateRequestBody10Visibility = "public"
 )
 
-// Defines values for CreateRequestBody2FieldType.
+// Defines values for CreateRequestBody11Mode.
 const (
-	CreateRequestBody2FieldTypeLink         CreateRequestBody2FieldType = "link"
-	CreateRequestBody2FieldTypeMultiSelect  CreateRequestBody2FieldType = "multi_select"
-	CreateRequestBody2FieldTypeNumeric      CreateRequestBody2FieldType = "numeric"
-	CreateRequestBody2FieldTypeSingleSelect CreateRequestBody2FieldType = "single_select"
-	CreateRequestBody2FieldTypeText         CreateRequestBody2FieldType = "text"
+	CreateRequestBody11ModeRetrospective CreateRequestBody11Mode = "retrospective"
+	CreateRequestBody11ModeStandard      CreateRequestBody11Mode = "standard"
+	CreateRequestBody11ModeTest          CreateRequestBody11Mode = "test"
+	CreateRequestBody11ModeTutorial      CreateRequestBody11Mode = "tutorial"
 )
 
-// Defines values for CreateRequestBody2Required.
+// Defines values for CreateRequestBody11Visibility.
 const (
-	CreateRequestBody2RequiredAlways        CreateRequestBody2Required = "always"
-	CreateRequestBody2RequiredBeforeClosure CreateRequestBody2Required = "before_closure"
-	CreateRequestBody2RequiredNever         CreateRequestBody2Required = "never"
-)
-
-// Defines values for CreateRequestBody2RequiredV2.
-const (
-	CreateRequestBody2RequiredV2Always           CreateRequestBody2RequiredV2 = "always"
-	CreateRequestBody2RequiredV2BeforeResolution CreateRequestBody2RequiredV2 = "before_resolution"
-	CreateRequestBody2RequiredV2Never            CreateRequestBody2RequiredV2 = "never"
+	CreateRequestBody11VisibilityPrivate CreateRequestBody11Visibility = "private"
+	CreateRequestBody11VisibilityPublic  CreateRequestBody11Visibility = "public"
 )
 
 // Defines values for CreateRequestBody3FieldType.
@@ -186,49 +207,50 @@ const (
 	CreateRequestBody3FieldTypeText         CreateRequestBody3FieldType = "text"
 )
 
-// Defines values for CreateRequestBody4ResourceResourceType.
+// Defines values for CreateRequestBody3Required.
 const (
-	CreateRequestBody4ResourceResourceTypeAtlassianStatuspageIncident CreateRequestBody4ResourceResourceType = "atlassian_statuspage_incident"
-	CreateRequestBody4ResourceResourceTypeDatadogMonitorAlert         CreateRequestBody4ResourceResourceType = "datadog_monitor_alert"
-	CreateRequestBody4ResourceResourceTypeGithubPullRequest           CreateRequestBody4ResourceResourceType = "github_pull_request"
-	CreateRequestBody4ResourceResourceTypeGitlabMergeRequest          CreateRequestBody4ResourceResourceType = "gitlab_merge_request"
-	CreateRequestBody4ResourceResourceTypeGoogleCalendarEvent         CreateRequestBody4ResourceResourceType = "google_calendar_event"
-	CreateRequestBody4ResourceResourceTypeJiraIssue                   CreateRequestBody4ResourceResourceType = "jira_issue"
-	CreateRequestBody4ResourceResourceTypeOpsgenieAlert               CreateRequestBody4ResourceResourceType = "opsgenie_alert"
-	CreateRequestBody4ResourceResourceTypePagerDutyIncident           CreateRequestBody4ResourceResourceType = "pager_duty_incident"
-	CreateRequestBody4ResourceResourceTypeScrubbed                    CreateRequestBody4ResourceResourceType = "scrubbed"
-	CreateRequestBody4ResourceResourceTypeSentryIssue                 CreateRequestBody4ResourceResourceType = "sentry_issue"
-	CreateRequestBody4ResourceResourceTypeStatuspageIncident          CreateRequestBody4ResourceResourceType = "statuspage_incident"
-	CreateRequestBody4ResourceResourceTypeZendeskTicket               CreateRequestBody4ResourceResourceType = "zendesk_ticket"
+	CreateRequestBody3RequiredAlways        CreateRequestBody3Required = "always"
+	CreateRequestBody3RequiredBeforeClosure CreateRequestBody3Required = "before_closure"
+	CreateRequestBody3RequiredNever         CreateRequestBody3Required = "never"
 )
 
-// Defines values for CreateRequestBody8Category.
+// Defines values for CreateRequestBody3RequiredV2.
 const (
-	CreateRequestBody8CategoryClosed   CreateRequestBody8Category = "closed"
-	CreateRequestBody8CategoryLearning CreateRequestBody8Category = "learning"
-	CreateRequestBody8CategoryLive     CreateRequestBody8Category = "live"
+	CreateRequestBody3RequiredV2Always           CreateRequestBody3RequiredV2 = "always"
+	CreateRequestBody3RequiredV2BeforeResolution CreateRequestBody3RequiredV2 = "before_resolution"
+	CreateRequestBody3RequiredV2Never            CreateRequestBody3RequiredV2 = "never"
 )
 
-// Defines values for CreateRequestBody9Mode.
+// Defines values for CreateRequestBody4FieldType.
 const (
-	CreateRequestBody9ModeReal CreateRequestBody9Mode = "real"
-	CreateRequestBody9ModeTest CreateRequestBody9Mode = "test"
+	CreateRequestBody4FieldTypeLink         CreateRequestBody4FieldType = "link"
+	CreateRequestBody4FieldTypeMultiSelect  CreateRequestBody4FieldType = "multi_select"
+	CreateRequestBody4FieldTypeNumeric      CreateRequestBody4FieldType = "numeric"
+	CreateRequestBody4FieldTypeSingleSelect CreateRequestBody4FieldType = "single_select"
+	CreateRequestBody4FieldTypeText         CreateRequestBody4FieldType = "text"
 )
 
-// Defines values for CreateRequestBody9Status.
+// Defines values for CreateRequestBody5ResourceResourceType.
 const (
-	CreateRequestBody9StatusClosed        CreateRequestBody9Status = "closed"
-	CreateRequestBody9StatusDeclined      CreateRequestBody9Status = "declined"
-	CreateRequestBody9StatusFixing        CreateRequestBody9Status = "fixing"
-	CreateRequestBody9StatusInvestigating CreateRequestBody9Status = "investigating"
-	CreateRequestBody9StatusMonitoring    CreateRequestBody9Status = "monitoring"
-	CreateRequestBody9StatusTriage        CreateRequestBody9Status = "triage"
+	CreateRequestBody5ResourceResourceTypeAtlassianStatuspageIncident CreateRequestBody5ResourceResourceType = "atlassian_statuspage_incident"
+	CreateRequestBody5ResourceResourceTypeDatadogMonitorAlert         CreateRequestBody5ResourceResourceType = "datadog_monitor_alert"
+	CreateRequestBody5ResourceResourceTypeGithubPullRequest           CreateRequestBody5ResourceResourceType = "github_pull_request"
+	CreateRequestBody5ResourceResourceTypeGitlabMergeRequest          CreateRequestBody5ResourceResourceType = "gitlab_merge_request"
+	CreateRequestBody5ResourceResourceTypeGoogleCalendarEvent         CreateRequestBody5ResourceResourceType = "google_calendar_event"
+	CreateRequestBody5ResourceResourceTypeJiraIssue                   CreateRequestBody5ResourceResourceType = "jira_issue"
+	CreateRequestBody5ResourceResourceTypeOpsgenieAlert               CreateRequestBody5ResourceResourceType = "opsgenie_alert"
+	CreateRequestBody5ResourceResourceTypePagerDutyIncident           CreateRequestBody5ResourceResourceType = "pager_duty_incident"
+	CreateRequestBody5ResourceResourceTypeScrubbed                    CreateRequestBody5ResourceResourceType = "scrubbed"
+	CreateRequestBody5ResourceResourceTypeSentryIssue                 CreateRequestBody5ResourceResourceType = "sentry_issue"
+	CreateRequestBody5ResourceResourceTypeStatuspageIncident          CreateRequestBody5ResourceResourceType = "statuspage_incident"
+	CreateRequestBody5ResourceResourceTypeZendeskTicket               CreateRequestBody5ResourceResourceType = "zendesk_ticket"
 )
 
-// Defines values for CreateRequestBody9Visibility.
+// Defines values for CreateRequestBody9Category.
 const (
-	CreateRequestBody9VisibilityPrivate CreateRequestBody9Visibility = "private"
-	CreateRequestBody9VisibilityPublic  CreateRequestBody9Visibility = "public"
+	CreateRequestBody9CategoryClosed   CreateRequestBody9Category = "closed"
+	CreateRequestBody9CategoryLearning CreateRequestBody9Category = "learning"
+	CreateRequestBody9CategoryLive     CreateRequestBody9Category = "live"
 )
 
 // Defines values for CreateTypeRequestBodyCategories.
@@ -255,30 +277,33 @@ const (
 
 // Defines values for CreateTypeRequestBodyIcon.
 const (
-	CreateTypeRequestBodyIconBolt       CreateTypeRequestBodyIcon = "bolt"
-	CreateTypeRequestBodyIconBox        CreateTypeRequestBodyIcon = "box"
-	CreateTypeRequestBodyIconBriefcase  CreateTypeRequestBodyIcon = "briefcase"
-	CreateTypeRequestBodyIconBrowser    CreateTypeRequestBodyIcon = "browser"
-	CreateTypeRequestBodyIconBulb       CreateTypeRequestBodyIcon = "bulb"
-	CreateTypeRequestBodyIconCalendar   CreateTypeRequestBodyIcon = "calendar"
-	CreateTypeRequestBodyIconClock      CreateTypeRequestBodyIcon = "clock"
-	CreateTypeRequestBodyIconCog        CreateTypeRequestBodyIcon = "cog"
-	CreateTypeRequestBodyIconComponents CreateTypeRequestBodyIcon = "components"
-	CreateTypeRequestBodyIconDatabase   CreateTypeRequestBodyIcon = "database"
-	CreateTypeRequestBodyIconDoc        CreateTypeRequestBodyIcon = "doc"
-	CreateTypeRequestBodyIconEmail      CreateTypeRequestBodyIcon = "email"
-	CreateTypeRequestBodyIconFiles      CreateTypeRequestBodyIcon = "files"
-	CreateTypeRequestBodyIconFlag       CreateTypeRequestBodyIcon = "flag"
-	CreateTypeRequestBodyIconFolder     CreateTypeRequestBodyIcon = "folder"
-	CreateTypeRequestBodyIconGlobe      CreateTypeRequestBodyIcon = "globe"
-	CreateTypeRequestBodyIconMoney      CreateTypeRequestBodyIcon = "money"
-	CreateTypeRequestBodyIconServer     CreateTypeRequestBodyIcon = "server"
-	CreateTypeRequestBodyIconSeverity   CreateTypeRequestBodyIcon = "severity"
-	CreateTypeRequestBodyIconStar       CreateTypeRequestBodyIcon = "star"
-	CreateTypeRequestBodyIconStore      CreateTypeRequestBodyIcon = "store"
-	CreateTypeRequestBodyIconTag        CreateTypeRequestBodyIcon = "tag"
-	CreateTypeRequestBodyIconUser       CreateTypeRequestBodyIcon = "user"
-	CreateTypeRequestBodyIconUsers      CreateTypeRequestBodyIcon = "users"
+	CreateTypeRequestBodyIconAlert          CreateTypeRequestBodyIcon = "alert"
+	CreateTypeRequestBodyIconBolt           CreateTypeRequestBodyIcon = "bolt"
+	CreateTypeRequestBodyIconBox            CreateTypeRequestBodyIcon = "box"
+	CreateTypeRequestBodyIconBriefcase      CreateTypeRequestBodyIcon = "briefcase"
+	CreateTypeRequestBodyIconBrowser        CreateTypeRequestBodyIcon = "browser"
+	CreateTypeRequestBodyIconBulb           CreateTypeRequestBodyIcon = "bulb"
+	CreateTypeRequestBodyIconCalendar       CreateTypeRequestBodyIcon = "calendar"
+	CreateTypeRequestBodyIconClock          CreateTypeRequestBodyIcon = "clock"
+	CreateTypeRequestBodyIconCog            CreateTypeRequestBodyIcon = "cog"
+	CreateTypeRequestBodyIconComponents     CreateTypeRequestBodyIcon = "components"
+	CreateTypeRequestBodyIconDatabase       CreateTypeRequestBodyIcon = "database"
+	CreateTypeRequestBodyIconDoc            CreateTypeRequestBodyIcon = "doc"
+	CreateTypeRequestBodyIconEmail          CreateTypeRequestBodyIcon = "email"
+	CreateTypeRequestBodyIconEscalationPath CreateTypeRequestBodyIcon = "escalation-path"
+	CreateTypeRequestBodyIconFiles          CreateTypeRequestBodyIcon = "files"
+	CreateTypeRequestBodyIconFlag           CreateTypeRequestBodyIcon = "flag"
+	CreateTypeRequestBodyIconFolder         CreateTypeRequestBodyIcon = "folder"
+	CreateTypeRequestBodyIconGlobe          CreateTypeRequestBodyIcon = "globe"
+	CreateTypeRequestBodyIconMoney          CreateTypeRequestBodyIcon = "money"
+	CreateTypeRequestBodyIconServer         CreateTypeRequestBodyIcon = "server"
+	CreateTypeRequestBodyIconSeverity       CreateTypeRequestBodyIcon = "severity"
+	CreateTypeRequestBodyIconStar           CreateTypeRequestBodyIcon = "star"
+	CreateTypeRequestBodyIconStatusPage     CreateTypeRequestBodyIcon = "status-page"
+	CreateTypeRequestBodyIconStore          CreateTypeRequestBodyIcon = "store"
+	CreateTypeRequestBodyIconTag            CreateTypeRequestBodyIcon = "tag"
+	CreateTypeRequestBodyIconUser           CreateTypeRequestBodyIcon = "user"
+	CreateTypeRequestBodyIconUsers          CreateTypeRequestBodyIcon = "users"
 )
 
 // Defines values for CreateWorkflowRequestBodyRunsOnIncidentModes.
@@ -410,6 +435,19 @@ const (
 	ExpressionOperationV2OperationTypeNavigate ExpressionOperationV2OperationType = "navigate"
 	ExpressionOperationV2OperationTypeParse    ExpressionOperationV2OperationType = "parse"
 	ExpressionOperationV2OperationTypeRandom   ExpressionOperationV2OperationType = "random"
+)
+
+// Defines values for ExpressionOperationV3OperationType.
+const (
+	Branches ExpressionOperationV3OperationType = "branches"
+	Count    ExpressionOperationV3OperationType = "count"
+	Filter   ExpressionOperationV3OperationType = "filter"
+	First    ExpressionOperationV3OperationType = "first"
+	Max      ExpressionOperationV3OperationType = "max"
+	Min      ExpressionOperationV3OperationType = "min"
+	Navigate ExpressionOperationV3OperationType = "navigate"
+	Parse    ExpressionOperationV3OperationType = "parse"
+	Random   ExpressionOperationV3OperationType = "random"
 )
 
 // Defines values for ExternalIssueReferenceV1Provider.
@@ -584,18 +622,18 @@ const (
 	Wednesday ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "wednesday"
 )
 
-// Defines values for UpdateRequestBody2Required.
+// Defines values for UpdateRequestBody3Required.
 const (
-	UpdateRequestBody2RequiredAlways        UpdateRequestBody2Required = "always"
-	UpdateRequestBody2RequiredBeforeClosure UpdateRequestBody2Required = "before_closure"
-	UpdateRequestBody2RequiredNever         UpdateRequestBody2Required = "never"
+	UpdateRequestBody3RequiredAlways        UpdateRequestBody3Required = "always"
+	UpdateRequestBody3RequiredBeforeClosure UpdateRequestBody3Required = "before_closure"
+	UpdateRequestBody3RequiredNever         UpdateRequestBody3Required = "never"
 )
 
-// Defines values for UpdateRequestBody2RequiredV2.
+// Defines values for UpdateRequestBody3RequiredV2.
 const (
-	Always           UpdateRequestBody2RequiredV2 = "always"
-	BeforeResolution UpdateRequestBody2RequiredV2 = "before_resolution"
-	Never            UpdateRequestBody2RequiredV2 = "never"
+	Always           UpdateRequestBody3RequiredV2 = "always"
+	BeforeResolution UpdateRequestBody3RequiredV2 = "before_resolution"
+	Never            UpdateRequestBody3RequiredV2 = "never"
 )
 
 // Defines values for UpdateTypeRequestBodyCategories.
@@ -622,30 +660,33 @@ const (
 
 // Defines values for UpdateTypeRequestBodyIcon.
 const (
-	UpdateTypeRequestBodyIconBolt       UpdateTypeRequestBodyIcon = "bolt"
-	UpdateTypeRequestBodyIconBox        UpdateTypeRequestBodyIcon = "box"
-	UpdateTypeRequestBodyIconBriefcase  UpdateTypeRequestBodyIcon = "briefcase"
-	UpdateTypeRequestBodyIconBrowser    UpdateTypeRequestBodyIcon = "browser"
-	UpdateTypeRequestBodyIconBulb       UpdateTypeRequestBodyIcon = "bulb"
-	UpdateTypeRequestBodyIconCalendar   UpdateTypeRequestBodyIcon = "calendar"
-	UpdateTypeRequestBodyIconClock      UpdateTypeRequestBodyIcon = "clock"
-	UpdateTypeRequestBodyIconCog        UpdateTypeRequestBodyIcon = "cog"
-	UpdateTypeRequestBodyIconComponents UpdateTypeRequestBodyIcon = "components"
-	UpdateTypeRequestBodyIconDatabase   UpdateTypeRequestBodyIcon = "database"
-	UpdateTypeRequestBodyIconDoc        UpdateTypeRequestBodyIcon = "doc"
-	UpdateTypeRequestBodyIconEmail      UpdateTypeRequestBodyIcon = "email"
-	UpdateTypeRequestBodyIconFiles      UpdateTypeRequestBodyIcon = "files"
-	UpdateTypeRequestBodyIconFlag       UpdateTypeRequestBodyIcon = "flag"
-	UpdateTypeRequestBodyIconFolder     UpdateTypeRequestBodyIcon = "folder"
-	UpdateTypeRequestBodyIconGlobe      UpdateTypeRequestBodyIcon = "globe"
-	UpdateTypeRequestBodyIconMoney      UpdateTypeRequestBodyIcon = "money"
-	UpdateTypeRequestBodyIconServer     UpdateTypeRequestBodyIcon = "server"
-	UpdateTypeRequestBodyIconSeverity   UpdateTypeRequestBodyIcon = "severity"
-	UpdateTypeRequestBodyIconStar       UpdateTypeRequestBodyIcon = "star"
-	UpdateTypeRequestBodyIconStore      UpdateTypeRequestBodyIcon = "store"
-	UpdateTypeRequestBodyIconTag        UpdateTypeRequestBodyIcon = "tag"
-	UpdateTypeRequestBodyIconUser       UpdateTypeRequestBodyIcon = "user"
-	UpdateTypeRequestBodyIconUsers      UpdateTypeRequestBodyIcon = "users"
+	UpdateTypeRequestBodyIconAlert          UpdateTypeRequestBodyIcon = "alert"
+	UpdateTypeRequestBodyIconBolt           UpdateTypeRequestBodyIcon = "bolt"
+	UpdateTypeRequestBodyIconBox            UpdateTypeRequestBodyIcon = "box"
+	UpdateTypeRequestBodyIconBriefcase      UpdateTypeRequestBodyIcon = "briefcase"
+	UpdateTypeRequestBodyIconBrowser        UpdateTypeRequestBodyIcon = "browser"
+	UpdateTypeRequestBodyIconBulb           UpdateTypeRequestBodyIcon = "bulb"
+	UpdateTypeRequestBodyIconCalendar       UpdateTypeRequestBodyIcon = "calendar"
+	UpdateTypeRequestBodyIconClock          UpdateTypeRequestBodyIcon = "clock"
+	UpdateTypeRequestBodyIconCog            UpdateTypeRequestBodyIcon = "cog"
+	UpdateTypeRequestBodyIconComponents     UpdateTypeRequestBodyIcon = "components"
+	UpdateTypeRequestBodyIconDatabase       UpdateTypeRequestBodyIcon = "database"
+	UpdateTypeRequestBodyIconDoc            UpdateTypeRequestBodyIcon = "doc"
+	UpdateTypeRequestBodyIconEmail          UpdateTypeRequestBodyIcon = "email"
+	UpdateTypeRequestBodyIconEscalationPath UpdateTypeRequestBodyIcon = "escalation-path"
+	UpdateTypeRequestBodyIconFiles          UpdateTypeRequestBodyIcon = "files"
+	UpdateTypeRequestBodyIconFlag           UpdateTypeRequestBodyIcon = "flag"
+	UpdateTypeRequestBodyIconFolder         UpdateTypeRequestBodyIcon = "folder"
+	UpdateTypeRequestBodyIconGlobe          UpdateTypeRequestBodyIcon = "globe"
+	UpdateTypeRequestBodyIconMoney          UpdateTypeRequestBodyIcon = "money"
+	UpdateTypeRequestBodyIconServer         UpdateTypeRequestBodyIcon = "server"
+	UpdateTypeRequestBodyIconSeverity       UpdateTypeRequestBodyIcon = "severity"
+	UpdateTypeRequestBodyIconStar           UpdateTypeRequestBodyIcon = "star"
+	UpdateTypeRequestBodyIconStatusPage     UpdateTypeRequestBodyIcon = "status-page"
+	UpdateTypeRequestBodyIconStore          UpdateTypeRequestBodyIcon = "store"
+	UpdateTypeRequestBodyIconTag            UpdateTypeRequestBodyIcon = "tag"
+	UpdateTypeRequestBodyIconUser           UpdateTypeRequestBodyIcon = "user"
+	UpdateTypeRequestBodyIconUsers          UpdateTypeRequestBodyIcon = "users"
 )
 
 // Defines values for UpdateWorkflowRequestBodyRunsOnIncidentModes.
@@ -877,6 +918,89 @@ type AlertResultMessage string
 // AlertResultStatus Status of the event
 type AlertResultStatus string
 
+// AlertRouteEscalationBindingPayloadV2 defines model for AlertRouteEscalationBindingPayloadV2.
+type AlertRouteEscalationBindingPayloadV2 struct {
+	Binding EngineParamBindingPayloadV2 `json:"binding"`
+}
+
+// AlertRouteEscalationBindingV2 defines model for AlertRouteEscalationBindingV2.
+type AlertRouteEscalationBindingV2 struct {
+	Binding EngineParamBindingV2 `json:"binding"`
+}
+
+// AlertRouteIncidentTemplatePayloadV2 defines model for AlertRouteIncidentTemplatePayloadV2.
+type AlertRouteIncidentTemplatePayloadV2 struct {
+	// CustomFieldPriorities lookup of the priority options for each custom field in the template
+	CustomFieldPriorities map[string]string `json:"custom_field_priorities"`
+
+	// CustomFields Custom field keys mapped to values
+	CustomFields *map[string]EngineParamBindingPayloadV2 `json:"custom_fields,omitempty"`
+	IncidentMode *EngineParamBindingPayloadV2            `json:"incident_mode,omitempty"`
+	IncidentType *EngineParamBindingPayloadV2            `json:"incident_type,omitempty"`
+	Name         *EngineParamBindingPayloadV2            `json:"name,omitempty"`
+
+	// PrioritySeverity option defining whether to cause subsequent alerts to increase the severity
+	PrioritySeverity AlertRouteIncidentTemplatePayloadV2PrioritySeverity `json:"priority_severity"`
+	Severity         *EngineParamBindingPayloadV2                        `json:"severity,omitempty"`
+	Summary          *EngineParamBindingPayloadV2                        `json:"summary,omitempty"`
+	Workspace        *EngineParamBindingPayloadV2                        `json:"workspace,omitempty"`
+}
+
+// AlertRouteIncidentTemplatePayloadV2PrioritySeverity option defining whether to cause subsequent alerts to increase the severity
+type AlertRouteIncidentTemplatePayloadV2PrioritySeverity string
+
+// AlertRouteIncidentTemplateV2 defines model for AlertRouteIncidentTemplateV2.
+type AlertRouteIncidentTemplateV2 struct {
+	// CustomFieldPriorities lookup of the priority options for each custom field in the template
+	CustomFieldPriorities map[string]AlertRouteIncidentTemplateV2CustomFieldPriorities `json:"custom_field_priorities"`
+
+	// CustomFields Custom field keys mapped to values
+	CustomFields *map[string]EngineParamBindingV2 `json:"custom_fields,omitempty"`
+	IncidentMode *EngineParamBindingV2            `json:"incident_mode,omitempty"`
+	IncidentType *EngineParamBindingV2            `json:"incident_type,omitempty"`
+	Name         *EngineParamBindingV2            `json:"name,omitempty"`
+
+	// PrioritySeverity binding to use to resolve the workspace to create an incident in
+	PrioritySeverity AlertRouteIncidentTemplateV2PrioritySeverity `json:"priority_severity"`
+	Severity         *EngineParamBindingV2                        `json:"severity,omitempty"`
+	Summary          *EngineParamBindingV2                        `json:"summary,omitempty"`
+	Workspace        *EngineParamBindingV2                        `json:"workspace,omitempty"`
+}
+
+// AlertRouteIncidentTemplateV2CustomFieldPriorities defines model for AlertRouteIncidentTemplateV2.CustomFieldPriorities.
+type AlertRouteIncidentTemplateV2CustomFieldPriorities string
+
+// AlertRouteIncidentTemplateV2PrioritySeverity binding to use to resolve the workspace to create an incident in
+type AlertRouteIncidentTemplateV2PrioritySeverity string
+
+// AlertRouteV2 defines model for AlertRouteV2.
+type AlertRouteV2 struct {
+	// ConditionGroups What condition groups must be true for this alert route to fire?
+	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
+
+	// DeferTimeSeconds How long should the escalation defer time be?
+	DeferTimeSeconds int64 `json:"defer_time_seconds"`
+
+	// EscalationBindings Which escalation paths should this alert route escalate to?
+	EscalationBindings []AlertRouteEscalationBindingV2 `json:"escalation_bindings"`
+
+	// Expressions The expressions used in this template
+	Expressions *[]ExpressionV2 `json:"expressions,omitempty"`
+
+	// GroupingKeys Which attributes should this alert route use to group alerts?
+	GroupingKeys []GroupingKeyV2 `json:"grouping_keys"`
+
+	// GroupingWindowSeconds How large should the grouping window be?
+	GroupingWindowSeconds int64 `json:"grouping_window_seconds"`
+
+	// Id Unique identifier for this alert route config
+	Id string `json:"id"`
+
+	// Name The name of this alert route config, for the user's reference
+	Name     string                        `json:"name"`
+	Template *AlertRouteIncidentTemplateV2 `json:"template,omitempty"`
+}
+
 // CatalogEntryEngineParamBindingV2 defines model for CatalogEntryEngineParamBindingV2.
 type CatalogEntryEngineParamBindingV2 struct {
 	// ArrayValue If array_value is set, this helps render the values
@@ -888,13 +1012,13 @@ type CatalogEntryEngineParamBindingV2 struct {
 type CatalogEntryEngineParamBindingValueV2 struct {
 	CatalogEntry *CatalogEntryReferenceV2 `json:"catalog_entry,omitempty"`
 
-	// Helptext Gives a description of the option to the user
+	// Helptext This field is deprecated. It will not be present in any responses, and will be removed in a future version
 	Helptext *string `json:"helptext,omitempty"`
 
-	// ImageUrl If appropriate, URL to an image that can be displayed alongside the option
+	// ImageUrl This field is deprecated. It will not be present in any responses, and will be removed in a future version
 	ImageUrl *string `json:"image_url,omitempty"`
 
-	// IsImageSlackIcon If true, the image_url is a Slack icon and should be displayed as such
+	// IsImageSlackIcon This field is deprecated. It will not be present in any responses, and will be removed in a future version
 	IsImageSlackIcon *bool `json:"is_image_slack_icon,omitempty"`
 
 	// Label Human readable label to be displayed for user to select
@@ -903,16 +1027,16 @@ type CatalogEntryEngineParamBindingValueV2 struct {
 	// Literal If set, this is the literal value of the step parameter
 	Literal *string `json:"literal,omitempty"`
 
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	// Reference This field is deprecated. It will not be present in any responses, and will be removed in a future version
 	Reference *string `json:"reference,omitempty"`
 
-	// SortKey Gives an indication of how to sort the options when displayed to the user
+	// SortKey This field is deprecated. It will not be present in any responses, and will be removed in a future version
 	SortKey string `json:"sort_key"`
 
-	// Unavailable Unavailable is true if we've failed to build the value for this binding
+	// Unavailable This field is deprecated. It will not be present in any responses, and will be removed in a future version
 	Unavailable *bool `json:"unavailable,omitempty"`
 
-	// Value Either the reference or the literal: this field is designed purely to make working with react-select easier
+	// Value This field is deprecated. It will not be present in any responses, and will be removed in a future version
 	Value *string `json:"value,omitempty"`
 }
 
@@ -1142,6 +1266,12 @@ type ConditionGroupPayloadV2 struct {
 // ConditionGroupV2 defines model for ConditionGroupV2.
 type ConditionGroupV2 struct {
 	// Conditions All conditions in this list must be satisfied for the group to be satisfied
+	Conditions []ConditionV2 `json:"conditions"`
+}
+
+// ConditionGroupV3 defines model for ConditionGroupV3.
+type ConditionGroupV3 struct {
+	// Conditions All conditions in this list must be satisfied for the group to be satisfied
 	Conditions []ConditionV3 `json:"conditions"`
 }
 
@@ -1300,18 +1430,97 @@ type CreatePathResponseBody struct {
 
 // CreateRequestBody defines model for CreateRequestBody.
 type CreateRequestBody struct {
-	// CustomFieldId ID of the custom field this option belongs to
-	CustomFieldId string `json:"custom_field_id"`
+	// AlertSourceIds The alert sources that will match this alert route
+	AlertSourceIds *[]string `json:"alert_source_ids,omitempty"`
 
-	// SortKey Sort key used to order the custom field options correctly
-	SortKey *int64 `json:"sort_key,omitempty"`
+	// AutoDeclineEnabled Should triage incidents be declined when alerts are resolved?
+	AutoDeclineEnabled *bool `json:"auto_decline_enabled,omitempty"`
 
-	// Value Human readable name for the custom field option
-	Value string `json:"value"`
+	// ConditionGroups What condition groups must be true for this alert route to fire?
+	ConditionGroups *[]ConditionGroupPayloadV2 `json:"condition_groups,omitempty"`
+
+	// DeferTimeSeconds How long should the escalation defer time be?
+	DeferTimeSeconds *int64 `json:"defer_time_seconds,omitempty"`
+
+	// Enabled Whether this alert route is enabled or not
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// EscalationBindings Which escalation paths should this alert route escalate to?
+	EscalationBindings *[]AlertRouteEscalationBindingPayloadV2 `json:"escalation_bindings,omitempty"`
+
+	// Expressions The expressions used in this template
+	Expressions *[]ExpressionPayloadV2 `json:"expressions,omitempty"`
+
+	// GroupingKeys Which attributes should this alert route use to group alerts?
+	GroupingKeys *[]GroupingKeyV2 `json:"grouping_keys,omitempty"`
+
+	// GroupingWindowSeconds How large should the grouping window be?
+	GroupingWindowSeconds *int64 `json:"grouping_window_seconds,omitempty"`
+
+	// IncidentConditionGroups What condition groups must be true for this alert route to create an incident?
+	IncidentConditionGroups *[]ConditionGroupPayloadV2 `json:"incident_condition_groups,omitempty"`
+
+	// IncidentEnabled Whether this alert route will create incidents or not
+	IncidentEnabled *bool `json:"incident_enabled,omitempty"`
+
+	// Name The name of this alert route config, for the user's reference
+	Name     *string                              `json:"name,omitempty"`
+	Template *AlertRouteIncidentTemplatePayloadV2 `json:"template,omitempty"`
 }
 
 // CreateRequestBody10 defines model for CreateRequestBody10.
 type CreateRequestBody10 struct {
+	// CustomFieldEntries Set the incident's custom fields to these values
+	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
+
+	// IdempotencyKey Unique string used to de-duplicate incident create requests
+	IdempotencyKey string `json:"idempotency_key"`
+
+	// IncidentRoleAssignments Assign incident roles to these people
+	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV1 `json:"incident_role_assignments,omitempty"`
+
+	// IncidentTypeId Incident type to create this incident as
+	IncidentTypeId *string `json:"incident_type_id,omitempty"`
+
+	// Mode Whether the incident is real or test
+	Mode *CreateRequestBody10Mode `json:"mode,omitempty"`
+
+	// Name Explanation of the incident
+	Name *string `json:"name,omitempty"`
+
+	// SeverityId Severity to create incident as
+	SeverityId *string `json:"severity_id,omitempty"`
+
+	// SlackTeamId ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
+	SlackTeamId *string `json:"slack_team_id,omitempty"`
+
+	// SourceMessageChannelId Channel ID of the source message, if this incident was created from one
+	SourceMessageChannelId *string `json:"source_message_channel_id,omitempty"`
+
+	// SourceMessageTimestamp Timestamp of the source message, if this incident was created from one
+	SourceMessageTimestamp *string `json:"source_message_timestamp,omitempty"`
+
+	// Status Current status of the incident
+	Status *CreateRequestBody10Status `json:"status,omitempty"`
+
+	// Summary Detailed description of the incident
+	Summary *string `json:"summary,omitempty"`
+
+	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+	Visibility CreateRequestBody10Visibility `json:"visibility"`
+}
+
+// CreateRequestBody10Mode Whether the incident is real or test
+type CreateRequestBody10Mode string
+
+// CreateRequestBody10Status Current status of the incident
+type CreateRequestBody10Status string
+
+// CreateRequestBody10Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+type CreateRequestBody10Visibility string
+
+// CreateRequestBody11 defines model for CreateRequestBody11.
+type CreateRequestBody11 struct {
 	// CustomFieldEntries Set the incident's custom fields to these values
 	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
 
@@ -1334,7 +1543,7 @@ type CreateRequestBody10 struct {
 	IncidentTypeId *string `json:"incident_type_id,omitempty"`
 
 	// Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
-	Mode *CreateRequestBody10Mode `json:"mode,omitempty"`
+	Mode *CreateRequestBody11Mode `json:"mode,omitempty"`
 
 	// Name Explanation of the incident
 	Name                         *string                         `json:"name,omitempty"`
@@ -1353,22 +1562,22 @@ type CreateRequestBody10 struct {
 	Summary *string `json:"summary,omitempty"`
 
 	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-	Visibility CreateRequestBody10Visibility `json:"visibility"`
+	Visibility CreateRequestBody11Visibility `json:"visibility"`
 }
 
-// CreateRequestBody10Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
-type CreateRequestBody10Mode string
+// CreateRequestBody11Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
+type CreateRequestBody11Mode string
 
-// CreateRequestBody10Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-type CreateRequestBody10Visibility string
-
-// CreateRequestBody11 defines model for CreateRequestBody11.
-type CreateRequestBody11 struct {
-	Schedule ScheduleCreatePayloadV2 `json:"schedule"`
-}
+// CreateRequestBody11Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+type CreateRequestBody11Visibility string
 
 // CreateRequestBody12 defines model for CreateRequestBody12.
 type CreateRequestBody12 struct {
+	Schedule ScheduleCreatePayloadV2 `json:"schedule"`
+}
+
+// CreateRequestBody13 defines model for CreateRequestBody13.
+type CreateRequestBody13 struct {
 	// Description Description of the severity
 	Description string `json:"description"`
 
@@ -1381,20 +1590,32 @@ type CreateRequestBody12 struct {
 
 // CreateRequestBody2 defines model for CreateRequestBody2.
 type CreateRequestBody2 struct {
+	// CustomFieldId ID of the custom field this option belongs to
+	CustomFieldId string `json:"custom_field_id"`
+
+	// SortKey Sort key used to order the custom field options correctly
+	SortKey *int64 `json:"sort_key,omitempty"`
+
+	// Value Human readable name for the custom field option
+	Value string `json:"value"`
+}
+
+// CreateRequestBody3 defines model for CreateRequestBody3.
+type CreateRequestBody3 struct {
 	// Description Description of the custom field
 	Description string `json:"description"`
 
 	// FieldType Type of custom field
-	FieldType CreateRequestBody2FieldType `json:"field_type"`
+	FieldType CreateRequestBody3FieldType `json:"field_type"`
 
 	// Name Human readable name for the custom field
 	Name string `json:"name"`
 
 	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-	Required *CreateRequestBody2Required `json:"required,omitempty"`
+	Required *CreateRequestBody3Required `json:"required,omitempty"`
 
 	// RequiredV2 When this custom field must be set during the incident lifecycle.
-	RequiredV2 *CreateRequestBody2RequiredV2 `json:"required_v2,omitempty"`
+	RequiredV2 *CreateRequestBody3RequiredV2 `json:"required_v2,omitempty"`
 
 	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
 	ShowBeforeClosure bool `json:"show_before_closure"`
@@ -1409,32 +1630,32 @@ type CreateRequestBody2 struct {
 	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
 }
 
-// CreateRequestBody2FieldType Type of custom field
-type CreateRequestBody2FieldType string
+// CreateRequestBody3FieldType Type of custom field
+type CreateRequestBody3FieldType string
 
-// CreateRequestBody2Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-type CreateRequestBody2Required string
+// CreateRequestBody3Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+type CreateRequestBody3Required string
 
-// CreateRequestBody2RequiredV2 When this custom field must be set during the incident lifecycle.
-type CreateRequestBody2RequiredV2 string
+// CreateRequestBody3RequiredV2 When this custom field must be set during the incident lifecycle.
+type CreateRequestBody3RequiredV2 string
 
-// CreateRequestBody3 defines model for CreateRequestBody3.
-type CreateRequestBody3 struct {
+// CreateRequestBody4 defines model for CreateRequestBody4.
+type CreateRequestBody4 struct {
 	// Description Description of the custom field
 	Description string `json:"description"`
 
 	// FieldType Type of custom field
-	FieldType CreateRequestBody3FieldType `json:"field_type"`
+	FieldType CreateRequestBody4FieldType `json:"field_type"`
 
 	// Name Human readable name for the custom field
 	Name string `json:"name"`
 }
 
-// CreateRequestBody3FieldType Type of custom field
-type CreateRequestBody3FieldType string
+// CreateRequestBody4FieldType Type of custom field
+type CreateRequestBody4FieldType string
 
-// CreateRequestBody4 defines model for CreateRequestBody4.
-type CreateRequestBody4 struct {
+// CreateRequestBody5 defines model for CreateRequestBody5.
+type CreateRequestBody5 struct {
 	// IncidentId ID of the incident to add an attachment to
 	IncidentId string `json:"incident_id"`
 	Resource   struct {
@@ -1442,21 +1663,21 @@ type CreateRequestBody4 struct {
 		ExternalId string `json:"external_id"`
 
 		// ResourceType E.g. PagerDuty: the external system that holds the resource
-		ResourceType CreateRequestBody4ResourceResourceType `json:"resource_type"`
+		ResourceType CreateRequestBody5ResourceResourceType `json:"resource_type"`
 	} `json:"resource"`
 }
 
-// CreateRequestBody4ResourceResourceType E.g. PagerDuty: the external system that holds the resource
-type CreateRequestBody4ResourceResourceType string
+// CreateRequestBody5ResourceResourceType E.g. PagerDuty: the external system that holds the resource
+type CreateRequestBody5ResourceResourceType string
 
-// CreateRequestBody5 defines model for CreateRequestBody5.
-type CreateRequestBody5 struct {
+// CreateRequestBody6 defines model for CreateRequestBody6.
+type CreateRequestBody6 struct {
 	IncidentId string `json:"incident_id"`
 	UserId     string `json:"user_id"`
 }
 
-// CreateRequestBody6 defines model for CreateRequestBody6.
-type CreateRequestBody6 struct {
+// CreateRequestBody7 defines model for CreateRequestBody7.
+type CreateRequestBody7 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -1473,8 +1694,8 @@ type CreateRequestBody6 struct {
 	Shortform string `json:"shortform"`
 }
 
-// CreateRequestBody7 defines model for CreateRequestBody7.
-type CreateRequestBody7 struct {
+// CreateRequestBody8 defines model for CreateRequestBody8.
+type CreateRequestBody8 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -1488,10 +1709,10 @@ type CreateRequestBody7 struct {
 	Shortform string `json:"shortform"`
 }
 
-// CreateRequestBody8 defines model for CreateRequestBody8.
-type CreateRequestBody8 struct {
+// CreateRequestBody9 defines model for CreateRequestBody9.
+type CreateRequestBody9 struct {
 	// Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
-	Category CreateRequestBody8Category `json:"category"`
+	Category CreateRequestBody9Category `json:"category"`
 
 	// Description Rich text description of the incident status
 	Description string `json:"description"`
@@ -1500,67 +1721,21 @@ type CreateRequestBody8 struct {
 	Name string `json:"name"`
 }
 
-// CreateRequestBody8Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
-type CreateRequestBody8Category string
-
-// CreateRequestBody9 defines model for CreateRequestBody9.
-type CreateRequestBody9 struct {
-	// CustomFieldEntries Set the incident's custom fields to these values
-	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
-
-	// IdempotencyKey Unique string used to de-duplicate incident create requests
-	IdempotencyKey string `json:"idempotency_key"`
-
-	// IncidentRoleAssignments Assign incident roles to these people
-	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV1 `json:"incident_role_assignments,omitempty"`
-
-	// IncidentTypeId Incident type to create this incident as
-	IncidentTypeId *string `json:"incident_type_id,omitempty"`
-
-	// Mode Whether the incident is real or test
-	Mode *CreateRequestBody9Mode `json:"mode,omitempty"`
-
-	// Name Explanation of the incident
-	Name *string `json:"name,omitempty"`
-
-	// SeverityId Severity to create incident as
-	SeverityId *string `json:"severity_id,omitempty"`
-
-	// SlackTeamId ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
-	SlackTeamId *string `json:"slack_team_id,omitempty"`
-
-	// SourceMessageChannelId Channel ID of the source message, if this incident was created from one
-	SourceMessageChannelId *string `json:"source_message_channel_id,omitempty"`
-
-	// SourceMessageTimestamp Timestamp of the source message, if this incident was created from one
-	SourceMessageTimestamp *string `json:"source_message_timestamp,omitempty"`
-
-	// Status Current status of the incident
-	Status *CreateRequestBody9Status `json:"status,omitempty"`
-
-	// Summary Detailed description of the incident
-	Summary *string `json:"summary,omitempty"`
-
-	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-	Visibility CreateRequestBody9Visibility `json:"visibility"`
-}
-
-// CreateRequestBody9Mode Whether the incident is real or test
-type CreateRequestBody9Mode string
-
-// CreateRequestBody9Status Current status of the incident
-type CreateRequestBody9Status string
-
-// CreateRequestBody9Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-type CreateRequestBody9Visibility string
+// CreateRequestBody9Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
+type CreateRequestBody9Category string
 
 // CreateResponseBody defines model for CreateResponseBody.
 type CreateResponseBody struct {
-	IncidentAttachment IncidentAttachmentV1 `json:"incident_attachment"`
+	AlertRoute AlertRouteV2 `json:"alert_route"`
 }
 
 // CreateResponseBody2 defines model for CreateResponseBody2.
 type CreateResponseBody2 struct {
+	IncidentAttachment IncidentAttachmentV1 `json:"incident_attachment"`
+}
+
+// CreateResponseBody3 defines model for CreateResponseBody3.
+type CreateResponseBody3 struct {
 	IncidentMembership IncidentMembership `json:"incident_membership"`
 }
 
@@ -2067,6 +2242,13 @@ type ExpressionBranchPayloadV2 struct {
 type ExpressionBranchV2 struct {
 	// ConditionGroups When one of these condition groups are satisfied, this branch will be evaluated
 	ConditionGroups []ConditionGroupV2   `json:"condition_groups"`
+	Result          EngineParamBindingV2 `json:"result"`
+}
+
+// ExpressionBranchV3 defines model for ExpressionBranchV3.
+type ExpressionBranchV3 struct {
+	// ConditionGroups When one of these condition groups are satisfied, this branch will be evaluated
+	ConditionGroups []ConditionGroupV3   `json:"condition_groups"`
 	Result          EngineParamBindingV3 `json:"result"`
 }
 
@@ -2084,6 +2266,13 @@ type ExpressionBranchesOptsV2 struct {
 	Returns  ReturnsMetaV2        `json:"returns"`
 }
 
+// ExpressionBranchesOptsV3 defines model for ExpressionBranchesOptsV3.
+type ExpressionBranchesOptsV3 struct {
+	// Branches The branches to apply for this operation
+	Branches []ExpressionBranchV3 `json:"branches"`
+	Returns  ReturnsMetaV2        `json:"returns"`
+}
+
 // ExpressionElseBranchPayloadV2 defines model for ExpressionElseBranchPayloadV2.
 type ExpressionElseBranchPayloadV2 struct {
 	Result EngineParamBindingPayloadV2 `json:"result"`
@@ -2091,6 +2280,11 @@ type ExpressionElseBranchPayloadV2 struct {
 
 // ExpressionElseBranchV2 defines model for ExpressionElseBranchV2.
 type ExpressionElseBranchV2 struct {
+	Result EngineParamBindingV2 `json:"result"`
+}
+
+// ExpressionElseBranchV3 defines model for ExpressionElseBranchV3.
+type ExpressionElseBranchV3 struct {
 	Result EngineParamBindingV3 `json:"result"`
 }
 
@@ -2104,6 +2298,12 @@ type ExpressionFilterOptsPayloadV2 struct {
 type ExpressionFilterOptsV2 struct {
 	// ConditionGroups The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
 	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
+}
+
+// ExpressionFilterOptsV3 defines model for ExpressionFilterOptsV3.
+type ExpressionFilterOptsV3 struct {
+	// ConditionGroups The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
+	ConditionGroups []ConditionGroupV3 `json:"condition_groups"`
 }
 
 // ExpressionNavigateOptsPayloadV2 defines model for ExpressionNavigateOptsPayloadV2.
@@ -2129,7 +2329,7 @@ type ExpressionOperationPayloadV2 struct {
 
 	// OperationType The type of the operation
 	OperationType ExpressionOperationPayloadV2OperationType `json:"operation_type"`
-	Parse         *ExpressionParseOptsV2                    `json:"parse,omitempty"`
+	Parse         *ExpressionParseOptsPayloadV2             `json:"parse,omitempty"`
 }
 
 // ExpressionOperationPayloadV2OperationType The type of the operation
@@ -2143,15 +2343,30 @@ type ExpressionOperationV2 struct {
 
 	// OperationType The type of the operation
 	OperationType ExpressionOperationV2OperationType `json:"operation_type"`
-	Parse         *ExpressionParseOptsV2             `json:"parse,omitempty"`
+	Parse         *ExpressionParseOptsPayloadV2      `json:"parse,omitempty"`
 	Returns       ReturnsMetaV2                      `json:"returns"`
 }
 
 // ExpressionOperationV2OperationType The type of the operation
 type ExpressionOperationV2OperationType string
 
-// ExpressionParseOptsV2 defines model for ExpressionParseOptsV2.
-type ExpressionParseOptsV2 struct {
+// ExpressionOperationV3 defines model for ExpressionOperationV3.
+type ExpressionOperationV3 struct {
+	Branches *ExpressionBranchesOptsV3 `json:"branches,omitempty"`
+	Filter   *ExpressionFilterOptsV3   `json:"filter,omitempty"`
+	Navigate *ExpressionNavigateOptsV2 `json:"navigate,omitempty"`
+
+	// OperationType The type of the operation
+	OperationType ExpressionOperationV3OperationType `json:"operation_type"`
+	Parse         *ExpressionParseOptsPayloadV2      `json:"parse,omitempty"`
+	Returns       ReturnsMetaV2                      `json:"returns"`
+}
+
+// ExpressionOperationV3OperationType The type of the operation
+type ExpressionOperationV3OperationType string
+
+// ExpressionParseOptsPayloadV2 defines model for ExpressionParseOptsPayloadV2.
+type ExpressionParseOptsPayloadV2 struct {
 	Returns ReturnsMetaV2 `json:"returns"`
 
 	// Source Source expression that is evaluated to a result
@@ -2180,6 +2395,22 @@ type ExpressionV2 struct {
 	// Label The human readable label of the expression
 	Label      string                  `json:"label"`
 	Operations []ExpressionOperationV2 `json:"operations"`
+
+	// Reference A short ID that can be used to reference the expression
+	Reference string        `json:"reference"`
+	Returns   ReturnsMetaV2 `json:"returns"`
+
+	// RootReference The root reference for this expression (i.e. where the expression starts)
+	RootReference string `json:"root_reference"`
+}
+
+// ExpressionV3 defines model for ExpressionV3.
+type ExpressionV3 struct {
+	ElseBranch *ExpressionElseBranchV3 `json:"else_branch,omitempty"`
+
+	// Label The human readable label of the expression
+	Label      string                  `json:"label"`
+	Operations []ExpressionOperationV3 `json:"operations"`
 
 	// Reference A short ID that can be used to reference the expression
 	Reference string        `json:"reference"`
@@ -2285,6 +2516,12 @@ type FollowUpV2 struct {
 
 // FollowUpV2Status Status of the follow-up
 type FollowUpV2Status string
+
+// GroupingKeyV2 defines model for GroupingKeyV2.
+type GroupingKeyV2 struct {
+	// Id Unique identifier of the alert attribute the user wishes to group on
+	Id string `json:"id"`
+}
 
 // IdentityResponseBody defines model for IdentityResponseBody.
 type IdentityResponseBody struct {
@@ -2965,8 +3202,9 @@ type ScheduleConfigV2 struct {
 // ScheduleCreatePayloadV2 defines model for ScheduleCreatePayloadV2.
 type ScheduleCreatePayloadV2 struct {
 	// Annotations Annotations that can track metadata about the schedule
-	Annotations *map[string]string             `json:"annotations,omitempty"`
-	Config      *ScheduleConfigCreatePayloadV2 `json:"config,omitempty"`
+	Annotations          *map[string]string              `json:"annotations,omitempty"`
+	Config               *ScheduleConfigCreatePayloadV2  `json:"config,omitempty"`
+	HolidaysPublicConfig *ScheduleHolidaysPublicConfigV2 `json:"holidays_public_config,omitempty"`
 
 	// Name Name of the schedule
 	Name *string `json:"name,omitempty"`
@@ -2999,6 +3237,12 @@ type ScheduleEntryV2 struct {
 	RotationId *string   `json:"rotation_id,omitempty"`
 	StartAt    time.Time `json:"start_at"`
 	User       *UserV1   `json:"user,omitempty"`
+}
+
+// ScheduleHolidaysPublicConfigV2 defines model for ScheduleHolidaysPublicConfigV2.
+type ScheduleHolidaysPublicConfigV2 struct {
+	// CountryCodes ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for
+	CountryCodes []string `json:"country_codes"`
 }
 
 // ScheduleLayerCreatePayloadV2 defines model for ScheduleLayerCreatePayloadV2.
@@ -3101,8 +3345,9 @@ type ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday string
 // ScheduleUpdatePayloadV2 defines model for ScheduleUpdatePayloadV2.
 type ScheduleUpdatePayloadV2 struct {
 	// Annotations Annotations that can track metadata about the schedule
-	Annotations *map[string]string             `json:"annotations,omitempty"`
-	Config      *ScheduleConfigUpdatePayloadV2 `json:"config,omitempty"`
+	Annotations          *map[string]string              `json:"annotations,omitempty"`
+	Config               *ScheduleConfigUpdatePayloadV2  `json:"config,omitempty"`
+	HolidaysPublicConfig *ScheduleHolidaysPublicConfigV2 `json:"holidays_public_config,omitempty"`
 
 	// Name Name of the schedule
 	Name *string `json:"name,omitempty"`
@@ -3119,7 +3364,8 @@ type ScheduleV2 struct {
 	CreatedAt   time.Time         `json:"created_at"`
 
 	// CurrentShifts Shifts that are on-going for this schedule, if a native schedule
-	CurrentShifts *[]ScheduleEntryV2 `json:"current_shifts,omitempty"`
+	CurrentShifts        *[]ScheduleEntryV2              `json:"current_shifts,omitempty"`
+	HolidaysPublicConfig *ScheduleHolidaysPublicConfigV2 `json:"holidays_public_config,omitempty"`
 
 	// Id Unique internal ID of the schedule
 	Id string `json:"id"`
@@ -3316,6 +3562,46 @@ type UpdateEntryRequestBody struct {
 
 // UpdateRequestBody defines model for UpdateRequestBody.
 type UpdateRequestBody struct {
+	// AlertSourceIds The alert sources that will match this alert route
+	AlertSourceIds []string `json:"alert_source_ids"`
+
+	// AutoDeclineEnabled Should triage incidents be declined when alerts are resolved?
+	AutoDeclineEnabled bool `json:"auto_decline_enabled"`
+
+	// ConditionGroups What condition groups must be true for this alert route to fire?
+	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
+
+	// DeferTimeSeconds How long should the escalation defer time be?
+	DeferTimeSeconds int64 `json:"defer_time_seconds"`
+
+	// Enabled Whether this alert route is enabled or not
+	Enabled bool `json:"enabled"`
+
+	// EscalationBindings Which escalation paths should this alert route escalate to?
+	EscalationBindings []AlertRouteEscalationBindingPayloadV2 `json:"escalation_bindings"`
+
+	// Expressions The expressions used in this template
+	Expressions *[]ExpressionPayloadV2 `json:"expressions,omitempty"`
+
+	// GroupingKeys Which attributes should this alert route use to group alerts?
+	GroupingKeys []GroupingKeyV2 `json:"grouping_keys"`
+
+	// GroupingWindowSeconds How large should the grouping window be?
+	GroupingWindowSeconds int64 `json:"grouping_window_seconds"`
+
+	// IncidentConditionGroups What condition groups must be true for this alert route to create an incident?
+	IncidentConditionGroups []ConditionGroupPayloadV2 `json:"incident_condition_groups"`
+
+	// IncidentEnabled Whether this alert route will create incidents or not
+	IncidentEnabled bool `json:"incident_enabled"`
+
+	// Name The name of this alert route config, for the user's reference
+	Name     string                               `json:"name"`
+	Template *AlertRouteIncidentTemplatePayloadV2 `json:"template,omitempty"`
+}
+
+// UpdateRequestBody2 defines model for UpdateRequestBody2.
+type UpdateRequestBody2 struct {
 	// SortKey Sort key used to order the custom field options correctly
 	SortKey int64 `json:"sort_key"`
 
@@ -3323,8 +3609,8 @@ type UpdateRequestBody struct {
 	Value string `json:"value"`
 }
 
-// UpdateRequestBody2 defines model for UpdateRequestBody2.
-type UpdateRequestBody2 struct {
+// UpdateRequestBody3 defines model for UpdateRequestBody3.
+type UpdateRequestBody3 struct {
 	// Description Description of the custom field
 	Description string `json:"description"`
 
@@ -3332,10 +3618,10 @@ type UpdateRequestBody2 struct {
 	Name string `json:"name"`
 
 	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-	Required *UpdateRequestBody2Required `json:"required,omitempty"`
+	Required *UpdateRequestBody3Required `json:"required,omitempty"`
 
 	// RequiredV2 When this custom field must be set during the incident lifecycle.
-	RequiredV2 *UpdateRequestBody2RequiredV2 `json:"required_v2,omitempty"`
+	RequiredV2 *UpdateRequestBody3RequiredV2 `json:"required_v2,omitempty"`
 
 	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
 	ShowBeforeClosure bool `json:"show_before_closure"`
@@ -3350,14 +3636,14 @@ type UpdateRequestBody2 struct {
 	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
 }
 
-// UpdateRequestBody2Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-type UpdateRequestBody2Required string
+// UpdateRequestBody3Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+type UpdateRequestBody3Required string
 
-// UpdateRequestBody2RequiredV2 When this custom field must be set during the incident lifecycle.
-type UpdateRequestBody2RequiredV2 string
+// UpdateRequestBody3RequiredV2 When this custom field must be set during the incident lifecycle.
+type UpdateRequestBody3RequiredV2 string
 
-// UpdateRequestBody3 defines model for UpdateRequestBody3.
-type UpdateRequestBody3 struct {
+// UpdateRequestBody4 defines model for UpdateRequestBody4.
+type UpdateRequestBody4 struct {
 	// Description Description of the custom field
 	Description string `json:"description"`
 
@@ -3365,8 +3651,8 @@ type UpdateRequestBody3 struct {
 	Name string `json:"name"`
 }
 
-// UpdateRequestBody4 defines model for UpdateRequestBody4.
-type UpdateRequestBody4 struct {
+// UpdateRequestBody5 defines model for UpdateRequestBody5.
+type UpdateRequestBody5 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -3383,8 +3669,8 @@ type UpdateRequestBody4 struct {
 	Shortform string `json:"shortform"`
 }
 
-// UpdateRequestBody5 defines model for UpdateRequestBody5.
-type UpdateRequestBody5 struct {
+// UpdateRequestBody6 defines model for UpdateRequestBody6.
+type UpdateRequestBody6 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -3398,8 +3684,8 @@ type UpdateRequestBody5 struct {
 	Shortform string `json:"shortform"`
 }
 
-// UpdateRequestBody6 defines model for UpdateRequestBody6.
-type UpdateRequestBody6 struct {
+// UpdateRequestBody7 defines model for UpdateRequestBody7.
+type UpdateRequestBody7 struct {
 	// Description Rich text description of the incident status
 	Description string `json:"description"`
 
@@ -3407,8 +3693,8 @@ type UpdateRequestBody6 struct {
 	Name string `json:"name"`
 }
 
-// UpdateRequestBody7 defines model for UpdateRequestBody7.
-type UpdateRequestBody7 struct {
+// UpdateRequestBody8 defines model for UpdateRequestBody8.
+type UpdateRequestBody8 struct {
 	Schedule ScheduleUpdatePayloadV2 `json:"schedule"`
 }
 
@@ -3588,14 +3874,14 @@ type WeekdayIntervalV2 struct {
 // Workflow defines model for Workflow.
 type Workflow struct {
 	// ConditionGroups Conditions that apply to the workflow trigger
-	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
+	ConditionGroups []ConditionGroupV3 `json:"condition_groups"`
 
 	// ContinueOnStepError Whether to continue executing the workflow if a step fails
 	ContinueOnStepError bool           `json:"continue_on_step_error"`
 	Delay               *WorkflowDelay `json:"delay,omitempty"`
 
 	// Expressions Expressions that make variables available in the scope
-	Expressions []ExpressionV2 `json:"expressions"`
+	Expressions []ExpressionV3 `json:"expressions"`
 
 	// Folder Folder to display the workflow in
 	Folder *string `json:"folder,omitempty"`
@@ -3653,14 +3939,14 @@ type WorkflowDelay struct {
 // WorkflowSlim defines model for WorkflowSlim.
 type WorkflowSlim struct {
 	// ConditionGroups Conditions that apply to the workflow trigger
-	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
+	ConditionGroups []ConditionGroupV3 `json:"condition_groups"`
 
 	// ContinueOnStepError Whether to continue executing the workflow if a step fails
 	ContinueOnStepError bool           `json:"continue_on_step_error"`
 	Delay               *WorkflowDelay `json:"delay,omitempty"`
 
 	// Expressions Expressions that make variables available in the scope
-	Expressions []ExpressionV2 `json:"expressions"`
+	Expressions []ExpressionV3 `json:"expressions"`
 
 	// Folder Folder to display the workflow in
 	Folder *string `json:"folder,omitempty"`
@@ -3887,49 +4173,55 @@ type UsersV2ListParams struct {
 }
 
 // CustomFieldOptionsV1CreateJSONRequestBody defines body for CustomFieldOptionsV1Create for application/json ContentType.
-type CustomFieldOptionsV1CreateJSONRequestBody = CreateRequestBody
+type CustomFieldOptionsV1CreateJSONRequestBody = CreateRequestBody2
 
 // CustomFieldOptionsV1UpdateJSONRequestBody defines body for CustomFieldOptionsV1Update for application/json ContentType.
-type CustomFieldOptionsV1UpdateJSONRequestBody = UpdateRequestBody
+type CustomFieldOptionsV1UpdateJSONRequestBody = UpdateRequestBody2
 
 // CustomFieldsV1CreateJSONRequestBody defines body for CustomFieldsV1Create for application/json ContentType.
-type CustomFieldsV1CreateJSONRequestBody = CreateRequestBody2
+type CustomFieldsV1CreateJSONRequestBody = CreateRequestBody3
 
 // CustomFieldsV1UpdateJSONRequestBody defines body for CustomFieldsV1Update for application/json ContentType.
-type CustomFieldsV1UpdateJSONRequestBody = UpdateRequestBody2
+type CustomFieldsV1UpdateJSONRequestBody = UpdateRequestBody3
 
 // IncidentAttachmentsV1CreateJSONRequestBody defines body for IncidentAttachmentsV1Create for application/json ContentType.
-type IncidentAttachmentsV1CreateJSONRequestBody = CreateRequestBody4
+type IncidentAttachmentsV1CreateJSONRequestBody = CreateRequestBody5
 
 // IncidentMembershipsV1CreateJSONRequestBody defines body for IncidentMembershipsV1Create for application/json ContentType.
-type IncidentMembershipsV1CreateJSONRequestBody = CreateRequestBody5
+type IncidentMembershipsV1CreateJSONRequestBody = CreateRequestBody6
 
 // IncidentMembershipsV1RevokeJSONRequestBody defines body for IncidentMembershipsV1Revoke for application/json ContentType.
-type IncidentMembershipsV1RevokeJSONRequestBody = CreateRequestBody5
+type IncidentMembershipsV1RevokeJSONRequestBody = CreateRequestBody6
 
 // IncidentRolesV1CreateJSONRequestBody defines body for IncidentRolesV1Create for application/json ContentType.
-type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody6
+type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody7
 
 // IncidentRolesV1UpdateJSONRequestBody defines body for IncidentRolesV1Update for application/json ContentType.
-type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody4
+type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody5
 
 // IncidentStatusesV1CreateJSONRequestBody defines body for IncidentStatusesV1Create for application/json ContentType.
-type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody8
+type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody9
 
 // IncidentStatusesV1UpdateJSONRequestBody defines body for IncidentStatusesV1Update for application/json ContentType.
-type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody6
+type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody7
 
 // IncidentsV1CreateJSONRequestBody defines body for IncidentsV1Create for application/json ContentType.
-type IncidentsV1CreateJSONRequestBody = CreateRequestBody9
+type IncidentsV1CreateJSONRequestBody = CreateRequestBody10
 
 // SeveritiesV1CreateJSONRequestBody defines body for SeveritiesV1Create for application/json ContentType.
-type SeveritiesV1CreateJSONRequestBody = CreateRequestBody12
+type SeveritiesV1CreateJSONRequestBody = CreateRequestBody13
 
 // SeveritiesV1UpdateJSONRequestBody defines body for SeveritiesV1Update for application/json ContentType.
-type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody12
+type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody13
 
 // AlertEventsV2CreateHTTPJSONRequestBody defines body for AlertEventsV2CreateHTTP for application/json ContentType.
 type AlertEventsV2CreateHTTPJSONRequestBody = CreateHTTPRequestBody
+
+// AlertRoutesV2CreateJSONRequestBody defines body for AlertRoutesV2Create for application/json ContentType.
+type AlertRoutesV2CreateJSONRequestBody = CreateRequestBody
+
+// AlertRoutesV2UpdateJSONRequestBody defines body for AlertRoutesV2Update for application/json ContentType.
+type AlertRoutesV2UpdateJSONRequestBody = UpdateRequestBody
 
 // CatalogV2CreateEntryJSONRequestBody defines body for CatalogV2CreateEntry for application/json ContentType.
 type CatalogV2CreateEntryJSONRequestBody = CreateEntryRequestBody
@@ -3947,10 +4239,10 @@ type CatalogV2UpdateTypeJSONRequestBody = UpdateTypeRequestBody
 type CatalogV2UpdateTypeSchemaJSONRequestBody = UpdateTypeSchemaRequestBody
 
 // CustomFieldsV2CreateJSONRequestBody defines body for CustomFieldsV2Create for application/json ContentType.
-type CustomFieldsV2CreateJSONRequestBody = CreateRequestBody3
+type CustomFieldsV2CreateJSONRequestBody = CreateRequestBody4
 
 // CustomFieldsV2UpdateJSONRequestBody defines body for CustomFieldsV2Update for application/json ContentType.
-type CustomFieldsV2UpdateJSONRequestBody = UpdateRequestBody3
+type CustomFieldsV2UpdateJSONRequestBody = UpdateRequestBody4
 
 // EscalationsV2CreatePathJSONRequestBody defines body for EscalationsV2CreatePath for application/json ContentType.
 type EscalationsV2CreatePathJSONRequestBody = CreatePathRequestBody
@@ -3959,13 +4251,13 @@ type EscalationsV2CreatePathJSONRequestBody = CreatePathRequestBody
 type EscalationsV2UpdatePathJSONRequestBody = CreatePathRequestBody
 
 // IncidentRolesV2CreateJSONRequestBody defines body for IncidentRolesV2Create for application/json ContentType.
-type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody7
+type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody8
 
 // IncidentRolesV2UpdateJSONRequestBody defines body for IncidentRolesV2Update for application/json ContentType.
-type IncidentRolesV2UpdateJSONRequestBody = UpdateRequestBody5
+type IncidentRolesV2UpdateJSONRequestBody = UpdateRequestBody6
 
 // IncidentsV2CreateJSONRequestBody defines body for IncidentsV2Create for application/json ContentType.
-type IncidentsV2CreateJSONRequestBody = CreateRequestBody10
+type IncidentsV2CreateJSONRequestBody = CreateRequestBody11
 
 // IncidentsV2EditJSONRequestBody defines body for IncidentsV2Edit for application/json ContentType.
 type IncidentsV2EditJSONRequestBody = EditRequestBody
@@ -3974,10 +4266,10 @@ type IncidentsV2EditJSONRequestBody = EditRequestBody
 type ManagedResourcesV2CreateManagedResourceJSONRequestBody = CreateManagedResourceRequestBody
 
 // SchedulesV2CreateJSONRequestBody defines body for SchedulesV2Create for application/json ContentType.
-type SchedulesV2CreateJSONRequestBody = CreateRequestBody11
+type SchedulesV2CreateJSONRequestBody = CreateRequestBody12
 
 // SchedulesV2UpdateJSONRequestBody defines body for SchedulesV2Update for application/json ContentType.
-type SchedulesV2UpdateJSONRequestBody = UpdateRequestBody7
+type SchedulesV2UpdateJSONRequestBody = UpdateRequestBody8
 
 // WorkflowsV2CreateWorkflowJSONRequestBody defines body for WorkflowsV2CreateWorkflow for application/json ContentType.
 type WorkflowsV2CreateWorkflowJSONRequestBody = CreateWorkflowRequestBody
@@ -4216,6 +4508,22 @@ type ClientInterface interface {
 	AlertEventsV2CreateHTTPWithBody(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	AlertEventsV2CreateHTTP(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, body AlertEventsV2CreateHTTPJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AlertRoutesV2Create request with any body
+	AlertRoutesV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AlertRoutesV2Create(ctx context.Context, body AlertRoutesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AlertRoutesV2Destroy request
+	AlertRoutesV2Destroy(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AlertRoutesV2Show request
+	AlertRoutesV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AlertRoutesV2Update request with any body
+	AlertRoutesV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AlertRoutesV2Update(ctx context.Context, id string, body AlertRoutesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CatalogV2ListEntries request
 	CatalogV2ListEntries(ctx context.Context, params *CatalogV2ListEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5087,6 +5395,78 @@ func (c *Client) AlertEventsV2CreateHTTPWithBody(ctx context.Context, alertSourc
 
 func (c *Client) AlertEventsV2CreateHTTP(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, body AlertEventsV2CreateHTTPJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewAlertEventsV2CreateHTTPRequest(c.Server, alertSourceConfigId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AlertRoutesV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertRoutesV2CreateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AlertRoutesV2Create(ctx context.Context, body AlertRoutesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertRoutesV2CreateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AlertRoutesV2Destroy(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertRoutesV2DestroyRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AlertRoutesV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertRoutesV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AlertRoutesV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertRoutesV2UpdateRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AlertRoutesV2Update(ctx context.Context, id string, body AlertRoutesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertRoutesV2UpdateRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7664,6 +8044,161 @@ func NewAlertEventsV2CreateHTTPRequestWithBody(server string, alertSourceConfigI
 	return req, nil
 }
 
+// NewAlertRoutesV2CreateRequest calls the generic AlertRoutesV2Create builder with application/json body
+func NewAlertRoutesV2CreateRequest(server string, body AlertRoutesV2CreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAlertRoutesV2CreateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAlertRoutesV2CreateRequestWithBody generates requests for AlertRoutesV2Create with any type of body
+func NewAlertRoutesV2CreateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/alert_routes")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewAlertRoutesV2DestroyRequest generates requests for AlertRoutesV2Destroy
+func NewAlertRoutesV2DestroyRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/alert_routes/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAlertRoutesV2ShowRequest generates requests for AlertRoutesV2Show
+func NewAlertRoutesV2ShowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/alert_routes/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAlertRoutesV2UpdateRequest calls the generic AlertRoutesV2Update builder with application/json body
+func NewAlertRoutesV2UpdateRequest(server string, id string, body AlertRoutesV2UpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAlertRoutesV2UpdateRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewAlertRoutesV2UpdateRequestWithBody generates requests for AlertRoutesV2Update with any type of body
+func NewAlertRoutesV2UpdateRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/alert_routes/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewCatalogV2ListEntriesRequest generates requests for CatalogV2ListEntries
 func NewCatalogV2ListEntriesRequest(server string, params *CatalogV2ListEntriesParams) (*http.Request, error) {
 	var err error
@@ -10080,6 +10615,22 @@ type ClientWithResponsesInterface interface {
 
 	AlertEventsV2CreateHTTPWithResponse(ctx context.Context, alertSourceConfigId string, params *AlertEventsV2CreateHTTPParams, body AlertEventsV2CreateHTTPJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertEventsV2CreateHTTPResponse, error)
 
+	// AlertRoutesV2Create request with any body
+	AlertRoutesV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AlertRoutesV2CreateResponse, error)
+
+	AlertRoutesV2CreateWithResponse(ctx context.Context, body AlertRoutesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertRoutesV2CreateResponse, error)
+
+	// AlertRoutesV2Destroy request
+	AlertRoutesV2DestroyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*AlertRoutesV2DestroyResponse, error)
+
+	// AlertRoutesV2Show request
+	AlertRoutesV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*AlertRoutesV2ShowResponse, error)
+
+	// AlertRoutesV2Update request with any body
+	AlertRoutesV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AlertRoutesV2UpdateResponse, error)
+
+	AlertRoutesV2UpdateWithResponse(ctx context.Context, id string, body AlertRoutesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertRoutesV2UpdateResponse, error)
+
 	// CatalogV2ListEntries request
 	CatalogV2ListEntriesWithResponse(ctx context.Context, params *CatalogV2ListEntriesParams, reqEditors ...RequestEditorFn) (*CatalogV2ListEntriesResponse, error)
 
@@ -10573,7 +11124,7 @@ func (r IncidentAttachmentsV1ListResponse) StatusCode() int {
 type IncidentAttachmentsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *CreateResponseBody
+	JSON201      *CreateResponseBody2
 }
 
 // Status returns HTTPResponse.Status
@@ -10616,7 +11167,7 @@ func (r IncidentAttachmentsV1DeleteResponse) StatusCode() int {
 type IncidentMembershipsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *CreateResponseBody2
+	JSON201      *CreateResponseBody3
 }
 
 // Status returns HTTPResponse.Status
@@ -11197,6 +11748,93 @@ func (r AlertEventsV2CreateHTTPResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r AlertEventsV2CreateHTTPResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AlertRoutesV2CreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *CreateResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r AlertRoutesV2CreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AlertRoutesV2CreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AlertRoutesV2DestroyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r AlertRoutesV2DestroyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AlertRoutesV2DestroyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AlertRoutesV2ShowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CreateResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r AlertRoutesV2ShowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AlertRoutesV2ShowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AlertRoutesV2UpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CreateResponseBody
+}
+
+// Status returns HTTPResponse.Status
+func (r AlertRoutesV2UpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AlertRoutesV2UpdateResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12781,6 +13419,58 @@ func (c *ClientWithResponses) AlertEventsV2CreateHTTPWithResponse(ctx context.Co
 	return ParseAlertEventsV2CreateHTTPResponse(rsp)
 }
 
+// AlertRoutesV2CreateWithBodyWithResponse request with arbitrary body returning *AlertRoutesV2CreateResponse
+func (c *ClientWithResponses) AlertRoutesV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AlertRoutesV2CreateResponse, error) {
+	rsp, err := c.AlertRoutesV2CreateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertRoutesV2CreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) AlertRoutesV2CreateWithResponse(ctx context.Context, body AlertRoutesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertRoutesV2CreateResponse, error) {
+	rsp, err := c.AlertRoutesV2Create(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertRoutesV2CreateResponse(rsp)
+}
+
+// AlertRoutesV2DestroyWithResponse request returning *AlertRoutesV2DestroyResponse
+func (c *ClientWithResponses) AlertRoutesV2DestroyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*AlertRoutesV2DestroyResponse, error) {
+	rsp, err := c.AlertRoutesV2Destroy(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertRoutesV2DestroyResponse(rsp)
+}
+
+// AlertRoutesV2ShowWithResponse request returning *AlertRoutesV2ShowResponse
+func (c *ClientWithResponses) AlertRoutesV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*AlertRoutesV2ShowResponse, error) {
+	rsp, err := c.AlertRoutesV2Show(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertRoutesV2ShowResponse(rsp)
+}
+
+// AlertRoutesV2UpdateWithBodyWithResponse request with arbitrary body returning *AlertRoutesV2UpdateResponse
+func (c *ClientWithResponses) AlertRoutesV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AlertRoutesV2UpdateResponse, error) {
+	rsp, err := c.AlertRoutesV2UpdateWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertRoutesV2UpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) AlertRoutesV2UpdateWithResponse(ctx context.Context, id string, body AlertRoutesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertRoutesV2UpdateResponse, error) {
+	rsp, err := c.AlertRoutesV2Update(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertRoutesV2UpdateResponse(rsp)
+}
+
 // CatalogV2ListEntriesWithResponse request returning *CatalogV2ListEntriesResponse
 func (c *ClientWithResponses) CatalogV2ListEntriesWithResponse(ctx context.Context, params *CatalogV2ListEntriesParams, reqEditors ...RequestEditorFn) (*CatalogV2ListEntriesResponse, error) {
 	rsp, err := c.CatalogV2ListEntries(ctx, params, reqEditors...)
@@ -13725,7 +14415,7 @@ func ParseIncidentAttachmentsV1CreateResponse(rsp *http.Response) (*IncidentAtta
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest CreateResponseBody
+		var dest CreateResponseBody2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -13767,7 +14457,7 @@ func ParseIncidentMembershipsV1CreateResponse(rsp *http.Response) (*IncidentMemb
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest CreateResponseBody2
+		var dest CreateResponseBody3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -14408,6 +15098,100 @@ func ParseAlertEventsV2CreateHTTPResponse(rsp *http.Response) (*AlertEventsV2Cre
 			return nil, err
 		}
 		response.JSON202 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAlertRoutesV2CreateResponse parses an HTTP response from a AlertRoutesV2CreateWithResponse call
+func ParseAlertRoutesV2CreateResponse(rsp *http.Response) (*AlertRoutesV2CreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AlertRoutesV2CreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest CreateResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAlertRoutesV2DestroyResponse parses an HTTP response from a AlertRoutesV2DestroyWithResponse call
+func ParseAlertRoutesV2DestroyResponse(rsp *http.Response) (*AlertRoutesV2DestroyResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AlertRoutesV2DestroyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseAlertRoutesV2ShowResponse parses an HTTP response from a AlertRoutesV2ShowWithResponse call
+func ParseAlertRoutesV2ShowResponse(rsp *http.Response) (*AlertRoutesV2ShowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AlertRoutesV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CreateResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAlertRoutesV2UpdateResponse parses an HTTP response from a AlertRoutesV2UpdateWithResponse call
+func ParseAlertRoutesV2UpdateResponse(rsp *http.Response) (*AlertRoutesV2UpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AlertRoutesV2UpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CreateResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	}
 

--- a/internal/provider/incident_custom_field_resource.go
+++ b/internal/provider/incident_custom_field_resource.go
@@ -98,7 +98,7 @@ func (r *IncidentCustomFieldResource) Create(ctx context.Context, req resource.C
 	result, err := r.client.CustomFieldsV2CreateWithResponse(ctx, client.CustomFieldsV2CreateJSONRequestBody{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
-		FieldType:   client.CreateRequestBody3FieldType(data.FieldType.ValueString()),
+		FieldType:   client.CreateRequestBody4FieldType(data.FieldType.ValueString()),
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -77,7 +77,10 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 						"incident_schedule.example", "timezone", "Europe/London",
 					),
 					resource.TestCheckResourceAttr(
-						"incident_schedule.example", "holidays_public_config.country_codes", "[\"UK\",\"FR\"]",
+						"incident_schedule.example", "holidays_public_config.country_codes.0", "GB",
+					),
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "holidays_public_config.country_codes.1", "FR",
 					),
 				),
 			},

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -77,7 +77,7 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 						"incident_schedule.example", "timezone", "Europe/London",
 					),
 					resource.TestCheckResourceAttr(
-						"incident_schedule.example", "holidays_public_config", "{\"country_codes\":[\"UK\",\"FR\"]}",
+						"incident_schedule.example", "holidays_public_config.country_codes", "[\"UK\",\"FR\"]",
 					),
 				),
 			},

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/incident-io/terraform-provider-incident/internal/client"
 	"github.com/samber/lo"
+
+	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
 
 func TestAccIncidentScheduleResource(t *testing.T) {
@@ -70,9 +71,13 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"incident_schedule.example", "name", "example"),
+						"incident_schedule.example", "name", "example",
+					),
 					resource.TestCheckResourceAttr(
 						"incident_schedule.example", "timezone", "Europe/London",
+					),
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "holidays_public_config", "{\"country_codes\":[\"UK\",\"FR\"]}",
 					),
 				),
 			},
@@ -119,6 +124,9 @@ func incidentScheduleDefault() client.ScheduleV2 {
 				},
 			},
 		},
+		HolidaysPublicConfig: &client.ScheduleHolidaysPublicConfigV2{
+			CountryCodes: []string{"GB", "FR"},
+		},
 	}
 }
 
@@ -133,6 +141,13 @@ func generateScheduleTerraform(name string, schedule *client.ScheduleV2) string 
 	result += "  name     = " + quote(name) + "\n"
 	result += "  timezone = " + quote(schedule.Timezone) + "\n"
 	result += "  " + generateRotationsArray(schedule.Config.Rotations)
+
+	if schedule.HolidaysPublicConfig != nil {
+		result += "  holidays_public_config = {\n"
+		result += "    country_codes = " + generateCountryCodesArray(schedule.HolidaysPublicConfig.CountryCodes) + "\n"
+		result += "  }\n"
+	}
+
 	result += "}\n"
 	return result
 }
@@ -218,6 +233,22 @@ func generateUsersArray(users *[]client.UserV1) string {
 		result += "  {\n"
 		result += "    id   = " + quote(user.Id) + "\n"
 		result += "  },\n"
+	}
+	result += "]\n"
+	return result
+}
+
+func generateCountryCodesArray(codes []string) string {
+	var result string
+	if codes == nil {
+		return "[]"
+	}
+	result += "["
+	for idx, code := range codes {
+		if idx > 0 {
+			result += ", "
+		}
+		result += quote(code)
 	}
 	result += "]\n"
 	return result

--- a/internal/provider/incident_status_resource.go
+++ b/internal/provider/incident_status_resource.go
@@ -98,7 +98,7 @@ func (r *IncidentStatusResource) Create(ctx context.Context, req resource.Create
 	result, err := r.client.IncidentStatusesV1CreateWithResponse(ctx, client.IncidentStatusesV1CreateJSONRequestBody{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
-		Category:    client.CreateRequestBody8Category(data.Category.ValueString()),
+		Category:    client.CreateRequestBody9Category(data.Category.ValueString()),
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -12,9 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
-	"github.com/samber/lo"
 )
 
 var (
@@ -378,7 +379,7 @@ func (r *IncidentWorkflowResource) buildRunsOnIncidentModes(modes []client.Workf
 	return out
 }
 
-func (r *IncidentWorkflowResource) buildConditionGroups(groups []client.ConditionGroupV2) IncidentEngineConditionGroups {
+func (r *IncidentWorkflowResource) buildConditionGroups(groups []client.ConditionGroupV3) IncidentEngineConditionGroups {
 	var out IncidentEngineConditionGroups
 
 	for _, g := range groups {
@@ -433,7 +434,7 @@ func (r *IncidentWorkflowResource) buildParamBinding(pb client.EngineParamBindin
 	return IncidentEngineParamBinding{}.FromClientV3(pb)
 }
 
-func (r *IncidentWorkflowResource) buildExpressions(expressions []client.ExpressionV2) IncidentEngineExpressions {
+func (r *IncidentWorkflowResource) buildExpressions(expressions []client.ExpressionV3) IncidentEngineExpressions {
 	out := IncidentEngineExpressions{}
 
 	for _, e := range expressions {
@@ -454,7 +455,7 @@ func (r *IncidentWorkflowResource) buildExpressions(expressions []client.Express
 	return out
 }
 
-func (r *IncidentWorkflowResource) buildOperations(operations []client.ExpressionOperationV2) []IncidentEngineExpressionOperation {
+func (r *IncidentWorkflowResource) buildOperations(operations []client.ExpressionOperationV3) []IncidentEngineExpressionOperation {
 	out := []IncidentEngineExpressionOperation{}
 
 	for _, o := range operations {
@@ -489,7 +490,7 @@ func (r *IncidentWorkflowResource) buildOperations(operations []client.Expressio
 	return out
 }
 
-func (r *IncidentWorkflowResource) buildBranches(branches []client.ExpressionBranchV2) []IncidentEngineBranch {
+func (r *IncidentWorkflowResource) buildBranches(branches []client.ExpressionBranchV3) []IncidentEngineBranch {
 	out := []IncidentEngineBranch{}
 
 	for _, b := range branches {
@@ -631,7 +632,7 @@ func toPayloadOperations(operations []IncidentEngineExpressionOperation) []clien
 			}
 		}
 		if o.Parse != nil {
-			operation.Parse = &client.ExpressionParseOptsV2{
+			operation.Parse = &client.ExpressionParseOptsPayloadV2{
 				Returns: toPayloadReturns(o.Parse.Returns),
 				Source:  o.Parse.Source.ValueString(),
 			}


### PR DESCRIPTION
We recently shipped support for attaching public holidays for countries to your schedule. This adds terraform support so that people who already manage their schedules through tf can use it.

<img width="2002" alt="image" src="https://github.com/user-attachments/assets/cdb1e5d2-ec36-4175-9396-49d10e598097">
