### PR TITLE
ONC-3822 Unwrap pointer for round robin config

### DIFF
--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -406,9 +407,13 @@ func (r *IncidentEscalationPathResource) toPathModel(nodes []client.EscalationPa
 					}),
 			}
 			if value := node.Level.RoundRobinConfig; value != nil {
+				var rotateAfterSeconds basetypes.Int64Value
+				if value.RotateAfterSeconds != nil {
+					rotateAfterSeconds = types.Int64Value(*value.RotateAfterSeconds)
+				}
 				elem.Level.RoundRobinConfig = &IncidentEscalationRoundRobinConfig{
 					Enabled:            types.BoolValue(value.Enabled),
-					RotateAfterSeconds: types.Int64Value(*value.RotateAfterSeconds),
+					RotateAfterSeconds: rotateAfterSeconds,
 				}
 			}
 			if value := node.Level.TimeToAckSeconds; value != nil {


### PR DESCRIPTION
This resolves #99 and ONC-3822 where we're dereferencing a potentially nil pointer.

I've also realised a number of our API docs for fields like `RoundRobinConfig` aren't propogating for some reason through the open-api spec, I've opened ONC-3846 to investigate and fix that.