### PR TITLE
Use our new openAPI specs

### DIFF
--- a/internal/apischema/openapi.json
+++ b/internal/apischema/openapi.json
@@ -1233,10 +1233,7 @@
         "responses": {
           "200": {
             "description": "OK response.",
-            "schema": {
-              "type": "string",
-              "format": "binary"
-            }
+            "schema": {}
           }
         },
         "schemes": [
@@ -1255,10 +1252,7 @@
         "responses": {
           "200": {
             "description": "OK response.",
-            "schema": {
-              "type": "string",
-              "format": "binary"
-            }
+            "schema": {}
           }
         },
         "schemes": [
@@ -1554,7 +1548,7 @@
           "202": {
             "description": "Accepted response.",
             "schema": {
-              "$ref": "#/definitions/AlertEventsV2CreateHTTPResponseBody",
+              "$ref": "#/definitions/AlertResult",
               "required": [
                 "status",
                 "message",
@@ -1666,6 +1660,7 @@
                 "enabled",
                 "incident_enabled",
                 "incident_condition_groups",
+                "alert_sources",
                 "alert_source_ids",
                 "auto_cancel_escalations"
               ]
@@ -1768,7 +1763,7 @@
           "Catalog V2"
         ],
         "summary": "CreateEntry Catalog V2",
-        "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.",
+        "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.\n\nIf you call this API with a payload where the external_id and catalog_type_id match an existing entry, the existing entry will be updated.",
         "operationId": "Catalog V2#CreateEntry",
         "parameters": [
           {
@@ -2935,7 +2930,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/IncidentsV2CreateRequestBody",
+              "$ref": "#/definitions/IncidentCreatePayloadV2",
               "required": [
                 "idempotency_key",
                 "visibility"
@@ -3083,7 +3078,7 @@
           "Schedules V2"
         ],
         "summary": "ListScheduleEntries Schedules V2",
-        "description": "Get a list of schedule entries.",
+        "description": "Get a list of schedule entries. The endpoint will return all entries that overlap with the given window, if one is provided.",
         "operationId": "Schedules V2#ListScheduleEntries",
         "parameters": [
           {
@@ -3435,7 +3430,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowsV2CreateWorkflowRequestBody",
+              "$ref": "#/definitions/CreateWorkflowPayload",
               "required": [
                 "name",
                 "trigger",
@@ -3521,7 +3516,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WorkflowsV2UpdateWorkflowRequestBody",
+              "$ref": "#/definitions/UpdateWorkflowPayload",
               "required": [
                 "name",
                 "once_for",
@@ -6621,8 +6616,8 @@
     }
   },
   "definitions": {
-    "APIKeyV1ResponseBody": {
-      "title": "APIKeyV1ResponseBody",
+    "APIKeyV1": {
+      "title": "APIKeyV1",
       "type": "object",
       "properties": {
         "id": {
@@ -6647,8 +6642,8 @@
         "created_by"
       ]
     },
-    "APIKeyV2ResponseBody": {
-      "title": "APIKeyV2ResponseBody",
+    "APIKeyV2": {
+      "title": "APIKeyV2",
       "type": "object",
       "properties": {
         "id": {
@@ -6673,12 +6668,12 @@
         "created_by"
       ]
     },
-    "ActionV1ResponseBody": {
-      "title": "ActionV1ResponseBody",
+    "ActionV1": {
+      "title": "ActionV1",
       "type": "object",
       "properties": {
         "assignee": {
-          "$ref": "#/definitions/UserV1ResponseBody"
+          "$ref": "#/definitions/UserV1"
         },
         "completed_at": {
           "type": "string",
@@ -6698,7 +6693,7 @@
           "example": "Call the fire brigade"
         },
         "external_issue_reference": {
-          "$ref": "#/definitions/ExternalIssueReferenceV1ResponseBody"
+          "$ref": "#/definitions/ExternalIssueReferenceV1"
         },
         "follow_up": {
           "type": "boolean",
@@ -6764,12 +6759,12 @@
         "updated_at"
       ]
     },
-    "ActionV2ResponseBody": {
-      "title": "ActionV2ResponseBody",
+    "ActionV2": {
+      "title": "ActionV2",
       "type": "object",
       "properties": {
         "assignee": {
-          "$ref": "#/definitions/UserV2ResponseBody"
+          "$ref": "#/definitions/UserV2"
         },
         "completed_at": {
           "type": "string",
@@ -6848,7 +6843,7 @@
         "actions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ActionV1ResponseBody"
+            "$ref": "#/definitions/ActionV1"
           },
           "example": [
             {
@@ -6911,7 +6906,7 @@
       "type": "object",
       "properties": {
         "action": {
-          "$ref": "#/definitions/ActionV1ResponseBody"
+          "$ref": "#/definitions/ActionV1"
         }
       },
       "example": {
@@ -6949,7 +6944,7 @@
         "actions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ActionV2ResponseBody"
+            "$ref": "#/definitions/ActionV2"
           },
           "example": [
             {
@@ -7000,7 +6995,7 @@
       "type": "object",
       "properties": {
         "action": {
-          "$ref": "#/definitions/ActionV2ResponseBody"
+          "$ref": "#/definitions/ActionV2"
         }
       },
       "example": {
@@ -7025,15 +7020,15 @@
         "action"
       ]
     },
-    "ActorV1ResponseBody": {
-      "title": "ActorV1ResponseBody",
+    "ActorV1": {
+      "title": "ActorV1",
       "type": "object",
       "properties": {
         "api_key": {
-          "$ref": "#/definitions/APIKeyV1ResponseBody"
+          "$ref": "#/definitions/APIKeyV1"
         },
         "user": {
-          "$ref": "#/definitions/UserV1ResponseBody"
+          "$ref": "#/definitions/UserV1"
         }
       },
       "example": {
@@ -7050,15 +7045,15 @@
         }
       }
     },
-    "ActorV2ResponseBody": {
-      "title": "ActorV2ResponseBody",
+    "ActorV2": {
+      "title": "ActorV2",
       "type": "object",
       "properties": {
         "api_key": {
-          "$ref": "#/definitions/APIKeyV2ResponseBody"
+          "$ref": "#/definitions/APIKeyV2"
         },
         "user": {
-          "$ref": "#/definitions/UserV2ResponseBody"
+          "$ref": "#/definitions/UserV2"
         }
       },
       "example": {
@@ -7075,8 +7070,8 @@
         }
       }
     },
-    "AfterPaginationMetaResultV2ResponseBody": {
-      "title": "AfterPaginationMetaResultV2ResponseBody",
+    "AfterPaginationMetaResultV2": {
+      "title": "AfterPaginationMetaResultV2",
       "type": "object",
       "properties": {
         "after": {
@@ -7162,8 +7157,8 @@
         "status"
       ]
     },
-    "AlertEventsV2CreateHTTPResponseBody": {
-      "title": "AlertEventsV2CreateHTTPResponseBody",
+    "AlertResult": {
+      "title": "AlertResult",
       "type": "object",
       "properties": {
         "deduplication_key": {
@@ -7202,12 +7197,12 @@
         "deduplication_key"
       ]
     },
-    "AlertRouteEscalationBindingPayloadV2RequestBody": {
-      "title": "AlertRouteEscalationBindingPayloadV2RequestBody",
+    "AlertRouteEscalationBindingPayloadV2": {
+      "title": "AlertRouteEscalationBindingPayloadV2",
       "type": "object",
       "properties": {
         "binding": {
-          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingPayloadV2"
         }
       },
       "example": {
@@ -7228,12 +7223,12 @@
         "binding"
       ]
     },
-    "AlertRouteEscalationBindingV2ResponseBody": {
-      "title": "AlertRouteEscalationBindingV2ResponseBody",
+    "AlertRouteEscalationBindingV2": {
+      "title": "AlertRouteEscalationBindingV2",
       "type": "object",
       "properties": {
         "binding": {
-          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingV2"
         }
       },
       "example": {
@@ -7256,8 +7251,8 @@
         "binding"
       ]
     },
-    "AlertRouteIncidentTemplatePayloadV2RequestBody": {
-      "title": "AlertRouteIncidentTemplatePayloadV2RequestBody",
+    "AlertRouteIncidentTemplatePayloadV2": {
+      "title": "AlertRouteIncidentTemplatePayloadV2",
       "type": "object",
       "properties": {
         "custom_field_priorities": {
@@ -7289,17 +7284,17 @@
             }
           },
           "additionalProperties": {
-            "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+            "$ref": "#/definitions/EngineParamBindingPayloadV2"
           }
         },
         "incident_mode": {
-          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingPayloadV2"
         },
         "incident_type": {
-          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingPayloadV2"
         },
         "name": {
-          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingPayloadV2"
         },
         "priority_severity": {
           "type": "string",
@@ -7311,13 +7306,13 @@
           ]
         },
         "severity": {
-          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingPayloadV2"
         },
         "summary": {
-          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingPayloadV2"
         },
         "workspace": {
-          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingPayloadV2"
         }
       },
       "example": {
@@ -7417,8 +7412,8 @@
         "priority_severity"
       ]
     },
-    "AlertRouteIncidentTemplateV2ResponseBody": {
-      "title": "AlertRouteIncidentTemplateV2ResponseBody",
+    "AlertRouteIncidentTemplateV2": {
+      "title": "AlertRouteIncidentTemplateV2",
       "type": "object",
       "properties": {
         "custom_field_priorities": {
@@ -7457,17 +7452,17 @@
             }
           },
           "additionalProperties": {
-            "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+            "$ref": "#/definitions/EngineParamBindingV2"
           }
         },
         "incident_mode": {
-          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingV2"
         },
         "incident_type": {
-          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingV2"
         },
         "name": {
-          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingV2"
         },
         "priority_severity": {
           "type": "string",
@@ -7479,13 +7474,13 @@
           ]
         },
         "severity": {
-          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingV2"
         },
         "summary": {
-          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingV2"
         },
         "workspace": {
-          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingV2"
         }
       },
       "example": {
@@ -7599,14 +7594,14 @@
         "priority_severity"
       ]
     },
-    "AlertRouteV2ResponseBody": {
-      "title": "AlertRouteV2ResponseBody",
+    "AlertRouteV2": {
+      "title": "AlertRouteV2",
       "type": "object",
       "properties": {
         "condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupV2ResponseBody"
+            "$ref": "#/definitions/ConditionGroupV2"
           },
           "description": "What condition groups must be true for this alert route to fire?",
           "example": [
@@ -7651,7 +7646,7 @@
         "escalation_bindings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AlertRouteEscalationBindingV2ResponseBody"
+            "$ref": "#/definitions/AlertRouteEscalationBindingV2"
           },
           "description": "Which escalation paths should this alert route escalate to?",
           "example": [
@@ -7676,7 +7671,7 @@
         "expressions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ExpressionV2ResponseBody"
+            "$ref": "#/definitions/ExpressionV2"
           },
           "description": "The expressions used in this template",
           "example": [
@@ -7820,7 +7815,7 @@
         "grouping_keys": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/GroupingKeyV2ResponseBody"
+            "$ref": "#/definitions/GroupingKeyV2"
           },
           "description": "Which attributes should this alert route use to group alerts?",
           "example": [
@@ -7846,7 +7841,7 @@
           "example": "Production incidents"
         },
         "template": {
-          "$ref": "#/definitions/AlertRouteIncidentTemplateV2ResponseBody"
+          "$ref": "#/definitions/AlertRouteIncidentTemplateV2"
         }
       },
       "example": {
@@ -8165,6 +8160,7 @@
         "enabled",
         "incident_enabled",
         "incident_condition_groups",
+        "alert_sources",
         "alert_source_ids",
         "auto_cancel_escalations"
       ]
@@ -8179,7 +8175,7 @@
             "type": "string",
             "example": "abc123"
           },
-          "description": "The alert sources that will match this alert route",
+          "description": "Legacy field - the alert sources that will match this alert route",
           "example": [
             "02FCNDV6P870EA6S7TK1DSYDG2"
           ]
@@ -8192,7 +8188,7 @@
         "condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+            "$ref": "#/definitions/ConditionGroupPayloadV2"
           },
           "description": "What condition groups must be true for this alert route to fire?",
           "example": [
@@ -8234,7 +8230,7 @@
         "escalation_bindings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AlertRouteEscalationBindingPayloadV2RequestBody"
+            "$ref": "#/definitions/AlertRouteEscalationBindingPayloadV2"
           },
           "description": "Which escalation paths should this alert route escalate to?",
           "example": [
@@ -8257,7 +8253,7 @@
         "expressions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ExpressionPayloadV2RequestBody"
+            "$ref": "#/definitions/ExpressionPayloadV2"
           },
           "description": "The expressions used in this template",
           "example": [
@@ -8372,7 +8368,7 @@
         "grouping_keys": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/GroupingKeyV2RequestBody"
+            "$ref": "#/definitions/GroupingKeyV2"
           },
           "description": "Which attributes should this alert route use to group alerts?",
           "example": [
@@ -8390,7 +8386,7 @@
         "incident_condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+            "$ref": "#/definitions/ConditionGroupPayloadV2"
           },
           "description": "What condition groups must be true for this alert route to create an incident?",
           "example": [
@@ -8429,7 +8425,7 @@
           "example": "Production incidents"
         },
         "template": {
-          "$ref": "#/definitions/AlertRouteIncidentTemplatePayloadV2RequestBody"
+          "$ref": "#/definitions/AlertRouteIncidentTemplatePayloadV2"
         }
       },
       "example": {
@@ -8718,7 +8714,7 @@
       "type": "object",
       "properties": {
         "alert_route": {
-          "$ref": "#/definitions/AlertRouteV2ResponseBody"
+          "$ref": "#/definitions/AlertRouteV2"
         }
       },
       "example": {
@@ -9036,7 +9032,7 @@
       "type": "object",
       "properties": {
         "alert_route": {
-          "$ref": "#/definitions/AlertRouteV2ResponseBody"
+          "$ref": "#/definitions/AlertRouteV2"
         }
       },
       "example": {
@@ -9359,7 +9355,7 @@
             "type": "string",
             "example": "abc123"
           },
-          "description": "The alert sources that will match this alert route",
+          "description": "Legacy field - the alert sources that will match this alert route",
           "example": [
             "02FCNDV6P870EA6S7TK1DSYDG2"
           ]
@@ -9372,7 +9368,7 @@
         "condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+            "$ref": "#/definitions/ConditionGroupPayloadV2"
           },
           "description": "What condition groups must be true for this alert route to fire?",
           "example": [
@@ -9414,7 +9410,7 @@
         "escalation_bindings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AlertRouteEscalationBindingPayloadV2RequestBody"
+            "$ref": "#/definitions/AlertRouteEscalationBindingPayloadV2"
           },
           "description": "Which escalation paths should this alert route escalate to?",
           "example": [
@@ -9437,7 +9433,7 @@
         "expressions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ExpressionPayloadV2RequestBody"
+            "$ref": "#/definitions/ExpressionPayloadV2"
           },
           "description": "The expressions used in this template",
           "example": [
@@ -9552,7 +9548,7 @@
         "grouping_keys": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/GroupingKeyV2RequestBody"
+            "$ref": "#/definitions/GroupingKeyV2"
           },
           "description": "Which attributes should this alert route use to group alerts?",
           "example": [
@@ -9570,7 +9566,7 @@
         "incident_condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+            "$ref": "#/definitions/ConditionGroupPayloadV2"
           },
           "description": "What condition groups must be true for this alert route to create an incident?",
           "example": [
@@ -9609,7 +9605,7 @@
           "example": "Production incidents"
         },
         "template": {
-          "$ref": "#/definitions/AlertRouteIncidentTemplatePayloadV2RequestBody"
+          "$ref": "#/definitions/AlertRouteIncidentTemplatePayloadV2"
         }
       },
       "example": {
@@ -9903,6 +9899,7 @@
         "enabled",
         "incident_enabled",
         "incident_condition_groups",
+        "alert_sources",
         "alert_source_ids",
         "auto_cancel_escalations"
       ]
@@ -9912,7 +9909,7 @@
       "type": "object",
       "properties": {
         "alert_route": {
-          "$ref": "#/definitions/AlertRouteV2ResponseBody"
+          "$ref": "#/definitions/AlertRouteV2"
         }
       },
       "example": {
@@ -10225,8 +10222,8 @@
         "alert_route"
       ]
     },
-    "AuditLogActorMetadataV2ResponseBody": {
-      "title": "AuditLogActorMetadataV2ResponseBody",
+    "AuditLogActorMetadataV2": {
+      "title": "AuditLogActorMetadataV2",
       "type": "object",
       "properties": {
         "api_key_roles": {
@@ -10263,8 +10260,8 @@
         "user_custom_role_slugs": "engineering,security"
       }
     },
-    "AuditLogActorV2ResponseBody": {
-      "title": "AuditLogActorV2ResponseBody",
+    "AuditLogActorV2": {
+      "title": "AuditLogActorV2",
       "type": "object",
       "properties": {
         "id": {
@@ -10273,7 +10270,7 @@
           "example": "01FCNDV6P870EA6S7TK1DSYDG0"
         },
         "metadata": {
-          "$ref": "#/definitions/AuditLogActorMetadataV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorMetadataV2"
         },
         "name": {
           "type": "string",
@@ -10307,8 +10304,8 @@
         "type"
       ]
     },
-    "AuditLogEntryContextV2ResponseBody": {
-      "title": "AuditLogEntryContextV2ResponseBody",
+    "AuditLogEntryContextV2": {
+      "title": "AuditLogEntryContextV2",
       "type": "object",
       "properties": {
         "location": {
@@ -10330,8 +10327,8 @@
         "location"
       ]
     },
-    "AuditLogPrivateIncidentAccessAttemptedMetadataV2ResponseBody": {
-      "title": "AuditLogPrivateIncidentAccessAttemptedMetadataV2ResponseBody",
+    "AuditLogPrivateIncidentAccessAttemptedMetadataV2": {
+      "title": "AuditLogPrivateIncidentAccessAttemptedMetadataV2",
       "type": "object",
       "properties": {
         "outcome": {
@@ -10348,8 +10345,8 @@
         "outcome": "granted"
       }
     },
-    "AuditLogTargetV2ResponseBody": {
-      "title": "AuditLogTargetV2ResponseBody",
+    "AuditLogTargetV2": {
+      "title": "AuditLogTargetV2",
       "type": "object",
       "properties": {
         "id": {
@@ -10412,8 +10409,8 @@
         "type"
       ]
     },
-    "AuditLogUserRoleMembershipChangedMetadataV2ResponseBody": {
-      "title": "AuditLogUserRoleMembershipChangedMetadataV2ResponseBody",
+    "AuditLogUserRoleMembershipChangedMetadataV2": {
+      "title": "AuditLogUserRoleMembershipChangedMetadataV2",
       "type": "object",
       "properties": {
         "after_base_role_slug": {
@@ -10450,8 +10447,8 @@
         "after_custom_role_slugs"
       ]
     },
-    "AuditLogUserSCIMGroupMappingChangedMetadataV2ResponseBody": {
-      "title": "AuditLogUserSCIMGroupMappingChangedMetadataV2ResponseBody",
+    "AuditLogUserSCIMGroupMappingChangedMetadataV2": {
+      "title": "AuditLogUserSCIMGroupMappingChangedMetadataV2",
       "type": "object",
       "properties": {
         "after_base_role_slug": {
@@ -10492,10 +10489,10 @@
           "example": "api_key.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -10506,7 +10503,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -10568,10 +10565,10 @@
           "example": "api_key.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -10582,7 +10579,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -10644,10 +10641,10 @@
           "example": "alert_route.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -10658,7 +10655,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -10720,10 +10717,10 @@
           "example": "alert_route.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -10734,7 +10731,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -10796,10 +10793,10 @@
           "example": "alert_route.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -10810,7 +10807,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -10872,10 +10869,10 @@
           "example": "alert_schema.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -10886,7 +10883,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -10948,10 +10945,10 @@
           "example": "alert_source_config.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -10962,7 +10959,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11024,10 +11021,10 @@
           "example": "alert_source_config.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11038,7 +11035,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11100,10 +11097,10 @@
           "example": "alert_source_config.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11114,7 +11111,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11176,10 +11173,10 @@
           "example": "announcement_rule.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11190,7 +11187,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11252,10 +11249,10 @@
           "example": "announcement_rule.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11266,7 +11263,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11328,10 +11325,10 @@
           "example": "announcement_rule.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11342,7 +11339,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11404,10 +11401,10 @@
           "example": "catalog_type.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11418,7 +11415,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11480,10 +11477,10 @@
           "example": "catalog_type.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11494,7 +11491,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11556,10 +11553,10 @@
           "example": "catalog_type.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11570,7 +11567,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11632,10 +11629,10 @@
           "example": "custom_field.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11646,7 +11643,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11708,10 +11705,10 @@
           "example": "custom_field.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11722,7 +11719,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11784,10 +11781,10 @@
           "example": "custom_field.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11798,7 +11795,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11860,10 +11857,10 @@
           "example": "debrief_invite_rule.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11874,7 +11871,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -11936,10 +11933,10 @@
           "example": "debrief_invite_rule.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -11950,7 +11947,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12012,10 +12009,10 @@
           "example": "debrief_invite_rule.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12026,7 +12023,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12088,10 +12085,10 @@
           "example": "escalation_path.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12102,7 +12099,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12164,10 +12161,10 @@
           "example": "escalation_path.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12178,7 +12175,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12240,10 +12237,10 @@
           "example": "escalation_path.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12254,7 +12251,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12316,10 +12313,10 @@
           "example": "follow_up_priority.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12330,7 +12327,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12392,10 +12389,10 @@
           "example": "follow_up_priority.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12406,7 +12403,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12468,10 +12465,10 @@
           "example": "follow_up_priority.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12482,7 +12479,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12544,10 +12541,10 @@
           "example": "holiday_user_feed.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12558,7 +12555,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12620,10 +12617,10 @@
           "example": "holiday_user_feed.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12634,7 +12631,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12696,10 +12693,10 @@
           "example": "holiday_user_feed.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12710,7 +12707,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12772,10 +12769,10 @@
           "example": "incident_call_setting.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12786,7 +12783,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12848,10 +12845,10 @@
           "example": "incident_duration_metric.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12862,7 +12859,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -12924,10 +12921,10 @@
           "example": "incident_duration_metric.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -12938,7 +12935,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13000,10 +12997,10 @@
           "example": "incident_duration_metric.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13014,7 +13011,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13076,10 +13073,10 @@
           "example": "incident_role.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13090,7 +13087,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13152,10 +13149,10 @@
           "example": "incident_role.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13166,7 +13163,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13228,10 +13225,10 @@
           "example": "incident_role.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13242,7 +13239,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13304,10 +13301,10 @@
           "example": "incident_status.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13318,7 +13315,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13380,10 +13377,10 @@
           "example": "incident_status.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13394,7 +13391,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13456,10 +13453,10 @@
           "example": "incident_status.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13470,7 +13467,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13532,10 +13529,10 @@
           "example": "incident_timestamp.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13546,7 +13543,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13608,10 +13605,10 @@
           "example": "incident_timestamp.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13622,7 +13619,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13684,10 +13681,10 @@
           "example": "incident_timestamp.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13698,7 +13695,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13760,10 +13757,10 @@
           "example": "incident_type.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13774,7 +13771,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13836,10 +13833,10 @@
           "example": "incident_type.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13850,7 +13847,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13912,10 +13909,10 @@
           "example": "incident_type.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -13926,7 +13923,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -13988,10 +13985,10 @@
           "example": "integration.installed"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14002,7 +13999,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14064,10 +14061,10 @@
           "example": "integration.uninstalled"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14078,7 +14075,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14140,10 +14137,10 @@
           "example": "internal_status_page.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14154,7 +14151,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14216,10 +14213,10 @@
           "example": "internal_status_page.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14230,7 +14227,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14292,10 +14289,10 @@
           "example": "internal_status_page.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14306,7 +14303,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14368,10 +14365,10 @@
           "example": "nudge.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14382,7 +14379,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14444,10 +14441,10 @@
           "example": "nudge.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14458,7 +14455,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14520,10 +14517,10 @@
           "example": "nudge.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14534,7 +14531,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14596,10 +14593,10 @@
           "example": "policy.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14610,7 +14607,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14672,10 +14669,10 @@
           "example": "policy.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14686,7 +14683,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14748,10 +14745,10 @@
           "example": "policy.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14762,7 +14759,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14824,10 +14821,10 @@
           "example": "post_incident_task.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14838,7 +14835,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14900,10 +14897,10 @@
           "example": "post_incident_task.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14914,7 +14911,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -14976,10 +14973,10 @@
           "example": "post_incident_task.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -14990,7 +14987,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15052,13 +15049,13 @@
           "example": "private_incident.access_attempted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "metadata": {
-          "$ref": "#/definitions/AuditLogPrivateIncidentAccessAttemptedMetadataV2ResponseBody"
+          "$ref": "#/definitions/AuditLogPrivateIncidentAccessAttemptedMetadataV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15069,7 +15066,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15135,10 +15132,10 @@
           "example": "private_incident.access_requested"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15149,7 +15146,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15211,10 +15208,10 @@
           "example": "private_incident_membership.granted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15225,7 +15222,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15297,10 +15294,10 @@
           "example": "private_incident_membership.revoked"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15311,7 +15308,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15383,10 +15380,10 @@
           "example": "rbac_role.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15397,7 +15394,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15459,10 +15456,10 @@
           "example": "rbac_role.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15473,7 +15470,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15535,10 +15532,10 @@
           "example": "rbac_role.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15549,7 +15546,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15611,10 +15608,10 @@
           "example": "schedule.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15625,7 +15622,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15687,10 +15684,10 @@
           "example": "schedule.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15701,7 +15698,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15763,10 +15760,10 @@
           "example": "schedule.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15777,7 +15774,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15839,13 +15836,13 @@
           "example": "scim_group.role_mappings_updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "metadata": {
-          "$ref": "#/definitions/AuditLogUserSCIMGroupMappingChangedMetadataV2ResponseBody"
+          "$ref": "#/definitions/AuditLogUserSCIMGroupMappingChangedMetadataV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15856,7 +15853,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -15925,10 +15922,10 @@
           "example": "severity.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -15939,7 +15936,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16001,10 +15998,10 @@
           "example": "severity.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16015,7 +16012,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16077,10 +16074,10 @@
           "example": "severity.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16091,7 +16088,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16153,10 +16150,10 @@
           "example": "status_page.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16167,7 +16164,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16229,10 +16226,10 @@
           "example": "status_page.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16243,7 +16240,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16305,10 +16302,10 @@
           "example": "status_page_sub_page.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16319,7 +16316,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16381,10 +16378,10 @@
           "example": "status_page_sub_page.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16395,7 +16392,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16457,10 +16454,10 @@
           "example": "status_page_sub_page.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16471,7 +16468,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16533,10 +16530,10 @@
           "example": "status_page_template.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16547,7 +16544,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16609,10 +16606,10 @@
           "example": "status_page_template.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16623,7 +16620,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16685,10 +16682,10 @@
           "example": "status_page_template.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16699,7 +16696,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16761,10 +16758,10 @@
           "example": "status_page.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16775,7 +16772,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16837,10 +16834,10 @@
           "example": "user.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16851,7 +16848,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16913,10 +16910,10 @@
           "example": "user.deactivated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -16927,7 +16924,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -16989,10 +16986,10 @@
           "example": "user.reinstated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -17003,7 +17000,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -17065,13 +17062,13 @@
           "example": "user.role_memberships_updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "metadata": {
-          "$ref": "#/definitions/AuditLogUserRoleMembershipChangedMetadataV2ResponseBody"
+          "$ref": "#/definitions/AuditLogUserRoleMembershipChangedMetadataV2"
         },
         "occurred_at": {
           "type": "string",
@@ -17082,7 +17079,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -17151,10 +17148,10 @@
           "example": "user.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -17165,7 +17162,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -17227,10 +17224,10 @@
           "example": "workflow.created"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -17241,7 +17238,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -17303,10 +17300,10 @@
           "example": "workflow.deleted"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -17317,7 +17314,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -17379,10 +17376,10 @@
           "example": "workflow.updated"
         },
         "actor": {
-          "$ref": "#/definitions/AuditLogActorV2ResponseBody"
+          "$ref": "#/definitions/AuditLogActorV2"
         },
         "context": {
-          "$ref": "#/definitions/AuditLogEntryContextV2ResponseBody"
+          "$ref": "#/definitions/AuditLogEntryContextV2"
         },
         "occurred_at": {
           "type": "string",
@@ -17393,7 +17390,7 @@
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AuditLogTargetV2ResponseBody"
+            "$ref": "#/definitions/AuditLogTargetV2"
           },
           "description": "The custom field that was created",
           "example": [
@@ -17445,14 +17442,14 @@
         "context"
       ]
     },
-    "CatalogEntryEngineParamBindingV2ResponseBody": {
-      "title": "CatalogEntryEngineParamBindingV2ResponseBody",
+    "CatalogEntryEngineParamBindingV2": {
+      "title": "CatalogEntryEngineParamBindingV2",
       "type": "object",
       "properties": {
         "array_value": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CatalogEntryEngineParamBindingValueV2ResponseBody"
+            "$ref": "#/definitions/CatalogEntryEngineParamBindingValueV2"
           },
           "description": "If array_value is set, this helps render the values",
           "example": [
@@ -17476,7 +17473,7 @@
           ]
         },
         "value": {
-          "$ref": "#/definitions/CatalogEntryEngineParamBindingValueV2ResponseBody"
+          "$ref": "#/definitions/CatalogEntryEngineParamBindingValueV2"
         }
       },
       "example": {
@@ -17518,12 +17515,12 @@
         }
       }
     },
-    "CatalogEntryEngineParamBindingValueV2ResponseBody": {
-      "title": "CatalogEntryEngineParamBindingValueV2ResponseBody",
+    "CatalogEntryEngineParamBindingValueV2": {
+      "title": "CatalogEntryEngineParamBindingValueV2",
       "type": "object",
       "properties": {
         "catalog_entry": {
-          "$ref": "#/definitions/CatalogEntryReferenceV2ResponseBody"
+          "$ref": "#/definitions/CatalogEntryReferenceV2"
         },
         "helptext": {
           "type": "string",
@@ -17593,8 +17590,8 @@
         "sort_key"
       ]
     },
-    "CatalogEntryReferenceV2ResponseBody": {
-      "title": "CatalogEntryReferenceV2ResponseBody",
+    "CatalogEntryReferenceV2": {
+      "title": "CatalogEntryReferenceV2",
       "type": "object",
       "properties": {
         "archived_at": {
@@ -17631,8 +17628,8 @@
         "catalog_entry_name"
       ]
     },
-    "CatalogEntryV2ResponseBody": {
-      "title": "CatalogEntryV2ResponseBody",
+    "CatalogEntryV2": {
+      "title": "CatalogEntryV2",
       "type": "object",
       "properties": {
         "aliases": {
@@ -17697,7 +17694,7 @@
             }
           },
           "additionalProperties": {
-            "$ref": "#/definitions/CatalogEntryEngineParamBindingV2ResponseBody"
+            "$ref": "#/definitions/CatalogEntryEngineParamBindingV2"
           }
         },
         "catalog_type_id": {
@@ -17804,8 +17801,8 @@
         "updated_at"
       ]
     },
-    "CatalogResourceV2ResponseBody": {
-      "title": "CatalogResourceV2ResponseBody",
+    "CatalogResourceV2": {
+      "title": "CatalogResourceV2",
       "type": "object",
       "properties": {
         "category": {
@@ -17856,8 +17853,8 @@
         "is_user_link"
       ]
     },
-    "CatalogTypeAttributePathItemPayloadV2RequestBody": {
-      "title": "CatalogTypeAttributePathItemPayloadV2RequestBody",
+    "CatalogTypeAttributePathItemPayloadV2": {
+      "title": "CatalogTypeAttributePathItemPayloadV2",
       "type": "object",
       "properties": {
         "attribute_id": {
@@ -17873,8 +17870,8 @@
         "attribute_id"
       ]
     },
-    "CatalogTypeAttributePathItemV2ResponseBody": {
-      "title": "CatalogTypeAttributePathItemV2ResponseBody",
+    "CatalogTypeAttributePathItemV2": {
+      "title": "CatalogTypeAttributePathItemV2",
       "type": "object",
       "properties": {
         "attribute_id": {
@@ -17897,8 +17894,8 @@
         "attribute_name"
       ]
     },
-    "CatalogTypeAttributePayloadV2RequestBody": {
-      "title": "CatalogTypeAttributePayloadV2RequestBody",
+    "CatalogTypeAttributePayloadV2": {
+      "title": "CatalogTypeAttributePayloadV2",
       "type": "object",
       "properties": {
         "array": {
@@ -17938,7 +17935,7 @@
         "path": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CatalogTypeAttributePathItemPayloadV2RequestBody"
+            "$ref": "#/definitions/CatalogTypeAttributePathItemPayloadV2"
           },
           "description": "The path to use (if this is an path)",
           "example": [
@@ -17972,8 +17969,8 @@
         "array"
       ]
     },
-    "CatalogTypeAttributeV2ResponseBody": {
-      "title": "CatalogTypeAttributeV2ResponseBody",
+    "CatalogTypeAttributeV2": {
+      "title": "CatalogTypeAttributeV2",
       "type": "object",
       "properties": {
         "array": {
@@ -18013,7 +18010,7 @@
         "path": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CatalogTypeAttributePathItemV2ResponseBody"
+            "$ref": "#/definitions/CatalogTypeAttributePathItemV2"
           },
           "description": "The path to use (if this is a path attribute)",
           "example": [
@@ -18051,14 +18048,14 @@
         "array"
       ]
     },
-    "CatalogTypeSchemaV2ResponseBody": {
-      "title": "CatalogTypeSchemaV2ResponseBody",
+    "CatalogTypeSchemaV2": {
+      "title": "CatalogTypeSchemaV2",
       "type": "object",
       "properties": {
         "attributes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CatalogTypeAttributeV2ResponseBody"
+            "$ref": "#/definitions/CatalogTypeAttributeV2"
           },
           "description": "Attributes of this catalog type",
           "example": [
@@ -18109,8 +18106,8 @@
         "version"
       ]
     },
-    "CatalogTypeV2ResponseBody": {
-      "title": "CatalogTypeV2ResponseBody",
+    "CatalogTypeV2": {
+      "title": "CatalogTypeV2",
       "type": "object",
       "properties": {
         "annotations": {
@@ -18257,7 +18254,7 @@
           ]
         },
         "schema": {
-          "$ref": "#/definitions/CatalogTypeSchemaV2ResponseBody"
+          "$ref": "#/definitions/CatalogTypeSchemaV2"
         },
         "semantic_type": {
           "type": "string",
@@ -18381,7 +18378,7 @@
             }
           },
           "additionalProperties": {
-            "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+            "$ref": "#/definitions/EngineParamBindingPayloadV2"
           }
         },
         "catalog_type_id": {
@@ -18441,7 +18438,7 @@
       "type": "object",
       "properties": {
         "catalog_entry": {
-          "$ref": "#/definitions/CatalogEntryV2ResponseBody"
+          "$ref": "#/definitions/CatalogEntryV2"
         }
       },
       "example": {
@@ -18638,7 +18635,7 @@
       "type": "object",
       "properties": {
         "catalog_type": {
-          "$ref": "#/definitions/CatalogTypeV2ResponseBody"
+          "$ref": "#/definitions/CatalogTypeV2"
         }
       },
       "example": {
@@ -18700,7 +18697,7 @@
         "catalog_entries": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CatalogEntryV2ResponseBody"
+            "$ref": "#/definitions/CatalogEntryV2"
           },
           "example": [
             {
@@ -18760,10 +18757,10 @@
           ]
         },
         "catalog_type": {
-          "$ref": "#/definitions/CatalogTypeV2ResponseBody"
+          "$ref": "#/definitions/CatalogTypeV2"
         },
         "pagination_meta": {
-          "$ref": "#/definitions/PaginationMetaResultResponseBody"
+          "$ref": "#/definitions/PaginationMetaResult"
         }
       },
       "example": {
@@ -18887,7 +18884,7 @@
         "resources": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CatalogResourceV2ResponseBody"
+            "$ref": "#/definitions/CatalogResourceV2"
           },
           "example": [
             {
@@ -18922,7 +18919,7 @@
         "catalog_types": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CatalogTypeV2ResponseBody"
+            "$ref": "#/definitions/CatalogTypeV2"
           },
           "example": [
             {
@@ -19033,10 +19030,10 @@
       "type": "object",
       "properties": {
         "catalog_entry": {
-          "$ref": "#/definitions/CatalogEntryV2ResponseBody"
+          "$ref": "#/definitions/CatalogEntryV2"
         },
         "catalog_type": {
-          "$ref": "#/definitions/CatalogTypeV2ResponseBody"
+          "$ref": "#/definitions/CatalogTypeV2"
         }
       },
       "example": {
@@ -19151,7 +19148,7 @@
       "type": "object",
       "properties": {
         "catalog_type": {
-          "$ref": "#/definitions/CatalogTypeV2ResponseBody"
+          "$ref": "#/definitions/CatalogTypeV2"
         }
       },
       "example": {
@@ -19240,7 +19237,7 @@
             }
           },
           "additionalProperties": {
-            "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+            "$ref": "#/definitions/EngineParamBindingPayloadV2"
           }
         },
         "external_id": {
@@ -19293,10 +19290,10 @@
       "type": "object",
       "properties": {
         "catalog_entry": {
-          "$ref": "#/definitions/CatalogEntryV2ResponseBody"
+          "$ref": "#/definitions/CatalogEntryV2"
         },
         "catalog_type": {
-          "$ref": "#/definitions/CatalogTypeV2ResponseBody"
+          "$ref": "#/definitions/CatalogTypeV2"
         }
       },
       "example": {
@@ -19534,7 +19531,7 @@
       "type": "object",
       "properties": {
         "catalog_type": {
-          "$ref": "#/definitions/CatalogTypeV2ResponseBody"
+          "$ref": "#/definitions/CatalogTypeV2"
         }
       },
       "example": {
@@ -19596,7 +19593,7 @@
         "attributes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CatalogTypeAttributePayloadV2RequestBody"
+            "$ref": "#/definitions/CatalogTypeAttributePayloadV2"
           },
           "example": [
             {
@@ -19664,7 +19661,7 @@
       "type": "object",
       "properties": {
         "catalog_type": {
-          "$ref": "#/definitions/CatalogTypeV2ResponseBody"
+          "$ref": "#/definitions/CatalogTypeV2"
         }
       },
       "example": {
@@ -19719,14 +19716,14 @@
         "catalog_type"
       ]
     },
-    "ConditionGroupPayloadV2RequestBody": {
-      "title": "ConditionGroupPayloadV2RequestBody",
+    "ConditionGroupPayloadV2": {
+      "title": "ConditionGroupPayloadV2",
       "type": "object",
       "properties": {
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionPayloadV2RequestBody"
+            "$ref": "#/definitions/ConditionPayloadV2"
           },
           "description": "All conditions in this list must be satisfied for the group to be satisfied",
           "example": [
@@ -19777,14 +19774,14 @@
         "conditions"
       ]
     },
-    "ConditionGroupV2ResponseBody": {
-      "title": "ConditionGroupV2ResponseBody",
+    "ConditionGroupV2": {
+      "title": "ConditionGroupV2",
       "type": "object",
       "properties": {
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionV2ResponseBody"
+            "$ref": "#/definitions/ConditionV2"
           },
           "description": "All conditions in this list must be satisfied for the group to be satisfied",
           "example": [
@@ -19851,8 +19848,8 @@
         "conditions"
       ]
     },
-    "ConditionOperationV2ResponseBody": {
-      "title": "ConditionOperationV2ResponseBody",
+    "ConditionOperationV2": {
+      "title": "ConditionOperationV2",
       "type": "object",
       "properties": {
         "label": {
@@ -19876,8 +19873,8 @@
         "sort_key"
       ]
     },
-    "ConditionPayloadV2RequestBody": {
-      "title": "ConditionPayloadV2RequestBody",
+    "ConditionPayloadV2": {
+      "title": "ConditionPayloadV2",
       "type": "object",
       "properties": {
         "operation": {
@@ -19888,7 +19885,7 @@
         "param_bindings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+            "$ref": "#/definitions/EngineParamBindingPayloadV2"
           },
           "description": "List of parameter bindings",
           "example": [
@@ -19936,8 +19933,8 @@
         "param_bindings"
       ]
     },
-    "ConditionSubjectV2ResponseBody": {
-      "title": "ConditionSubjectV2ResponseBody",
+    "ConditionSubjectV2": {
+      "title": "ConditionSubjectV2",
       "type": "object",
       "properties": {
         "label": {
@@ -19961,17 +19958,17 @@
         "icon"
       ]
     },
-    "ConditionV2ResponseBody": {
-      "title": "ConditionV2ResponseBody",
+    "ConditionV2": {
+      "title": "ConditionV2",
       "type": "object",
       "properties": {
         "operation": {
-          "$ref": "#/definitions/ConditionOperationV2ResponseBody"
+          "$ref": "#/definitions/ConditionOperationV2"
         },
         "param_bindings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+            "$ref": "#/definitions/EngineParamBindingV2"
           },
           "description": "Bindings for the operation parameters",
           "example": [
@@ -19992,7 +19989,7 @@
           ]
         },
         "subject": {
-          "$ref": "#/definitions/ConditionSubjectV2ResponseBody"
+          "$ref": "#/definitions/ConditionSubjectV2"
         }
       },
       "example": {
@@ -20028,8 +20025,463 @@
         "params"
       ]
     },
-    "CustomFieldEntryPayloadV1RequestBody": {
-      "title": "CustomFieldEntryPayloadV1RequestBody",
+    "CreateWorkflowPayload": {
+      "title": "CreateWorkflowPayload",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "description": "Annotations that track metadata about this resource",
+          "example": {
+            "incident.io/terraform/version": "3.0.0"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "example": "abc123"
+          }
+        },
+        "condition_groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConditionGroupPayloadV2"
+          },
+          "description": "List of conditions to apply to the workflow",
+          "example": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ]
+        },
+        "continue_on_step_error": {
+          "type": "boolean",
+          "description": "Whether to continue executing the workflow if a step fails",
+          "example": true
+        },
+        "delay": {
+          "$ref": "#/definitions/WorkflowDelay"
+        },
+        "expressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressionPayloadV2"
+          },
+          "description": "The expressions used in the workflow",
+          "example": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ]
+        },
+        "folder": {
+          "type": "string",
+          "description": "Folder to display the workflow in",
+          "example": "My folder 01"
+        },
+        "include_private_incidents": {
+          "type": "boolean",
+          "description": "Whether to include private incidents",
+          "example": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The human-readable name of the workflow",
+          "example": "My workflow"
+        },
+        "once_for": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "incident.url"
+          },
+          "description": "Once For strategy to apply to this workflow",
+          "example": [
+            "incident.url"
+          ]
+        },
+        "runs_on_incident_modes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "test",
+            "enum": [
+              "standard",
+              "test",
+              "retrospective"
+            ]
+          },
+          "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+          "example": [
+            "standard",
+            "retrospective"
+          ]
+        },
+        "runs_on_incidents": {
+          "type": "string",
+          "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+          "example": "newly_created",
+          "enum": [
+            "newly_created",
+            "newly_created_and_active"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "description": "The state of the workflow (e.g. is it draft, or disabled)",
+          "example": "active",
+          "enum": [
+            "active",
+            "disabled",
+            "draft",
+            "error"
+          ]
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StepConfigPayload"
+          },
+          "description": "List of step to execute as part of the workflow",
+          "example": [
+            {
+              "for_each": "abc123",
+              "id": "abc123",
+              "name": "pagerduty.escalate",
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "trigger": {
+          "type": "string",
+          "description": "Trigger to set on the workflow",
+          "example": "incident.updated"
+        }
+      },
+      "example": {
+        "annotations": {
+          "incident.io/terraform/version": "3.0.0"
+        },
+        "condition_groups": [
+          {
+            "conditions": [
+              {
+                "operation": "one_of",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": "incident.severity"
+              }
+            ]
+          }
+        ],
+        "continue_on_step_error": true,
+        "delay": {
+          "conditions_apply_over_delay": false,
+          "for_seconds": 60
+        },
+        "expressions": [
+          {
+            "else_branch": {
+              "result": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "label": "Team Slack channel",
+            "operations": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": "one_of",
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": "incident.severity"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                }
+              }
+            ],
+            "reference": "abc123",
+            "root_reference": "incident.status"
+          }
+        ],
+        "folder": "My folder 01",
+        "include_private_incidents": true,
+        "name": "My workflow",
+        "once_for": [
+          "incident.url"
+        ],
+        "runs_on_incident_modes": [
+          "standard",
+          "retrospective"
+        ],
+        "runs_on_incidents": "newly_created",
+        "state": "active",
+        "steps": [
+          {
+            "for_each": "abc123",
+            "id": "abc123",
+            "name": "pagerduty.escalate",
+            "param_bindings": [
+              {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        ],
+        "trigger": "incident.updated"
+      },
+      "required": [
+        "name",
+        "trigger",
+        "once_for",
+        "condition_groups",
+        "steps",
+        "expressions",
+        "include_private_incidents",
+        "runs_on_incident_modes",
+        "continue_on_step_error",
+        "runs_on_incidents"
+      ]
+    },
+    "CustomFieldEntryPayloadV1": {
+      "title": "CustomFieldEntryPayloadV1",
       "type": "object",
       "properties": {
         "custom_field_id": {
@@ -20040,7 +20492,7 @@
         "values": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldValuePayloadV1RequestBody"
+            "$ref": "#/definitions/CustomFieldValuePayloadV1"
           },
           "description": "List of values to associate with this entry. Use an empty array to unset the value of the custom field.",
           "example": [
@@ -20075,8 +20527,8 @@
         "values"
       ]
     },
-    "CustomFieldEntryPayloadV2RequestBody": {
-      "title": "CustomFieldEntryPayloadV2RequestBody",
+    "CustomFieldEntryPayloadV2": {
+      "title": "CustomFieldEntryPayloadV2",
       "type": "object",
       "properties": {
         "custom_field_id": {
@@ -20087,7 +20539,7 @@
         "values": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldValuePayloadV2RequestBody"
+            "$ref": "#/definitions/CustomFieldValuePayloadV2"
           },
           "description": "List of values to associate with this entry. Use an empty array to unset the value of the custom field.",
           "example": [
@@ -20122,17 +20574,17 @@
         "values"
       ]
     },
-    "CustomFieldEntryV1ResponseBody": {
-      "title": "CustomFieldEntryV1ResponseBody",
+    "CustomFieldEntryV1": {
+      "title": "CustomFieldEntryV1",
       "type": "object",
       "properties": {
         "custom_field": {
-          "$ref": "#/definitions/CustomFieldTypeInfoV1ResponseBody"
+          "$ref": "#/definitions/CustomFieldTypeInfoV1"
         },
         "values": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldValueV1ResponseBody"
+            "$ref": "#/definitions/CustomFieldValueV1"
           },
           "description": "List of custom field values set on this entry",
           "example": [
@@ -20202,17 +20654,17 @@
         "values"
       ]
     },
-    "CustomFieldEntryV2ResponseBody": {
-      "title": "CustomFieldEntryV2ResponseBody",
+    "CustomFieldEntryV2": {
+      "title": "CustomFieldEntryV2",
       "type": "object",
       "properties": {
         "custom_field": {
-          "$ref": "#/definitions/CustomFieldTypeInfoV2ResponseBody"
+          "$ref": "#/definitions/CustomFieldTypeInfoV2"
         },
         "values": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldValueV2ResponseBody"
+            "$ref": "#/definitions/CustomFieldValueV2"
           },
           "description": "List of custom field values set on this entry",
           "example": [
@@ -20282,8 +20734,8 @@
         "values"
       ]
     },
-    "CustomFieldOptionV1ResponseBody": {
-      "title": "CustomFieldOptionV1ResponseBody",
+    "CustomFieldOptionV1": {
+      "title": "CustomFieldOptionV1",
       "type": "object",
       "properties": {
         "custom_field_id": {
@@ -20322,8 +20774,8 @@
         "sort_key"
       ]
     },
-    "CustomFieldOptionV2ResponseBody": {
-      "title": "CustomFieldOptionV2ResponseBody",
+    "CustomFieldOptionV2": {
+      "title": "CustomFieldOptionV2",
       "type": "object",
       "properties": {
         "custom_field_id": {
@@ -20399,7 +20851,7 @@
       "type": "object",
       "properties": {
         "custom_field_option": {
-          "$ref": "#/definitions/CustomFieldOptionV1ResponseBody"
+          "$ref": "#/definitions/CustomFieldOptionV1"
         }
       },
       "example": {
@@ -20421,7 +20873,7 @@
         "custom_field_options": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldOptionV1ResponseBody"
+            "$ref": "#/definitions/CustomFieldOptionV1"
           },
           "example": [
             {
@@ -20433,7 +20885,7 @@
           ]
         },
         "pagination_meta": {
-          "$ref": "#/definitions/PaginationMetaResultResponseBody"
+          "$ref": "#/definitions/PaginationMetaResult"
         }
       },
       "example": {
@@ -20460,7 +20912,7 @@
       "type": "object",
       "properties": {
         "custom_field_option": {
-          "$ref": "#/definitions/CustomFieldOptionV1ResponseBody"
+          "$ref": "#/definitions/CustomFieldOptionV1"
         }
       },
       "example": {
@@ -20507,7 +20959,7 @@
       "type": "object",
       "properties": {
         "custom_field_option": {
-          "$ref": "#/definitions/CustomFieldOptionV1ResponseBody"
+          "$ref": "#/definitions/CustomFieldOptionV1"
         }
       },
       "example": {
@@ -20522,8 +20974,8 @@
         "custom_field_option"
       ]
     },
-    "CustomFieldTypeInfoV1ResponseBody": {
-      "title": "CustomFieldTypeInfoV1ResponseBody",
+    "CustomFieldTypeInfoV1": {
+      "title": "CustomFieldTypeInfoV1",
       "type": "object",
       "properties": {
         "description": {
@@ -20557,7 +21009,7 @@
         "options": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldOptionV1ResponseBody"
+            "$ref": "#/definitions/CustomFieldOptionV1"
           },
           "description": "What options are available for this custom field, if this field has options",
           "example": [
@@ -20601,8 +21053,8 @@
         "updated_at"
       ]
     },
-    "CustomFieldTypeInfoV2ResponseBody": {
-      "title": "CustomFieldTypeInfoV2ResponseBody",
+    "CustomFieldTypeInfoV2": {
+      "title": "CustomFieldTypeInfoV2",
       "type": "object",
       "properties": {
         "description": {
@@ -20636,7 +21088,7 @@
         "options": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldOptionV2ResponseBody"
+            "$ref": "#/definitions/CustomFieldOptionV2"
           },
           "description": "What options are available for this custom field, if this field has options",
           "example": [
@@ -20680,8 +21132,8 @@
         "updated_at"
       ]
     },
-    "CustomFieldV1ResponseBody": {
-      "title": "CustomFieldV1ResponseBody",
+    "CustomFieldV1": {
+      "title": "CustomFieldV1",
       "type": "object",
       "properties": {
         "catalog_type_id": {
@@ -20726,7 +21178,7 @@
         "options": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldOptionV1ResponseBody"
+            "$ref": "#/definitions/CustomFieldOptionV1"
           },
           "description": "What options are available for this custom field, if this field has options",
           "example": [
@@ -20821,8 +21273,8 @@
         "updated_at"
       ]
     },
-    "CustomFieldV2ResponseBody": {
-      "title": "CustomFieldV2ResponseBody",
+    "CustomFieldV2": {
+      "title": "CustomFieldV2",
       "type": "object",
       "properties": {
         "catalog_type_id": {
@@ -20890,8 +21342,8 @@
         "updated_at"
       ]
     },
-    "CustomFieldValuePayloadV1RequestBody": {
-      "title": "CustomFieldValuePayloadV1RequestBody",
+    "CustomFieldValuePayloadV1": {
+      "title": "CustomFieldValuePayloadV1",
       "type": "object",
       "properties": {
         "id": {
@@ -20940,8 +21392,8 @@
         "value_timestamp": ""
       }
     },
-    "CustomFieldValuePayloadV2RequestBody": {
-      "title": "CustomFieldValuePayloadV2RequestBody",
+    "CustomFieldValuePayloadV2": {
+      "title": "CustomFieldValuePayloadV2",
       "type": "object",
       "properties": {
         "id": {
@@ -20990,12 +21442,12 @@
         "value_timestamp": ""
       }
     },
-    "CustomFieldValueV1ResponseBody": {
-      "title": "CustomFieldValueV1ResponseBody",
+    "CustomFieldValueV1": {
+      "title": "CustomFieldValueV1",
       "type": "object",
       "properties": {
         "value_catalog_entry": {
-          "$ref": "#/definitions/EmbeddedCatalogEntryV1ResponseBody"
+          "$ref": "#/definitions/EmbeddedCatalogEntryV1"
         },
         "value_link": {
           "type": "string",
@@ -21008,7 +21460,7 @@
           "example": "123.456"
         },
         "value_option": {
-          "$ref": "#/definitions/CustomFieldOptionV1ResponseBody"
+          "$ref": "#/definitions/CustomFieldOptionV1"
         },
         "value_text": {
           "type": "string",
@@ -21037,12 +21489,12 @@
         "value_text": "This is my text field, I hope you like it"
       }
     },
-    "CustomFieldValueV2ResponseBody": {
-      "title": "CustomFieldValueV2ResponseBody",
+    "CustomFieldValueV2": {
+      "title": "CustomFieldValueV2",
       "type": "object",
       "properties": {
         "value_catalog_entry": {
-          "$ref": "#/definitions/EmbeddedCatalogEntryV2ResponseBody"
+          "$ref": "#/definitions/EmbeddedCatalogEntryV2"
         },
         "value_link": {
           "type": "string",
@@ -21055,7 +21507,7 @@
           "example": "123.456"
         },
         "value_option": {
-          "$ref": "#/definitions/CustomFieldOptionV2ResponseBody"
+          "$ref": "#/definitions/CustomFieldOptionV2"
         },
         "value_text": {
           "type": "string",
@@ -21181,7 +21633,7 @@
       "type": "object",
       "properties": {
         "custom_field": {
-          "$ref": "#/definitions/CustomFieldV1ResponseBody"
+          "$ref": "#/definitions/CustomFieldV1"
         }
       },
       "example": {
@@ -21220,7 +21672,7 @@
         "custom_fields": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldV1ResponseBody"
+            "$ref": "#/definitions/CustomFieldV1"
           },
           "example": [
             {
@@ -21285,7 +21737,7 @@
       "type": "object",
       "properties": {
         "custom_field": {
-          "$ref": "#/definitions/CustomFieldV1ResponseBody"
+          "$ref": "#/definitions/CustomFieldV1"
         }
       },
       "example": {
@@ -21400,7 +21852,7 @@
       "type": "object",
       "properties": {
         "custom_field": {
-          "$ref": "#/definitions/CustomFieldV1ResponseBody"
+          "$ref": "#/definitions/CustomFieldV1"
         }
       },
       "example": {
@@ -21480,7 +21932,7 @@
       "type": "object",
       "properties": {
         "custom_field": {
-          "$ref": "#/definitions/CustomFieldV2ResponseBody"
+          "$ref": "#/definitions/CustomFieldV2"
         }
       },
       "example": {
@@ -21505,7 +21957,7 @@
         "custom_fields": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldV2ResponseBody"
+            "$ref": "#/definitions/CustomFieldV2"
           },
           "example": [
             {
@@ -21542,7 +21994,7 @@
       "type": "object",
       "properties": {
         "custom_field": {
-          "$ref": "#/definitions/CustomFieldV2ResponseBody"
+          "$ref": "#/definitions/CustomFieldV2"
         }
       },
       "example": {
@@ -21594,7 +22046,7 @@
       "type": "object",
       "properties": {
         "custom_field": {
-          "$ref": "#/definitions/CustomFieldV2ResponseBody"
+          "$ref": "#/definitions/CustomFieldV2"
         }
       },
       "example": {
@@ -21612,8 +22064,8 @@
         "custom_field"
       ]
     },
-    "EmbeddedCatalogEntryV1ResponseBody": {
-      "title": "EmbeddedCatalogEntryV1ResponseBody",
+    "EmbeddedCatalogEntryV1": {
+      "title": "EmbeddedCatalogEntryV1",
       "type": "object",
       "properties": {
         "aliases": {
@@ -21659,8 +22111,8 @@
         "catalog_type_id"
       ]
     },
-    "EmbeddedCatalogEntryV2ResponseBody": {
-      "title": "EmbeddedCatalogEntryV2ResponseBody",
+    "EmbeddedCatalogEntryV2": {
+      "title": "EmbeddedCatalogEntryV2",
       "type": "object",
       "properties": {
         "aliases": {
@@ -21706,8 +22158,8 @@
         "catalog_type_id"
       ]
     },
-    "EmbeddedIncidentRoleV2ResponseBody": {
-      "title": "EmbeddedIncidentRoleV2ResponseBody",
+    "EmbeddedIncidentRoleV2": {
+      "title": "EmbeddedIncidentRoleV2",
       "type": "object",
       "properties": {
         "created_at": {
@@ -21788,14 +22240,14 @@
         "updated_at"
       ]
     },
-    "EngineParamBindingPayloadV2RequestBody": {
-      "title": "EngineParamBindingPayloadV2RequestBody",
+    "EngineParamBindingPayloadV2": {
+      "title": "EngineParamBindingPayloadV2",
       "type": "object",
       "properties": {
         "array_value": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineParamBindingValuePayloadV2RequestBody"
+            "$ref": "#/definitions/EngineParamBindingValuePayloadV2"
           },
           "description": "If set, this is the array value of the step parameter",
           "example": [
@@ -21806,7 +22258,7 @@
           ]
         },
         "value": {
-          "$ref": "#/definitions/EngineParamBindingValuePayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingValuePayloadV2"
         }
       },
       "example": {
@@ -21822,14 +22274,14 @@
         }
       }
     },
-    "EngineParamBindingV2ResponseBody": {
-      "title": "EngineParamBindingV2ResponseBody",
+    "EngineParamBindingV2": {
+      "title": "EngineParamBindingV2",
       "type": "object",
       "properties": {
         "array_value": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineParamBindingValueV2ResponseBody"
+            "$ref": "#/definitions/EngineParamBindingValueV2"
           },
           "description": "If array_value is set, this helps render the values",
           "example": [
@@ -21841,7 +22293,7 @@
           ]
         },
         "value": {
-          "$ref": "#/definitions/EngineParamBindingValueV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingValueV2"
         }
       },
       "example": {
@@ -21859,8 +22311,8 @@
         }
       }
     },
-    "EngineParamBindingValuePayloadV2RequestBody": {
-      "title": "EngineParamBindingValuePayloadV2RequestBody",
+    "EngineParamBindingValuePayloadV2": {
+      "title": "EngineParamBindingValuePayloadV2",
       "type": "object",
       "properties": {
         "literal": {
@@ -21879,8 +22331,8 @@
         "reference": "incident.severity"
       }
     },
-    "EngineParamBindingValueV2ResponseBody": {
-      "title": "EngineParamBindingValueV2ResponseBody",
+    "EngineParamBindingValueV2": {
+      "title": "EngineParamBindingValueV2",
       "type": "object",
       "properties": {
         "label": {
@@ -21909,8 +22361,8 @@
         "sort_key"
       ]
     },
-    "EngineReferenceV2ResponseBody": {
-      "title": "EngineReferenceV2ResponseBody",
+    "EngineReferenceV2": {
+      "title": "EngineReferenceV2",
       "type": "object",
       "properties": {
         "array": {
@@ -21949,14 +22401,14 @@
         "hide_filter"
       ]
     },
-    "EscalationPathNodeIfElsePayloadV2RequestBody": {
-      "title": "EscalationPathNodeIfElsePayloadV2RequestBody",
+    "EscalationPathNodeIfElsePayloadV2": {
+      "title": "EscalationPathNodeIfElsePayloadV2",
       "type": "object",
       "properties": {
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionPayloadV2RequestBody"
+            "$ref": "#/definitions/ConditionPayloadV2"
           },
           "description": "The condition that defines which branch to take",
           "example": [
@@ -21983,7 +22435,7 @@
         "else_path": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EscalationPathNodePayloadV2RequestBody"
+            "$ref": "#/definitions/EscalationPathNodePayloadV2"
           },
           "description": "The nodes that form the levels if our condition is not met",
           "example": [
@@ -22045,7 +22497,7 @@
         "then_path": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EscalationPathNodePayloadV2RequestBody"
+            "$ref": "#/definitions/EscalationPathNodePayloadV2"
           },
           "description": "The nodes that form the levels if our condition is met",
           "example": [
@@ -22242,14 +22694,14 @@
         "else_path"
       ]
     },
-    "EscalationPathNodeIfElseV2ResponseBody": {
-      "title": "EscalationPathNodeIfElseV2ResponseBody",
+    "EscalationPathNodeIfElseV2": {
+      "title": "EscalationPathNodeIfElseV2",
       "type": "object",
       "properties": {
         "conditions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionV2ResponseBody"
+            "$ref": "#/definitions/ConditionV2"
           },
           "description": "The condition that defines which branch to take",
           "example": [
@@ -22284,7 +22736,7 @@
         "else_path": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EscalationPathNodeV2ResponseBody"
+            "$ref": "#/definitions/EscalationPathNodeV2"
           },
           "description": "The nodes that form the levels if our condition is not met",
           "example": [
@@ -22354,7 +22806,7 @@
         "then_path": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EscalationPathNodeV2ResponseBody"
+            "$ref": "#/definitions/EscalationPathNodeV2"
           },
           "description": "The nodes that form the levels if our condition is met",
           "example": [
@@ -22584,17 +23036,17 @@
         "else_path"
       ]
     },
-    "EscalationPathNodeLevelV2RequestBody": {
-      "title": "EscalationPathNodeLevelV2RequestBody",
+    "EscalationPathNodeLevelV2": {
+      "title": "EscalationPathNodeLevelV2",
       "type": "object",
       "properties": {
         "round_robin_config": {
-          "$ref": "#/definitions/EscalationPathRoundRobinConfigV2RequestBody"
+          "$ref": "#/definitions/EscalationPathRoundRobinConfigV2"
         },
         "targets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EscalationPathTargetV2RequestBody"
+            "$ref": "#/definitions/EscalationPathTargetV2"
           },
           "description": "The targets for this level",
           "example": [
@@ -22648,72 +23100,8 @@
         "targets"
       ]
     },
-    "EscalationPathNodeLevelV2ResponseBody": {
-      "title": "EscalationPathNodeLevelV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "round_robin_config": {
-          "$ref": "#/definitions/EscalationPathRoundRobinConfigV2ResponseBody"
-        },
-        "targets": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EscalationPathTargetV2ResponseBody"
-          },
-          "description": "The targets for this level",
-          "example": [
-            {
-              "id": "lawrencejones",
-              "schedule_mode": "currently_on_call",
-              "type": "user",
-              "urgency": "high"
-            }
-          ]
-        },
-        "time_to_ack_interval_condition": {
-          "type": "string",
-          "description": "If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive",
-          "example": "active",
-          "enum": [
-            "active",
-            "inactive"
-          ]
-        },
-        "time_to_ack_seconds": {
-          "type": "integer",
-          "description": "How long should we wait for this level to acknowledge before escalating?",
-          "example": 1800,
-          "format": "int64"
-        },
-        "time_to_ack_weekday_interval_config_id": {
-          "type": "string",
-          "description": "If the time to ack is relative to a time window, this identifies which window it is relative to",
-          "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-        }
-      },
-      "example": {
-        "round_robin_config": {
-          "enabled": false,
-          "rotate_after_seconds": 120
-        },
-        "targets": [
-          {
-            "id": "lawrencejones",
-            "schedule_mode": "currently_on_call",
-            "type": "user",
-            "urgency": "high"
-          }
-        ],
-        "time_to_ack_interval_condition": "active",
-        "time_to_ack_seconds": 1800,
-        "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-      },
-      "required": [
-        "targets"
-      ]
-    },
-    "EscalationPathNodePayloadV2RequestBody": {
-      "title": "EscalationPathNodePayloadV2RequestBody",
+    "EscalationPathNodePayloadV2": {
+      "title": "EscalationPathNodePayloadV2",
       "type": "object",
       "properties": {
         "id": {
@@ -22722,13 +23110,13 @@
           "example": "01FCNDV6P870EA6S7TK1DSYDG0"
         },
         "if_else": {
-          "$ref": "#/definitions/EscalationPathNodeIfElsePayloadV2RequestBody"
+          "$ref": "#/definitions/EscalationPathNodeIfElsePayloadV2"
         },
         "level": {
-          "$ref": "#/definitions/EscalationPathNodeLevelV2RequestBody"
+          "$ref": "#/definitions/EscalationPathNodeLevelV2"
         },
         "repeat": {
-          "$ref": "#/definitions/EscalationPathNodeRepeatV2RequestBody"
+          "$ref": "#/definitions/EscalationPathNodeRepeatV2"
         },
         "type": {
           "type": "string",
@@ -22800,8 +23188,8 @@
         "type"
       ]
     },
-    "EscalationPathNodeRepeatV2RequestBody": {
-      "title": "EscalationPathNodeRepeatV2RequestBody",
+    "EscalationPathNodeRepeatV2": {
+      "title": "EscalationPathNodeRepeatV2",
       "type": "object",
       "properties": {
         "repeat_times": {
@@ -22825,33 +23213,8 @@
         "repeat_times"
       ]
     },
-    "EscalationPathNodeRepeatV2ResponseBody": {
-      "title": "EscalationPathNodeRepeatV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "repeat_times": {
-          "type": "integer",
-          "description": "How many times to repeat these steps",
-          "example": 3,
-          "format": "int64"
-        },
-        "to_node": {
-          "type": "string",
-          "description": "Which node ID we begin repeating from",
-          "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-        }
-      },
-      "example": {
-        "repeat_times": 3,
-        "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
-      },
-      "required": [
-        "to_node",
-        "repeat_times"
-      ]
-    },
-    "EscalationPathNodeV2ResponseBody": {
-      "title": "EscalationPathNodeV2ResponseBody",
+    "EscalationPathNodeV2": {
+      "title": "EscalationPathNodeV2",
       "type": "object",
       "properties": {
         "id": {
@@ -22860,13 +23223,13 @@
           "example": "01FCNDV6P870EA6S7TK1DSYDG0"
         },
         "if_else": {
-          "$ref": "#/definitions/EscalationPathNodeIfElseV2ResponseBody"
+          "$ref": "#/definitions/EscalationPathNodeIfElseV2"
         },
         "level": {
-          "$ref": "#/definitions/EscalationPathNodeLevelV2ResponseBody"
+          "$ref": "#/definitions/EscalationPathNodeLevelV2"
         },
         "repeat": {
-          "$ref": "#/definitions/EscalationPathNodeRepeatV2ResponseBody"
+          "$ref": "#/definitions/EscalationPathNodeRepeatV2"
         },
         "type": {
           "type": "string",
@@ -22946,8 +23309,8 @@
         "type"
       ]
     },
-    "EscalationPathRoundRobinConfigV2RequestBody": {
-      "title": "EscalationPathRoundRobinConfigV2RequestBody",
+    "EscalationPathRoundRobinConfigV2": {
+      "title": "EscalationPathRoundRobinConfigV2",
       "type": "object",
       "properties": {
         "enabled": {
@@ -22970,32 +23333,8 @@
         "enabled"
       ]
     },
-    "EscalationPathRoundRobinConfigV2ResponseBody": {
-      "title": "EscalationPathRoundRobinConfigV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Whether round robin is enabled for this level",
-          "example": false
-        },
-        "rotate_after_seconds": {
-          "type": "integer",
-          "description": "How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.",
-          "example": 120,
-          "format": "int64"
-        }
-      },
-      "example": {
-        "enabled": false,
-        "rotate_after_seconds": 120
-      },
-      "required": [
-        "enabled"
-      ]
-    },
-    "EscalationPathTargetV2RequestBody": {
-      "title": "EscalationPathTargetV2RequestBody",
+    "EscalationPathTargetV2": {
+      "title": "EscalationPathTargetV2",
       "type": "object",
       "properties": {
         "id": {
@@ -23046,60 +23385,8 @@
         "urgency"
       ]
     },
-    "EscalationPathTargetV2ResponseBody": {
-      "title": "EscalationPathTargetV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Uniquely identifies an entity of this type",
-          "example": "lawrencejones"
-        },
-        "schedule_mode": {
-          "type": "string",
-          "description": "Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule",
-          "example": "currently_on_call",
-          "enum": [
-            "currently_on_call",
-            "all_users_for_rota",
-            "all_users",
-            ""
-          ]
-        },
-        "type": {
-          "type": "string",
-          "description": "Controls what type of entity this target identifies, such as EscalationPolicy or User",
-          "example": "user",
-          "enum": [
-            "schedule",
-            "user",
-            "slack_channel"
-          ]
-        },
-        "urgency": {
-          "type": "string",
-          "description": "The urgency of this escalation path target",
-          "example": "high",
-          "enum": [
-            "high",
-            "low"
-          ]
-        }
-      },
-      "example": {
-        "id": "lawrencejones",
-        "schedule_mode": "currently_on_call",
-        "type": "user",
-        "urgency": "high"
-      },
-      "required": [
-        "type",
-        "id",
-        "urgency"
-      ]
-    },
-    "EscalationPathV2ResponseBody": {
-      "title": "EscalationPathV2ResponseBody",
+    "EscalationPathV2": {
+      "title": "EscalationPathV2",
       "type": "object",
       "properties": {
         "id": {
@@ -23115,7 +23402,7 @@
         "path": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EscalationPathNodeV2ResponseBody"
+            "$ref": "#/definitions/EscalationPathNodeV2"
           },
           "description": "The nodes that form the levels and branches of this escalation path.",
           "example": [
@@ -23185,7 +23472,7 @@
         "working_hours": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/WeekdayIntervalConfigV2ResponseBody"
+            "$ref": "#/definitions/WeekdayIntervalConfigV2"
           },
           "description": "The working hours for this escalation path.",
           "example": [
@@ -23305,7 +23592,7 @@
         "path": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EscalationPathNodePayloadV2RequestBody"
+            "$ref": "#/definitions/EscalationPathNodePayloadV2"
           },
           "description": "The nodes that form the levels and branches of this escalation path.",
           "example": [
@@ -23367,7 +23654,7 @@
         "working_hours": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/WeekdayIntervalConfigV2RequestBody"
+            "$ref": "#/definitions/WeekdayIntervalConfigV2"
           },
           "description": "The working hours for this escalation path.",
           "example": [
@@ -23468,7 +23755,7 @@
       "type": "object",
       "properties": {
         "escalation_path": {
-          "$ref": "#/definitions/EscalationPathV2ResponseBody"
+          "$ref": "#/definitions/EscalationPathV2"
         }
       },
       "example": {
@@ -23563,7 +23850,7 @@
       "type": "object",
       "properties": {
         "escalation_path": {
-          "$ref": "#/definitions/EscalationPathV2ResponseBody"
+          "$ref": "#/definitions/EscalationPathV2"
         }
       },
       "example": {
@@ -23665,7 +23952,7 @@
         "path": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EscalationPathNodePayloadV2RequestBody"
+            "$ref": "#/definitions/EscalationPathNodePayloadV2"
           },
           "description": "The nodes that form the levels and branches of this escalation path.",
           "example": [
@@ -23727,7 +24014,7 @@
         "working_hours": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/WeekdayIntervalConfigV2RequestBody"
+            "$ref": "#/definitions/WeekdayIntervalConfigV2"
           },
           "description": "The working hours for this escalation path.",
           "example": [
@@ -23828,7 +24115,7 @@
       "type": "object",
       "properties": {
         "escalation_path": {
-          "$ref": "#/definitions/EscalationPathV2ResponseBody"
+          "$ref": "#/definitions/EscalationPathV2"
         }
       },
       "example": {
@@ -23918,14 +24205,14 @@
         "escalation_path"
       ]
     },
-    "ExpressionBranchPayloadV2RequestBody": {
-      "title": "ExpressionBranchPayloadV2RequestBody",
+    "ExpressionBranchPayloadV2": {
+      "title": "ExpressionBranchPayloadV2",
       "type": "object",
       "properties": {
         "condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+            "$ref": "#/definitions/ConditionGroupPayloadV2"
           },
           "description": "When one of these condition groups are satisfied, this branch will be evaluated",
           "example": [
@@ -23954,7 +24241,7 @@
           ]
         },
         "result": {
-          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingPayloadV2"
         }
       },
       "example": {
@@ -24000,14 +24287,14 @@
         "result"
       ]
     },
-    "ExpressionBranchV2ResponseBody": {
-      "title": "ExpressionBranchV2ResponseBody",
+    "ExpressionBranchV2": {
+      "title": "ExpressionBranchV2",
       "type": "object",
       "properties": {
         "condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupV2ResponseBody"
+            "$ref": "#/definitions/ConditionGroupV2"
           },
           "description": "When one of these condition groups are satisfied, this branch will be evaluated",
           "example": [
@@ -24044,7 +24331,7 @@
           ]
         },
         "result": {
-          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingV2"
         }
       },
       "example": {
@@ -24100,14 +24387,14 @@
         "result"
       ]
     },
-    "ExpressionBranchesOptsPayloadV2RequestBody": {
-      "title": "ExpressionBranchesOptsPayloadV2RequestBody",
+    "ExpressionBranchesOptsPayloadV2": {
+      "title": "ExpressionBranchesOptsPayloadV2",
       "type": "object",
       "properties": {
         "branches": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ExpressionBranchPayloadV2RequestBody"
+            "$ref": "#/definitions/ExpressionBranchPayloadV2"
           },
           "description": "The branches to apply for this operation",
           "example": [
@@ -24152,7 +24439,7 @@
           ]
         },
         "returns": {
-          "$ref": "#/definitions/ReturnsMetaV2RequestBody"
+          "$ref": "#/definitions/ReturnsMetaV2"
         }
       },
       "example": {
@@ -24206,14 +24493,14 @@
         "returns"
       ]
     },
-    "ExpressionBranchesOptsV2ResponseBody": {
-      "title": "ExpressionBranchesOptsV2ResponseBody",
+    "ExpressionBranchesOptsV2": {
+      "title": "ExpressionBranchesOptsV2",
       "type": "object",
       "properties": {
         "branches": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ExpressionBranchV2ResponseBody"
+            "$ref": "#/definitions/ExpressionBranchV2"
           },
           "description": "The branches to apply for this operation",
           "example": [
@@ -24268,7 +24555,7 @@
           ]
         },
         "returns": {
-          "$ref": "#/definitions/ReturnsMetaV2ResponseBody"
+          "$ref": "#/definitions/ReturnsMetaV2"
         }
       },
       "example": {
@@ -24332,12 +24619,12 @@
         "returns"
       ]
     },
-    "ExpressionElseBranchPayloadV2RequestBody": {
-      "title": "ExpressionElseBranchPayloadV2RequestBody",
+    "ExpressionElseBranchPayloadV2": {
+      "title": "ExpressionElseBranchPayloadV2",
       "type": "object",
       "properties": {
         "result": {
-          "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
+          "$ref": "#/definitions/EngineParamBindingPayloadV2"
         }
       },
       "example": {
@@ -24358,12 +24645,12 @@
         "result"
       ]
     },
-    "ExpressionElseBranchV2ResponseBody": {
-      "title": "ExpressionElseBranchV2ResponseBody",
+    "ExpressionElseBranchV2": {
+      "title": "ExpressionElseBranchV2",
       "type": "object",
       "properties": {
         "result": {
-          "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+          "$ref": "#/definitions/EngineParamBindingV2"
         }
       },
       "example": {
@@ -24386,14 +24673,14 @@
         "result"
       ]
     },
-    "ExpressionFilterOptsPayloadV2RequestBody": {
-      "title": "ExpressionFilterOptsPayloadV2RequestBody",
+    "ExpressionFilterOptsPayloadV2": {
+      "title": "ExpressionFilterOptsPayloadV2",
       "type": "object",
       "properties": {
         "condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
+            "$ref": "#/definitions/ConditionGroupPayloadV2"
           },
           "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
           "example": [
@@ -24452,14 +24739,14 @@
         "condition_groups"
       ]
     },
-    "ExpressionFilterOptsV2ResponseBody": {
-      "title": "ExpressionFilterOptsV2ResponseBody",
+    "ExpressionFilterOptsV2": {
+      "title": "ExpressionFilterOptsV2",
       "type": "object",
       "properties": {
         "condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupV2ResponseBody"
+            "$ref": "#/definitions/ConditionGroupV2"
           },
           "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
           "example": [
@@ -24534,8 +24821,8 @@
         "condition_groups"
       ]
     },
-    "ExpressionNavigateOptsPayloadV2RequestBody": {
-      "title": "ExpressionNavigateOptsPayloadV2RequestBody",
+    "ExpressionNavigateOptsPayloadV2": {
+      "title": "ExpressionNavigateOptsPayloadV2",
       "type": "object",
       "properties": {
         "reference": {
@@ -24551,8 +24838,8 @@
         "reference"
       ]
     },
-    "ExpressionNavigateOptsV2ResponseBody": {
-      "title": "ExpressionNavigateOptsV2ResponseBody",
+    "ExpressionNavigateOptsV2": {
+      "title": "ExpressionNavigateOptsV2",
       "type": "object",
       "properties": {
         "reference": {
@@ -24575,18 +24862,18 @@
         "reference_label"
       ]
     },
-    "ExpressionOperationPayloadV2RequestBody": {
-      "title": "ExpressionOperationPayloadV2RequestBody",
+    "ExpressionOperationPayloadV2": {
+      "title": "ExpressionOperationPayloadV2",
       "type": "object",
       "properties": {
         "branches": {
-          "$ref": "#/definitions/ExpressionBranchesOptsPayloadV2RequestBody"
+          "$ref": "#/definitions/ExpressionBranchesOptsPayloadV2"
         },
         "filter": {
-          "$ref": "#/definitions/ExpressionFilterOptsPayloadV2RequestBody"
+          "$ref": "#/definitions/ExpressionFilterOptsPayloadV2"
         },
         "navigate": {
-          "$ref": "#/definitions/ExpressionNavigateOptsPayloadV2RequestBody"
+          "$ref": "#/definitions/ExpressionNavigateOptsPayloadV2"
         },
         "operation_type": {
           "type": "string",
@@ -24605,7 +24892,7 @@
           ]
         },
         "parse": {
-          "$ref": "#/definitions/ExpressionParseOptsPayloadV2RequestBody"
+          "$ref": "#/definitions/ExpressionParseOptsPayloadV2"
         }
       },
       "example": {
@@ -24698,18 +24985,18 @@
         "returns"
       ]
     },
-    "ExpressionOperationV2ResponseBody": {
-      "title": "ExpressionOperationV2ResponseBody",
+    "ExpressionOperationV2": {
+      "title": "ExpressionOperationV2",
       "type": "object",
       "properties": {
         "branches": {
-          "$ref": "#/definitions/ExpressionBranchesOptsV2ResponseBody"
+          "$ref": "#/definitions/ExpressionBranchesOptsV2"
         },
         "filter": {
-          "$ref": "#/definitions/ExpressionFilterOptsV2ResponseBody"
+          "$ref": "#/definitions/ExpressionFilterOptsV2"
         },
         "navigate": {
-          "$ref": "#/definitions/ExpressionNavigateOptsV2ResponseBody"
+          "$ref": "#/definitions/ExpressionNavigateOptsV2"
         },
         "operation_type": {
           "type": "string",
@@ -24728,10 +25015,10 @@
           ]
         },
         "parse": {
-          "$ref": "#/definitions/ExpressionParseOptsV2ResponseBody"
+          "$ref": "#/definitions/ExpressionParseOptsV2"
         },
         "returns": {
-          "$ref": "#/definitions/ReturnsMetaV2ResponseBody"
+          "$ref": "#/definitions/ReturnsMetaV2"
         }
       },
       "example": {
@@ -24847,12 +25134,12 @@
         "returns"
       ]
     },
-    "ExpressionParseOptsPayloadV2RequestBody": {
-      "title": "ExpressionParseOptsPayloadV2RequestBody",
+    "ExpressionParseOptsPayloadV2": {
+      "title": "ExpressionParseOptsPayloadV2",
       "type": "object",
       "properties": {
         "returns": {
-          "$ref": "#/definitions/ReturnsMetaV2RequestBody"
+          "$ref": "#/definitions/ReturnsMetaV2"
         },
         "source": {
           "type": "string",
@@ -24872,12 +25159,12 @@
         "returns"
       ]
     },
-    "ExpressionParseOptsV2ResponseBody": {
-      "title": "ExpressionParseOptsV2ResponseBody",
+    "ExpressionParseOptsV2": {
+      "title": "ExpressionParseOptsV2",
       "type": "object",
       "properties": {
         "returns": {
-          "$ref": "#/definitions/ReturnsMetaV2ResponseBody"
+          "$ref": "#/definitions/ReturnsMetaV2"
         },
         "source": {
           "type": "string",
@@ -24897,12 +25184,12 @@
         "returns"
       ]
     },
-    "ExpressionPayloadV2RequestBody": {
-      "title": "ExpressionPayloadV2RequestBody",
+    "ExpressionPayloadV2": {
+      "title": "ExpressionPayloadV2",
       "type": "object",
       "properties": {
         "else_branch": {
-          "$ref": "#/definitions/ExpressionElseBranchPayloadV2RequestBody"
+          "$ref": "#/definitions/ExpressionElseBranchPayloadV2"
         },
         "label": {
           "type": "string",
@@ -24912,7 +25199,7 @@
         "operations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ExpressionOperationPayloadV2RequestBody"
+            "$ref": "#/definitions/ExpressionOperationPayloadV2"
           },
           "example": [
             {
@@ -25126,12 +25413,12 @@
         "operations"
       ]
     },
-    "ExpressionV2ResponseBody": {
-      "title": "ExpressionV2ResponseBody",
+    "ExpressionV2": {
+      "title": "ExpressionV2",
       "type": "object",
       "properties": {
         "else_branch": {
-          "$ref": "#/definitions/ExpressionElseBranchV2ResponseBody"
+          "$ref": "#/definitions/ExpressionElseBranchV2"
         },
         "label": {
           "type": "string",
@@ -25141,7 +25428,7 @@
         "operations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ExpressionOperationV2ResponseBody"
+            "$ref": "#/definitions/ExpressionOperationV2"
           },
           "example": [
             {
@@ -25260,7 +25547,7 @@
           "example": "abc123"
         },
         "returns": {
-          "$ref": "#/definitions/ReturnsMetaV2ResponseBody"
+          "$ref": "#/definitions/ReturnsMetaV2"
         },
         "root_reference": {
           "type": "string",
@@ -25412,8 +25699,8 @@
         "id"
       ]
     },
-    "ExternalIssueReferenceV1ResponseBody": {
-      "title": "ExternalIssueReferenceV1ResponseBody",
+    "ExternalIssueReferenceV1": {
+      "title": "ExternalIssueReferenceV1",
       "type": "object",
       "properties": {
         "issue_name": {
@@ -25448,8 +25735,8 @@
         "provider": "asana"
       }
     },
-    "ExternalIssueReferenceV2ResponseBody": {
-      "title": "ExternalIssueReferenceV2ResponseBody",
+    "ExternalIssueReferenceV2": {
+      "title": "ExternalIssueReferenceV2",
       "type": "object",
       "properties": {
         "issue_name": {
@@ -25491,8 +25778,8 @@
         "issue_id"
       ]
     },
-    "ExternalResourceV1ResponseBody": {
-      "title": "ExternalResourceV1ResponseBody",
+    "ExternalResourceV1": {
+      "title": "ExternalResourceV1",
       "type": "object",
       "properties": {
         "external_id": {
@@ -25547,8 +25834,8 @@
         "updated_at"
       ]
     },
-    "FollowUpPriorityV2ResponseBody": {
-      "title": "FollowUpPriorityV2ResponseBody",
+    "FollowUpPriorityV2": {
+      "title": "FollowUpPriorityV2",
       "type": "object",
       "properties": {
         "description": {
@@ -25585,12 +25872,12 @@
         "rank"
       ]
     },
-    "FollowUpV2ResponseBody": {
-      "title": "FollowUpV2ResponseBody",
+    "FollowUpV2": {
+      "title": "FollowUpV2",
       "type": "object",
       "properties": {
         "assignee": {
-          "$ref": "#/definitions/UserV2ResponseBody"
+          "$ref": "#/definitions/UserV2"
         },
         "completed_at": {
           "type": "string",
@@ -25610,7 +25897,7 @@
           "example": "Call the fire brigade"
         },
         "external_issue_reference": {
-          "$ref": "#/definitions/ExternalIssueReferenceV2ResponseBody"
+          "$ref": "#/definitions/ExternalIssueReferenceV2"
         },
         "id": {
           "type": "string",
@@ -25623,7 +25910,7 @@
           "example": "01FCNDV6P870EA6S7TK1DSYDG0"
         },
         "priority": {
-          "$ref": "#/definitions/FollowUpPriorityV2ResponseBody"
+          "$ref": "#/definitions/FollowUpPriorityV2"
         },
         "status": {
           "type": "string",
@@ -25692,7 +25979,7 @@
         "follow_ups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/FollowUpV2ResponseBody"
+            "$ref": "#/definitions/FollowUpV2"
           },
           "example": [
             {
@@ -25767,7 +26054,7 @@
       "type": "object",
       "properties": {
         "follow_up": {
-          "$ref": "#/definitions/FollowUpV2ResponseBody"
+          "$ref": "#/definitions/FollowUpV2"
         }
       },
       "example": {
@@ -25804,8 +26091,8 @@
         "follow_up"
       ]
     },
-    "GroupingKeyV2RequestBody": {
-      "title": "GroupingKeyV2RequestBody",
+    "GroupingKeyV2": {
+      "title": "GroupingKeyV2",
       "type": "object",
       "properties": {
         "id": {
@@ -25821,25 +26108,8 @@
         "id"
       ]
     },
-    "GroupingKeyV2ResponseBody": {
-      "title": "GroupingKeyV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Unique identifier of the alert attribute the user wishes to group on",
-          "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-        }
-      },
-      "example": {
-        "id": "01FCNDV6P870EA6S7TK1DSYDG0"
-      },
-      "required": [
-        "id"
-      ]
-    },
-    "IdentityV1ResponseBody": {
-      "title": "IdentityV1ResponseBody",
+    "IdentityV1": {
+      "title": "IdentityV1",
       "type": "object",
       "properties": {
         "dashboard_url": {
@@ -25892,8 +26162,8 @@
         "dashboard_url"
       ]
     },
-    "IncidentAttachmentV1ResponseBody": {
-      "title": "IncidentAttachmentV1ResponseBody",
+    "IncidentAttachmentV1": {
+      "title": "IncidentAttachmentV1",
       "type": "object",
       "properties": {
         "id": {
@@ -25907,7 +26177,7 @@
           "example": "01FCNDV6P870EA6S7TK1DSYD5H"
         },
         "resource": {
-          "$ref": "#/definitions/ExternalResourceV1ResponseBody"
+          "$ref": "#/definitions/ExternalResourceV1"
         }
       },
       "example": {
@@ -25999,7 +26269,7 @@
       "type": "object",
       "properties": {
         "incident_attachment": {
-          "$ref": "#/definitions/IncidentAttachmentV1ResponseBody"
+          "$ref": "#/definitions/IncidentAttachmentV1"
         }
       },
       "example": {
@@ -26025,7 +26295,7 @@
         "incident_attachments": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentAttachmentV1ResponseBody"
+            "$ref": "#/definitions/IncidentAttachmentV1"
           },
           "example": [
             {
@@ -26059,8 +26329,188 @@
         "incident_attachments"
       ]
     },
-    "IncidentDurationMetricV2ResponseBody": {
-      "title": "IncidentDurationMetricV2ResponseBody",
+    "IncidentCreatePayloadV2": {
+      "title": "IncidentCreatePayloadV2",
+      "type": "object",
+      "properties": {
+        "custom_field_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CustomFieldEntryPayloadV2"
+          },
+          "description": "Set the incident's custom fields to these values",
+          "example": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the incident",
+          "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+        },
+        "idempotency_key": {
+          "type": "string",
+          "description": "Unique string used to de-duplicate incident create requests",
+          "example": "alert-uuid"
+        },
+        "incident_role_assignments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IncidentRoleAssignmentPayloadV2"
+          },
+          "description": "Assign incident roles to these people",
+          "example": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ]
+        },
+        "incident_status_id": {
+          "type": "string",
+          "description": "Incident status to assign to the incident",
+          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "incident_timestamp_values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IncidentTimestampValuePayloadV2"
+          },
+          "description": "Assign the incident's timestamps to these values",
+          "example": [
+            {
+              "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "value": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "incident_type_id": {
+          "type": "string",
+          "description": "Incident type to create this incident as",
+          "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+        },
+        "mode": {
+          "type": "string",
+          "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
+          "example": "standard",
+          "enum": [
+            "standard",
+            "retrospective",
+            "test",
+            "tutorial"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Explanation of the incident",
+          "example": "Our database is sad"
+        },
+        "retrospective_incident_options": {
+          "$ref": "#/definitions/RetrospectiveIncidentOptionsV2"
+        },
+        "severity_id": {
+          "type": "string",
+          "description": "Severity to create incident as",
+          "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+        },
+        "slack_channel_name_override": {
+          "type": "string",
+          "description": "Name of the Slack channel to create for this incident",
+          "example": "inc-123-database-down"
+        },
+        "slack_team_id": {
+          "type": "string",
+          "description": "Slack Team to create the incident in",
+          "example": "T02A1FSLE8J"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Detailed description of the incident",
+          "example": "Our database is really really sad, and we don't know why yet."
+        },
+        "visibility": {
+          "type": "string",
+          "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+          "example": "public",
+          "enum": [
+            "public",
+            "private"
+          ]
+        }
+      },
+      "example": {
+        "custom_field_entries": [
+          {
+            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "values": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_link": "https://google.com/",
+                "value_numeric": "123.456",
+                "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_text": "This is my text field, I hope you like it",
+                "value_timestamp": ""
+              }
+            ]
+          }
+        ],
+        "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+        "idempotency_key": "alert-uuid",
+        "incident_role_assignments": [
+          {
+            "assignee": {
+              "email": "bob@example.com",
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "slack_user_id": "USER123"
+            },
+            "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          }
+        ],
+        "incident_status_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+        "incident_timestamp_values": [
+          {
+            "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "value": "2021-08-17T13:28:57.801578Z"
+          }
+        ],
+        "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+        "mode": "standard",
+        "name": "Our database is sad",
+        "retrospective_incident_options": {
+          "postmortem_document_url": "https://docs.google.com/my_doc_id",
+          "slack_channel_id": "abc123"
+        },
+        "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+        "slack_channel_name_override": "inc-123-database-down",
+        "slack_team_id": "T02A1FSLE8J",
+        "summary": "Our database is really really sad, and we don't know why yet.",
+        "visibility": "public"
+      },
+      "required": [
+        "idempotency_key",
+        "visibility"
+      ]
+    },
+    "IncidentDurationMetricV2": {
+      "title": "IncidentDurationMetricV2",
       "type": "object",
       "properties": {
         "id": {
@@ -26091,12 +26541,12 @@
         "validate"
       ]
     },
-    "IncidentDurationMetricWithValueV2ResponseBody": {
-      "title": "IncidentDurationMetricWithValueV2ResponseBody",
+    "IncidentDurationMetricWithValueV2": {
+      "title": "IncidentDurationMetricWithValueV2",
       "type": "object",
       "properties": {
         "duration_metric": {
-          "$ref": "#/definitions/IncidentDurationMetricV2ResponseBody"
+          "$ref": "#/definitions/IncidentDurationMetricV2"
         },
         "value_seconds": {
           "type": "integer",
@@ -26116,8 +26566,8 @@
         "duration_metric"
       ]
     },
-    "IncidentEditPayloadV2RequestBody": {
-      "title": "IncidentEditPayloadV2RequestBody",
+    "IncidentEditPayloadV2": {
+      "title": "IncidentEditPayloadV2",
       "type": "object",
       "properties": {
         "call_url": {
@@ -26128,7 +26578,7 @@
         "custom_field_entries": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldEntryPayloadV2RequestBody"
+            "$ref": "#/definitions/CustomFieldEntryPayloadV2"
           },
           "description": "Set the incident's custom fields to these values",
           "example": [
@@ -26151,7 +26601,7 @@
         "incident_role_assignments": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentRoleAssignmentPayloadV2RequestBody"
+            "$ref": "#/definitions/IncidentRoleAssignmentPayloadV2"
           },
           "description": "Assign incident roles to these people",
           "example": [
@@ -26173,7 +26623,7 @@
         "incident_timestamp_values": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentTimestampValuePayloadV2RequestBody"
+            "$ref": "#/definitions/IncidentTimestampValuePayloadV2"
           },
           "description": "Assign the incident's timestamps to these values",
           "example": [
@@ -26245,8 +26695,8 @@
         "summary": "Our database is really really sad, and we don't know why yet."
       }
     },
-    "IncidentMembershipResponseBody": {
-      "title": "IncidentMembershipResponseBody",
+    "IncidentMembership": {
+      "title": "IncidentMembership",
       "type": "object",
       "properties": {
         "created_at": {
@@ -26272,7 +26722,7 @@
           "format": "date-time"
         },
         "user": {
-          "$ref": "#/definitions/UserV2ResponseBody"
+          "$ref": "#/definitions/UserV2"
         }
       },
       "example": {
@@ -26323,7 +26773,7 @@
       "type": "object",
       "properties": {
         "incident_membership": {
-          "$ref": "#/definitions/IncidentMembershipResponseBody"
+          "$ref": "#/definitions/IncidentMembership"
         }
       },
       "example": {
@@ -26368,12 +26818,12 @@
         "incident_id"
       ]
     },
-    "IncidentRoleAssignmentPayloadV1RequestBody": {
-      "title": "IncidentRoleAssignmentPayloadV1RequestBody",
+    "IncidentRoleAssignmentPayloadV1": {
+      "title": "IncidentRoleAssignmentPayloadV1",
       "type": "object",
       "properties": {
         "assignee": {
-          "$ref": "#/definitions/UserReferencePayloadV1RequestBody"
+          "$ref": "#/definitions/UserReferencePayloadV1"
         },
         "incident_role_id": {
           "type": "string",
@@ -26394,12 +26844,12 @@
         "assignee"
       ]
     },
-    "IncidentRoleAssignmentPayloadV2RequestBody": {
-      "title": "IncidentRoleAssignmentPayloadV2RequestBody",
+    "IncidentRoleAssignmentPayloadV2": {
+      "title": "IncidentRoleAssignmentPayloadV2",
       "type": "object",
       "properties": {
         "assignee": {
-          "$ref": "#/definitions/UserReferencePayloadV2RequestBody"
+          "$ref": "#/definitions/UserReferencePayloadV2"
         },
         "incident_role_id": {
           "type": "string",
@@ -26419,15 +26869,15 @@
         "incident_role_id"
       ]
     },
-    "IncidentRoleAssignmentV1ResponseBody": {
-      "title": "IncidentRoleAssignmentV1ResponseBody",
+    "IncidentRoleAssignmentV1": {
+      "title": "IncidentRoleAssignmentV1",
       "type": "object",
       "properties": {
         "assignee": {
-          "$ref": "#/definitions/UserV1ResponseBody"
+          "$ref": "#/definitions/UserV1"
         },
         "role": {
-          "$ref": "#/definitions/IncidentRoleV1ResponseBody"
+          "$ref": "#/definitions/IncidentRoleV1"
         }
       },
       "example": {
@@ -26454,15 +26904,15 @@
         "role"
       ]
     },
-    "IncidentRoleAssignmentV2ResponseBody": {
-      "title": "IncidentRoleAssignmentV2ResponseBody",
+    "IncidentRoleAssignmentV2": {
+      "title": "IncidentRoleAssignmentV2",
       "type": "object",
       "properties": {
         "assignee": {
-          "$ref": "#/definitions/UserV2ResponseBody"
+          "$ref": "#/definitions/UserV2"
         },
         "role": {
-          "$ref": "#/definitions/EmbeddedIncidentRoleV2ResponseBody"
+          "$ref": "#/definitions/EmbeddedIncidentRoleV2"
         }
       },
       "example": {
@@ -26489,8 +26939,8 @@
         "role"
       ]
     },
-    "IncidentRoleV1ResponseBody": {
-      "title": "IncidentRoleV1ResponseBody",
+    "IncidentRoleV1": {
+      "title": "IncidentRoleV1",
       "type": "object",
       "properties": {
         "created_at": {
@@ -26571,8 +27021,8 @@
         "updated_at"
       ]
     },
-    "IncidentRoleV2ResponseBody": {
-      "title": "IncidentRoleV2ResponseBody",
+    "IncidentRoleV2": {
+      "title": "IncidentRoleV2",
       "type": "object",
       "properties": {
         "created_at": {
@@ -26704,7 +27154,7 @@
       "type": "object",
       "properties": {
         "incident_role": {
-          "$ref": "#/definitions/IncidentRoleV1ResponseBody"
+          "$ref": "#/definitions/IncidentRoleV1"
         }
       },
       "example": {
@@ -26731,7 +27181,7 @@
         "incident_roles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentRoleV1ResponseBody"
+            "$ref": "#/definitions/IncidentRoleV1"
           },
           "example": [
             {
@@ -26772,7 +27222,7 @@
       "type": "object",
       "properties": {
         "incident_role": {
-          "$ref": "#/definitions/IncidentRoleV1ResponseBody"
+          "$ref": "#/definitions/IncidentRoleV1"
         }
       },
       "example": {
@@ -26847,7 +27297,7 @@
       "type": "object",
       "properties": {
         "incident_role": {
-          "$ref": "#/definitions/IncidentRoleV1ResponseBody"
+          "$ref": "#/definitions/IncidentRoleV1"
         }
       },
       "example": {
@@ -26917,7 +27367,7 @@
       "type": "object",
       "properties": {
         "incident_role": {
-          "$ref": "#/definitions/IncidentRoleV2ResponseBody"
+          "$ref": "#/definitions/IncidentRoleV2"
         }
       },
       "example": {
@@ -26943,7 +27393,7 @@
         "incident_roles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentRoleV2ResponseBody"
+            "$ref": "#/definitions/IncidentRoleV2"
           },
           "example": [
             {
@@ -26982,7 +27432,7 @@
       "type": "object",
       "properties": {
         "incident_role": {
-          "$ref": "#/definitions/IncidentRoleV2ResponseBody"
+          "$ref": "#/definitions/IncidentRoleV2"
         }
       },
       "example": {
@@ -27050,7 +27500,7 @@
       "type": "object",
       "properties": {
         "incident_role": {
-          "$ref": "#/definitions/IncidentRoleV2ResponseBody"
+          "$ref": "#/definitions/IncidentRoleV2"
         }
       },
       "example": {
@@ -27069,8 +27519,8 @@
         "incident_role"
       ]
     },
-    "IncidentStatusV1ResponseBody": {
-      "title": "IncidentStatusV1ResponseBody",
+    "IncidentStatusV1": {
+      "title": "IncidentStatusV1",
       "type": "object",
       "properties": {
         "category": {
@@ -27139,8 +27589,8 @@
         "updated_at"
       ]
     },
-    "IncidentStatusV2ResponseBody": {
-      "title": "IncidentStatusV2ResponseBody",
+    "IncidentStatusV2": {
+      "title": "IncidentStatusV2",
       "type": "object",
       "properties": {
         "category": {
@@ -27254,7 +27704,7 @@
       "type": "object",
       "properties": {
         "incident_status": {
-          "$ref": "#/definitions/IncidentStatusV1ResponseBody"
+          "$ref": "#/definitions/IncidentStatusV1"
         }
       },
       "example": {
@@ -27279,7 +27729,7 @@
         "incident_statuses": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentStatusV1ResponseBody"
+            "$ref": "#/definitions/IncidentStatusV1"
           },
           "example": [
             {
@@ -27316,7 +27766,7 @@
       "type": "object",
       "properties": {
         "incident_status": {
-          "$ref": "#/definitions/IncidentStatusV1ResponseBody"
+          "$ref": "#/definitions/IncidentStatusV1"
         }
       },
       "example": {
@@ -27367,7 +27817,7 @@
       "type": "object",
       "properties": {
         "incident_status": {
-          "$ref": "#/definitions/IncidentStatusV1ResponseBody"
+          "$ref": "#/definitions/IncidentStatusV1"
         }
       },
       "example": {
@@ -27385,8 +27835,8 @@
         "incident_status"
       ]
     },
-    "IncidentTimestampV1ResponseBody": {
-      "title": "IncidentTimestampV1ResponseBody",
+    "IncidentTimestampV1": {
+      "title": "IncidentTimestampV1",
       "type": "object",
       "properties": {
         "last_occurred_at": {
@@ -27409,8 +27859,8 @@
         "name"
       ]
     },
-    "IncidentTimestampV2ResponseBody": {
-      "title": "IncidentTimestampV2ResponseBody",
+    "IncidentTimestampV2": {
+      "title": "IncidentTimestampV2",
       "type": "object",
       "properties": {
         "id": {
@@ -27449,8 +27899,8 @@
         "updated_at"
       ]
     },
-    "IncidentTimestampValuePayloadV2RequestBody": {
-      "title": "IncidentTimestampValuePayloadV2RequestBody",
+    "IncidentTimestampValuePayloadV2": {
+      "title": "IncidentTimestampValuePayloadV2",
       "type": "object",
       "properties": {
         "incident_timestamp_id": {
@@ -27476,8 +27926,8 @@
         "created_at"
       ]
     },
-    "IncidentTimestampValueV2ResponseBody": {
-      "title": "IncidentTimestampValueV2ResponseBody",
+    "IncidentTimestampValueV2": {
+      "title": "IncidentTimestampValueV2",
       "type": "object",
       "properties": {
         "value": {
@@ -27497,15 +27947,15 @@
         "created_at"
       ]
     },
-    "IncidentTimestampWithValueV2ResponseBody": {
-      "title": "IncidentTimestampWithValueV2ResponseBody",
+    "IncidentTimestampWithValueV2": {
+      "title": "IncidentTimestampWithValueV2",
       "type": "object",
       "properties": {
         "incident_timestamp": {
-          "$ref": "#/definitions/IncidentTimestampV2ResponseBody"
+          "$ref": "#/definitions/IncidentTimestampV2"
         },
         "value": {
-          "$ref": "#/definitions/IncidentTimestampValueV2ResponseBody"
+          "$ref": "#/definitions/IncidentTimestampValueV2"
         }
       },
       "example": {
@@ -27529,7 +27979,7 @@
         "incident_timestamps": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentTimestampV2ResponseBody"
+            "$ref": "#/definitions/IncidentTimestampV2"
           },
           "example": [
             {
@@ -27558,7 +28008,7 @@
       "type": "object",
       "properties": {
         "incident_timestamp": {
-          "$ref": "#/definitions/IncidentTimestampV2ResponseBody"
+          "$ref": "#/definitions/IncidentTimestampV2"
         }
       },
       "example": {
@@ -27572,8 +28022,8 @@
         "incident_timestamp"
       ]
     },
-    "IncidentTypeV1ResponseBody": {
-      "title": "IncidentTypeV1ResponseBody",
+    "IncidentTypeV1": {
+      "title": "IncidentTypeV1",
       "type": "object",
       "properties": {
         "create_in_triage": {
@@ -27652,8 +28102,8 @@
         "auto_archive_slack_channels_delay_days"
       ]
     },
-    "IncidentTypeV2ResponseBody": {
-      "title": "IncidentTypeV2ResponseBody",
+    "IncidentTypeV2": {
+      "title": "IncidentTypeV2",
       "type": "object",
       "properties": {
         "create_in_triage": {
@@ -27739,7 +28189,7 @@
         "incident_types": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentTypeV1ResponseBody"
+            "$ref": "#/definitions/IncidentTypeV1"
           },
           "example": [
             {
@@ -27778,7 +28228,7 @@
       "type": "object",
       "properties": {
         "incident_type": {
-          "$ref": "#/definitions/IncidentTypeV1ResponseBody"
+          "$ref": "#/definitions/IncidentTypeV1"
         }
       },
       "example": {
@@ -27797,8 +28247,8 @@
         "incident_type"
       ]
     },
-    "IncidentUpdateV2ResponseBody": {
-      "title": "IncidentUpdateV2ResponseBody",
+    "IncidentUpdateV2": {
+      "title": "IncidentUpdateV2",
       "type": "object",
       "properties": {
         "created_at": {
@@ -27828,13 +28278,13 @@
           "example": "We're working on a fix, hoping to ship in the next 30 minutes"
         },
         "new_incident_status": {
-          "$ref": "#/definitions/IncidentStatusV2ResponseBody"
+          "$ref": "#/definitions/IncidentStatusV2"
         },
         "new_severity": {
-          "$ref": "#/definitions/SeverityV2ResponseBody"
+          "$ref": "#/definitions/SeverityV2"
         },
         "updater": {
-          "$ref": "#/definitions/ActorV2ResponseBody"
+          "$ref": "#/definitions/ActorV2"
         }
       },
       "example": {
@@ -27890,7 +28340,7 @@
         "incident_updates": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentUpdateV2ResponseBody"
+            "$ref": "#/definitions/IncidentUpdateV2"
           },
           "example": [
             {
@@ -27933,7 +28383,7 @@
           ]
         },
         "pagination_meta": {
-          "$ref": "#/definitions/PaginationMetaResultResponseBody"
+          "$ref": "#/definitions/PaginationMetaResult"
         }
       },
       "example": {
@@ -27985,8 +28435,8 @@
         "incident_updates"
       ]
     },
-    "IncidentV1ResponseBody": {
-      "title": "IncidentV1ResponseBody",
+    "IncidentV1": {
+      "title": "IncidentV1",
       "type": "object",
       "properties": {
         "call_url": {
@@ -28001,12 +28451,12 @@
           "format": "date-time"
         },
         "creator": {
-          "$ref": "#/definitions/ActorV1ResponseBody"
+          "$ref": "#/definitions/ActorV1"
         },
         "custom_field_entries": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldEntryV1ResponseBody"
+            "$ref": "#/definitions/CustomFieldEntryV1"
           },
           "description": "Custom field entries for this incident",
           "example": [
@@ -28058,7 +28508,7 @@
         "incident_role_assignments": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentRoleAssignmentV1ResponseBody"
+            "$ref": "#/definitions/IncidentRoleAssignmentV1"
           },
           "description": "A list of who is assigned to each role for this incident",
           "example": [
@@ -28085,7 +28535,7 @@
           ]
         },
         "incident_type": {
-          "$ref": "#/definitions/IncidentTypeV1ResponseBody"
+          "$ref": "#/definitions/IncidentTypeV1"
         },
         "mode": {
           "type": "string",
@@ -28118,7 +28568,7 @@
           "example": "INC-123"
         },
         "severity": {
-          "$ref": "#/definitions/SeverityV1ResponseBody"
+          "$ref": "#/definitions/SeverityV1"
         },
         "slack_channel_id": {
           "type": "string",
@@ -28156,7 +28606,7 @@
         "timestamps": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentTimestampV1ResponseBody"
+            "$ref": "#/definitions/IncidentTimestampV1"
           },
           "description": "Incident lifecycle events and when they last occurred",
           "example": [
@@ -28321,8 +28771,8 @@
         "reported_at"
       ]
     },
-    "IncidentV2ResponseBody": {
-      "title": "IncidentV2ResponseBody",
+    "IncidentV2": {
+      "title": "IncidentV2",
       "type": "object",
       "properties": {
         "call_url": {
@@ -28337,12 +28787,12 @@
           "format": "date-time"
         },
         "creator": {
-          "$ref": "#/definitions/ActorV2ResponseBody"
+          "$ref": "#/definitions/ActorV2"
         },
         "custom_field_entries": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldEntryV2ResponseBody"
+            "$ref": "#/definitions/CustomFieldEntryV2"
           },
           "description": "Custom field entries for this incident",
           "example": [
@@ -28389,7 +28839,7 @@
         "duration_metrics": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentDurationMetricWithValueV2ResponseBody"
+            "$ref": "#/definitions/IncidentDurationMetricWithValueV2"
           },
           "description": "Incident duration metrics and their measurements for this incident",
           "example": [
@@ -28403,7 +28853,7 @@
           ]
         },
         "external_issue_reference": {
-          "$ref": "#/definitions/ExternalIssueReferenceV2ResponseBody"
+          "$ref": "#/definitions/ExternalIssueReferenceV2"
         },
         "id": {
           "type": "string",
@@ -28413,7 +28863,7 @@
         "incident_role_assignments": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentRoleAssignmentV2ResponseBody"
+            "$ref": "#/definitions/IncidentRoleAssignmentV2"
           },
           "description": "A list of who is assigned to each role for this incident",
           "example": [
@@ -28440,12 +28890,12 @@
           ]
         },
         "incident_status": {
-          "$ref": "#/definitions/IncidentStatusV2ResponseBody"
+          "$ref": "#/definitions/IncidentStatusV2"
         },
         "incident_timestamp_values": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentTimestampWithValueV2ResponseBody"
+            "$ref": "#/definitions/IncidentTimestampWithValueV2"
           },
           "description": "Incident lifecycle events and when they occurred",
           "example": [
@@ -28462,7 +28912,7 @@
           ]
         },
         "incident_type": {
-          "$ref": "#/definitions/IncidentTypeV2ResponseBody"
+          "$ref": "#/definitions/IncidentTypeV2"
         },
         "mode": {
           "type": "string",
@@ -28496,7 +28946,7 @@
           "example": "INC-123"
         },
         "severity": {
-          "$ref": "#/definitions/SeverityV2ResponseBody"
+          "$ref": "#/definitions/SeverityV2"
         },
         "slack_channel_id": {
           "type": "string",
@@ -28728,18 +29178,18 @@
         "reported_at"
       ]
     },
-    "IncidentWithStatusChangeV2ResponseBody": {
-      "title": "IncidentWithStatusChangeV2ResponseBody",
+    "IncidentWithStatusChangeV2": {
+      "title": "IncidentWithStatusChangeV2",
       "type": "object",
       "properties": {
         "incident": {
-          "$ref": "#/definitions/IncidentV2ResponseBody"
+          "$ref": "#/definitions/IncidentV2"
         },
         "new_status": {
-          "$ref": "#/definitions/IncidentStatusV2ResponseBody"
+          "$ref": "#/definitions/IncidentStatusV2"
         },
         "previous_status": {
-          "$ref": "#/definitions/IncidentStatusV2ResponseBody"
+          "$ref": "#/definitions/IncidentStatusV2"
         }
       },
       "example": {
@@ -28923,7 +29373,7 @@
         "custom_field_entries": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CustomFieldEntryPayloadV1RequestBody"
+            "$ref": "#/definitions/CustomFieldEntryPayloadV1"
           },
           "description": "Set the incident's custom fields to these values",
           "example": [
@@ -28951,7 +29401,7 @@
         "incident_role_assignments": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentRoleAssignmentPayloadV1RequestBody"
+            "$ref": "#/definitions/IncidentRoleAssignmentPayloadV1"
           },
           "description": "Assign incident roles to these people",
           "example": [
@@ -29081,7 +29531,7 @@
       "type": "object",
       "properties": {
         "incident": {
-          "$ref": "#/definitions/IncidentV1ResponseBody"
+          "$ref": "#/definitions/IncidentV1"
         }
       },
       "example": {
@@ -29213,7 +29663,7 @@
         "incidents": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentV1ResponseBody"
+            "$ref": "#/definitions/IncidentV1"
           },
           "example": [
             {
@@ -29335,7 +29785,7 @@
           ]
         },
         "pagination_meta": {
-          "$ref": "#/definitions/PaginationMetaResultWithTotalResponseBody"
+          "$ref": "#/definitions/PaginationMetaResultWithTotal"
         }
       },
       "example": {
@@ -29472,7 +29922,7 @@
       "type": "object",
       "properties": {
         "incident": {
-          "$ref": "#/definitions/IncidentV1ResponseBody"
+          "$ref": "#/definitions/IncidentV1"
         }
       },
       "example": {
@@ -29597,192 +30047,12 @@
         "incident"
       ]
     },
-    "IncidentsV2CreateRequestBody": {
-      "title": "IncidentsV2CreateRequestBody",
-      "type": "object",
-      "properties": {
-        "custom_field_entries": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CustomFieldEntryPayloadV2RequestBody"
-          },
-          "description": "Set the incident's custom fields to these values",
-          "example": [
-            {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "values": [
-                {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_text": "This is my text field, I hope you like it",
-                  "value_timestamp": ""
-                }
-              ]
-            }
-          ]
-        },
-        "id": {
-          "type": "string",
-          "description": "Unique identifier for the incident",
-          "example": "01FDAG4SAP5TYPT98WGR2N7W91"
-        },
-        "idempotency_key": {
-          "type": "string",
-          "description": "Unique string used to de-duplicate incident create requests",
-          "example": "alert-uuid"
-        },
-        "incident_role_assignments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/IncidentRoleAssignmentPayloadV2RequestBody"
-          },
-          "description": "Assign incident roles to these people",
-          "example": [
-            {
-              "assignee": {
-                "email": "bob@example.com",
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                "slack_user_id": "USER123"
-              },
-              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-            }
-          ]
-        },
-        "incident_status_id": {
-          "type": "string",
-          "description": "Incident status to assign to the incident",
-          "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
-        },
-        "incident_timestamp_values": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/IncidentTimestampValuePayloadV2RequestBody"
-          },
-          "description": "Assign the incident's timestamps to these values",
-          "example": [
-            {
-              "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "value": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "incident_type_id": {
-          "type": "string",
-          "description": "Incident type to create this incident as",
-          "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-        },
-        "mode": {
-          "type": "string",
-          "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
-          "example": "standard",
-          "enum": [
-            "standard",
-            "retrospective",
-            "test",
-            "tutorial"
-          ]
-        },
-        "name": {
-          "type": "string",
-          "description": "Explanation of the incident",
-          "example": "Our database is sad"
-        },
-        "retrospective_incident_options": {
-          "$ref": "#/definitions/RetrospectiveIncidentOptionsV2RequestBody"
-        },
-        "severity_id": {
-          "type": "string",
-          "description": "Severity to create incident as",
-          "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-        },
-        "slack_channel_name_override": {
-          "type": "string",
-          "description": "Name of the Slack channel to create for this incident",
-          "example": "inc-123-database-down"
-        },
-        "slack_team_id": {
-          "type": "string",
-          "description": "Slack Team to create the incident in",
-          "example": "T02A1FSLE8J"
-        },
-        "summary": {
-          "type": "string",
-          "description": "Detailed description of the incident",
-          "example": "Our database is really really sad, and we don't know why yet."
-        },
-        "visibility": {
-          "type": "string",
-          "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-          "example": "public",
-          "enum": [
-            "public",
-            "private"
-          ]
-        }
-      },
-      "example": {
-        "custom_field_entries": [
-          {
-            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "values": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "value_link": "https://google.com/",
-                "value_numeric": "123.456",
-                "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "value_text": "This is my text field, I hope you like it",
-                "value_timestamp": ""
-              }
-            ]
-          }
-        ],
-        "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-        "idempotency_key": "alert-uuid",
-        "incident_role_assignments": [
-          {
-            "assignee": {
-              "email": "bob@example.com",
-              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-              "slack_user_id": "USER123"
-            },
-            "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          }
-        ],
-        "incident_status_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-        "incident_timestamp_values": [
-          {
-            "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "value": "2021-08-17T13:28:57.801578Z"
-          }
-        ],
-        "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-        "mode": "standard",
-        "name": "Our database is sad",
-        "retrospective_incident_options": {
-          "postmortem_document_url": "https://docs.google.com/my_doc_id",
-          "slack_channel_id": "abc123"
-        },
-        "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-        "slack_channel_name_override": "inc-123-database-down",
-        "slack_team_id": "T02A1FSLE8J",
-        "summary": "Our database is really really sad, and we don't know why yet.",
-        "visibility": "public"
-      },
-      "required": [
-        "idempotency_key",
-        "visibility"
-      ]
-    },
     "IncidentsV2CreateResponseBody": {
       "title": "IncidentsV2CreateResponseBody",
       "type": "object",
       "properties": {
         "incident": {
-          "$ref": "#/definitions/IncidentV2ResponseBody"
+          "$ref": "#/definitions/IncidentV2"
         }
       },
       "example": {
@@ -29944,7 +30214,7 @@
       "type": "object",
       "properties": {
         "incident": {
-          "$ref": "#/definitions/IncidentEditPayloadV2RequestBody"
+          "$ref": "#/definitions/IncidentEditPayloadV2"
         },
         "notify_incident_channel": {
           "type": "boolean",
@@ -30005,7 +30275,7 @@
       "type": "object",
       "properties": {
         "incident": {
-          "$ref": "#/definitions/IncidentV2ResponseBody"
+          "$ref": "#/definitions/IncidentV2"
         }
       },
       "example": {
@@ -30169,7 +30439,7 @@
         "incidents": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/IncidentV2ResponseBody"
+            "$ref": "#/definitions/IncidentV2"
           },
           "example": [
             {
@@ -30323,7 +30593,7 @@
           ]
         },
         "pagination_meta": {
-          "$ref": "#/definitions/PaginationMetaResultWithTotalResponseBody"
+          "$ref": "#/definitions/PaginationMetaResultWithTotal"
         }
       },
       "example": {
@@ -30492,7 +30762,7 @@
       "type": "object",
       "properties": {
         "incident": {
-          "$ref": "#/definitions/IncidentV2ResponseBody"
+          "$ref": "#/definitions/IncidentV2"
         }
       },
       "example": {
@@ -30649,8 +30919,8 @@
         "incident"
       ]
     },
-    "ManagedResourceV2ResponseBody": {
-      "title": "ManagedResourceV2ResponseBody",
+    "ManagedResourceV2": {
+      "title": "ManagedResourceV2",
       "type": "object",
       "properties": {
         "annotations": {
@@ -30759,7 +31029,7 @@
       "type": "object",
       "properties": {
         "managed_resource": {
-          "$ref": "#/definitions/ManagedResourceV2ResponseBody"
+          "$ref": "#/definitions/ManagedResourceV2"
         }
       },
       "example": {
@@ -30777,8 +31047,8 @@
         "managed_resource"
       ]
     },
-    "ManagementMetaV2ResponseBody": {
-      "title": "ManagementMetaV2ResponseBody",
+    "ManagementMetaV2": {
+      "title": "ManagementMetaV2",
       "type": "object",
       "properties": {
         "annotations": {
@@ -30820,8 +31090,8 @@
         "managed_by"
       ]
     },
-    "PaginationMetaResultResponseBody": {
-      "title": "PaginationMetaResultResponseBody",
+    "PaginationMetaResult": {
+      "title": "PaginationMetaResult",
       "type": "object",
       "properties": {
         "after": {
@@ -30845,8 +31115,8 @@
         "page_size"
       ]
     },
-    "PaginationMetaResultWithTotalResponseBody": {
-      "title": "PaginationMetaResultWithTotalResponseBody",
+    "PaginationMetaResultWithTotal": {
+      "title": "PaginationMetaResultWithTotal",
       "type": "object",
       "properties": {
         "after": {
@@ -30877,8 +31147,8 @@
         "page_size"
       ]
     },
-    "RBACRoleV2ResponseBody": {
-      "title": "RBACRoleV2ResponseBody",
+    "RBACRoleV2": {
+      "title": "RBACRoleV2",
       "type": "object",
       "properties": {
         "description": {
@@ -30914,8 +31184,8 @@
         "slug"
       ]
     },
-    "RetrospectiveIncidentOptionsV2RequestBody": {
-      "title": "RetrospectiveIncidentOptionsV2RequestBody",
+    "RetrospectiveIncidentOptionsV2": {
+      "title": "RetrospectiveIncidentOptionsV2",
       "type": "object",
       "properties": {
         "postmortem_document_url": {
@@ -30934,8 +31204,8 @@
         "slack_channel_id": "abc123"
       }
     },
-    "ReturnsMetaV2RequestBody": {
-      "title": "ReturnsMetaV2RequestBody",
+    "ReturnsMetaV2": {
+      "title": "ReturnsMetaV2",
       "type": "object",
       "properties": {
         "array": {
@@ -30958,38 +31228,14 @@
         "array"
       ]
     },
-    "ReturnsMetaV2ResponseBody": {
-      "title": "ReturnsMetaV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "array": {
-          "type": "boolean",
-          "description": "Whether the return value should be single or multi-value",
-          "example": true
-        },
-        "type": {
-          "type": "string",
-          "description": "Expected return type of this expression (what to try casting the result to)",
-          "example": "IncidentStatus"
-        }
-      },
-      "example": {
-        "array": true,
-        "type": "IncidentStatus"
-      },
-      "required": [
-        "type",
-        "array"
-      ]
-    },
-    "ScheduleConfigCreatePayloadV2RequestBody": {
-      "title": "ScheduleConfigCreatePayloadV2RequestBody",
+    "ScheduleConfigCreatePayloadV2": {
+      "title": "ScheduleConfigCreatePayloadV2",
       "type": "object",
       "properties": {
         "rotations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleRotationCreatePayloadV2RequestBody"
+            "$ref": "#/definitions/ScheduleRotationCreatePayloadV2"
           },
           "example": [
             {
@@ -31064,14 +31310,14 @@
         ]
       }
     },
-    "ScheduleConfigUpdatePayloadV2RequestBody": {
-      "title": "ScheduleConfigUpdatePayloadV2RequestBody",
+    "ScheduleConfigUpdatePayloadV2": {
+      "title": "ScheduleConfigUpdatePayloadV2",
       "type": "object",
       "properties": {
         "rotations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleRotationUpdatePayloadV2RequestBody"
+            "$ref": "#/definitions/ScheduleRotationUpdatePayloadV2"
           },
           "example": [
             {
@@ -31146,14 +31392,14 @@
         ]
       }
     },
-    "ScheduleConfigV2ResponseBody": {
-      "title": "ScheduleConfigV2ResponseBody",
+    "ScheduleConfigV2": {
+      "title": "ScheduleConfigV2",
       "type": "object",
       "properties": {
         "rotations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleRotationV2ResponseBody"
+            "$ref": "#/definitions/ScheduleRotationV2"
           },
           "description": "Rotas in this schedule",
           "example": [
@@ -31237,8 +31483,8 @@
         "version"
       ]
     },
-    "ScheduleCreatePayloadV2RequestBody": {
-      "title": "ScheduleCreatePayloadV2RequestBody",
+    "ScheduleCreatePayloadV2": {
+      "title": "ScheduleCreatePayloadV2",
       "type": "object",
       "properties": {
         "annotations": {
@@ -31253,10 +31499,10 @@
           }
         },
         "config": {
-          "$ref": "#/definitions/ScheduleConfigCreatePayloadV2RequestBody"
+          "$ref": "#/definitions/ScheduleConfigCreatePayloadV2"
         },
         "holidays_public_config": {
-          "$ref": "#/definitions/ScheduleHolidaysPublicConfigPayloadV2RequestBody"
+          "$ref": "#/definitions/ScheduleHolidaysPublicConfigPayloadV2"
         },
         "name": {
           "type": "string",
@@ -31318,14 +31564,14 @@
         "timezone": "America/Los_Angeles"
       }
     },
-    "ScheduleEntriesListPayloadV2ResponseBody": {
-      "title": "ScheduleEntriesListPayloadV2ResponseBody",
+    "ScheduleEntriesListPayloadV2": {
+      "title": "ScheduleEntriesListPayloadV2",
       "type": "object",
       "properties": {
         "final": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleEntryV2ResponseBody"
+            "$ref": "#/definitions/ScheduleEntryV2"
           },
           "example": [
             {
@@ -31348,7 +31594,7 @@
         "overrides": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleEntryV2ResponseBody"
+            "$ref": "#/definitions/ScheduleEntryV2"
           },
           "example": [
             {
@@ -31371,7 +31617,7 @@
         "scheduled": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleEntryV2ResponseBody"
+            "$ref": "#/definitions/ScheduleEntryV2"
           },
           "example": [
             {
@@ -31451,8 +31697,8 @@
         "final"
       ]
     },
-    "ScheduleEntryV2ResponseBody": {
-      "title": "ScheduleEntryV2ResponseBody",
+    "ScheduleEntryV2": {
+      "title": "ScheduleEntryV2",
       "type": "object",
       "properties": {
         "end_at": {
@@ -31486,7 +31732,7 @@
           "format": "date-time"
         },
         "user": {
-          "$ref": "#/definitions/UserV2ResponseBody"
+          "$ref": "#/definitions/UserV2"
         }
       },
       "example": {
@@ -31510,8 +31756,8 @@
         "end_at"
       ]
     },
-    "ScheduleHolidaysPublicConfigPayloadV2RequestBody": {
-      "title": "ScheduleHolidaysPublicConfigPayloadV2RequestBody",
+    "ScheduleHolidaysPublicConfigPayloadV2": {
+      "title": "ScheduleHolidaysPublicConfigPayloadV2",
       "type": "object",
       "properties": {
         "country_codes": {
@@ -31535,8 +31781,8 @@
         "country_codes"
       ]
     },
-    "ScheduleHolidaysPublicConfigV2ResponseBody": {
-      "title": "ScheduleHolidaysPublicConfigV2ResponseBody",
+    "ScheduleHolidaysPublicConfigV2": {
+      "title": "ScheduleHolidaysPublicConfigV2",
       "type": "object",
       "properties": {
         "country_codes": {
@@ -31562,8 +31808,8 @@
         "country_codes"
       ]
     },
-    "ScheduleLayerCreatePayloadV2RequestBody": {
-      "title": "ScheduleLayerCreatePayloadV2RequestBody",
+    "ScheduleLayerCreatePayloadV2": {
+      "title": "ScheduleLayerCreatePayloadV2",
       "type": "object",
       "properties": {
         "id": {
@@ -31585,8 +31831,8 @@
         "name"
       ]
     },
-    "ScheduleLayerUpdatePayloadV2RequestBody": {
-      "title": "ScheduleLayerUpdatePayloadV2RequestBody",
+    "ScheduleLayerUpdatePayloadV2": {
+      "title": "ScheduleLayerUpdatePayloadV2",
       "type": "object",
       "properties": {
         "id": {
@@ -31605,8 +31851,8 @@
         "name": "Layer 1"
       }
     },
-    "ScheduleLayerV2ResponseBody": {
-      "title": "ScheduleLayerV2ResponseBody",
+    "ScheduleLayerV2": {
+      "title": "ScheduleLayerV2",
       "type": "object",
       "properties": {
         "id": {
@@ -31625,8 +31871,8 @@
         "name": "Layer 1"
       }
     },
-    "ScheduleRotationCreatePayloadV2RequestBody": {
-      "title": "ScheduleRotationCreatePayloadV2RequestBody",
+    "ScheduleRotationCreatePayloadV2": {
+      "title": "ScheduleRotationCreatePayloadV2",
       "type": "object",
       "properties": {
         "effective_from": {
@@ -31642,7 +31888,7 @@
         "handovers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleRotationHandoverV2RequestBody"
+            "$ref": "#/definitions/ScheduleRotationHandoverV2"
           },
           "example": [
             {
@@ -31659,7 +31905,7 @@
         "layers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleLayerCreatePayloadV2RequestBody"
+            "$ref": "#/definitions/ScheduleLayerCreatePayloadV2"
           },
           "example": [
             {
@@ -31676,7 +31922,7 @@
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/UserReferencePayloadV2RequestBody"
+            "$ref": "#/definitions/UserReferencePayloadV2"
           },
           "example": [
             {
@@ -31689,7 +31935,7 @@
         "working_interval": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleRotationWorkingIntervalCreatePayloadV2RequestBody"
+            "$ref": "#/definitions/ScheduleRotationWorkingIntervalCreatePayloadV2"
           },
           "example": [
             {
@@ -31736,8 +31982,8 @@
         "name"
       ]
     },
-    "ScheduleRotationHandoverV2RequestBody": {
-      "title": "ScheduleRotationHandoverV2RequestBody",
+    "ScheduleRotationHandoverV2": {
+      "title": "ScheduleRotationHandoverV2",
       "type": "object",
       "properties": {
         "interval": {
@@ -31760,32 +32006,8 @@
         "interval_type": "daily"
       }
     },
-    "ScheduleRotationHandoverV2ResponseBody": {
-      "title": "ScheduleRotationHandoverV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "interval": {
-          "type": "integer",
-          "example": 1,
-          "format": "int64"
-        },
-        "interval_type": {
-          "type": "string",
-          "example": "daily",
-          "enum": [
-            "hourly",
-            "daily",
-            "weekly"
-          ]
-        }
-      },
-      "example": {
-        "interval": 1,
-        "interval_type": "daily"
-      }
-    },
-    "ScheduleRotationUpdatePayloadV2RequestBody": {
-      "title": "ScheduleRotationUpdatePayloadV2RequestBody",
+    "ScheduleRotationUpdatePayloadV2": {
+      "title": "ScheduleRotationUpdatePayloadV2",
       "type": "object",
       "properties": {
         "effective_from": {
@@ -31801,7 +32023,7 @@
         "handovers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleRotationHandoverV2RequestBody"
+            "$ref": "#/definitions/ScheduleRotationHandoverV2"
           },
           "example": [
             {
@@ -31818,7 +32040,7 @@
         "layers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleLayerUpdatePayloadV2RequestBody"
+            "$ref": "#/definitions/ScheduleLayerUpdatePayloadV2"
           },
           "example": [
             {
@@ -31835,7 +32057,7 @@
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/UserReferencePayloadV2RequestBody"
+            "$ref": "#/definitions/UserReferencePayloadV2"
           },
           "example": [
             {
@@ -31848,7 +32070,7 @@
         "working_interval": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleRotationWorkingIntervalUpdatePayloadV2RequestBody"
+            "$ref": "#/definitions/ScheduleRotationWorkingIntervalUpdatePayloadV2"
           },
           "example": [
             {
@@ -31892,8 +32114,8 @@
         ]
       }
     },
-    "ScheduleRotationV2ResponseBody": {
-      "title": "ScheduleRotationV2ResponseBody",
+    "ScheduleRotationV2": {
+      "title": "ScheduleRotationV2",
       "type": "object",
       "properties": {
         "effective_from": {
@@ -31911,7 +32133,7 @@
         "handovers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleRotationHandoverV2ResponseBody"
+            "$ref": "#/definitions/ScheduleRotationHandoverV2"
           },
           "description": "Defines the handover intervals for this rota, in order they should apply",
           "example": [
@@ -31929,7 +32151,7 @@
         "layers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleLayerV2ResponseBody"
+            "$ref": "#/definitions/ScheduleLayerV2"
           },
           "description": "Controls how many people are on-call concurrently",
           "example": [
@@ -31947,7 +32169,7 @@
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/UserV2ResponseBody"
+            "$ref": "#/definitions/UserV2"
           },
           "example": [
             {
@@ -31962,7 +32184,7 @@
         "working_interval": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleRotationWorkingIntervalV2ResponseBody"
+            "$ref": "#/definitions/ScheduleRotationWorkingIntervalV2"
           },
           "example": [
             {
@@ -32017,8 +32239,8 @@
         "handovers"
       ]
     },
-    "ScheduleRotationWorkingIntervalCreatePayloadV2RequestBody": {
-      "title": "ScheduleRotationWorkingIntervalCreatePayloadV2RequestBody",
+    "ScheduleRotationWorkingIntervalCreatePayloadV2": {
+      "title": "ScheduleRotationWorkingIntervalCreatePayloadV2",
       "type": "object",
       "properties": {
         "end_time": {
@@ -32057,8 +32279,8 @@
         "end_time"
       ]
     },
-    "ScheduleRotationWorkingIntervalUpdatePayloadV2RequestBody": {
-      "title": "ScheduleRotationWorkingIntervalUpdatePayloadV2RequestBody",
+    "ScheduleRotationWorkingIntervalUpdatePayloadV2": {
+      "title": "ScheduleRotationWorkingIntervalUpdatePayloadV2",
       "type": "object",
       "properties": {
         "end_time": {
@@ -32092,8 +32314,8 @@
         "weekday": "tuesday"
       }
     },
-    "ScheduleRotationWorkingIntervalV2ResponseBody": {
-      "title": "ScheduleRotationWorkingIntervalV2ResponseBody",
+    "ScheduleRotationWorkingIntervalV2": {
+      "title": "ScheduleRotationWorkingIntervalV2",
       "type": "object",
       "properties": {
         "end_time": {
@@ -32132,8 +32354,8 @@
         "end_time"
       ]
     },
-    "ScheduleUpdatePayloadV2RequestBody": {
-      "title": "ScheduleUpdatePayloadV2RequestBody",
+    "ScheduleUpdatePayloadV2": {
+      "title": "ScheduleUpdatePayloadV2",
       "type": "object",
       "properties": {
         "annotations": {
@@ -32148,10 +32370,10 @@
           }
         },
         "config": {
-          "$ref": "#/definitions/ScheduleConfigUpdatePayloadV2RequestBody"
+          "$ref": "#/definitions/ScheduleConfigUpdatePayloadV2"
         },
         "holidays_public_config": {
-          "$ref": "#/definitions/ScheduleHolidaysPublicConfigPayloadV2RequestBody"
+          "$ref": "#/definitions/ScheduleHolidaysPublicConfigPayloadV2"
         },
         "name": {
           "type": "string",
@@ -32213,8 +32435,8 @@
         "timezone": "America/Los_Angeles"
       }
     },
-    "ScheduleV2ResponseBody": {
-      "title": "ScheduleV2ResponseBody",
+    "ScheduleV2": {
+      "title": "ScheduleV2",
       "type": "object",
       "properties": {
         "annotations": {
@@ -32229,7 +32451,7 @@
           }
         },
         "config": {
-          "$ref": "#/definitions/ScheduleConfigV2ResponseBody"
+          "$ref": "#/definitions/ScheduleConfigV2"
         },
         "created_at": {
           "type": "string",
@@ -32239,7 +32461,7 @@
         "current_shifts": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleEntryV2ResponseBody"
+            "$ref": "#/definitions/ScheduleEntryV2"
           },
           "description": "Shifts that are on-going for this schedule, if a native schedule",
           "example": [
@@ -32261,7 +32483,7 @@
           ]
         },
         "holidays_public_config": {
-          "$ref": "#/definitions/ScheduleHolidaysPublicConfigV2ResponseBody"
+          "$ref": "#/definitions/ScheduleHolidaysPublicConfigV2"
         },
         "id": {
           "type": "string",
@@ -32371,7 +32593,7 @@
       "type": "object",
       "properties": {
         "schedule": {
-          "$ref": "#/definitions/ScheduleCreatePayloadV2RequestBody"
+          "$ref": "#/definitions/ScheduleCreatePayloadV2"
         }
       },
       "example": {
@@ -32433,7 +32655,7 @@
       "type": "object",
       "properties": {
         "schedule": {
-          "$ref": "#/definitions/ScheduleV2ResponseBody"
+          "$ref": "#/definitions/ScheduleV2"
         }
       },
       "example": {
@@ -32518,12 +32740,12 @@
       "type": "object",
       "properties": {
         "pagination_meta": {
-          "$ref": "#/definitions/PaginationMetaResultWithTotalResponseBody"
+          "$ref": "#/definitions/PaginationMetaResultWithTotal"
         },
         "schedules": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ScheduleV2ResponseBody"
+            "$ref": "#/definitions/ScheduleV2"
           },
           "example": [
             {
@@ -32689,10 +32911,10 @@
       "type": "object",
       "properties": {
         "pagination_meta": {
-          "$ref": "#/definitions/AfterPaginationMetaResultV2ResponseBody"
+          "$ref": "#/definitions/AfterPaginationMetaResultV2"
         },
         "schedule_entries": {
-          "$ref": "#/definitions/ScheduleEntriesListPayloadV2ResponseBody"
+          "$ref": "#/definitions/ScheduleEntriesListPayloadV2"
         }
       },
       "example": {
@@ -32763,7 +32985,7 @@
       "type": "object",
       "properties": {
         "schedule": {
-          "$ref": "#/definitions/ScheduleV2ResponseBody"
+          "$ref": "#/definitions/ScheduleV2"
         }
       },
       "example": {
@@ -32848,7 +33070,7 @@
       "type": "object",
       "properties": {
         "schedule": {
-          "$ref": "#/definitions/ScheduleUpdatePayloadV2RequestBody"
+          "$ref": "#/definitions/ScheduleUpdatePayloadV2"
         }
       },
       "example": {
@@ -32917,7 +33139,7 @@
       "type": "object",
       "properties": {
         "schedule": {
-          "$ref": "#/definitions/ScheduleV2ResponseBody"
+          "$ref": "#/definitions/ScheduleV2"
         }
       },
       "example": {
@@ -33034,7 +33256,7 @@
       "type": "object",
       "properties": {
         "severity": {
-          "$ref": "#/definitions/SeverityV1ResponseBody"
+          "$ref": "#/definitions/SeverityV1"
         }
       },
       "example": {
@@ -33058,7 +33280,7 @@
         "severities": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/SeverityV1ResponseBody"
+            "$ref": "#/definitions/SeverityV1"
           },
           "example": [
             {
@@ -33093,7 +33315,7 @@
       "type": "object",
       "properties": {
         "severity": {
-          "$ref": "#/definitions/SeverityV1ResponseBody"
+          "$ref": "#/definitions/SeverityV1"
         }
       },
       "example": {
@@ -33147,7 +33369,7 @@
       "type": "object",
       "properties": {
         "severity": {
-          "$ref": "#/definitions/SeverityV1ResponseBody"
+          "$ref": "#/definitions/SeverityV1"
         }
       },
       "example": {
@@ -33164,8 +33386,8 @@
         "severity"
       ]
     },
-    "SeverityV1ResponseBody": {
-      "title": "SeverityV1ResponseBody",
+    "SeverityV1": {
+      "title": "SeverityV1",
       "type": "object",
       "properties": {
         "created_at": {
@@ -33220,8 +33442,8 @@
         "updated_at"
       ]
     },
-    "SeverityV2ResponseBody": {
-      "title": "SeverityV2ResponseBody",
+    "SeverityV2": {
+      "title": "SeverityV2",
       "type": "object",
       "properties": {
         "created_at": {
@@ -33276,77 +33498,8 @@
         "updated_at"
       ]
     },
-    "StepConfigPayloadRequestBody": {
-      "title": "StepConfigPayloadRequestBody",
-      "type": "object",
-      "properties": {
-        "for_each": {
-          "type": "string",
-          "description": "Reference to an expression that returns resources to run this step over",
-          "example": "abc123"
-        },
-        "id": {
-          "type": "string",
-          "description": "Unique ID of this step in a workflow. This must be a valid ULID.",
-          "example": "abc123"
-        },
-        "name": {
-          "type": "string",
-          "description": "Unique name of the step in the engine",
-          "example": "pagerduty.escalate"
-        },
-        "param_bindings": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EngineParamBindingPayloadV2RequestBody"
-          },
-          "description": "List of parameter bindings",
-          "example": [
-            {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          ]
-        }
-      },
-      "example": {
-        "for_each": "abc123",
-        "id": "abc123",
-        "name": "pagerduty.escalate",
-        "param_bindings": [
-          {
-            "array_value": [
-              {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "value": {
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          }
-        ]
-      },
-      "required": [
-        "id",
-        "name",
-        "param_bindings",
-        "label",
-        "description",
-        "params"
-      ]
-    },
-    "StepConfigResponseBody": {
-      "title": "StepConfigResponseBody",
+    "StepConfig": {
+      "title": "StepConfig",
       "type": "object",
       "properties": {
         "for_each": {
@@ -33372,7 +33525,7 @@
         "param_bindings": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineParamBindingV2ResponseBody"
+            "$ref": "#/definitions/EngineParamBindingV2"
           },
           "description": "Bindings for the step parameters",
           "example": [
@@ -33424,8 +33577,77 @@
         "params"
       ]
     },
-    "StepConfigSlimResponseBody": {
-      "title": "StepConfigSlimResponseBody",
+    "StepConfigPayload": {
+      "title": "StepConfigPayload",
+      "type": "object",
+      "properties": {
+        "for_each": {
+          "type": "string",
+          "description": "Reference to an expression that returns resources to run this step over",
+          "example": "abc123"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique ID of this step in a workflow. This must be a valid ULID.",
+          "example": "abc123"
+        },
+        "name": {
+          "type": "string",
+          "description": "Unique name of the step in the engine",
+          "example": "pagerduty.escalate"
+        },
+        "param_bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EngineParamBindingPayloadV2"
+          },
+          "description": "List of parameter bindings",
+          "example": [
+            {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        }
+      },
+      "example": {
+        "for_each": "abc123",
+        "id": "abc123",
+        "name": "pagerduty.escalate",
+        "param_bindings": [
+          {
+            "array_value": [
+              {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        ]
+      },
+      "required": [
+        "id",
+        "name",
+        "param_bindings",
+        "label",
+        "description",
+        "params"
+      ]
+    },
+    "StepConfigSlim": {
+      "title": "StepConfigSlim",
       "type": "object",
       "properties": {
         "label": {
@@ -33450,8 +33672,8 @@
         "params"
       ]
     },
-    "TriggerSlimResponseBody": {
-      "title": "TriggerSlimResponseBody",
+    "TriggerSlim": {
+      "title": "TriggerSlim",
       "type": "object",
       "properties": {
         "label": {
@@ -33474,8 +33696,456 @@
         "label"
       ]
     },
-    "UserReferencePayloadV1RequestBody": {
-      "title": "UserReferencePayloadV1RequestBody",
+    "UpdateWorkflowPayload": {
+      "title": "UpdateWorkflowPayload",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "description": "Annotations that track metadata about this resource",
+          "example": {
+            "incident.io/terraform/version": "3.0.0"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "example": "abc123"
+          }
+        },
+        "condition_groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConditionGroupPayloadV2"
+          },
+          "description": "List of conditions to apply to the workflow",
+          "example": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ]
+        },
+        "continue_on_step_error": {
+          "type": "boolean",
+          "description": "Whether to continue executing the workflow if a step fails",
+          "example": true
+        },
+        "delay": {
+          "$ref": "#/definitions/WorkflowDelay"
+        },
+        "expressions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExpressionPayloadV2"
+          },
+          "description": "The expressions used in the workflow",
+          "example": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ]
+        },
+        "folder": {
+          "type": "string",
+          "description": "Folder to display the workflow in",
+          "example": "My folder 01"
+        },
+        "include_private_incidents": {
+          "type": "boolean",
+          "description": "Whether to include private incidents",
+          "example": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The human-readable name of the workflow",
+          "example": "My workflow"
+        },
+        "once_for": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "incident.url"
+          },
+          "description": "Once For strategy to apply to this workflow",
+          "example": [
+            "incident.url"
+          ]
+        },
+        "runs_on_incident_modes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "test",
+            "enum": [
+              "standard",
+              "test",
+              "retrospective"
+            ]
+          },
+          "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+          "example": [
+            "standard",
+            "retrospective"
+          ]
+        },
+        "runs_on_incidents": {
+          "type": "string",
+          "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+          "example": "newly_created",
+          "enum": [
+            "newly_created",
+            "newly_created_and_active"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "description": "The state of the workflow (e.g. is it draft, or disabled)",
+          "example": "active",
+          "enum": [
+            "active",
+            "disabled",
+            "draft",
+            "error"
+          ]
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StepConfigPayload"
+          },
+          "description": "List of step to execute as part of the workflow",
+          "example": [
+            {
+              "for_each": "abc123",
+              "id": "abc123",
+              "name": "pagerduty.escalate",
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "example": {
+        "annotations": {
+          "incident.io/terraform/version": "3.0.0"
+        },
+        "condition_groups": [
+          {
+            "conditions": [
+              {
+                "operation": "one_of",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": "incident.severity"
+              }
+            ]
+          }
+        ],
+        "continue_on_step_error": true,
+        "delay": {
+          "conditions_apply_over_delay": false,
+          "for_seconds": 60
+        },
+        "expressions": [
+          {
+            "else_branch": {
+              "result": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "label": "Team Slack channel",
+            "operations": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": "one_of",
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": "incident.severity"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                }
+              }
+            ],
+            "reference": "abc123",
+            "root_reference": "incident.status"
+          }
+        ],
+        "folder": "My folder 01",
+        "include_private_incidents": true,
+        "name": "My workflow",
+        "once_for": [
+          "incident.url"
+        ],
+        "runs_on_incident_modes": [
+          "standard",
+          "retrospective"
+        ],
+        "runs_on_incidents": "newly_created",
+        "state": "active",
+        "steps": [
+          {
+            "for_each": "abc123",
+            "id": "abc123",
+            "name": "pagerduty.escalate",
+            "param_bindings": [
+              {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "required": [
+        "name",
+        "once_for",
+        "condition_groups",
+        "steps",
+        "expressions",
+        "include_private_incidents",
+        "runs_on_incident_modes",
+        "continue_on_step_error",
+        "runs_on_incidents"
+      ]
+    },
+    "UserReferencePayloadV1": {
+      "title": "UserReferencePayloadV1",
       "type": "object",
       "properties": {
         "email": {
@@ -33500,8 +34170,8 @@
         "slack_user_id": "USER123"
       }
     },
-    "UserReferencePayloadV2RequestBody": {
-      "title": "UserReferencePayloadV2RequestBody",
+    "UserReferencePayloadV2": {
+      "title": "UserReferencePayloadV2",
       "type": "object",
       "properties": {
         "email": {
@@ -33526,8 +34196,8 @@
         "slack_user_id": "USER123"
       }
     },
-    "UserV1ResponseBody": {
-      "title": "UserV1ResponseBody",
+    "UserV1": {
+      "title": "UserV1",
       "type": "object",
       "properties": {
         "email": {
@@ -33579,8 +34249,8 @@
         "organisation_id"
       ]
     },
-    "UserV2ResponseBody": {
-      "title": "UserV2ResponseBody",
+    "UserV2": {
+      "title": "UserV2",
       "type": "object",
       "properties": {
         "email": {
@@ -33632,17 +34302,17 @@
         "organisation_id"
       ]
     },
-    "UserWithRolesV2ResponseBody": {
-      "title": "UserWithRolesV2ResponseBody",
+    "UserWithRolesV2": {
+      "title": "UserWithRolesV2",
       "type": "object",
       "properties": {
         "base_role": {
-          "$ref": "#/definitions/RBACRoleV2ResponseBody"
+          "$ref": "#/definitions/RBACRoleV2"
         },
         "custom_roles": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/RBACRoleV2ResponseBody"
+            "$ref": "#/definitions/RBACRoleV2"
           },
           "example": [
             {
@@ -33723,12 +34393,12 @@
       "type": "object",
       "properties": {
         "pagination_meta": {
-          "$ref": "#/definitions/PaginationMetaResultResponseBody"
+          "$ref": "#/definitions/PaginationMetaResult"
         },
         "users": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/UserWithRolesV2ResponseBody"
+            "$ref": "#/definitions/UserWithRolesV2"
           },
           "example": [
             {
@@ -33794,7 +34464,7 @@
       "type": "object",
       "properties": {
         "user": {
-          "$ref": "#/definitions/UserWithRolesV2ResponseBody"
+          "$ref": "#/definitions/UserWithRolesV2"
         }
       },
       "example": {
@@ -33829,7 +34499,7 @@
       "type": "object",
       "properties": {
         "identity": {
-          "$ref": "#/definitions/IdentityV1ResponseBody"
+          "$ref": "#/definitions/IdentityV1"
         }
       },
       "example": {
@@ -33843,6 +34513,474 @@
       },
       "required": [
         "identity"
+      ]
+    },
+    "WebhookIncidentUserV2": {
+      "title": "WebhookIncidentUserV2",
+      "type": "object",
+      "properties": {
+        "actor_user_id": {
+          "type": "string",
+          "description": "The ID of the user who performed this action. If the action was not taken by a user, for example it was taken by a Workflow, this will be empty.",
+          "example": "abc123"
+        },
+        "incident_id": {
+          "type": "string",
+          "description": "The ID of the incident",
+          "example": "abc123"
+        },
+        "user_id": {
+          "type": "string",
+          "description": "The ID of the user",
+          "example": "abc123"
+        }
+      },
+      "example": {
+        "actor_user_id": "abc123",
+        "incident_id": "abc123",
+        "user_id": "abc123"
+      },
+      "required": [
+        "incident_id",
+        "user_id"
+      ]
+    },
+    "WebhookIncidentV2": {
+      "title": "WebhookIncidentV2",
+      "type": "object",
+      "properties": {
+        "call_url": {
+          "type": "string",
+          "description": "The call URL attached to this incident",
+          "example": "https://zoom.us/foo"
+        },
+        "created_at": {
+          "type": "string",
+          "description": "When the incident was created",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "creator": {
+          "$ref": "#/definitions/ActorV2"
+        },
+        "custom_field_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CustomFieldEntryV2"
+          },
+          "description": "Custom field entries for this incident",
+          "example": [
+            {
+              "custom_field": {
+                "description": "Which team is impacted by this issue",
+                "field_type": "single_select",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Affected Team",
+                "options": [
+                  {
+                    "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "sort_key": 10,
+                    "value": "Product"
+                  }
+                ]
+              },
+              "values": [
+                {
+                  "value_catalog_entry": {
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
+                    "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Primary On-call"
+                  },
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option": {
+                    "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "sort_key": 10,
+                    "value": "Product"
+                  },
+                  "value_text": "This is my text field, I hope you like it"
+                }
+              ]
+            }
+          ]
+        },
+        "duration_metrics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IncidentDurationMetricWithValueV2"
+          },
+          "description": "Incident duration metrics and their measurements for this incident",
+          "example": [
+            {
+              "duration_metric": {
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Lasted"
+              },
+              "value_seconds": 1
+            }
+          ]
+        },
+        "external_issue_reference": {
+          "$ref": "#/definitions/ExternalIssueReferenceV2"
+        },
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the incident",
+          "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+        },
+        "incident_role_assignments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IncidentRoleAssignmentV2"
+          },
+          "description": "A list of who is assigned to each role for this incident",
+          "example": [
+            {
+              "assignee": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "role": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "The person currently coordinating the incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "required": false,
+                "role_type": "lead",
+                "shortform": "lead",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            }
+          ]
+        },
+        "incident_status": {
+          "$ref": "#/definitions/IncidentStatusV2"
+        },
+        "incident_timestamp_values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IncidentTimestampWithValueV2"
+          },
+          "description": "Incident lifecycle events and when they occurred",
+          "example": [
+            {
+              "incident_timestamp": {
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Impact started",
+                "rank": 1
+              },
+              "value": {
+                "value": "2021-08-17T13:28:57.801578Z"
+              }
+            }
+          ]
+        },
+        "incident_type": {
+          "$ref": "#/definitions/IncidentTypeV2"
+        },
+        "mode": {
+          "type": "string",
+          "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
+          "example": "standard",
+          "enum": [
+            "standard",
+            "retrospective",
+            "test",
+            "tutorial"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Explanation of the incident",
+          "example": "Our database is sad"
+        },
+        "permalink": {
+          "type": "string",
+          "description": "A permanent link to the homepage for this incident",
+          "example": "https://app.incident.io/incidents/123"
+        },
+        "postmortem_document_url": {
+          "type": "string",
+          "description": "Description of the incident",
+          "example": "https://docs.google.com/my_doc_id"
+        },
+        "reference": {
+          "type": "string",
+          "description": "Reference to this incident, as displayed across the product",
+          "example": "INC-123"
+        },
+        "related_incidents": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "example": "abc123"
+          },
+          "description": "Incident IDs of incidents related to this incident",
+          "example": [
+            "INC-237"
+          ]
+        },
+        "severity": {
+          "$ref": "#/definitions/SeverityV2"
+        },
+        "slack_channel_id": {
+          "type": "string",
+          "description": "ID of the Slack channel in the organisation Slack workspace. Note that the channel is sometimes created asynchronously, so may not be present when the incident is just created.",
+          "example": "C02AW36C1M5"
+        },
+        "slack_channel_name": {
+          "type": "string",
+          "description": "Name of the slack channel",
+          "example": "inc-165-green-parrot"
+        },
+        "slack_team_id": {
+          "type": "string",
+          "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
+          "example": "T02A1FSLE8J"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Detailed description of the incident",
+          "example": "Our database is really really sad, and we don't know why yet."
+        },
+        "updated_at": {
+          "type": "string",
+          "description": "When the incident was last updated",
+          "example": "2021-08-17T13:28:57.801578Z",
+          "format": "date-time"
+        },
+        "visibility": {
+          "type": "string",
+          "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+          "example": "public",
+          "enum": [
+            "public",
+            "private"
+          ]
+        },
+        "workload_minutes_late": {
+          "type": "number",
+          "description": "Amount of time spent on the incident in late hours",
+          "example": 40.7,
+          "format": "double"
+        },
+        "workload_minutes_sleeping": {
+          "type": "number",
+          "description": "Amount of time spent on the incident in sleeping hours",
+          "example": 0,
+          "format": "double"
+        },
+        "workload_minutes_total": {
+          "type": "number",
+          "description": "Amount of time spent on the incident in total",
+          "example": 60.7,
+          "format": "double"
+        },
+        "workload_minutes_working": {
+          "type": "number",
+          "description": "Amount of time spent on the incident in working hours",
+          "example": 20,
+          "format": "double"
+        }
+      },
+      "example": {
+        "call_url": "https://zoom.us/foo",
+        "created_at": "2021-08-17T13:28:57.801578Z",
+        "creator": {
+          "api_key": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "My test API key"
+          },
+          "user": {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          }
+        },
+        "custom_field_entries": [
+          {
+            "custom_field": {
+              "description": "Which team is impacted by this issue",
+              "field_type": "single_select",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Affected Team",
+              "options": [
+                {
+                  "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "sort_key": 10,
+                  "value": "Product"
+                }
+              ]
+            },
+            "values": [
+              {
+                "value_catalog_entry": {
+                  "aliases": [
+                    "lawrence@incident.io",
+                    "lawrence"
+                  ],
+                  "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Primary On-call"
+                },
+                "value_link": "https://google.com/",
+                "value_numeric": "123.456",
+                "value_option": {
+                  "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "sort_key": 10,
+                  "value": "Product"
+                },
+                "value_text": "This is my text field, I hope you like it"
+              }
+            ]
+          }
+        ],
+        "duration_metrics": [
+          {
+            "duration_metric": {
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Lasted"
+            },
+            "value_seconds": 1
+          }
+        ],
+        "external_issue_reference": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        },
+        "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+        "incident_role_assignments": [
+          {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "role": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "The person currently coordinating the incident",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+              "name": "Incident Lead",
+              "required": false,
+              "role_type": "lead",
+              "shortform": "lead",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          }
+        ],
+        "incident_status": {
+          "category": "triage",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+          "name": "Closed",
+          "rank": 4,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "incident_timestamp_values": [
+          {
+            "incident_timestamp": {
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Impact started",
+              "rank": 1
+            },
+            "value": {
+              "value": "2021-08-17T13:28:57.801578Z"
+            }
+          }
+        ],
+        "incident_type": {
+          "create_in_triage": "always",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Customer facing production outages",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "is_default": false,
+          "name": "Production Outage",
+          "private_incidents_only": false,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "mode": "standard",
+        "name": "Our database is sad",
+        "permalink": "https://app.incident.io/incidents/123",
+        "postmortem_document_url": "https://docs.google.com/my_doc_id",
+        "reference": "INC-123",
+        "related_incidents": [
+          "INC-237"
+        ],
+        "severity": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Issues with **low impact**.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Minor",
+          "rank": 1,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "slack_channel_id": "C02AW36C1M5",
+        "slack_channel_name": "inc-165-green-parrot",
+        "slack_team_id": "T02A1FSLE8J",
+        "summary": "Our database is really really sad, and we don't know why yet.",
+        "updated_at": "2021-08-17T13:28:57.801578Z",
+        "visibility": "public",
+        "workload_minutes_late": 40.7,
+        "workload_minutes_sleeping": 0,
+        "workload_minutes_total": 60.7,
+        "workload_minutes_working": 20
+      },
+      "required": [
+        "incident_status",
+        "id",
+        "external_id",
+        "reference",
+        "name",
+        "idempotency_key",
+        "did_opt_out_of_post_incident_flow",
+        "visibility",
+        "mode",
+        "organisation_id",
+        "creator",
+        "last_activity_at",
+        "incident_role_assignments",
+        "custom_field_entries",
+        "slack_team_id",
+        "slack_channel_id",
+        "created_at",
+        "updated_at",
+        "reported_at"
+      ]
+    },
+    "WebhookPrivateResourceV2": {
+      "title": "WebhookPrivateResourceV2",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the resource",
+          "example": "abc123"
+        }
+      },
+      "example": {
+        "id": "abc123"
+      },
+      "required": [
+        "id"
       ]
     },
     "WebhooksAllResponseBody": {
@@ -33872,49 +35010,49 @@
           ]
         },
         "private_incident.action_created_v1": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         },
         "private_incident.action_updated_v1": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         },
         "private_incident.follow_up_created_v1": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         },
         "private_incident.follow_up_updated_v1": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         },
         "private_incident.incident_created_v2": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         },
         "private_incident.incident_updated_v2": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         },
         "private_incident.membership_granted_v1": {
-          "$ref": "#/definitions/webhook_incident_userV2ResponseBody"
+          "$ref": "#/definitions/WebhookIncidentUserV2"
         },
         "private_incident.membership_revoked_v1": {
-          "$ref": "#/definitions/webhook_incident_userV2ResponseBody"
+          "$ref": "#/definitions/WebhookIncidentUserV2"
         },
         "public_incident.action_created_v1": {
-          "$ref": "#/definitions/ActionV1ResponseBody"
+          "$ref": "#/definitions/ActionV1"
         },
         "public_incident.action_updated_v1": {
-          "$ref": "#/definitions/ActionV1ResponseBody"
+          "$ref": "#/definitions/ActionV1"
         },
         "public_incident.follow_up_created_v1": {
-          "$ref": "#/definitions/ActionV1ResponseBody"
+          "$ref": "#/definitions/ActionV1"
         },
         "public_incident.follow_up_updated_v1": {
-          "$ref": "#/definitions/ActionV1ResponseBody"
+          "$ref": "#/definitions/ActionV1"
         },
         "public_incident.incident_created_v2": {
-          "$ref": "#/definitions/webhook_incidentV2ResponseBody"
+          "$ref": "#/definitions/WebhookIncidentV2"
         },
         "public_incident.incident_status_updated_v2": {
-          "$ref": "#/definitions/IncidentWithStatusChangeV2ResponseBody"
+          "$ref": "#/definitions/IncidentWithStatusChangeV2"
         },
         "public_incident.incident_updated_v2": {
-          "$ref": "#/definitions/webhook_incidentV2ResponseBody"
+          "$ref": "#/definitions/WebhookIncidentV2"
         }
       },
       "example": {
@@ -34537,7 +35675,7 @@
           ]
         },
         "private_incident.action_created_v1": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         }
       },
       "example": {
@@ -34578,7 +35716,7 @@
           ]
         },
         "private_incident.action_updated_v1": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         }
       },
       "example": {
@@ -34619,7 +35757,7 @@
           ]
         },
         "private_incident.follow_up_created_v1": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         }
       },
       "example": {
@@ -34660,7 +35798,7 @@
           ]
         },
         "private_incident.follow_up_updated_v1": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         }
       },
       "example": {
@@ -34701,7 +35839,7 @@
           ]
         },
         "private_incident.incident_created_v2": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         }
       },
       "example": {
@@ -34742,7 +35880,7 @@
           ]
         },
         "private_incident.incident_updated_v2": {
-          "$ref": "#/definitions/webhook_private_resourceV2ResponseBody"
+          "$ref": "#/definitions/WebhookPrivateResourceV2"
         }
       },
       "example": {
@@ -34783,7 +35921,7 @@
           ]
         },
         "private_incident.membership_granted_v1": {
-          "$ref": "#/definitions/webhook_incident_userV2ResponseBody"
+          "$ref": "#/definitions/WebhookIncidentUserV2"
         }
       },
       "example": {
@@ -34826,7 +35964,7 @@
           ]
         },
         "private_incident.membership_revoked_v1": {
-          "$ref": "#/definitions/webhook_incident_userV2ResponseBody"
+          "$ref": "#/definitions/WebhookIncidentUserV2"
         }
       },
       "example": {
@@ -34869,7 +36007,7 @@
           ]
         },
         "public_incident.action_created_v1": {
-          "$ref": "#/definitions/ActionV1ResponseBody"
+          "$ref": "#/definitions/ActionV1"
         }
       },
       "example": {
@@ -34929,7 +36067,7 @@
           ]
         },
         "public_incident.action_updated_v1": {
-          "$ref": "#/definitions/ActionV1ResponseBody"
+          "$ref": "#/definitions/ActionV1"
         }
       },
       "example": {
@@ -34989,7 +36127,7 @@
           ]
         },
         "public_incident.follow_up_created_v1": {
-          "$ref": "#/definitions/ActionV1ResponseBody"
+          "$ref": "#/definitions/ActionV1"
         }
       },
       "example": {
@@ -35049,7 +36187,7 @@
           ]
         },
         "public_incident.follow_up_updated_v1": {
-          "$ref": "#/definitions/ActionV1ResponseBody"
+          "$ref": "#/definitions/ActionV1"
         }
       },
       "example": {
@@ -35109,7 +36247,7 @@
           ]
         },
         "public_incident.incident_created_v2": {
-          "$ref": "#/definitions/webhook_incidentV2ResponseBody"
+          "$ref": "#/definitions/WebhookIncidentV2"
         }
       },
       "example": {
@@ -35298,7 +36436,7 @@
           ]
         },
         "public_incident.incident_status_updated_v2": {
-          "$ref": "#/definitions/IncidentWithStatusChangeV2ResponseBody"
+          "$ref": "#/definitions/IncidentWithStatusChangeV2"
         }
       },
       "example": {
@@ -35504,7 +36642,7 @@
           ]
         },
         "public_incident.incident_updated_v2": {
-          "$ref": "#/definitions/webhook_incidentV2ResponseBody"
+          "$ref": "#/definitions/WebhookIncidentV2"
         }
       },
       "example": {
@@ -35666,8 +36804,8 @@
         "public_incident.incident_updated_v2"
       ]
     },
-    "WeekdayIntervalConfigV2RequestBody": {
-      "title": "WeekdayIntervalConfigV2RequestBody",
+    "WeekdayIntervalConfigV2": {
+      "title": "WeekdayIntervalConfigV2",
       "type": "object",
       "properties": {
         "id": {
@@ -35688,7 +36826,7 @@
         "weekday_intervals": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/WeekdayIntervalV2RequestBody"
+            "$ref": "#/definitions/WeekdayIntervalV2"
           },
           "example": [
             {
@@ -35718,60 +36856,8 @@
         "weekday_intervals"
       ]
     },
-    "WeekdayIntervalConfigV2ResponseBody": {
-      "title": "WeekdayIntervalConfigV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The unique identifier for this set of working intervals",
-          "example": "abc123"
-        },
-        "name": {
-          "type": "string",
-          "description": "A human readable label for this set of working intervals",
-          "example": "abc123"
-        },
-        "timezone": {
-          "type": "string",
-          "description": "How to interpret all the intervals",
-          "example": "abc123"
-        },
-        "weekday_intervals": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/WeekdayIntervalV2ResponseBody"
-          },
-          "example": [
-            {
-              "end_time": "17:00",
-              "start_time": "09:00",
-              "weekday": "abc123"
-            }
-          ]
-        }
-      },
-      "example": {
-        "id": "abc123",
-        "name": "abc123",
-        "timezone": "abc123",
-        "weekday_intervals": [
-          {
-            "end_time": "17:00",
-            "start_time": "09:00",
-            "weekday": "abc123"
-          }
-        ]
-      },
-      "required": [
-        "id",
-        "name",
-        "timezone",
-        "weekday_intervals"
-      ]
-    },
-    "WeekdayIntervalV2RequestBody": {
-      "title": "WeekdayIntervalV2RequestBody",
+    "WeekdayIntervalV2": {
+      "title": "WeekdayIntervalV2",
       "type": "object",
       "properties": {
         "end_time": {
@@ -35801,95 +36887,14 @@
         "end_time"
       ]
     },
-    "WeekdayIntervalV2ResponseBody": {
-      "title": "WeekdayIntervalV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "end_time": {
-          "type": "string",
-          "description": "End time of the interval, in 24hr format",
-          "example": "17:00"
-        },
-        "start_time": {
-          "type": "string",
-          "description": "Start time of the interval, in 24hr format",
-          "example": "09:00"
-        },
-        "weekday": {
-          "type": "string",
-          "description": "Weekday this interval applies to",
-          "example": "abc123"
-        }
-      },
-      "example": {
-        "end_time": "17:00",
-        "start_time": "09:00",
-        "weekday": "abc123"
-      },
-      "required": [
-        "weekday",
-        "start_time",
-        "end_time"
-      ]
-    },
-    "WorkflowDelayRequestBody": {
-      "title": "WorkflowDelayRequestBody",
-      "type": "object",
-      "properties": {
-        "conditions_apply_over_delay": {
-          "type": "boolean",
-          "description": "If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution",
-          "example": false
-        },
-        "for_seconds": {
-          "type": "integer",
-          "description": "Delay in seconds between trigger firing and running the workflow",
-          "example": 60,
-          "format": "int64"
-        }
-      },
-      "example": {
-        "conditions_apply_over_delay": false,
-        "for_seconds": 60
-      },
-      "required": [
-        "for_seconds",
-        "conditions_apply_over_delay"
-      ]
-    },
-    "WorkflowDelayResponseBody": {
-      "title": "WorkflowDelayResponseBody",
-      "type": "object",
-      "properties": {
-        "conditions_apply_over_delay": {
-          "type": "boolean",
-          "description": "If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution",
-          "example": false
-        },
-        "for_seconds": {
-          "type": "integer",
-          "description": "Delay in seconds between trigger firing and running the workflow",
-          "example": 60,
-          "format": "int64"
-        }
-      },
-      "example": {
-        "conditions_apply_over_delay": false,
-        "for_seconds": 60
-      },
-      "required": [
-        "for_seconds",
-        "conditions_apply_over_delay"
-      ]
-    },
-    "WorkflowResponseBody": {
-      "title": "WorkflowResponseBody",
+    "Workflow": {
+      "title": "Workflow",
       "type": "object",
       "properties": {
         "condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupV2ResponseBody"
+            "$ref": "#/definitions/ConditionGroupV2"
           },
           "description": "Conditions that apply to the workflow trigger",
           "example": [
@@ -35931,12 +36936,12 @@
           "example": true
         },
         "delay": {
-          "$ref": "#/definitions/WorkflowDelayResponseBody"
+          "$ref": "#/definitions/WorkflowDelay"
         },
         "expressions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ExpressionV2ResponseBody"
+            "$ref": "#/definitions/ExpressionV2"
           },
           "description": "Expressions that make variables available in the scope",
           "example": [
@@ -36100,7 +37105,7 @@
         "once_for": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineReferenceV2ResponseBody"
+            "$ref": "#/definitions/EngineReferenceV2"
           },
           "description": "This workflow will run 'once for' a list of references",
           "example": [
@@ -36158,7 +37163,7 @@
         "steps": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/StepConfigResponseBody"
+            "$ref": "#/definitions/StepConfig"
           },
           "description": "Steps that are executed as part of the workflow",
           "example": [
@@ -36187,7 +37192,7 @@
           ]
         },
         "trigger": {
-          "$ref": "#/definitions/TriggerSlimResponseBody"
+          "$ref": "#/definitions/TriggerSlim"
         },
         "version": {
           "type": "integer",
@@ -36436,14 +37441,39 @@
         "state"
       ]
     },
-    "WorkflowSlimResponseBody": {
-      "title": "WorkflowSlimResponseBody",
+    "WorkflowDelay": {
+      "title": "WorkflowDelay",
+      "type": "object",
+      "properties": {
+        "conditions_apply_over_delay": {
+          "type": "boolean",
+          "description": "If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution",
+          "example": false
+        },
+        "for_seconds": {
+          "type": "integer",
+          "description": "Delay in seconds between trigger firing and running the workflow",
+          "example": 60,
+          "format": "int64"
+        }
+      },
+      "example": {
+        "conditions_apply_over_delay": false,
+        "for_seconds": 60
+      },
+      "required": [
+        "for_seconds",
+        "conditions_apply_over_delay"
+      ]
+    },
+    "WorkflowSlim": {
+      "title": "WorkflowSlim",
       "type": "object",
       "properties": {
         "condition_groups": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ConditionGroupV2ResponseBody"
+            "$ref": "#/definitions/ConditionGroupV2"
           },
           "description": "Conditions that apply to the workflow trigger",
           "example": [
@@ -36485,12 +37515,12 @@
           "example": true
         },
         "delay": {
-          "$ref": "#/definitions/WorkflowDelayResponseBody"
+          "$ref": "#/definitions/WorkflowDelay"
         },
         "expressions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ExpressionV2ResponseBody"
+            "$ref": "#/definitions/ExpressionV2"
           },
           "description": "Expressions that make variables available in the scope",
           "example": [
@@ -36654,7 +37684,7 @@
         "once_for": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineReferenceV2ResponseBody"
+            "$ref": "#/definitions/EngineReferenceV2"
           },
           "description": "This workflow will run 'once for' a list of references",
           "example": [
@@ -36712,7 +37742,7 @@
         "steps": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/StepConfigSlimResponseBody"
+            "$ref": "#/definitions/StepConfigSlim"
           },
           "description": "Steps that are executed as part of the workflow",
           "example": [
@@ -36723,7 +37753,7 @@
           ]
         },
         "trigger": {
-          "$ref": "#/definitions/TriggerSlimResponseBody"
+          "$ref": "#/definitions/TriggerSlim"
         },
         "version": {
           "type": "integer",
@@ -36954,470 +37984,15 @@
         "state"
       ]
     },
-    "WorkflowsV2CreateWorkflowRequestBody": {
-      "title": "WorkflowsV2CreateWorkflowRequestBody",
-      "type": "object",
-      "properties": {
-        "annotations": {
-          "type": "object",
-          "description": "Annotations that track metadata about this resource",
-          "example": {
-            "incident.io/terraform/version": "3.0.0"
-          },
-          "additionalProperties": {
-            "type": "string",
-            "example": "abc123"
-          }
-        },
-        "condition_groups": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
-          },
-          "description": "List of conditions to apply to the workflow",
-          "example": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ]
-        },
-        "continue_on_step_error": {
-          "type": "boolean",
-          "description": "Whether to continue executing the workflow if a step fails",
-          "example": true
-        },
-        "delay": {
-          "$ref": "#/definitions/WorkflowDelayRequestBody"
-        },
-        "expressions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ExpressionPayloadV2RequestBody"
-          },
-          "description": "The expressions used in the workflow",
-          "example": [
-            {
-              "else_branch": {
-                "result": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              },
-              "label": "Team Slack channel",
-              "operations": [
-                {
-                  "branches": {
-                    "branches": [
-                      {
-                        "condition_groups": [
-                          {
-                            "conditions": [
-                              {
-                                "operation": "one_of",
-                                "param_bindings": [
-                                  {
-                                    "array_value": [
-                                      {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    ],
-                                    "value": {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ],
-                                "subject": "incident.severity"
-                              }
-                            ]
-                          }
-                        ],
-                        "result": {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      }
-                    ],
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
-                  },
-                  "filter": {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": "one_of",
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": "incident.severity"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "navigate": {
-                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                  },
-                  "operation_type": "navigate",
-                  "parse": {
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    },
-                    "source": "metadata.annotations[\"github.com/repo\"]"
-                  }
-                }
-              ],
-              "reference": "abc123",
-              "root_reference": "incident.status"
-            }
-          ]
-        },
-        "folder": {
-          "type": "string",
-          "description": "Folder to display the workflow in",
-          "example": "My folder 01"
-        },
-        "include_private_incidents": {
-          "type": "boolean",
-          "description": "Whether to include private incidents",
-          "example": true
-        },
-        "name": {
-          "type": "string",
-          "description": "The human-readable name of the workflow",
-          "example": "My workflow"
-        },
-        "once_for": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "example": "incident.url"
-          },
-          "description": "Once For strategy to apply to this workflow",
-          "example": [
-            "incident.url"
-          ]
-        },
-        "runs_on_incident_modes": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "example": "test",
-            "enum": [
-              "standard",
-              "test",
-              "retrospective"
-            ]
-          },
-          "description": "Which modes of incident this should run on (defaults to just standard incidents)",
-          "example": [
-            "standard",
-            "retrospective"
-          ]
-        },
-        "runs_on_incidents": {
-          "type": "string",
-          "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
-          "example": "newly_created",
-          "enum": [
-            "newly_created",
-            "newly_created_and_active"
-          ]
-        },
-        "state": {
-          "type": "string",
-          "description": "The state of the workflow (e.g. is it draft, or disabled)",
-          "example": "active",
-          "enum": [
-            "active",
-            "disabled",
-            "draft",
-            "error"
-          ]
-        },
-        "steps": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/StepConfigPayloadRequestBody"
-          },
-          "description": "List of step to execute as part of the workflow",
-          "example": [
-            {
-              "for_each": "abc123",
-              "id": "abc123",
-              "name": "pagerduty.escalate",
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "trigger": {
-          "type": "string",
-          "description": "Trigger to set on the workflow",
-          "example": "incident.updated"
-        }
-      },
-      "example": {
-        "annotations": {
-          "incident.io/terraform/version": "3.0.0"
-        },
-        "condition_groups": [
-          {
-            "conditions": [
-              {
-                "operation": "one_of",
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ],
-                "subject": "incident.severity"
-              }
-            ]
-          }
-        ],
-        "continue_on_step_error": true,
-        "delay": {
-          "conditions_apply_over_delay": false,
-          "for_seconds": 60
-        },
-        "expressions": [
-          {
-            "else_branch": {
-              "result": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            },
-            "label": "Team Slack channel",
-            "operations": [
-              {
-                "branches": {
-                  "branches": [
-                    {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": "one_of",
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": "incident.severity"
-                            }
-                          ]
-                        }
-                      ],
-                      "result": {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    }
-                  ],
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  }
-                },
-                "filter": {
-                  "condition_groups": [
-                    {
-                      "conditions": [
-                        {
-                          "operation": "one_of",
-                          "param_bindings": [
-                            {
-                              "array_value": [
-                                {
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              ],
-                              "value": {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            }
-                          ],
-                          "subject": "incident.severity"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "navigate": {
-                  "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                },
-                "operation_type": "navigate",
-                "parse": {
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  },
-                  "source": "metadata.annotations[\"github.com/repo\"]"
-                }
-              }
-            ],
-            "reference": "abc123",
-            "root_reference": "incident.status"
-          }
-        ],
-        "folder": "My folder 01",
-        "include_private_incidents": true,
-        "name": "My workflow",
-        "once_for": [
-          "incident.url"
-        ],
-        "runs_on_incident_modes": [
-          "standard",
-          "retrospective"
-        ],
-        "runs_on_incidents": "newly_created",
-        "state": "active",
-        "steps": [
-          {
-            "for_each": "abc123",
-            "id": "abc123",
-            "name": "pagerduty.escalate",
-            "param_bindings": [
-              {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            ]
-          }
-        ],
-        "trigger": "incident.updated"
-      },
-      "required": [
-        "name",
-        "trigger",
-        "once_for",
-        "condition_groups",
-        "steps",
-        "expressions",
-        "include_private_incidents",
-        "runs_on_incident_modes",
-        "continue_on_step_error",
-        "runs_on_incidents"
-      ]
-    },
     "WorkflowsV2CreateWorkflowResponseBody": {
       "title": "WorkflowsV2CreateWorkflowResponseBody",
       "type": "object",
       "properties": {
         "management_meta": {
-          "$ref": "#/definitions/ManagementMetaV2ResponseBody"
+          "$ref": "#/definitions/ManagementMetaV2"
         },
         "workflow": {
-          "$ref": "#/definitions/WorkflowResponseBody"
+          "$ref": "#/definitions/Workflow"
         }
       },
       "example": {
@@ -37665,7 +38240,7 @@
         "workflows": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/WorkflowSlimResponseBody"
+            "$ref": "#/definitions/WorkflowSlim"
           },
           "example": [
             {
@@ -38096,10 +38671,10 @@
       "type": "object",
       "properties": {
         "management_meta": {
-          "$ref": "#/definitions/ManagementMetaV2ResponseBody"
+          "$ref": "#/definitions/ManagementMetaV2"
         },
         "workflow": {
-          "$ref": "#/definitions/WorkflowResponseBody"
+          "$ref": "#/definitions/Workflow"
         }
       },
       "example": {
@@ -38338,454 +38913,6 @@
       "required": [
         "workflow",
         "management_meta"
-      ]
-    },
-    "WorkflowsV2UpdateWorkflowRequestBody": {
-      "title": "WorkflowsV2UpdateWorkflowRequestBody",
-      "type": "object",
-      "properties": {
-        "annotations": {
-          "type": "object",
-          "description": "Annotations that track metadata about this resource",
-          "example": {
-            "incident.io/terraform/version": "3.0.0"
-          },
-          "additionalProperties": {
-            "type": "string",
-            "example": "abc123"
-          }
-        },
-        "condition_groups": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ConditionGroupPayloadV2RequestBody"
-          },
-          "description": "List of conditions to apply to the workflow",
-          "example": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ]
-        },
-        "continue_on_step_error": {
-          "type": "boolean",
-          "description": "Whether to continue executing the workflow if a step fails",
-          "example": true
-        },
-        "delay": {
-          "$ref": "#/definitions/WorkflowDelayRequestBody"
-        },
-        "expressions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ExpressionPayloadV2RequestBody"
-          },
-          "description": "The expressions used in the workflow",
-          "example": [
-            {
-              "else_branch": {
-                "result": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              },
-              "label": "Team Slack channel",
-              "operations": [
-                {
-                  "branches": {
-                    "branches": [
-                      {
-                        "condition_groups": [
-                          {
-                            "conditions": [
-                              {
-                                "operation": "one_of",
-                                "param_bindings": [
-                                  {
-                                    "array_value": [
-                                      {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    ],
-                                    "value": {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ],
-                                "subject": "incident.severity"
-                              }
-                            ]
-                          }
-                        ],
-                        "result": {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      }
-                    ],
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
-                  },
-                  "filter": {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": "one_of",
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": "incident.severity"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "navigate": {
-                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                  },
-                  "operation_type": "navigate",
-                  "parse": {
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    },
-                    "source": "metadata.annotations[\"github.com/repo\"]"
-                  }
-                }
-              ],
-              "reference": "abc123",
-              "root_reference": "incident.status"
-            }
-          ]
-        },
-        "folder": {
-          "type": "string",
-          "description": "Folder to display the workflow in",
-          "example": "My folder 01"
-        },
-        "include_private_incidents": {
-          "type": "boolean",
-          "description": "Whether to include private incidents",
-          "example": true
-        },
-        "name": {
-          "type": "string",
-          "description": "The human-readable name of the workflow",
-          "example": "My workflow"
-        },
-        "once_for": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "example": "incident.url"
-          },
-          "description": "Once For strategy to apply to this workflow",
-          "example": [
-            "incident.url"
-          ]
-        },
-        "runs_on_incident_modes": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "example": "test",
-            "enum": [
-              "standard",
-              "test",
-              "retrospective"
-            ]
-          },
-          "description": "Which modes of incident this should run on (defaults to just standard incidents)",
-          "example": [
-            "standard",
-            "retrospective"
-          ]
-        },
-        "runs_on_incidents": {
-          "type": "string",
-          "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
-          "example": "newly_created",
-          "enum": [
-            "newly_created",
-            "newly_created_and_active"
-          ]
-        },
-        "state": {
-          "type": "string",
-          "description": "The state of the workflow (e.g. is it draft, or disabled)",
-          "example": "active",
-          "enum": [
-            "active",
-            "disabled",
-            "draft",
-            "error"
-          ]
-        },
-        "steps": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/StepConfigPayloadRequestBody"
-          },
-          "description": "List of step to execute as part of the workflow",
-          "example": [
-            {
-              "for_each": "abc123",
-              "id": "abc123",
-              "name": "pagerduty.escalate",
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "example": {
-        "annotations": {
-          "incident.io/terraform/version": "3.0.0"
-        },
-        "condition_groups": [
-          {
-            "conditions": [
-              {
-                "operation": "one_of",
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ],
-                "subject": "incident.severity"
-              }
-            ]
-          }
-        ],
-        "continue_on_step_error": true,
-        "delay": {
-          "conditions_apply_over_delay": false,
-          "for_seconds": 60
-        },
-        "expressions": [
-          {
-            "else_branch": {
-              "result": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            },
-            "label": "Team Slack channel",
-            "operations": [
-              {
-                "branches": {
-                  "branches": [
-                    {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": "one_of",
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": "incident.severity"
-                            }
-                          ]
-                        }
-                      ],
-                      "result": {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    }
-                  ],
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  }
-                },
-                "filter": {
-                  "condition_groups": [
-                    {
-                      "conditions": [
-                        {
-                          "operation": "one_of",
-                          "param_bindings": [
-                            {
-                              "array_value": [
-                                {
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              ],
-                              "value": {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            }
-                          ],
-                          "subject": "incident.severity"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "navigate": {
-                  "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                },
-                "operation_type": "navigate",
-                "parse": {
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  },
-                  "source": "metadata.annotations[\"github.com/repo\"]"
-                }
-              }
-            ],
-            "reference": "abc123",
-            "root_reference": "incident.status"
-          }
-        ],
-        "folder": "My folder 01",
-        "include_private_incidents": true,
-        "name": "My workflow",
-        "once_for": [
-          "incident.url"
-        ],
-        "runs_on_incident_modes": [
-          "standard",
-          "retrospective"
-        ],
-        "runs_on_incidents": "newly_created",
-        "state": "active",
-        "steps": [
-          {
-            "for_each": "abc123",
-            "id": "abc123",
-            "name": "pagerduty.escalate",
-            "param_bindings": [
-              {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "required": [
-        "name",
-        "once_for",
-        "condition_groups",
-        "steps",
-        "expressions",
-        "include_private_incidents",
-        "runs_on_incident_modes",
-        "continue_on_step_error",
-        "runs_on_incidents"
       ]
     },
     "WorkflowsV2UpdateWorkflowResponseBody": {
@@ -38793,10 +38920,10 @@
       "type": "object",
       "properties": {
         "management_meta": {
-          "$ref": "#/definitions/ManagementMetaV2ResponseBody"
+          "$ref": "#/definitions/ManagementMetaV2"
         },
         "workflow": {
-          "$ref": "#/definitions/WorkflowResponseBody"
+          "$ref": "#/definitions/Workflow"
         }
       },
       "example": {
@@ -39035,474 +39162,6 @@
       "required": [
         "workflow",
         "management_meta"
-      ]
-    },
-    "webhook_incidentV2ResponseBody": {
-      "title": "webhook_incidentV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "call_url": {
-          "type": "string",
-          "description": "The call URL attached to this incident",
-          "example": "https://zoom.us/foo"
-        },
-        "created_at": {
-          "type": "string",
-          "description": "When the incident was created",
-          "example": "2021-08-17T13:28:57.801578Z",
-          "format": "date-time"
-        },
-        "creator": {
-          "$ref": "#/definitions/ActorV2ResponseBody"
-        },
-        "custom_field_entries": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CustomFieldEntryV2ResponseBody"
-          },
-          "description": "Custom field entries for this incident",
-          "example": [
-            {
-              "custom_field": {
-                "description": "Which team is impacted by this issue",
-                "field_type": "single_select",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Affected Team",
-                "options": [
-                  {
-                    "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "sort_key": 10,
-                    "value": "Product"
-                  }
-                ]
-              },
-              "values": [
-                {
-                  "value_catalog_entry": {
-                    "aliases": [
-                      "lawrence@incident.io",
-                      "lawrence"
-                    ],
-                    "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "Primary On-call"
-                  },
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option": {
-                    "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "sort_key": 10,
-                    "value": "Product"
-                  },
-                  "value_text": "This is my text field, I hope you like it"
-                }
-              ]
-            }
-          ]
-        },
-        "duration_metrics": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/IncidentDurationMetricWithValueV2ResponseBody"
-          },
-          "description": "Incident duration metrics and their measurements for this incident",
-          "example": [
-            {
-              "duration_metric": {
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Lasted"
-              },
-              "value_seconds": 1
-            }
-          ]
-        },
-        "external_issue_reference": {
-          "$ref": "#/definitions/ExternalIssueReferenceV2ResponseBody"
-        },
-        "id": {
-          "type": "string",
-          "description": "Unique identifier for the incident",
-          "example": "01FDAG4SAP5TYPT98WGR2N7W91"
-        },
-        "incident_role_assignments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/IncidentRoleAssignmentV2ResponseBody"
-          },
-          "description": "A list of who is assigned to each role for this incident",
-          "example": [
-            {
-              "assignee": {
-                "email": "lisa@incident.io",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Lisa Karlin Curtis",
-                "role": "viewer",
-                "slack_user_id": "U02AYNF2XJM"
-              },
-              "role": {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "The person currently coordinating the incident",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                "name": "Incident Lead",
-                "required": false,
-                "role_type": "lead",
-                "shortform": "lead",
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            }
-          ]
-        },
-        "incident_status": {
-          "$ref": "#/definitions/IncidentStatusV2ResponseBody"
-        },
-        "incident_timestamp_values": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/IncidentTimestampWithValueV2ResponseBody"
-          },
-          "description": "Incident lifecycle events and when they occurred",
-          "example": [
-            {
-              "incident_timestamp": {
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Impact started",
-                "rank": 1
-              },
-              "value": {
-                "value": "2021-08-17T13:28:57.801578Z"
-              }
-            }
-          ]
-        },
-        "incident_type": {
-          "$ref": "#/definitions/IncidentTypeV2ResponseBody"
-        },
-        "mode": {
-          "type": "string",
-          "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
-          "example": "standard",
-          "enum": [
-            "standard",
-            "retrospective",
-            "test",
-            "tutorial"
-          ]
-        },
-        "name": {
-          "type": "string",
-          "description": "Explanation of the incident",
-          "example": "Our database is sad"
-        },
-        "permalink": {
-          "type": "string",
-          "description": "A permanent link to the homepage for this incident",
-          "example": "https://app.incident.io/incidents/123"
-        },
-        "postmortem_document_url": {
-          "type": "string",
-          "description": "Description of the incident",
-          "example": "https://docs.google.com/my_doc_id"
-        },
-        "reference": {
-          "type": "string",
-          "description": "Reference to this incident, as displayed across the product",
-          "example": "INC-123"
-        },
-        "related_incidents": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "example": "abc123"
-          },
-          "description": "Incident IDs of incidents related to this incident",
-          "example": [
-            "INC-237"
-          ]
-        },
-        "severity": {
-          "$ref": "#/definitions/SeverityV2ResponseBody"
-        },
-        "slack_channel_id": {
-          "type": "string",
-          "description": "ID of the Slack channel in the organisation Slack workspace. Note that the channel is sometimes created asynchronously, so may not be present when the incident is just created.",
-          "example": "C02AW36C1M5"
-        },
-        "slack_channel_name": {
-          "type": "string",
-          "description": "Name of the slack channel",
-          "example": "inc-165-green-parrot"
-        },
-        "slack_team_id": {
-          "type": "string",
-          "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
-          "example": "T02A1FSLE8J"
-        },
-        "summary": {
-          "type": "string",
-          "description": "Detailed description of the incident",
-          "example": "Our database is really really sad, and we don't know why yet."
-        },
-        "updated_at": {
-          "type": "string",
-          "description": "When the incident was last updated",
-          "example": "2021-08-17T13:28:57.801578Z",
-          "format": "date-time"
-        },
-        "visibility": {
-          "type": "string",
-          "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-          "example": "public",
-          "enum": [
-            "public",
-            "private"
-          ]
-        },
-        "workload_minutes_late": {
-          "type": "number",
-          "description": "Amount of time spent on the incident in late hours",
-          "example": 40.7,
-          "format": "double"
-        },
-        "workload_minutes_sleeping": {
-          "type": "number",
-          "description": "Amount of time spent on the incident in sleeping hours",
-          "example": 0,
-          "format": "double"
-        },
-        "workload_minutes_total": {
-          "type": "number",
-          "description": "Amount of time spent on the incident in total",
-          "example": 60.7,
-          "format": "double"
-        },
-        "workload_minutes_working": {
-          "type": "number",
-          "description": "Amount of time spent on the incident in working hours",
-          "example": 20,
-          "format": "double"
-        }
-      },
-      "example": {
-        "call_url": "https://zoom.us/foo",
-        "created_at": "2021-08-17T13:28:57.801578Z",
-        "creator": {
-          "api_key": {
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "My test API key"
-          },
-          "user": {
-            "email": "lisa@incident.io",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Lisa Karlin Curtis",
-            "role": "viewer",
-            "slack_user_id": "U02AYNF2XJM"
-          }
-        },
-        "custom_field_entries": [
-          {
-            "custom_field": {
-              "description": "Which team is impacted by this issue",
-              "field_type": "single_select",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Affected Team",
-              "options": [
-                {
-                  "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "sort_key": 10,
-                  "value": "Product"
-                }
-              ]
-            },
-            "values": [
-              {
-                "value_catalog_entry": {
-                  "aliases": [
-                    "lawrence@incident.io",
-                    "lawrence"
-                  ],
-                  "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Primary On-call"
-                },
-                "value_link": "https://google.com/",
-                "value_numeric": "123.456",
-                "value_option": {
-                  "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "sort_key": 10,
-                  "value": "Product"
-                },
-                "value_text": "This is my text field, I hope you like it"
-              }
-            ]
-          }
-        ],
-        "duration_metrics": [
-          {
-            "duration_metric": {
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Lasted"
-            },
-            "value_seconds": 1
-          }
-        ],
-        "external_issue_reference": {
-          "issue_name": "INC-123",
-          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-          "provider": "asana"
-        },
-        "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-        "incident_role_assignments": [
-          {
-            "assignee": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            },
-            "role": {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "The person currently coordinating the incident",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-              "name": "Incident Lead",
-              "required": false,
-              "role_type": "lead",
-              "shortform": "lead",
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          }
-        ],
-        "incident_status": {
-          "category": "triage",
-          "created_at": "2021-08-17T13:28:57.801578Z",
-          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-          "name": "Closed",
-          "rank": 4,
-          "updated_at": "2021-08-17T13:28:57.801578Z"
-        },
-        "incident_timestamp_values": [
-          {
-            "incident_timestamp": {
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Impact started",
-              "rank": 1
-            },
-            "value": {
-              "value": "2021-08-17T13:28:57.801578Z"
-            }
-          }
-        ],
-        "incident_type": {
-          "create_in_triage": "always",
-          "created_at": "2021-08-17T13:28:57.801578Z",
-          "description": "Customer facing production outages",
-          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "is_default": false,
-          "name": "Production Outage",
-          "private_incidents_only": false,
-          "updated_at": "2021-08-17T13:28:57.801578Z"
-        },
-        "mode": "standard",
-        "name": "Our database is sad",
-        "permalink": "https://app.incident.io/incidents/123",
-        "postmortem_document_url": "https://docs.google.com/my_doc_id",
-        "reference": "INC-123",
-        "related_incidents": [
-          "INC-237"
-        ],
-        "severity": {
-          "created_at": "2021-08-17T13:28:57.801578Z",
-          "description": "Issues with **low impact**.",
-          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "name": "Minor",
-          "rank": 1,
-          "updated_at": "2021-08-17T13:28:57.801578Z"
-        },
-        "slack_channel_id": "C02AW36C1M5",
-        "slack_channel_name": "inc-165-green-parrot",
-        "slack_team_id": "T02A1FSLE8J",
-        "summary": "Our database is really really sad, and we don't know why yet.",
-        "updated_at": "2021-08-17T13:28:57.801578Z",
-        "visibility": "public",
-        "workload_minutes_late": 40.7,
-        "workload_minutes_sleeping": 0,
-        "workload_minutes_total": 60.7,
-        "workload_minutes_working": 20
-      },
-      "required": [
-        "incident_status",
-        "id",
-        "external_id",
-        "reference",
-        "name",
-        "idempotency_key",
-        "did_opt_out_of_post_incident_flow",
-        "visibility",
-        "mode",
-        "organisation_id",
-        "creator",
-        "last_activity_at",
-        "incident_role_assignments",
-        "custom_field_entries",
-        "slack_team_id",
-        "slack_channel_id",
-        "created_at",
-        "updated_at",
-        "reported_at"
-      ]
-    },
-    "webhook_incident_userV2ResponseBody": {
-      "title": "webhook_incident_userV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "actor_user_id": {
-          "type": "string",
-          "description": "The ID of the user who performed this action. If the action was not taken by a user, for example it was taken by a Workflow, this will be empty.",
-          "example": "abc123"
-        },
-        "incident_id": {
-          "type": "string",
-          "description": "The ID of the incident",
-          "example": "abc123"
-        },
-        "user_id": {
-          "type": "string",
-          "description": "The ID of the user",
-          "example": "abc123"
-        }
-      },
-      "example": {
-        "actor_user_id": "abc123",
-        "incident_id": "abc123",
-        "user_id": "abc123"
-      },
-      "required": [
-        "incident_id",
-        "user_id"
-      ]
-    },
-    "webhook_private_resourceV2ResponseBody": {
-      "title": "webhook_private_resourceV2ResponseBody",
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The ID of the resource",
-          "example": "abc123"
-        }
-      },
-      "example": {
-        "id": "abc123"
-      },
-      "required": [
-        "id"
       ]
     }
   },

--- a/internal/apischema/openapi.yaml
+++ b/internal/apischema/openapi.yaml
@@ -15002,7 +15002,7 @@ definitions:
             - custom_field_id
             - value
             - sort_key
-    CustomFieldOptionsV1CreateRequestBody:
+    []CustomFieldOptionsV1CreateRequestBody:
         title: CustomFieldOptionsV1CreateRequestBody
         type: object
         properties:

--- a/internal/apischema/openapi.yaml
+++ b/internal/apischema/openapi.yaml
@@ -978,9 +978,7 @@ paths:
             responses:
                 "200":
                     description: OK response.
-                    schema:
-                        type: string
-                        format: binary
+                    schema: {}
             schemes:
                 - https
     /v1/openapiV3.json:
@@ -993,9 +991,7 @@ paths:
             responses:
                 "200":
                     description: OK response.
-                    schema:
-                        type: string
-                        format: binary
+                    schema: {}
             schemes:
                 - https
     /v1/severities:
@@ -1196,7 +1192,7 @@ paths:
                 "202":
                     description: Accepted response.
                     schema:
-                        $ref: '#/definitions/AlertEventsV2CreateHTTPResponseBody'
+                        $ref: '#/definitions/AlertResult'
                         required:
                             - status
                             - message
@@ -1287,6 +1283,7 @@ paths:
                         - enabled
                         - incident_enabled
                         - incident_condition_groups
+                        - alert_sources
                         - alert_source_ids
                         - auto_cancel_escalations
             responses:
@@ -1359,7 +1356,10 @@ paths:
             tags:
                 - Catalog V2
             summary: CreateEntry Catalog V2
-            description: Create an entry within the catalog. We support a maximum of 50,000 entries per type.
+            description: |-
+                Create an entry within the catalog. We support a maximum of 50,000 entries per type.
+
+                If you call this API with a payload where the external_id and catalog_type_id match an existing entry, the existing entry will be updated.
             operationId: Catalog V2#CreateEntry
             parameters:
                 - name: CreateEntryRequestBody
@@ -2328,7 +2328,7 @@ paths:
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/IncidentsV2CreateRequestBody'
+                    $ref: '#/definitions/IncidentCreatePayloadV2'
                     required:
                         - idempotency_key
                         - visibility
@@ -2438,7 +2438,7 @@ paths:
             tags:
                 - Schedules V2
             summary: ListScheduleEntries Schedules V2
-            description: Get a list of schedule entries.
+            description: Get a list of schedule entries. The endpoint will return all entries that overlap with the given window, if one is provided.
             operationId: Schedules V2#ListScheduleEntries
             parameters:
                 - name: schedule_id
@@ -2681,7 +2681,7 @@ paths:
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/WorkflowsV2CreateWorkflowRequestBody'
+                    $ref: '#/definitions/CreateWorkflowPayload'
                     required:
                         - name
                         - trigger
@@ -2742,7 +2742,7 @@ paths:
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/WorkflowsV2UpdateWorkflowRequestBody'
+                    $ref: '#/definitions/UpdateWorkflowPayload'
                     required:
                         - name
                         - once_for
@@ -4966,8 +4966,8 @@ paths:
             schemes:
                 - https
 definitions:
-    APIKeyV1ResponseBody:
-        title: APIKeyV1ResponseBody
+    APIKeyV1:
+        title: APIKeyV1
         type: object
         properties:
             id:
@@ -4986,8 +4986,8 @@ definitions:
             - name
             - roles
             - created_by
-    APIKeyV2ResponseBody:
-        title: APIKeyV2ResponseBody
+    APIKeyV2:
+        title: APIKeyV2
         type: object
         properties:
             id:
@@ -5006,12 +5006,12 @@ definitions:
             - name
             - roles
             - created_by
-    ActionV1ResponseBody:
-        title: ActionV1ResponseBody
+    ActionV1:
+        title: ActionV1
         type: object
         properties:
             assignee:
-                $ref: '#/definitions/UserV1ResponseBody'
+                $ref: '#/definitions/UserV1'
             completed_at:
                 type: string
                 description: When the action was completed
@@ -5027,7 +5027,7 @@ definitions:
                 description: Description of the action
                 example: Call the fire brigade
             external_issue_reference:
-                $ref: '#/definitions/ExternalIssueReferenceV1ResponseBody'
+                $ref: '#/definitions/ExternalIssueReferenceV1'
             follow_up:
                 type: boolean
                 description: Whether an action is marked as follow-up
@@ -5080,12 +5080,12 @@ definitions:
             - follow_up
             - created_at
             - updated_at
-    ActionV2ResponseBody:
-        title: ActionV2ResponseBody
+    ActionV2:
+        title: ActionV2
         type: object
         properties:
             assignee:
-                $ref: '#/definitions/UserV2ResponseBody'
+                $ref: '#/definitions/UserV2'
             completed_at:
                 type: string
                 description: When the action was completed
@@ -5150,7 +5150,7 @@ definitions:
             actions:
                 type: array
                 items:
-                    $ref: '#/definitions/ActionV1ResponseBody'
+                    $ref: '#/definitions/ActionV1'
                 example:
                     - assignee:
                         email: lisa@incident.io
@@ -5197,7 +5197,7 @@ definitions:
         type: object
         properties:
             action:
-                $ref: '#/definitions/ActionV1ResponseBody'
+                $ref: '#/definitions/ActionV1'
         example:
             action:
                 assignee:
@@ -5227,7 +5227,7 @@ definitions:
             actions:
                 type: array
                 items:
-                    $ref: '#/definitions/ActionV2ResponseBody'
+                    $ref: '#/definitions/ActionV2'
                 example:
                     - assignee:
                         email: lisa@incident.io
@@ -5264,7 +5264,7 @@ definitions:
         type: object
         properties:
             action:
-                $ref: '#/definitions/ActionV2ResponseBody'
+                $ref: '#/definitions/ActionV2'
         example:
             action:
                 assignee:
@@ -5282,14 +5282,14 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - action
-    ActorV1ResponseBody:
-        title: ActorV1ResponseBody
+    ActorV1:
+        title: ActorV1
         type: object
         properties:
             api_key:
-                $ref: '#/definitions/APIKeyV1ResponseBody'
+                $ref: '#/definitions/APIKeyV1'
             user:
-                $ref: '#/definitions/UserV1ResponseBody'
+                $ref: '#/definitions/UserV1'
         example:
             api_key:
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -5300,14 +5300,14 @@ definitions:
                 name: Lisa Karlin Curtis
                 role: viewer
                 slack_user_id: U02AYNF2XJM
-    ActorV2ResponseBody:
-        title: ActorV2ResponseBody
+    ActorV2:
+        title: ActorV2
         type: object
         properties:
             api_key:
-                $ref: '#/definitions/APIKeyV2ResponseBody'
+                $ref: '#/definitions/APIKeyV2'
             user:
-                $ref: '#/definitions/UserV2ResponseBody'
+                $ref: '#/definitions/UserV2'
         example:
             api_key:
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -5318,8 +5318,8 @@ definitions:
                 name: Lisa Karlin Curtis
                 role: viewer
                 slack_user_id: U02AYNF2XJM
-    AfterPaginationMetaResultV2ResponseBody:
-        title: AfterPaginationMetaResultV2ResponseBody
+    AfterPaginationMetaResultV2:
+        title: AfterPaginationMetaResultV2
         type: object
         properties:
             after:
@@ -5384,8 +5384,8 @@ definitions:
         required:
             - title
             - status
-    AlertEventsV2CreateHTTPResponseBody:
-        title: AlertEventsV2CreateHTTPResponseBody
+    AlertResult:
+        title: AlertResult
         type: object
         properties:
             deduplication_key:
@@ -5414,12 +5414,12 @@ definitions:
             - status
             - message
             - deduplication_key
-    AlertRouteEscalationBindingPayloadV2RequestBody:
-        title: AlertRouteEscalationBindingPayloadV2RequestBody
+    AlertRouteEscalationBindingPayloadV2:
+        title: AlertRouteEscalationBindingPayloadV2
         type: object
         properties:
             binding:
-                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingPayloadV2'
         example:
             binding:
                 array_value:
@@ -5430,12 +5430,12 @@ definitions:
                     reference: incident.severity
         required:
             - binding
-    AlertRouteEscalationBindingV2ResponseBody:
-        title: AlertRouteEscalationBindingV2ResponseBody
+    AlertRouteEscalationBindingV2:
+        title: AlertRouteEscalationBindingV2
         type: object
         properties:
             binding:
-                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingV2'
         example:
             binding:
                 array_value:
@@ -5448,8 +5448,8 @@ definitions:
                     reference: incident.severity
         required:
             - binding
-    AlertRouteIncidentTemplatePayloadV2RequestBody:
-        title: AlertRouteIncidentTemplatePayloadV2RequestBody
+    AlertRouteIncidentTemplatePayloadV2:
+        title: AlertRouteIncidentTemplatePayloadV2
         type: object
         properties:
             custom_field_priorities:
@@ -5472,13 +5472,13 @@ definitions:
                             literal: SEV123
                             reference: incident.severity
                 additionalProperties:
-                    $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                    $ref: '#/definitions/EngineParamBindingPayloadV2'
             incident_mode:
-                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingPayloadV2'
             incident_type:
-                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingPayloadV2'
             name:
-                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingPayloadV2'
             priority_severity:
                 type: string
                 description: option defining whether to cause subsequent alerts to increase the severity
@@ -5487,11 +5487,11 @@ definitions:
                     - severity-first-wins
                     - severity-max
             severity:
-                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingPayloadV2'
             summary:
-                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingPayloadV2'
             workspace:
-                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingPayloadV2'
         example:
             custom_field_priorities:
                 abc123: abc123
@@ -5549,8 +5549,8 @@ definitions:
         required:
             - custom_field_priorities
             - priority_severity
-    AlertRouteIncidentTemplateV2ResponseBody:
-        title: AlertRouteIncidentTemplateV2ResponseBody
+    AlertRouteIncidentTemplateV2:
+        title: AlertRouteIncidentTemplateV2
         type: object
         properties:
             custom_field_priorities:
@@ -5579,13 +5579,13 @@ definitions:
                             literal: SEV123
                             reference: incident.severity
                 additionalProperties:
-                    $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                    $ref: '#/definitions/EngineParamBindingV2'
             incident_mode:
-                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingV2'
             incident_type:
-                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingV2'
             name:
-                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingV2'
             priority_severity:
                 type: string
                 description: binding to use to resolve the workspace to create an incident in
@@ -5594,11 +5594,11 @@ definitions:
                     - severity-first-wins
                     - severity-max
             severity:
-                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingV2'
             summary:
-                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingV2'
             workspace:
-                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingV2'
         example:
             custom_field_priorities:
                 abc123: first-wins
@@ -5670,14 +5670,14 @@ definitions:
         required:
             - custom_field_priorities
             - priority_severity
-    AlertRouteV2ResponseBody:
-        title: AlertRouteV2ResponseBody
+    AlertRouteV2:
+        title: AlertRouteV2
         type: object
         properties:
             condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupV2ResponseBody'
+                    $ref: '#/definitions/ConditionGroupV2'
                 description: What condition groups must be true for this alert route to fire?
                 example:
                     - conditions:
@@ -5704,7 +5704,7 @@ definitions:
             escalation_bindings:
                 type: array
                 items:
-                    $ref: '#/definitions/AlertRouteEscalationBindingV2ResponseBody'
+                    $ref: '#/definitions/AlertRouteEscalationBindingV2'
                 description: Which escalation paths should this alert route escalate to?
                 example:
                     - binding:
@@ -5719,7 +5719,7 @@ definitions:
             expressions:
                 type: array
                 items:
-                    $ref: '#/definitions/ExpressionV2ResponseBody'
+                    $ref: '#/definitions/ExpressionV2'
                 description: The expressions used in this template
                 example:
                     - else_branch:
@@ -5803,7 +5803,7 @@ definitions:
             grouping_keys:
                 type: array
                 items:
-                    $ref: '#/definitions/GroupingKeyV2ResponseBody'
+                    $ref: '#/definitions/GroupingKeyV2'
                 description: Which attributes should this alert route use to group alerts?
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -5821,7 +5821,7 @@ definitions:
                 description: The name of this alert route config, for the user's reference
                 example: Production incidents
             template:
-                $ref: '#/definitions/AlertRouteIncidentTemplateV2ResponseBody'
+                $ref: '#/definitions/AlertRouteIncidentTemplateV2'
         example:
             condition_groups:
                 - conditions:
@@ -6015,6 +6015,7 @@ definitions:
             - enabled
             - incident_enabled
             - incident_condition_groups
+            - alert_sources
             - alert_source_ids
             - auto_cancel_escalations
     AlertRoutesV2CreateRequestBody:
@@ -6026,7 +6027,7 @@ definitions:
                 items:
                     type: string
                     example: abc123
-                description: The alert sources that will match this alert route
+                description: Legacy field - the alert sources that will match this alert route
                 example:
                     - 02FCNDV6P870EA6S7TK1DSYDG2
             auto_decline_enabled:
@@ -6036,7 +6037,7 @@ definitions:
             condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                    $ref: '#/definitions/ConditionGroupPayloadV2'
                 description: What condition groups must be true for this alert route to fire?
                 example:
                     - conditions:
@@ -6061,7 +6062,7 @@ definitions:
             escalation_bindings:
                 type: array
                 items:
-                    $ref: '#/definitions/AlertRouteEscalationBindingPayloadV2RequestBody'
+                    $ref: '#/definitions/AlertRouteEscalationBindingPayloadV2'
                 description: Which escalation paths should this alert route escalate to?
                 example:
                     - binding:
@@ -6074,7 +6075,7 @@ definitions:
             expressions:
                 type: array
                 items:
-                    $ref: '#/definitions/ExpressionPayloadV2RequestBody'
+                    $ref: '#/definitions/ExpressionPayloadV2'
                 description: The expressions used in this template
                 example:
                     - else_branch:
@@ -6135,7 +6136,7 @@ definitions:
             grouping_keys:
                 type: array
                 items:
-                    $ref: '#/definitions/GroupingKeyV2RequestBody'
+                    $ref: '#/definitions/GroupingKeyV2'
                 description: Which attributes should this alert route use to group alerts?
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -6147,7 +6148,7 @@ definitions:
             incident_condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                    $ref: '#/definitions/ConditionGroupPayloadV2'
                 description: What condition groups must be true for this alert route to create an incident?
                 example:
                     - conditions:
@@ -6169,7 +6170,7 @@ definitions:
                 description: The name of this alert route config, for the user's reference
                 example: Production incidents
             template:
-                $ref: '#/definitions/AlertRouteIncidentTemplatePayloadV2RequestBody'
+                $ref: '#/definitions/AlertRouteIncidentTemplatePayloadV2'
         example:
             alert_source_ids:
                 - 02FCNDV6P870EA6S7TK1DSYDG2
@@ -6326,7 +6327,7 @@ definitions:
         type: object
         properties:
             alert_route:
-                $ref: '#/definitions/AlertRouteV2ResponseBody'
+                $ref: '#/definitions/AlertRouteV2'
         example:
             alert_route:
                 condition_groups:
@@ -6516,7 +6517,7 @@ definitions:
         type: object
         properties:
             alert_route:
-                $ref: '#/definitions/AlertRouteV2ResponseBody'
+                $ref: '#/definitions/AlertRouteV2'
         example:
             alert_route:
                 condition_groups:
@@ -6710,7 +6711,7 @@ definitions:
                 items:
                     type: string
                     example: abc123
-                description: The alert sources that will match this alert route
+                description: Legacy field - the alert sources that will match this alert route
                 example:
                     - 02FCNDV6P870EA6S7TK1DSYDG2
             auto_decline_enabled:
@@ -6720,7 +6721,7 @@ definitions:
             condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                    $ref: '#/definitions/ConditionGroupPayloadV2'
                 description: What condition groups must be true for this alert route to fire?
                 example:
                     - conditions:
@@ -6745,7 +6746,7 @@ definitions:
             escalation_bindings:
                 type: array
                 items:
-                    $ref: '#/definitions/AlertRouteEscalationBindingPayloadV2RequestBody'
+                    $ref: '#/definitions/AlertRouteEscalationBindingPayloadV2'
                 description: Which escalation paths should this alert route escalate to?
                 example:
                     - binding:
@@ -6758,7 +6759,7 @@ definitions:
             expressions:
                 type: array
                 items:
-                    $ref: '#/definitions/ExpressionPayloadV2RequestBody'
+                    $ref: '#/definitions/ExpressionPayloadV2'
                 description: The expressions used in this template
                 example:
                     - else_branch:
@@ -6819,7 +6820,7 @@ definitions:
             grouping_keys:
                 type: array
                 items:
-                    $ref: '#/definitions/GroupingKeyV2RequestBody'
+                    $ref: '#/definitions/GroupingKeyV2'
                 description: Which attributes should this alert route use to group alerts?
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -6831,7 +6832,7 @@ definitions:
             incident_condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                    $ref: '#/definitions/ConditionGroupPayloadV2'
                 description: What condition groups must be true for this alert route to create an incident?
                 example:
                     - conditions:
@@ -6853,7 +6854,7 @@ definitions:
                 description: The name of this alert route config, for the user's reference
                 example: Production incidents
             template:
-                $ref: '#/definitions/AlertRouteIncidentTemplatePayloadV2RequestBody'
+                $ref: '#/definitions/AlertRouteIncidentTemplatePayloadV2'
         example:
             alert_source_ids:
                 - 02FCNDV6P870EA6S7TK1DSYDG2
@@ -7016,6 +7017,7 @@ definitions:
             - enabled
             - incident_enabled
             - incident_condition_groups
+            - alert_sources
             - alert_source_ids
             - auto_cancel_escalations
     AlertRoutesV2UpdateResponseBody:
@@ -7023,7 +7025,7 @@ definitions:
         type: object
         properties:
             alert_route:
-                $ref: '#/definitions/AlertRouteV2ResponseBody'
+                $ref: '#/definitions/AlertRouteV2'
         example:
             alert_route:
                 condition_groups:
@@ -7208,8 +7210,8 @@ definitions:
                             reference: incident.severity
         required:
             - alert_route
-    AuditLogActorMetadataV2ResponseBody:
-        title: AuditLogActorMetadataV2ResponseBody
+    AuditLogActorMetadataV2:
+        title: AuditLogActorMetadataV2
         type: object
         properties:
             api_key_roles:
@@ -7238,8 +7240,8 @@ definitions:
             external_resource_type: pager_duty_incident
             user_base_role_slug: admin
             user_custom_role_slugs: engineering,security
-    AuditLogActorV2ResponseBody:
-        title: AuditLogActorV2ResponseBody
+    AuditLogActorV2:
+        title: AuditLogActorV2
         type: object
         properties:
             id:
@@ -7247,7 +7249,7 @@ definitions:
                 description: The ID of the actor
                 example: 01FCNDV6P870EA6S7TK1DSYDG0
             metadata:
-                $ref: '#/definitions/AuditLogActorMetadataV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorMetadataV2'
             name:
                 type: string
                 description: The name of the actor
@@ -7272,8 +7274,8 @@ definitions:
         required:
             - id
             - type
-    AuditLogEntryContextV2ResponseBody:
-        title: AuditLogEntryContextV2ResponseBody
+    AuditLogEntryContextV2:
+        title: AuditLogEntryContextV2
         type: object
         properties:
             location:
@@ -7289,8 +7291,8 @@ definitions:
             user_agent: Chrome/91.0.4472.114
         required:
             - location
-    AuditLogPrivateIncidentAccessAttemptedMetadataV2ResponseBody:
-        title: AuditLogPrivateIncidentAccessAttemptedMetadataV2ResponseBody
+    AuditLogPrivateIncidentAccessAttemptedMetadataV2:
+        title: AuditLogPrivateIncidentAccessAttemptedMetadataV2
         type: object
         properties:
             outcome:
@@ -7302,8 +7304,8 @@ definitions:
                     - denied
         example:
             outcome: granted
-    AuditLogTargetV2ResponseBody:
-        title: AuditLogTargetV2ResponseBody
+    AuditLogTargetV2:
+        title: AuditLogTargetV2
         type: object
         properties:
             id:
@@ -7358,8 +7360,8 @@ definitions:
         required:
             - id
             - type
-    AuditLogUserRoleMembershipChangedMetadataV2ResponseBody:
-        title: AuditLogUserRoleMembershipChangedMetadataV2ResponseBody
+    AuditLogUserRoleMembershipChangedMetadataV2:
+        title: AuditLogUserRoleMembershipChangedMetadataV2
         type: object
         properties:
             after_base_role_slug:
@@ -7388,8 +7390,8 @@ definitions:
             - before_custom_role_slugs
             - after_base_role_slug
             - after_custom_role_slugs
-    AuditLogUserSCIMGroupMappingChangedMetadataV2ResponseBody:
-        title: AuditLogUserSCIMGroupMappingChangedMetadataV2ResponseBody
+    AuditLogUserSCIMGroupMappingChangedMetadataV2:
+        title: AuditLogUserSCIMGroupMappingChangedMetadataV2
         type: object
         properties:
             after_base_role_slug:
@@ -7422,9 +7424,9 @@ definitions:
                 description: The type of log entry that this is
                 example: api_key.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7433,7 +7435,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7478,9 +7480,9 @@ definitions:
                 description: The type of log entry that this is
                 example: api_key.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7489,7 +7491,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7534,9 +7536,9 @@ definitions:
                 description: The type of log entry that this is
                 example: alert_route.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7545,7 +7547,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7590,9 +7592,9 @@ definitions:
                 description: The type of log entry that this is
                 example: alert_route.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7601,7 +7603,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7646,9 +7648,9 @@ definitions:
                 description: The type of log entry that this is
                 example: alert_route.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7657,7 +7659,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7702,9 +7704,9 @@ definitions:
                 description: The type of log entry that this is
                 example: alert_schema.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7713,7 +7715,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7758,9 +7760,9 @@ definitions:
                 description: The type of log entry that this is
                 example: alert_source_config.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7769,7 +7771,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7814,9 +7816,9 @@ definitions:
                 description: The type of log entry that this is
                 example: alert_source_config.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7825,7 +7827,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7870,9 +7872,9 @@ definitions:
                 description: The type of log entry that this is
                 example: alert_source_config.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7881,7 +7883,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7926,9 +7928,9 @@ definitions:
                 description: The type of log entry that this is
                 example: announcement_rule.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7937,7 +7939,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -7982,9 +7984,9 @@ definitions:
                 description: The type of log entry that this is
                 example: announcement_rule.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -7993,7 +7995,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8038,9 +8040,9 @@ definitions:
                 description: The type of log entry that this is
                 example: announcement_rule.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8049,7 +8051,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8094,9 +8096,9 @@ definitions:
                 description: The type of log entry that this is
                 example: catalog_type.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8105,7 +8107,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8150,9 +8152,9 @@ definitions:
                 description: The type of log entry that this is
                 example: catalog_type.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8161,7 +8163,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8206,9 +8208,9 @@ definitions:
                 description: The type of log entry that this is
                 example: catalog_type.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8217,7 +8219,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8262,9 +8264,9 @@ definitions:
                 description: The type of log entry that this is
                 example: custom_field.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8273,7 +8275,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8318,9 +8320,9 @@ definitions:
                 description: The type of log entry that this is
                 example: custom_field.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8329,7 +8331,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8374,9 +8376,9 @@ definitions:
                 description: The type of log entry that this is
                 example: custom_field.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8385,7 +8387,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8430,9 +8432,9 @@ definitions:
                 description: The type of log entry that this is
                 example: debrief_invite_rule.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8441,7 +8443,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8486,9 +8488,9 @@ definitions:
                 description: The type of log entry that this is
                 example: debrief_invite_rule.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8497,7 +8499,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8542,9 +8544,9 @@ definitions:
                 description: The type of log entry that this is
                 example: debrief_invite_rule.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8553,7 +8555,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8598,9 +8600,9 @@ definitions:
                 description: The type of log entry that this is
                 example: escalation_path.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8609,7 +8611,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8654,9 +8656,9 @@ definitions:
                 description: The type of log entry that this is
                 example: escalation_path.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8665,7 +8667,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8710,9 +8712,9 @@ definitions:
                 description: The type of log entry that this is
                 example: escalation_path.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8721,7 +8723,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8766,9 +8768,9 @@ definitions:
                 description: The type of log entry that this is
                 example: follow_up_priority.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8777,7 +8779,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8822,9 +8824,9 @@ definitions:
                 description: The type of log entry that this is
                 example: follow_up_priority.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8833,7 +8835,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8878,9 +8880,9 @@ definitions:
                 description: The type of log entry that this is
                 example: follow_up_priority.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8889,7 +8891,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8934,9 +8936,9 @@ definitions:
                 description: The type of log entry that this is
                 example: holiday_user_feed.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -8945,7 +8947,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -8990,9 +8992,9 @@ definitions:
                 description: The type of log entry that this is
                 example: holiday_user_feed.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9001,7 +9003,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9046,9 +9048,9 @@ definitions:
                 description: The type of log entry that this is
                 example: holiday_user_feed.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9057,7 +9059,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9102,9 +9104,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_call_setting.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9113,7 +9115,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9158,9 +9160,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_duration_metric.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9169,7 +9171,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9214,9 +9216,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_duration_metric.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9225,7 +9227,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9270,9 +9272,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_duration_metric.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9281,7 +9283,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9326,9 +9328,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_role.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9337,7 +9339,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9382,9 +9384,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_role.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9393,7 +9395,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9438,9 +9440,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_role.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9449,7 +9451,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9494,9 +9496,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_status.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9505,7 +9507,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9550,9 +9552,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_status.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9561,7 +9563,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9606,9 +9608,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_status.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9617,7 +9619,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9662,9 +9664,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_timestamp.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9673,7 +9675,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9718,9 +9720,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_timestamp.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9729,7 +9731,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9774,9 +9776,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_timestamp.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9785,7 +9787,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9830,9 +9832,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_type.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9841,7 +9843,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9886,9 +9888,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_type.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9897,7 +9899,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9942,9 +9944,9 @@ definitions:
                 description: The type of log entry that this is
                 example: incident_type.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -9953,7 +9955,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -9998,9 +10000,9 @@ definitions:
                 description: The type of log entry that this is
                 example: integration.installed
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10009,7 +10011,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: github
@@ -10054,9 +10056,9 @@ definitions:
                 description: The type of log entry that this is
                 example: integration.uninstalled
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10065,7 +10067,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: github
@@ -10110,9 +10112,9 @@ definitions:
                 description: The type of log entry that this is
                 example: internal_status_page.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10121,7 +10123,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10166,9 +10168,9 @@ definitions:
                 description: The type of log entry that this is
                 example: internal_status_page.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10177,7 +10179,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10222,9 +10224,9 @@ definitions:
                 description: The type of log entry that this is
                 example: internal_status_page.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10233,7 +10235,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10278,9 +10280,9 @@ definitions:
                 description: The type of log entry that this is
                 example: nudge.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10289,7 +10291,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10334,9 +10336,9 @@ definitions:
                 description: The type of log entry that this is
                 example: nudge.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10345,7 +10347,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10390,9 +10392,9 @@ definitions:
                 description: The type of log entry that this is
                 example: nudge.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10401,7 +10403,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10446,9 +10448,9 @@ definitions:
                 description: The type of log entry that this is
                 example: policy.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10457,7 +10459,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10502,9 +10504,9 @@ definitions:
                 description: The type of log entry that this is
                 example: policy.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10513,7 +10515,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10558,9 +10560,9 @@ definitions:
                 description: The type of log entry that this is
                 example: policy.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10569,7 +10571,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10614,9 +10616,9 @@ definitions:
                 description: The type of log entry that this is
                 example: post_incident_task.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10625,7 +10627,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10670,9 +10672,9 @@ definitions:
                 description: The type of log entry that this is
                 example: post_incident_task.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10681,7 +10683,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10726,9 +10728,9 @@ definitions:
                 description: The type of log entry that this is
                 example: post_incident_task.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10737,7 +10739,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10782,11 +10784,11 @@ definitions:
                 description: The type of log entry that this is
                 example: private_incident.access_attempted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             metadata:
-                $ref: '#/definitions/AuditLogPrivateIncidentAccessAttemptedMetadataV2ResponseBody'
+                $ref: '#/definitions/AuditLogPrivateIncidentAccessAttemptedMetadataV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10795,7 +10797,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10843,9 +10845,9 @@ definitions:
                 description: The type of log entry that this is
                 example: private_incident.access_requested
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10854,7 +10856,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10899,9 +10901,9 @@ definitions:
                 description: The type of log entry that this is
                 example: private_incident_membership.granted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10910,7 +10912,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -10961,9 +10963,9 @@ definitions:
                 description: The type of log entry that this is
                 example: private_incident_membership.revoked
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -10972,7 +10974,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11023,9 +11025,9 @@ definitions:
                 description: The type of log entry that this is
                 example: rbac_role.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11034,7 +11036,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11079,9 +11081,9 @@ definitions:
                 description: The type of log entry that this is
                 example: rbac_role.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11090,7 +11092,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11135,9 +11137,9 @@ definitions:
                 description: The type of log entry that this is
                 example: rbac_role.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11146,7 +11148,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11191,9 +11193,9 @@ definitions:
                 description: The type of log entry that this is
                 example: schedule.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11202,7 +11204,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11247,9 +11249,9 @@ definitions:
                 description: The type of log entry that this is
                 example: schedule.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11258,7 +11260,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11303,9 +11305,9 @@ definitions:
                 description: The type of log entry that this is
                 example: schedule.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11314,7 +11316,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11359,11 +11361,11 @@ definitions:
                 description: The type of log entry that this is
                 example: scim_group.role_mappings_updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             metadata:
-                $ref: '#/definitions/AuditLogUserSCIMGroupMappingChangedMetadataV2ResponseBody'
+                $ref: '#/definitions/AuditLogUserSCIMGroupMappingChangedMetadataV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11372,7 +11374,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11423,9 +11425,9 @@ definitions:
                 description: The type of log entry that this is
                 example: severity.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11434,7 +11436,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11479,9 +11481,9 @@ definitions:
                 description: The type of log entry that this is
                 example: severity.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11490,7 +11492,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11535,9 +11537,9 @@ definitions:
                 description: The type of log entry that this is
                 example: severity.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11546,7 +11548,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11591,9 +11593,9 @@ definitions:
                 description: The type of log entry that this is
                 example: status_page.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11602,7 +11604,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11647,9 +11649,9 @@ definitions:
                 description: The type of log entry that this is
                 example: status_page.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11658,7 +11660,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11703,9 +11705,9 @@ definitions:
                 description: The type of log entry that this is
                 example: status_page_sub_page.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11714,7 +11716,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11759,9 +11761,9 @@ definitions:
                 description: The type of log entry that this is
                 example: status_page_sub_page.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11770,7 +11772,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11815,9 +11817,9 @@ definitions:
                 description: The type of log entry that this is
                 example: status_page_sub_page.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11826,7 +11828,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11871,9 +11873,9 @@ definitions:
                 description: The type of log entry that this is
                 example: status_page_template.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11882,7 +11884,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11927,9 +11929,9 @@ definitions:
                 description: The type of log entry that this is
                 example: status_page_template.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11938,7 +11940,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11983,9 +11985,9 @@ definitions:
                 description: The type of log entry that this is
                 example: status_page_template.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -11994,7 +11996,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12039,9 +12041,9 @@ definitions:
                 description: The type of log entry that this is
                 example: status_page.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -12050,7 +12052,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12095,9 +12097,9 @@ definitions:
                 description: The type of log entry that this is
                 example: user.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -12106,7 +12108,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12151,9 +12153,9 @@ definitions:
                 description: The type of log entry that this is
                 example: user.deactivated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -12162,7 +12164,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12207,9 +12209,9 @@ definitions:
                 description: The type of log entry that this is
                 example: user.reinstated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -12218,7 +12220,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12263,11 +12265,11 @@ definitions:
                 description: The type of log entry that this is
                 example: user.role_memberships_updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             metadata:
-                $ref: '#/definitions/AuditLogUserRoleMembershipChangedMetadataV2ResponseBody'
+                $ref: '#/definitions/AuditLogUserRoleMembershipChangedMetadataV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -12276,7 +12278,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12327,9 +12329,9 @@ definitions:
                 description: The type of log entry that this is
                 example: user.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -12338,7 +12340,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12383,9 +12385,9 @@ definitions:
                 description: The type of log entry that this is
                 example: workflow.created
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -12394,7 +12396,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12439,9 +12441,9 @@ definitions:
                 description: The type of log entry that this is
                 example: workflow.deleted
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -12450,7 +12452,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12495,9 +12497,9 @@ definitions:
                 description: The type of log entry that this is
                 example: workflow.updated
             actor:
-                $ref: '#/definitions/AuditLogActorV2ResponseBody'
+                $ref: '#/definitions/AuditLogActorV2'
             context:
-                $ref: '#/definitions/AuditLogEntryContextV2ResponseBody'
+                $ref: '#/definitions/AuditLogEntryContextV2'
             occurred_at:
                 type: string
                 description: When the entry occurred
@@ -12506,7 +12508,7 @@ definitions:
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/AuditLogTargetV2ResponseBody'
+                    $ref: '#/definitions/AuditLogTargetV2'
                 description: The custom field that was created
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -12542,14 +12544,14 @@ definitions:
             - actor
             - targets
             - context
-    CatalogEntryEngineParamBindingV2ResponseBody:
-        title: CatalogEntryEngineParamBindingV2ResponseBody
+    CatalogEntryEngineParamBindingV2:
+        title: CatalogEntryEngineParamBindingV2
         type: object
         properties:
             array_value:
                 type: array
                 items:
-                    $ref: '#/definitions/CatalogEntryEngineParamBindingValueV2ResponseBody'
+                    $ref: '#/definitions/CatalogEntryEngineParamBindingValueV2'
                 description: If array_value is set, this helps render the values
                 example:
                     - catalog_entry:
@@ -12567,7 +12569,7 @@ definitions:
                       unavailable: false
                       value: abc123
             value:
-                $ref: '#/definitions/CatalogEntryEngineParamBindingValueV2ResponseBody'
+                $ref: '#/definitions/CatalogEntryEngineParamBindingValueV2'
         example:
             array_value:
                 - catalog_entry:
@@ -12599,12 +12601,12 @@ definitions:
                 sort_key: abc123
                 unavailable: false
                 value: abc123
-    CatalogEntryEngineParamBindingValueV2ResponseBody:
-        title: CatalogEntryEngineParamBindingValueV2ResponseBody
+    CatalogEntryEngineParamBindingValueV2:
+        title: CatalogEntryEngineParamBindingValueV2
         type: object
         properties:
             catalog_entry:
-                $ref: '#/definitions/CatalogEntryReferenceV2ResponseBody'
+                $ref: '#/definitions/CatalogEntryReferenceV2'
             helptext:
                 type: string
                 description: This field is deprecated. It will not be present in any responses, and will be removed in a future version
@@ -12659,8 +12661,8 @@ definitions:
         required:
             - label
             - sort_key
-    CatalogEntryReferenceV2ResponseBody:
-        title: CatalogEntryReferenceV2ResponseBody
+    CatalogEntryReferenceV2:
+        title: CatalogEntryReferenceV2
         type: object
         properties:
             archived_at:
@@ -12689,8 +12691,8 @@ definitions:
             - catalog_type_id
             - catalog_entry_id
             - catalog_entry_name
-    CatalogEntryV2ResponseBody:
-        title: CatalogEntryV2ResponseBody
+    CatalogEntryV2:
+        title: CatalogEntryV2
         type: object
         properties:
             aliases:
@@ -12743,7 +12745,7 @@ definitions:
                             unavailable: false
                             value: abc123
                 additionalProperties:
-                    $ref: '#/definitions/CatalogEntryEngineParamBindingV2ResponseBody'
+                    $ref: '#/definitions/CatalogEntryEngineParamBindingV2'
             catalog_type_id:
                 type: string
                 description: ID of this catalog type
@@ -12828,8 +12830,8 @@ definitions:
             - attribute_values
             - created_at
             - updated_at
-    CatalogResourceV2ResponseBody:
-        title: CatalogResourceV2ResponseBody
+    CatalogResourceV2:
+        title: CatalogResourceV2
         type: object
         properties:
             category:
@@ -12870,8 +12872,8 @@ definitions:
             - category
             - config
             - is_user_link
-    CatalogTypeAttributePathItemPayloadV2RequestBody:
-        title: CatalogTypeAttributePathItemPayloadV2RequestBody
+    CatalogTypeAttributePathItemPayloadV2:
+        title: CatalogTypeAttributePathItemPayloadV2
         type: object
         properties:
             attribute_id:
@@ -12882,8 +12884,8 @@ definitions:
             attribute_id: abc123
         required:
             - attribute_id
-    CatalogTypeAttributePathItemV2ResponseBody:
-        title: CatalogTypeAttributePathItemV2ResponseBody
+    CatalogTypeAttributePathItemV2:
+        title: CatalogTypeAttributePathItemV2
         type: object
         properties:
             attribute_id:
@@ -12900,8 +12902,8 @@ definitions:
         required:
             - attribute_id
             - attribute_name
-    CatalogTypeAttributePayloadV2RequestBody:
-        title: CatalogTypeAttributePayloadV2RequestBody
+    CatalogTypeAttributePayloadV2:
+        title: CatalogTypeAttributePayloadV2
         type: object
         properties:
             array:
@@ -12935,7 +12937,7 @@ definitions:
             path:
                 type: array
                 items:
-                    $ref: '#/definitions/CatalogTypeAttributePathItemPayloadV2RequestBody'
+                    $ref: '#/definitions/CatalogTypeAttributePathItemPayloadV2'
                 description: The path to use (if this is an path)
                 example:
                     - attribute_id: abc123
@@ -12956,8 +12958,8 @@ definitions:
             - name
             - type
             - array
-    CatalogTypeAttributeV2ResponseBody:
-        title: CatalogTypeAttributeV2ResponseBody
+    CatalogTypeAttributeV2:
+        title: CatalogTypeAttributeV2
         type: object
         properties:
             array:
@@ -12991,7 +12993,7 @@ definitions:
             path:
                 type: array
                 items:
-                    $ref: '#/definitions/CatalogTypeAttributePathItemV2ResponseBody'
+                    $ref: '#/definitions/CatalogTypeAttributePathItemV2'
                 description: The path to use (if this is a path attribute)
                 example:
                     - attribute_id: abc123
@@ -13016,14 +13018,14 @@ definitions:
             - name
             - type
             - array
-    CatalogTypeSchemaV2ResponseBody:
-        title: CatalogTypeSchemaV2ResponseBody
+    CatalogTypeSchemaV2:
+        title: CatalogTypeSchemaV2
         type: object
         properties:
             attributes:
                 type: array
                 items:
-                    $ref: '#/definitions/CatalogTypeAttributeV2ResponseBody'
+                    $ref: '#/definitions/CatalogTypeAttributeV2'
                 description: Attributes of this catalog type
                 example:
                     - array: false
@@ -13055,8 +13057,8 @@ definitions:
         required:
             - attributes
             - version
-    CatalogTypeV2ResponseBody:
-        title: CatalogTypeV2ResponseBody
+    CatalogTypeV2:
+        title: CatalogTypeV2
         type: object
         properties:
             annotations:
@@ -13179,7 +13181,7 @@ definitions:
                 example:
                     - pager_duty
             schema:
-                $ref: '#/definitions/CatalogTypeSchemaV2ResponseBody'
+                $ref: '#/definitions/CatalogTypeSchemaV2'
             semantic_type:
                 type: string
                 description: Semantic type of this resource (unused)
@@ -13275,7 +13277,7 @@ definitions:
                             literal: SEV123
                             reference: incident.severity
                 additionalProperties:
-                    $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                    $ref: '#/definitions/EngineParamBindingPayloadV2'
             catalog_type_id:
                 type: string
                 description: ID of this catalog type
@@ -13318,7 +13320,7 @@ definitions:
         type: object
         properties:
             catalog_entry:
-                $ref: '#/definitions/CatalogEntryV2ResponseBody'
+                $ref: '#/definitions/CatalogEntryV2'
         example:
             catalog_entry:
                 aliases:
@@ -13478,7 +13480,7 @@ definitions:
         type: object
         properties:
             catalog_type:
-                $ref: '#/definitions/CatalogTypeV2ResponseBody'
+                $ref: '#/definitions/CatalogTypeV2'
         example:
             catalog_type:
                 annotations:
@@ -13524,7 +13526,7 @@ definitions:
             catalog_entries:
                 type: array
                 items:
-                    $ref: '#/definitions/CatalogEntryV2ResponseBody'
+                    $ref: '#/definitions/CatalogEntryV2'
                 example:
                     - aliases:
                         - lawrence@incident.io
@@ -13570,9 +13572,9 @@ definitions:
                       rank: 3
                       updated_at: "2021-08-17T13:28:57.801578Z"
             catalog_type:
-                $ref: '#/definitions/CatalogTypeV2ResponseBody'
+                $ref: '#/definitions/CatalogTypeV2'
             pagination_meta:
-                $ref: '#/definitions/PaginationMetaResultResponseBody'
+                $ref: '#/definitions/PaginationMetaResult'
         example:
             catalog_entries:
                 - aliases:
@@ -13667,7 +13669,7 @@ definitions:
             resources:
                 type: array
                 items:
-                    $ref: '#/definitions/CatalogResourceV2ResponseBody'
+                    $ref: '#/definitions/CatalogResourceV2'
                 example:
                     - category: custom
                       description: Boolean true or false value
@@ -13690,7 +13692,7 @@ definitions:
             catalog_types:
                 type: array
                 items:
-                    $ref: '#/definitions/CatalogTypeV2ResponseBody'
+                    $ref: '#/definitions/CatalogTypeV2'
                 example:
                     - annotations:
                         incident.io/catalog-importer/id: id-of-config
@@ -13769,9 +13771,9 @@ definitions:
         type: object
         properties:
             catalog_entry:
-                $ref: '#/definitions/CatalogEntryV2ResponseBody'
+                $ref: '#/definitions/CatalogEntryV2'
             catalog_type:
-                $ref: '#/definitions/CatalogTypeV2ResponseBody'
+                $ref: '#/definitions/CatalogTypeV2'
         example:
             catalog_entry:
                 aliases:
@@ -13860,7 +13862,7 @@ definitions:
         type: object
         properties:
             catalog_type:
-                $ref: '#/definitions/CatalogTypeV2ResponseBody'
+                $ref: '#/definitions/CatalogTypeV2'
         example:
             catalog_type:
                 annotations:
@@ -13924,7 +13926,7 @@ definitions:
                             literal: SEV123
                             reference: incident.severity
                 additionalProperties:
-                    $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                    $ref: '#/definitions/EngineParamBindingPayloadV2'
             external_id:
                 type: string
                 description: An optional alternative ID for this entry, which is ensured to be unique for the type
@@ -13961,9 +13963,9 @@ definitions:
         type: object
         properties:
             catalog_entry:
-                $ref: '#/definitions/CatalogEntryV2ResponseBody'
+                $ref: '#/definitions/CatalogEntryV2'
             catalog_type:
-                $ref: '#/definitions/CatalogTypeV2ResponseBody'
+                $ref: '#/definitions/CatalogTypeV2'
         example:
             catalog_entry:
                 aliases:
@@ -14154,7 +14156,7 @@ definitions:
         type: object
         properties:
             catalog_type:
-                $ref: '#/definitions/CatalogTypeV2ResponseBody'
+                $ref: '#/definitions/CatalogTypeV2'
         example:
             catalog_type:
                 annotations:
@@ -14200,7 +14202,7 @@ definitions:
             attributes:
                 type: array
                 items:
-                    $ref: '#/definitions/CatalogTypeAttributePayloadV2RequestBody'
+                    $ref: '#/definitions/CatalogTypeAttributePayloadV2'
                 example:
                     - array: false
                       backlink_attribute: abc123
@@ -14249,7 +14251,7 @@ definitions:
         type: object
         properties:
             catalog_type:
-                $ref: '#/definitions/CatalogTypeV2ResponseBody'
+                $ref: '#/definitions/CatalogTypeV2'
         example:
             catalog_type:
                 annotations:
@@ -14288,14 +14290,14 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - catalog_type
-    ConditionGroupPayloadV2RequestBody:
-        title: ConditionGroupPayloadV2RequestBody
+    ConditionGroupPayloadV2:
+        title: ConditionGroupPayloadV2
         type: object
         properties:
             conditions:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionPayloadV2RequestBody'
+                    $ref: '#/definitions/ConditionPayloadV2'
                 description: All conditions in this list must be satisfied for the group to be satisfied
                 example:
                     - operation: one_of
@@ -14320,14 +14322,14 @@ definitions:
                   subject: incident.severity
         required:
             - conditions
-    ConditionGroupV2ResponseBody:
-        title: ConditionGroupV2ResponseBody
+    ConditionGroupV2:
+        title: ConditionGroupV2
         type: object
         properties:
             conditions:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionV2ResponseBody'
+                    $ref: '#/definitions/ConditionV2'
                 description: All conditions in this list must be satisfied for the group to be satisfied
                 example:
                     - operation:
@@ -14364,8 +14366,8 @@ definitions:
                     reference: incident.severity
         required:
             - conditions
-    ConditionOperationV2ResponseBody:
-        title: ConditionOperationV2ResponseBody
+    ConditionOperationV2:
+        title: ConditionOperationV2
         type: object
         properties:
             label:
@@ -14383,8 +14385,8 @@ definitions:
             - label
             - value
             - sort_key
-    ConditionPayloadV2RequestBody:
-        title: ConditionPayloadV2RequestBody
+    ConditionPayloadV2:
+        title: ConditionPayloadV2
         type: object
         properties:
             operation:
@@ -14394,7 +14396,7 @@ definitions:
             param_bindings:
                 type: array
                 items:
-                    $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                    $ref: '#/definitions/EngineParamBindingPayloadV2'
                 description: List of parameter bindings
                 example:
                     - array_value:
@@ -14421,8 +14423,8 @@ definitions:
             - subject
             - operation
             - param_bindings
-    ConditionSubjectV2ResponseBody:
-        title: ConditionSubjectV2ResponseBody
+    ConditionSubjectV2:
+        title: ConditionSubjectV2
         type: object
         properties:
             label:
@@ -14440,16 +14442,16 @@ definitions:
             - label
             - reference
             - icon
-    ConditionV2ResponseBody:
-        title: ConditionV2ResponseBody
+    ConditionV2:
+        title: ConditionV2
         type: object
         properties:
             operation:
-                $ref: '#/definitions/ConditionOperationV2ResponseBody'
+                $ref: '#/definitions/ConditionOperationV2'
             param_bindings:
                 type: array
                 items:
-                    $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                    $ref: '#/definitions/EngineParamBindingV2'
                 description: Bindings for the operation parameters
                 example:
                     - array_value:
@@ -14461,7 +14463,7 @@ definitions:
                         literal: SEV123
                         reference: incident.severity
             subject:
-                $ref: '#/definitions/ConditionSubjectV2ResponseBody'
+                $ref: '#/definitions/ConditionSubjectV2'
         example:
             operation:
                 label: Lawrence Jones
@@ -14483,8 +14485,279 @@ definitions:
             - operation
             - param_bindings
             - params
-    CustomFieldEntryPayloadV1RequestBody:
-        title: CustomFieldEntryPayloadV1RequestBody
+    CreateWorkflowPayload:
+        title: CreateWorkflowPayload
+        type: object
+        properties:
+            annotations:
+                type: object
+                description: Annotations that track metadata about this resource
+                example:
+                    incident.io/terraform/version: 3.0.0
+                additionalProperties:
+                    type: string
+                    example: abc123
+            condition_groups:
+                type: array
+                items:
+                    $ref: '#/definitions/ConditionGroupPayloadV2'
+                description: List of conditions to apply to the workflow
+                example:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+            continue_on_step_error:
+                type: boolean
+                description: Whether to continue executing the workflow if a step fails
+                example: true
+            delay:
+                $ref: '#/definitions/WorkflowDelay'
+            expressions:
+                type: array
+                items:
+                    $ref: '#/definitions/ExpressionPayloadV2'
+                description: The expressions used in the workflow
+                example:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                                  result:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                          navigate:
+                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                      reference: abc123
+                      root_reference: incident.status
+            folder:
+                type: string
+                description: Folder to display the workflow in
+                example: My folder 01
+            include_private_incidents:
+                type: boolean
+                description: Whether to include private incidents
+                example: true
+            name:
+                type: string
+                description: The human-readable name of the workflow
+                example: My workflow
+            once_for:
+                type: array
+                items:
+                    type: string
+                    example: incident.url
+                description: Once For strategy to apply to this workflow
+                example:
+                    - incident.url
+            runs_on_incident_modes:
+                type: array
+                items:
+                    type: string
+                    example: test
+                    enum:
+                        - standard
+                        - test
+                        - retrospective
+                description: Which modes of incident this should run on (defaults to just standard incidents)
+                example:
+                    - standard
+                    - retrospective
+            runs_on_incidents:
+                type: string
+                description: Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
+                example: newly_created
+                enum:
+                    - newly_created
+                    - newly_created_and_active
+            state:
+                type: string
+                description: The state of the workflow (e.g. is it draft, or disabled)
+                example: active
+                enum:
+                    - active
+                    - disabled
+                    - draft
+                    - error
+            steps:
+                type: array
+                items:
+                    $ref: '#/definitions/StepConfigPayload'
+                description: List of step to execute as part of the workflow
+                example:
+                    - for_each: abc123
+                      id: abc123
+                      name: pagerduty.escalate
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+            trigger:
+                type: string
+                description: Trigger to set on the workflow
+                example: incident.updated
+        example:
+            annotations:
+                incident.io/terraform/version: 3.0.0
+            condition_groups:
+                - conditions:
+                    - operation: one_of
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+                      subject: incident.severity
+            continue_on_step_error: true
+            delay:
+                conditions_apply_over_delay: false
+                for_seconds: 60
+            expressions:
+                - else_branch:
+                    result:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                  label: Team Slack channel
+                  operations:
+                    - branches:
+                        branches:
+                            - condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                              result:
+                                array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                      filter:
+                        condition_groups:
+                            - conditions:
+                                - operation: one_of
+                                  param_bindings:
+                                    - array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject: incident.severity
+                      navigate:
+                        reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                      operation_type: navigate
+                      parse:
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                        source: metadata.annotations["github.com/repo"]
+                  reference: abc123
+                  root_reference: incident.status
+            folder: My folder 01
+            include_private_incidents: true
+            name: My workflow
+            once_for:
+                - incident.url
+            runs_on_incident_modes:
+                - standard
+                - retrospective
+            runs_on_incidents: newly_created
+            state: active
+            steps:
+                - for_each: abc123
+                  id: abc123
+                  name: pagerduty.escalate
+                  param_bindings:
+                    - array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                      value:
+                        literal: SEV123
+                        reference: incident.severity
+            trigger: incident.updated
+        required:
+            - name
+            - trigger
+            - once_for
+            - condition_groups
+            - steps
+            - expressions
+            - include_private_incidents
+            - runs_on_incident_modes
+            - continue_on_step_error
+            - runs_on_incidents
+    CustomFieldEntryPayloadV1:
+        title: CustomFieldEntryPayloadV1
         type: object
         properties:
             custom_field_id:
@@ -14494,7 +14767,7 @@ definitions:
             values:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldValuePayloadV1RequestBody'
+                    $ref: '#/definitions/CustomFieldValuePayloadV1'
                 description: List of values to associate with this entry. Use an empty array to unset the value of the custom field.
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -14517,8 +14790,8 @@ definitions:
         required:
             - custom_field_id
             - values
-    CustomFieldEntryPayloadV2RequestBody:
-        title: CustomFieldEntryPayloadV2RequestBody
+    CustomFieldEntryPayloadV2:
+        title: CustomFieldEntryPayloadV2
         type: object
         properties:
             custom_field_id:
@@ -14528,7 +14801,7 @@ definitions:
             values:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldValuePayloadV2RequestBody'
+                    $ref: '#/definitions/CustomFieldValuePayloadV2'
                 description: List of values to associate with this entry. Use an empty array to unset the value of the custom field.
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -14551,16 +14824,16 @@ definitions:
         required:
             - custom_field_id
             - values
-    CustomFieldEntryV1ResponseBody:
-        title: CustomFieldEntryV1ResponseBody
+    CustomFieldEntryV1:
+        title: CustomFieldEntryV1
         type: object
         properties:
             custom_field:
-                $ref: '#/definitions/CustomFieldTypeInfoV1ResponseBody'
+                $ref: '#/definitions/CustomFieldTypeInfoV1'
             values:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldValueV1ResponseBody'
+                    $ref: '#/definitions/CustomFieldValueV1'
                 description: List of custom field values set on this entry
                 example:
                     - value_catalog_entry:
@@ -14608,16 +14881,16 @@ definitions:
         required:
             - custom_field
             - values
-    CustomFieldEntryV2ResponseBody:
-        title: CustomFieldEntryV2ResponseBody
+    CustomFieldEntryV2:
+        title: CustomFieldEntryV2
         type: object
         properties:
             custom_field:
-                $ref: '#/definitions/CustomFieldTypeInfoV2ResponseBody'
+                $ref: '#/definitions/CustomFieldTypeInfoV2'
             values:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldValueV2ResponseBody'
+                    $ref: '#/definitions/CustomFieldValueV2'
                 description: List of custom field values set on this entry
                 example:
                     - value_catalog_entry:
@@ -14665,8 +14938,8 @@ definitions:
         required:
             - custom_field
             - values
-    CustomFieldOptionV1ResponseBody:
-        title: CustomFieldOptionV1ResponseBody
+    CustomFieldOptionV1:
+        title: CustomFieldOptionV1
         type: object
         properties:
             custom_field_id:
@@ -14697,8 +14970,8 @@ definitions:
             - custom_field_id
             - value
             - sort_key
-    CustomFieldOptionV2ResponseBody:
-        title: CustomFieldOptionV2ResponseBody
+    CustomFieldOptionV2:
+        title: CustomFieldOptionV2
         type: object
         properties:
             custom_field_id:
@@ -14759,7 +15032,7 @@ definitions:
         type: object
         properties:
             custom_field_option:
-                $ref: '#/definitions/CustomFieldOptionV1ResponseBody'
+                $ref: '#/definitions/CustomFieldOptionV1'
         example:
             custom_field_option:
                 custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -14775,14 +15048,14 @@ definitions:
             custom_field_options:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldOptionV1ResponseBody'
+                    $ref: '#/definitions/CustomFieldOptionV1'
                 example:
                     - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
                       id: 01FCNDV6P870EA6S7TK1DSYDG0
                       sort_key: 10
                       value: Product
             pagination_meta:
-                $ref: '#/definitions/PaginationMetaResultResponseBody'
+                $ref: '#/definitions/PaginationMetaResult'
         example:
             custom_field_options:
                 - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -14800,7 +15073,7 @@ definitions:
         type: object
         properties:
             custom_field_option:
-                $ref: '#/definitions/CustomFieldOptionV1ResponseBody'
+                $ref: '#/definitions/CustomFieldOptionV1'
         example:
             custom_field_option:
                 custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -14835,7 +15108,7 @@ definitions:
         type: object
         properties:
             custom_field_option:
-                $ref: '#/definitions/CustomFieldOptionV1ResponseBody'
+                $ref: '#/definitions/CustomFieldOptionV1'
         example:
             custom_field_option:
                 custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -14844,8 +15117,8 @@ definitions:
                 value: Product
         required:
             - custom_field_option
-    CustomFieldTypeInfoV1ResponseBody:
-        title: CustomFieldTypeInfoV1ResponseBody
+    CustomFieldTypeInfoV1:
+        title: CustomFieldTypeInfoV1
         type: object
         properties:
             description:
@@ -14874,7 +15147,7 @@ definitions:
             options:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldOptionV1ResponseBody'
+                    $ref: '#/definitions/CustomFieldOptionV1'
                 description: What options are available for this custom field, if this field has options
                 example:
                     - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -14906,8 +15179,8 @@ definitions:
             - field_mode
             - created_at
             - updated_at
-    CustomFieldTypeInfoV2ResponseBody:
-        title: CustomFieldTypeInfoV2ResponseBody
+    CustomFieldTypeInfoV2:
+        title: CustomFieldTypeInfoV2
         type: object
         properties:
             description:
@@ -14936,7 +15209,7 @@ definitions:
             options:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldOptionV2ResponseBody'
+                    $ref: '#/definitions/CustomFieldOptionV2'
                 description: What options are available for this custom field, if this field has options
                 example:
                     - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -14968,8 +15241,8 @@ definitions:
             - field_mode
             - created_at
             - updated_at
-    CustomFieldV1ResponseBody:
-        title: CustomFieldV1ResponseBody
+    CustomFieldV1:
+        title: CustomFieldV1
         type: object
         properties:
             catalog_type_id:
@@ -15007,7 +15280,7 @@ definitions:
             options:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldOptionV1ResponseBody'
+                    $ref: '#/definitions/CustomFieldOptionV1'
                 description: What options are available for this custom field, if this field has options
                 example:
                     - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -15081,8 +15354,8 @@ definitions:
             - options
             - created_at
             - updated_at
-    CustomFieldV2ResponseBody:
-        title: CustomFieldV2ResponseBody
+    CustomFieldV2:
+        title: CustomFieldV2
         type: object
         properties:
             catalog_type_id:
@@ -15138,8 +15411,8 @@ definitions:
             - cannot_be_unset
             - created_at
             - updated_at
-    CustomFieldValuePayloadV1RequestBody:
-        title: CustomFieldValuePayloadV1RequestBody
+    CustomFieldValuePayloadV1:
+        title: CustomFieldValuePayloadV1
         type: object
         properties:
             id:
@@ -15178,8 +15451,8 @@ definitions:
             value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
             value_text: This is my text field, I hope you like it
             value_timestamp: ""
-    CustomFieldValuePayloadV2RequestBody:
-        title: CustomFieldValuePayloadV2RequestBody
+    CustomFieldValuePayloadV2:
+        title: CustomFieldValuePayloadV2
         type: object
         properties:
             id:
@@ -15218,12 +15491,12 @@ definitions:
             value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
             value_text: This is my text field, I hope you like it
             value_timestamp: ""
-    CustomFieldValueV1ResponseBody:
-        title: CustomFieldValueV1ResponseBody
+    CustomFieldValueV1:
+        title: CustomFieldValueV1
         type: object
         properties:
             value_catalog_entry:
-                $ref: '#/definitions/EmbeddedCatalogEntryV1ResponseBody'
+                $ref: '#/definitions/EmbeddedCatalogEntryV1'
             value_link:
                 type: string
                 description: If the custom field type is 'link', this will contain the value assigned.
@@ -15233,7 +15506,7 @@ definitions:
                 description: If the custom field type is 'numeric', this will contain the value assigned.
                 example: "123.456"
             value_option:
-                $ref: '#/definitions/CustomFieldOptionV1ResponseBody'
+                $ref: '#/definitions/CustomFieldOptionV1'
             value_text:
                 type: string
                 description: If the custom field type is 'text', this will contain the value assigned.
@@ -15254,12 +15527,12 @@ definitions:
                 sort_key: 10
                 value: Product
             value_text: This is my text field, I hope you like it
-    CustomFieldValueV2ResponseBody:
-        title: CustomFieldValueV2ResponseBody
+    CustomFieldValueV2:
+        title: CustomFieldValueV2
         type: object
         properties:
             value_catalog_entry:
-                $ref: '#/definitions/EmbeddedCatalogEntryV2ResponseBody'
+                $ref: '#/definitions/EmbeddedCatalogEntryV2'
             value_link:
                 type: string
                 description: If the custom field type is 'link', this will contain the value assigned.
@@ -15269,7 +15542,7 @@ definitions:
                 description: If the custom field type is 'numeric', this will contain the value assigned.
                 example: "123.456"
             value_option:
-                $ref: '#/definitions/CustomFieldOptionV2ResponseBody'
+                $ref: '#/definitions/CustomFieldOptionV2'
             value_text:
                 type: string
                 description: If the custom field type is 'text', this will contain the value assigned.
@@ -15371,7 +15644,7 @@ definitions:
         type: object
         properties:
             custom_field:
-                $ref: '#/definitions/CustomFieldV1ResponseBody'
+                $ref: '#/definitions/CustomFieldV1'
         example:
             custom_field:
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -15401,7 +15674,7 @@ definitions:
             custom_fields:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldV1ResponseBody'
+                    $ref: '#/definitions/CustomFieldV1'
                 example:
                     - catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
                       created_at: "2021-08-17T13:28:57.801578Z"
@@ -15448,7 +15721,7 @@ definitions:
         type: object
         properties:
             custom_field:
-                $ref: '#/definitions/CustomFieldV1ResponseBody'
+                $ref: '#/definitions/CustomFieldV1'
         example:
             custom_field:
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -15540,7 +15813,7 @@ definitions:
         type: object
         properties:
             custom_field:
-                $ref: '#/definitions/CustomFieldV1ResponseBody'
+                $ref: '#/definitions/CustomFieldV1'
         example:
             custom_field:
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -15603,7 +15876,7 @@ definitions:
         type: object
         properties:
             custom_field:
-                $ref: '#/definitions/CustomFieldV2ResponseBody'
+                $ref: '#/definitions/CustomFieldV2'
         example:
             custom_field:
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -15622,7 +15895,7 @@ definitions:
             custom_fields:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldV2ResponseBody'
+                    $ref: '#/definitions/CustomFieldV2'
                 example:
                     - catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
                       created_at: "2021-08-17T13:28:57.801578Z"
@@ -15647,7 +15920,7 @@ definitions:
         type: object
         properties:
             custom_field:
-                $ref: '#/definitions/CustomFieldV2ResponseBody'
+                $ref: '#/definitions/CustomFieldV2'
         example:
             custom_field:
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -15687,7 +15960,7 @@ definitions:
         type: object
         properties:
             custom_field:
-                $ref: '#/definitions/CustomFieldV2ResponseBody'
+                $ref: '#/definitions/CustomFieldV2'
         example:
             custom_field:
                 catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -15699,8 +15972,8 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - custom_field
-    EmbeddedCatalogEntryV1ResponseBody:
-        title: EmbeddedCatalogEntryV1ResponseBody
+    EmbeddedCatalogEntryV1:
+        title: EmbeddedCatalogEntryV1
         type: object
         properties:
             aliases:
@@ -15735,8 +16008,8 @@ definitions:
             - id
             - name
             - catalog_type_id
-    EmbeddedCatalogEntryV2ResponseBody:
-        title: EmbeddedCatalogEntryV2ResponseBody
+    EmbeddedCatalogEntryV2:
+        title: EmbeddedCatalogEntryV2
         type: object
         properties:
             aliases:
@@ -15771,8 +16044,8 @@ definitions:
             - id
             - name
             - catalog_type_id
-    EmbeddedIncidentRoleV2ResponseBody:
-        title: EmbeddedIncidentRoleV2ResponseBody
+    EmbeddedIncidentRoleV2:
+        title: EmbeddedIncidentRoleV2
         type: object
         properties:
             created_at:
@@ -15839,20 +16112,20 @@ definitions:
             - role_type
             - created_at
             - updated_at
-    EngineParamBindingPayloadV2RequestBody:
-        title: EngineParamBindingPayloadV2RequestBody
+    EngineParamBindingPayloadV2:
+        title: EngineParamBindingPayloadV2
         type: object
         properties:
             array_value:
                 type: array
                 items:
-                    $ref: '#/definitions/EngineParamBindingValuePayloadV2RequestBody'
+                    $ref: '#/definitions/EngineParamBindingValuePayloadV2'
                 description: If set, this is the array value of the step parameter
                 example:
                     - literal: SEV123
                       reference: incident.severity
             value:
-                $ref: '#/definitions/EngineParamBindingValuePayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingValuePayloadV2'
         example:
             array_value:
                 - literal: SEV123
@@ -15860,21 +16133,21 @@ definitions:
             value:
                 literal: SEV123
                 reference: incident.severity
-    EngineParamBindingV2ResponseBody:
-        title: EngineParamBindingV2ResponseBody
+    EngineParamBindingV2:
+        title: EngineParamBindingV2
         type: object
         properties:
             array_value:
                 type: array
                 items:
-                    $ref: '#/definitions/EngineParamBindingValueV2ResponseBody'
+                    $ref: '#/definitions/EngineParamBindingValueV2'
                 description: If array_value is set, this helps render the values
                 example:
                     - label: Lawrence Jones
                       literal: SEV123
                       reference: incident.severity
             value:
-                $ref: '#/definitions/EngineParamBindingValueV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingValueV2'
         example:
             array_value:
                 - label: Lawrence Jones
@@ -15884,8 +16157,8 @@ definitions:
                 label: Lawrence Jones
                 literal: SEV123
                 reference: incident.severity
-    EngineParamBindingValuePayloadV2RequestBody:
-        title: EngineParamBindingValuePayloadV2RequestBody
+    EngineParamBindingValuePayloadV2:
+        title: EngineParamBindingValuePayloadV2
         type: object
         properties:
             literal:
@@ -15899,8 +16172,8 @@ definitions:
         example:
             literal: SEV123
             reference: incident.severity
-    EngineParamBindingValueV2ResponseBody:
-        title: EngineParamBindingValueV2ResponseBody
+    EngineParamBindingValueV2:
+        title: EngineParamBindingValueV2
         type: object
         properties:
             label:
@@ -15922,8 +16195,8 @@ definitions:
         required:
             - label
             - sort_key
-    EngineReferenceV2ResponseBody:
-        title: EngineReferenceV2ResponseBody
+    EngineReferenceV2:
+        title: EngineReferenceV2
         type: object
         properties:
             array:
@@ -15954,14 +16227,14 @@ definitions:
             - array
             - node_label
             - hide_filter
-    EscalationPathNodeIfElsePayloadV2RequestBody:
-        title: EscalationPathNodeIfElsePayloadV2RequestBody
+    EscalationPathNodeIfElsePayloadV2:
+        title: EscalationPathNodeIfElsePayloadV2
         type: object
         properties:
             conditions:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionPayloadV2RequestBody'
+                    $ref: '#/definitions/ConditionPayloadV2'
                 description: The condition that defines which branch to take
                 example:
                     - operation: one_of
@@ -15976,7 +16249,7 @@ definitions:
             else_path:
                 type: array
                 items:
-                    $ref: '#/definitions/EscalationPathNodePayloadV2RequestBody'
+                    $ref: '#/definitions/EscalationPathNodePayloadV2'
                 description: The nodes that form the levels if our condition is not met
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -16014,7 +16287,7 @@ definitions:
             then_path:
                 type: array
                 items:
-                    $ref: '#/definitions/EscalationPathNodePayloadV2RequestBody'
+                    $ref: '#/definitions/EscalationPathNodePayloadV2'
                 description: The nodes that form the levels if our condition is met
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -16129,14 +16402,14 @@ definitions:
         required:
             - then_path
             - else_path
-    EscalationPathNodeIfElseV2ResponseBody:
-        title: EscalationPathNodeIfElseV2ResponseBody
+    EscalationPathNodeIfElseV2:
+        title: EscalationPathNodeIfElseV2
         type: object
         properties:
             conditions:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionV2ResponseBody'
+                    $ref: '#/definitions/ConditionV2'
                 description: The condition that defines which branch to take
                 example:
                     - operation:
@@ -16157,7 +16430,7 @@ definitions:
             else_path:
                 type: array
                 items:
-                    $ref: '#/definitions/EscalationPathNodeV2ResponseBody'
+                    $ref: '#/definitions/EscalationPathNodeV2'
                 description: The nodes that form the levels if our condition is not met
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -16201,7 +16474,7 @@ definitions:
             then_path:
                 type: array
                 items:
-                    $ref: '#/definitions/EscalationPathNodeV2ResponseBody'
+                    $ref: '#/definitions/EscalationPathNodeV2'
                 description: The nodes that form the levels if our condition is met
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -16341,16 +16614,16 @@ definitions:
             - conditions
             - then_path
             - else_path
-    EscalationPathNodeLevelV2RequestBody:
-        title: EscalationPathNodeLevelV2RequestBody
+    EscalationPathNodeLevelV2:
+        title: EscalationPathNodeLevelV2
         type: object
         properties:
             round_robin_config:
-                $ref: '#/definitions/EscalationPathRoundRobinConfigV2RequestBody'
+                $ref: '#/definitions/EscalationPathRoundRobinConfigV2'
             targets:
                 type: array
                 items:
-                    $ref: '#/definitions/EscalationPathTargetV2RequestBody'
+                    $ref: '#/definitions/EscalationPathTargetV2'
                 description: The targets for this level
                 example:
                     - id: lawrencejones
@@ -16387,54 +16660,8 @@ definitions:
             time_to_ack_weekday_interval_config_id: 01FCNDV6P870EA6S7TK1DSYDG0
         required:
             - targets
-    EscalationPathNodeLevelV2ResponseBody:
-        title: EscalationPathNodeLevelV2ResponseBody
-        type: object
-        properties:
-            round_robin_config:
-                $ref: '#/definitions/EscalationPathRoundRobinConfigV2ResponseBody'
-            targets:
-                type: array
-                items:
-                    $ref: '#/definitions/EscalationPathTargetV2ResponseBody'
-                description: The targets for this level
-                example:
-                    - id: lawrencejones
-                      schedule_mode: currently_on_call
-                      type: user
-                      urgency: high
-            time_to_ack_interval_condition:
-                type: string
-                description: If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
-                example: active
-                enum:
-                    - active
-                    - inactive
-            time_to_ack_seconds:
-                type: integer
-                description: How long should we wait for this level to acknowledge before escalating?
-                example: 1800
-                format: int64
-            time_to_ack_weekday_interval_config_id:
-                type: string
-                description: If the time to ack is relative to a time window, this identifies which window it is relative to
-                example: 01FCNDV6P870EA6S7TK1DSYDG0
-        example:
-            round_robin_config:
-                enabled: false
-                rotate_after_seconds: 120
-            targets:
-                - id: lawrencejones
-                  schedule_mode: currently_on_call
-                  type: user
-                  urgency: high
-            time_to_ack_interval_condition: active
-            time_to_ack_seconds: 1800
-            time_to_ack_weekday_interval_config_id: 01FCNDV6P870EA6S7TK1DSYDG0
-        required:
-            - targets
-    EscalationPathNodePayloadV2RequestBody:
-        title: EscalationPathNodePayloadV2RequestBody
+    EscalationPathNodePayloadV2:
+        title: EscalationPathNodePayloadV2
         type: object
         properties:
             id:
@@ -16442,11 +16669,11 @@ definitions:
                 description: Unique internal ID of the escalation path node
                 example: 01FCNDV6P870EA6S7TK1DSYDG0
             if_else:
-                $ref: '#/definitions/EscalationPathNodeIfElsePayloadV2RequestBody'
+                $ref: '#/definitions/EscalationPathNodeIfElsePayloadV2'
             level:
-                $ref: '#/definitions/EscalationPathNodeLevelV2RequestBody'
+                $ref: '#/definitions/EscalationPathNodeLevelV2'
             repeat:
-                $ref: '#/definitions/EscalationPathNodeRepeatV2RequestBody'
+                $ref: '#/definitions/EscalationPathNodeRepeatV2'
             type:
                 type: string
                 description: 'The type of this node: level or branch'
@@ -16492,8 +16719,8 @@ definitions:
         required:
             - id
             - type
-    EscalationPathNodeRepeatV2RequestBody:
-        title: EscalationPathNodeRepeatV2RequestBody
+    EscalationPathNodeRepeatV2:
+        title: EscalationPathNodeRepeatV2
         type: object
         properties:
             repeat_times:
@@ -16511,27 +16738,8 @@ definitions:
         required:
             - to_node
             - repeat_times
-    EscalationPathNodeRepeatV2ResponseBody:
-        title: EscalationPathNodeRepeatV2ResponseBody
-        type: object
-        properties:
-            repeat_times:
-                type: integer
-                description: How many times to repeat these steps
-                example: 3
-                format: int64
-            to_node:
-                type: string
-                description: Which node ID we begin repeating from
-                example: 01FCNDV6P870EA6S7TK1DSYDG0
-        example:
-            repeat_times: 3
-            to_node: 01FCNDV6P870EA6S7TK1DSYDG0
-        required:
-            - to_node
-            - repeat_times
-    EscalationPathNodeV2ResponseBody:
-        title: EscalationPathNodeV2ResponseBody
+    EscalationPathNodeV2:
+        title: EscalationPathNodeV2
         type: object
         properties:
             id:
@@ -16539,11 +16747,11 @@ definitions:
                 description: Unique internal ID of the escalation path node
                 example: 01FCNDV6P870EA6S7TK1DSYDG0
             if_else:
-                $ref: '#/definitions/EscalationPathNodeIfElseV2ResponseBody'
+                $ref: '#/definitions/EscalationPathNodeIfElseV2'
             level:
-                $ref: '#/definitions/EscalationPathNodeLevelV2ResponseBody'
+                $ref: '#/definitions/EscalationPathNodeLevelV2'
             repeat:
-                $ref: '#/definitions/EscalationPathNodeRepeatV2ResponseBody'
+                $ref: '#/definitions/EscalationPathNodeRepeatV2'
             type:
                 type: string
                 description: 'The type of this node: level or branch'
@@ -16595,8 +16803,8 @@ definitions:
         required:
             - id
             - type
-    EscalationPathRoundRobinConfigV2RequestBody:
-        title: EscalationPathRoundRobinConfigV2RequestBody
+    EscalationPathRoundRobinConfigV2:
+        title: EscalationPathRoundRobinConfigV2
         type: object
         properties:
             enabled:
@@ -16613,26 +16821,8 @@ definitions:
             rotate_after_seconds: 120
         required:
             - enabled
-    EscalationPathRoundRobinConfigV2ResponseBody:
-        title: EscalationPathRoundRobinConfigV2ResponseBody
-        type: object
-        properties:
-            enabled:
-                type: boolean
-                description: Whether round robin is enabled for this level
-                example: false
-            rotate_after_seconds:
-                type: integer
-                description: How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
-                example: 120
-                format: int64
-        example:
-            enabled: false
-            rotate_after_seconds: 120
-        required:
-            - enabled
-    EscalationPathTargetV2RequestBody:
-        title: EscalationPathTargetV2RequestBody
+    EscalationPathTargetV2:
+        title: EscalationPathTargetV2
         type: object
         properties:
             id:
@@ -16672,49 +16862,8 @@ definitions:
             - type
             - id
             - urgency
-    EscalationPathTargetV2ResponseBody:
-        title: EscalationPathTargetV2ResponseBody
-        type: object
-        properties:
-            id:
-                type: string
-                description: Uniquely identifies an entity of this type
-                example: lawrencejones
-            schedule_mode:
-                type: string
-                description: Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
-                example: currently_on_call
-                enum:
-                    - currently_on_call
-                    - all_users_for_rota
-                    - all_users
-                    - ""
-            type:
-                type: string
-                description: Controls what type of entity this target identifies, such as EscalationPolicy or User
-                example: user
-                enum:
-                    - schedule
-                    - user
-                    - slack_channel
-            urgency:
-                type: string
-                description: The urgency of this escalation path target
-                example: high
-                enum:
-                    - high
-                    - low
-        example:
-            id: lawrencejones
-            schedule_mode: currently_on_call
-            type: user
-            urgency: high
-        required:
-            - type
-            - id
-            - urgency
-    EscalationPathV2ResponseBody:
-        title: EscalationPathV2ResponseBody
+    EscalationPathV2:
+        title: EscalationPathV2
         type: object
         properties:
             id:
@@ -16728,7 +16877,7 @@ definitions:
             path:
                 type: array
                 items:
-                    $ref: '#/definitions/EscalationPathNodeV2ResponseBody'
+                    $ref: '#/definitions/EscalationPathNodeV2'
                 description: The nodes that form the levels and branches of this escalation path.
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -16772,7 +16921,7 @@ definitions:
             working_hours:
                 type: array
                 items:
-                    $ref: '#/definitions/WeekdayIntervalConfigV2ResponseBody'
+                    $ref: '#/definitions/WeekdayIntervalConfigV2'
                 description: The working hours for this escalation path.
                 example:
                     - id: abc123
@@ -16849,7 +16998,7 @@ definitions:
             path:
                 type: array
                 items:
-                    $ref: '#/definitions/EscalationPathNodePayloadV2RequestBody'
+                    $ref: '#/definitions/EscalationPathNodePayloadV2'
                 description: The nodes that form the levels and branches of this escalation path.
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -16887,7 +17036,7 @@ definitions:
             working_hours:
                 type: array
                 items:
-                    $ref: '#/definitions/WeekdayIntervalConfigV2RequestBody'
+                    $ref: '#/definitions/WeekdayIntervalConfigV2'
                 description: The working hours for this escalation path.
                 example:
                     - id: abc123
@@ -16948,7 +17097,7 @@ definitions:
         type: object
         properties:
             escalation_path:
-                $ref: '#/definitions/EscalationPathV2ResponseBody'
+                $ref: '#/definitions/EscalationPathV2'
         example:
             escalation_path:
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -17007,7 +17156,7 @@ definitions:
         type: object
         properties:
             escalation_path:
-                $ref: '#/definitions/EscalationPathV2ResponseBody'
+                $ref: '#/definitions/EscalationPathV2'
         example:
             escalation_path:
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -17072,7 +17221,7 @@ definitions:
             path:
                 type: array
                 items:
-                    $ref: '#/definitions/EscalationPathNodePayloadV2RequestBody'
+                    $ref: '#/definitions/EscalationPathNodePayloadV2'
                 description: The nodes that form the levels and branches of this escalation path.
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -17110,7 +17259,7 @@ definitions:
             working_hours:
                 type: array
                 items:
-                    $ref: '#/definitions/WeekdayIntervalConfigV2RequestBody'
+                    $ref: '#/definitions/WeekdayIntervalConfigV2'
                 description: The working hours for this escalation path.
                 example:
                     - id: abc123
@@ -17171,7 +17320,7 @@ definitions:
         type: object
         properties:
             escalation_path:
-                $ref: '#/definitions/EscalationPathV2ResponseBody'
+                $ref: '#/definitions/EscalationPathV2'
         example:
             escalation_path:
                 id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -17225,14 +17374,14 @@ definitions:
                           weekday: abc123
         required:
             - escalation_path
-    ExpressionBranchPayloadV2RequestBody:
-        title: ExpressionBranchPayloadV2RequestBody
+    ExpressionBranchPayloadV2:
+        title: ExpressionBranchPayloadV2
         type: object
         properties:
             condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                    $ref: '#/definitions/ConditionGroupPayloadV2'
                 description: When one of these condition groups are satisfied, this branch will be evaluated
                 example:
                     - conditions:
@@ -17246,7 +17395,7 @@ definitions:
                                 reference: incident.severity
                           subject: incident.severity
             result:
-                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingPayloadV2'
         example:
             condition_groups:
                 - conditions:
@@ -17269,14 +17418,14 @@ definitions:
         required:
             - condition_groups
             - result
-    ExpressionBranchV2ResponseBody:
-        title: ExpressionBranchV2ResponseBody
+    ExpressionBranchV2:
+        title: ExpressionBranchV2
         type: object
         properties:
             condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupV2ResponseBody'
+                    $ref: '#/definitions/ConditionGroupV2'
                 description: When one of these condition groups are satisfied, this branch will be evaluated
                 example:
                     - conditions:
@@ -17296,7 +17445,7 @@ definitions:
                             label: Incident Severity
                             reference: incident.severity
             result:
-                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingV2'
         example:
             condition_groups:
                 - conditions:
@@ -17327,14 +17476,14 @@ definitions:
         required:
             - condition_groups
             - result
-    ExpressionBranchesOptsPayloadV2RequestBody:
-        title: ExpressionBranchesOptsPayloadV2RequestBody
+    ExpressionBranchesOptsPayloadV2:
+        title: ExpressionBranchesOptsPayloadV2
         type: object
         properties:
             branches:
                 type: array
                 items:
-                    $ref: '#/definitions/ExpressionBranchPayloadV2RequestBody'
+                    $ref: '#/definitions/ExpressionBranchPayloadV2'
                 description: The branches to apply for this operation
                 example:
                     - condition_groups:
@@ -17356,7 +17505,7 @@ definitions:
                             literal: SEV123
                             reference: incident.severity
             returns:
-                $ref: '#/definitions/ReturnsMetaV2RequestBody'
+                $ref: '#/definitions/ReturnsMetaV2'
         example:
             branches:
                 - condition_groups:
@@ -17383,14 +17532,14 @@ definitions:
         required:
             - branches
             - returns
-    ExpressionBranchesOptsV2ResponseBody:
-        title: ExpressionBranchesOptsV2ResponseBody
+    ExpressionBranchesOptsV2:
+        title: ExpressionBranchesOptsV2
         type: object
         properties:
             branches:
                 type: array
                 items:
-                    $ref: '#/definitions/ExpressionBranchV2ResponseBody'
+                    $ref: '#/definitions/ExpressionBranchV2'
                 description: The branches to apply for this operation
                 example:
                     - condition_groups:
@@ -17420,7 +17569,7 @@ definitions:
                             literal: SEV123
                             reference: incident.severity
             returns:
-                $ref: '#/definitions/ReturnsMetaV2ResponseBody'
+                $ref: '#/definitions/ReturnsMetaV2'
         example:
             branches:
                 - condition_groups:
@@ -17455,12 +17604,12 @@ definitions:
         required:
             - branches
             - returns
-    ExpressionElseBranchPayloadV2RequestBody:
-        title: ExpressionElseBranchPayloadV2RequestBody
+    ExpressionElseBranchPayloadV2:
+        title: ExpressionElseBranchPayloadV2
         type: object
         properties:
             result:
-                $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
+                $ref: '#/definitions/EngineParamBindingPayloadV2'
         example:
             result:
                 array_value:
@@ -17471,12 +17620,12 @@ definitions:
                     reference: incident.severity
         required:
             - result
-    ExpressionElseBranchV2ResponseBody:
-        title: ExpressionElseBranchV2ResponseBody
+    ExpressionElseBranchV2:
+        title: ExpressionElseBranchV2
         type: object
         properties:
             result:
-                $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                $ref: '#/definitions/EngineParamBindingV2'
         example:
             result:
                 array_value:
@@ -17489,14 +17638,14 @@ definitions:
                     reference: incident.severity
         required:
             - result
-    ExpressionFilterOptsPayloadV2RequestBody:
-        title: ExpressionFilterOptsPayloadV2RequestBody
+    ExpressionFilterOptsPayloadV2:
+        title: ExpressionFilterOptsPayloadV2
         type: object
         properties:
             condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
+                    $ref: '#/definitions/ConditionGroupPayloadV2'
                 description: The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
                 example:
                     - conditions:
@@ -17523,14 +17672,14 @@ definitions:
                       subject: incident.severity
         required:
             - condition_groups
-    ExpressionFilterOptsV2ResponseBody:
-        title: ExpressionFilterOptsV2ResponseBody
+    ExpressionFilterOptsV2:
+        title: ExpressionFilterOptsV2
         type: object
         properties:
             condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupV2ResponseBody'
+                    $ref: '#/definitions/ConditionGroupV2'
                 description: The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
                 example:
                     - conditions:
@@ -17569,8 +17718,8 @@ definitions:
                         reference: incident.severity
         required:
             - condition_groups
-    ExpressionNavigateOptsPayloadV2RequestBody:
-        title: ExpressionNavigateOptsPayloadV2RequestBody
+    ExpressionNavigateOptsPayloadV2:
+        title: ExpressionNavigateOptsPayloadV2
         type: object
         properties:
             reference:
@@ -17581,8 +17730,8 @@ definitions:
             reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
         required:
             - reference
-    ExpressionNavigateOptsV2ResponseBody:
-        title: ExpressionNavigateOptsV2ResponseBody
+    ExpressionNavigateOptsV2:
+        title: ExpressionNavigateOptsV2
         type: object
         properties:
             reference:
@@ -17599,16 +17748,16 @@ definitions:
         required:
             - reference
             - reference_label
-    ExpressionOperationPayloadV2RequestBody:
-        title: ExpressionOperationPayloadV2RequestBody
+    ExpressionOperationPayloadV2:
+        title: ExpressionOperationPayloadV2
         type: object
         properties:
             branches:
-                $ref: '#/definitions/ExpressionBranchesOptsPayloadV2RequestBody'
+                $ref: '#/definitions/ExpressionBranchesOptsPayloadV2'
             filter:
-                $ref: '#/definitions/ExpressionFilterOptsPayloadV2RequestBody'
+                $ref: '#/definitions/ExpressionFilterOptsPayloadV2'
             navigate:
-                $ref: '#/definitions/ExpressionNavigateOptsPayloadV2RequestBody'
+                $ref: '#/definitions/ExpressionNavigateOptsPayloadV2'
             operation_type:
                 type: string
                 description: The type of the operation
@@ -17624,7 +17773,7 @@ definitions:
                     - parse
                     - branches
             parse:
-                $ref: '#/definitions/ExpressionParseOptsPayloadV2RequestBody'
+                $ref: '#/definitions/ExpressionParseOptsPayloadV2'
         example:
             branches:
                 branches:
@@ -17672,16 +17821,16 @@ definitions:
         required:
             - operation_type
             - returns
-    ExpressionOperationV2ResponseBody:
-        title: ExpressionOperationV2ResponseBody
+    ExpressionOperationV2:
+        title: ExpressionOperationV2
         type: object
         properties:
             branches:
-                $ref: '#/definitions/ExpressionBranchesOptsV2ResponseBody'
+                $ref: '#/definitions/ExpressionBranchesOptsV2'
             filter:
-                $ref: '#/definitions/ExpressionFilterOptsV2ResponseBody'
+                $ref: '#/definitions/ExpressionFilterOptsV2'
             navigate:
-                $ref: '#/definitions/ExpressionNavigateOptsV2ResponseBody'
+                $ref: '#/definitions/ExpressionNavigateOptsV2'
             operation_type:
                 type: string
                 description: The type of the operation
@@ -17697,9 +17846,9 @@ definitions:
                     - parse
                     - branches
             parse:
-                $ref: '#/definitions/ExpressionParseOptsV2ResponseBody'
+                $ref: '#/definitions/ExpressionParseOptsV2'
             returns:
-                $ref: '#/definitions/ReturnsMetaV2ResponseBody'
+                $ref: '#/definitions/ReturnsMetaV2'
         example:
             branches:
                 branches:
@@ -17765,12 +17914,12 @@ definitions:
         required:
             - operation_type
             - returns
-    ExpressionParseOptsPayloadV2RequestBody:
-        title: ExpressionParseOptsPayloadV2RequestBody
+    ExpressionParseOptsPayloadV2:
+        title: ExpressionParseOptsPayloadV2
         type: object
         properties:
             returns:
-                $ref: '#/definitions/ReturnsMetaV2RequestBody'
+                $ref: '#/definitions/ReturnsMetaV2'
             source:
                 type: string
                 description: Source expression that is evaluated to a result
@@ -17783,12 +17932,12 @@ definitions:
         required:
             - source
             - returns
-    ExpressionParseOptsV2ResponseBody:
-        title: ExpressionParseOptsV2ResponseBody
+    ExpressionParseOptsV2:
+        title: ExpressionParseOptsV2
         type: object
         properties:
             returns:
-                $ref: '#/definitions/ReturnsMetaV2ResponseBody'
+                $ref: '#/definitions/ReturnsMetaV2'
             source:
                 type: string
                 description: Source expression that is evaluated to a result
@@ -17801,12 +17950,12 @@ definitions:
         required:
             - source
             - returns
-    ExpressionPayloadV2RequestBody:
-        title: ExpressionPayloadV2RequestBody
+    ExpressionPayloadV2:
+        title: ExpressionPayloadV2
         type: object
         properties:
             else_branch:
-                $ref: '#/definitions/ExpressionElseBranchPayloadV2RequestBody'
+                $ref: '#/definitions/ExpressionElseBranchPayloadV2'
             label:
                 type: string
                 description: The human readable label of the expression
@@ -17814,7 +17963,7 @@ definitions:
             operations:
                 type: array
                 items:
-                    $ref: '#/definitions/ExpressionOperationPayloadV2RequestBody'
+                    $ref: '#/definitions/ExpressionOperationPayloadV2'
                 example:
                     - branches:
                         branches:
@@ -17928,12 +18077,12 @@ definitions:
             - reference
             - root_reference
             - operations
-    ExpressionV2ResponseBody:
-        title: ExpressionV2ResponseBody
+    ExpressionV2:
+        title: ExpressionV2
         type: object
         properties:
             else_branch:
-                $ref: '#/definitions/ExpressionElseBranchV2ResponseBody'
+                $ref: '#/definitions/ExpressionElseBranchV2'
             label:
                 type: string
                 description: The human readable label of the expression
@@ -17941,7 +18090,7 @@ definitions:
             operations:
                 type: array
                 items:
-                    $ref: '#/definitions/ExpressionOperationV2ResponseBody'
+                    $ref: '#/definitions/ExpressionOperationV2'
                 example:
                     - branches:
                         branches:
@@ -18009,7 +18158,7 @@ definitions:
                 description: A short ID that can be used to reference the expression
                 example: abc123
             returns:
-                $ref: '#/definitions/ReturnsMetaV2ResponseBody'
+                $ref: '#/definitions/ReturnsMetaV2'
             root_reference:
                 type: string
                 description: The root reference for this expression (i.e. where the expression starts)
@@ -18100,8 +18249,8 @@ definitions:
             - root_reference
             - operations
             - id
-    ExternalIssueReferenceV1ResponseBody:
-        title: ExternalIssueReferenceV1ResponseBody
+    ExternalIssueReferenceV1:
+        title: ExternalIssueReferenceV1
         type: object
         properties:
             issue_name:
@@ -18129,8 +18278,8 @@ definitions:
             issue_name: INC-123
             issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
             provider: asana
-    ExternalIssueReferenceV2ResponseBody:
-        title: ExternalIssueReferenceV2ResponseBody
+    ExternalIssueReferenceV2:
+        title: ExternalIssueReferenceV2
         type: object
         properties:
             issue_name:
@@ -18164,8 +18313,8 @@ definitions:
             - issue_name
             - issue_permalink
             - issue_id
-    ExternalResourceV1ResponseBody:
-        title: ExternalResourceV1ResponseBody
+    ExternalResourceV1:
+        title: ExternalResourceV1
         type: object
         properties:
             external_id:
@@ -18211,8 +18360,8 @@ definitions:
             - resource_type_label
             - created_at
             - updated_at
-    FollowUpPriorityV2ResponseBody:
-        title: FollowUpPriorityV2ResponseBody
+    FollowUpPriorityV2:
+        title: FollowUpPriorityV2
         type: object
         properties:
             description:
@@ -18241,12 +18390,12 @@ definitions:
             - id
             - name
             - rank
-    FollowUpV2ResponseBody:
-        title: FollowUpV2ResponseBody
+    FollowUpV2:
+        title: FollowUpV2
         type: object
         properties:
             assignee:
-                $ref: '#/definitions/UserV2ResponseBody'
+                $ref: '#/definitions/UserV2'
             completed_at:
                 type: string
                 description: When the follow-up was completed
@@ -18262,7 +18411,7 @@ definitions:
                 description: Description of the follow-up
                 example: Call the fire brigade
             external_issue_reference:
-                $ref: '#/definitions/ExternalIssueReferenceV2ResponseBody'
+                $ref: '#/definitions/ExternalIssueReferenceV2'
             id:
                 type: string
                 description: Unique identifier for the follow-up
@@ -18272,7 +18421,7 @@ definitions:
                 description: Unique identifier of the incident the follow-up belongs to
                 example: 01FCNDV6P870EA6S7TK1DSYDG0
             priority:
-                $ref: '#/definitions/FollowUpPriorityV2ResponseBody'
+                $ref: '#/definitions/FollowUpPriorityV2'
             status:
                 type: string
                 description: Status of the follow-up
@@ -18329,7 +18478,7 @@ definitions:
             follow_ups:
                 type: array
                 items:
-                    $ref: '#/definitions/FollowUpV2ResponseBody'
+                    $ref: '#/definitions/FollowUpV2'
                 example:
                     - assignee:
                         email: lisa@incident.io
@@ -18386,7 +18535,7 @@ definitions:
         type: object
         properties:
             follow_up:
-                $ref: '#/definitions/FollowUpV2ResponseBody'
+                $ref: '#/definitions/FollowUpV2'
         example:
             follow_up:
                 assignee:
@@ -18414,8 +18563,8 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - follow_up
-    GroupingKeyV2RequestBody:
-        title: GroupingKeyV2RequestBody
+    GroupingKeyV2:
+        title: GroupingKeyV2
         type: object
         properties:
             id:
@@ -18426,20 +18575,8 @@ definitions:
             id: 01FCNDV6P870EA6S7TK1DSYDG0
         required:
             - id
-    GroupingKeyV2ResponseBody:
-        title: GroupingKeyV2ResponseBody
-        type: object
-        properties:
-            id:
-                type: string
-                description: Unique identifier of the alert attribute the user wishes to group on
-                example: 01FCNDV6P870EA6S7TK1DSYDG0
-        example:
-            id: 01FCNDV6P870EA6S7TK1DSYDG0
-        required:
-            - id
-    IdentityV1ResponseBody:
-        title: IdentityV1ResponseBody
+    IdentityV1:
+        title: IdentityV1
         type: object
         properties:
             dashboard_url:
@@ -18481,8 +18618,8 @@ definitions:
             - name
             - roles
             - dashboard_url
-    IncidentAttachmentV1ResponseBody:
-        title: IncidentAttachmentV1ResponseBody
+    IncidentAttachmentV1:
+        title: IncidentAttachmentV1
         type: object
         properties:
             id:
@@ -18494,7 +18631,7 @@ definitions:
                 description: Unique identifier of the incident
                 example: 01FCNDV6P870EA6S7TK1DSYD5H
             resource:
-                $ref: '#/definitions/ExternalResourceV1ResponseBody'
+                $ref: '#/definitions/ExternalResourceV1'
         example:
             id: 01FCNDV6P870EA6S7TK1DSYD5H
             incident_id: 01FCNDV6P870EA6S7TK1DSYD5H
@@ -18567,7 +18704,7 @@ definitions:
         type: object
         properties:
             incident_attachment:
-                $ref: '#/definitions/IncidentAttachmentV1ResponseBody'
+                $ref: '#/definitions/IncidentAttachmentV1'
         example:
             incident_attachment:
                 id: 01FCNDV6P870EA6S7TK1DSYD5H
@@ -18586,7 +18723,7 @@ definitions:
             incident_attachments:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentAttachmentV1ResponseBody'
+                    $ref: '#/definitions/IncidentAttachmentV1'
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYD5H
                       incident_id: 01FCNDV6P870EA6S7TK1DSYD5H
@@ -18606,8 +18743,137 @@ definitions:
                     title: The database has gone down
         required:
             - incident_attachments
-    IncidentDurationMetricV2ResponseBody:
-        title: IncidentDurationMetricV2ResponseBody
+    IncidentCreatePayloadV2:
+        title: IncidentCreatePayloadV2
+        type: object
+        properties:
+            custom_field_entries:
+                type: array
+                items:
+                    $ref: '#/definitions/CustomFieldEntryPayloadV2'
+                description: Set the incident's custom fields to these values
+                example:
+                    - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      values:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_link: https://google.com/
+                          value_numeric: "123.456"
+                          value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_text: This is my text field, I hope you like it
+                          value_timestamp: ""
+            id:
+                type: string
+                description: Unique identifier for the incident
+                example: 01FDAG4SAP5TYPT98WGR2N7W91
+            idempotency_key:
+                type: string
+                description: Unique string used to de-duplicate incident create requests
+                example: alert-uuid
+            incident_role_assignments:
+                type: array
+                items:
+                    $ref: '#/definitions/IncidentRoleAssignmentPayloadV2'
+                description: Assign incident roles to these people
+                example:
+                    - assignee:
+                        email: bob@example.com
+                        id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                        slack_user_id: USER123
+                      incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+            incident_status_id:
+                type: string
+                description: Incident status to assign to the incident
+                example: 01G0J1EXE7AXZ2C93K61WBPYEH
+            incident_timestamp_values:
+                type: array
+                items:
+                    $ref: '#/definitions/IncidentTimestampValuePayloadV2'
+                description: Assign the incident's timestamps to these values
+                example:
+                    - incident_timestamp_id: 01FCNDV6P870EA6S7TK1DSYD5H
+                      value: "2021-08-17T13:28:57.801578Z"
+            incident_type_id:
+                type: string
+                description: Incident type to create this incident as
+                example: 01FH5TZRWMNAFB0DZ23FD1TV96
+            mode:
+                type: string
+                description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
+                example: standard
+                enum:
+                    - standard
+                    - retrospective
+                    - test
+                    - tutorial
+            name:
+                type: string
+                description: Explanation of the incident
+                example: Our database is sad
+            retrospective_incident_options:
+                $ref: '#/definitions/RetrospectiveIncidentOptionsV2'
+            severity_id:
+                type: string
+                description: Severity to create incident as
+                example: 01FH5TZRWMNAFB0DZ23FD1TV96
+            slack_channel_name_override:
+                type: string
+                description: Name of the Slack channel to create for this incident
+                example: inc-123-database-down
+            slack_team_id:
+                type: string
+                description: Slack Team to create the incident in
+                example: T02A1FSLE8J
+            summary:
+                type: string
+                description: Detailed description of the incident
+                example: Our database is really really sad, and we don't know why yet.
+            visibility:
+                type: string
+                description: Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+                example: public
+                enum:
+                    - public
+                    - private
+        example:
+            custom_field_entries:
+                - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                  values:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      value_link: https://google.com/
+                      value_numeric: "123.456"
+                      value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      value_text: This is my text field, I hope you like it
+                      value_timestamp: ""
+            id: 01FDAG4SAP5TYPT98WGR2N7W91
+            idempotency_key: alert-uuid
+            incident_role_assignments:
+                - assignee:
+                    email: bob@example.com
+                    id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                    slack_user_id: USER123
+                  incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+            incident_status_id: 01G0J1EXE7AXZ2C93K61WBPYEH
+            incident_timestamp_values:
+                - incident_timestamp_id: 01FCNDV6P870EA6S7TK1DSYD5H
+                  value: "2021-08-17T13:28:57.801578Z"
+            incident_type_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+            mode: standard
+            name: Our database is sad
+            retrospective_incident_options:
+                postmortem_document_url: https://docs.google.com/my_doc_id
+                slack_channel_id: abc123
+            severity_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+            slack_channel_name_override: inc-123-database-down
+            slack_team_id: T02A1FSLE8J
+            summary: Our database is really really sad, and we don't know why yet.
+            visibility: public
+        required:
+            - idempotency_key
+            - visibility
+    IncidentDurationMetricV2:
+        title: IncidentDurationMetricV2
         type: object
         properties:
             id:
@@ -18632,12 +18898,12 @@ definitions:
             - created_at
             - updated_at
             - validate
-    IncidentDurationMetricWithValueV2ResponseBody:
-        title: IncidentDurationMetricWithValueV2ResponseBody
+    IncidentDurationMetricWithValueV2:
+        title: IncidentDurationMetricWithValueV2
         type: object
         properties:
             duration_metric:
-                $ref: '#/definitions/IncidentDurationMetricV2ResponseBody'
+                $ref: '#/definitions/IncidentDurationMetricV2'
             value_seconds:
                 type: integer
                 description: The calculated durations for this metric
@@ -18650,8 +18916,8 @@ definitions:
             value_seconds: 1
         required:
             - duration_metric
-    IncidentEditPayloadV2RequestBody:
-        title: IncidentEditPayloadV2RequestBody
+    IncidentEditPayloadV2:
+        title: IncidentEditPayloadV2
         type: object
         properties:
             call_url:
@@ -18661,7 +18927,7 @@ definitions:
             custom_field_entries:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldEntryPayloadV2RequestBody'
+                    $ref: '#/definitions/CustomFieldEntryPayloadV2'
                 description: Set the incident's custom fields to these values
                 example:
                     - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -18676,7 +18942,7 @@ definitions:
             incident_role_assignments:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentRoleAssignmentPayloadV2RequestBody'
+                    $ref: '#/definitions/IncidentRoleAssignmentPayloadV2'
                 description: Assign incident roles to these people
                 example:
                     - assignee:
@@ -18691,7 +18957,7 @@ definitions:
             incident_timestamp_values:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentTimestampValuePayloadV2RequestBody'
+                    $ref: '#/definitions/IncidentTimestampValuePayloadV2'
                 description: Assign the incident's timestamps to these values
                 example:
                     - incident_timestamp_id: 01FCNDV6P870EA6S7TK1DSYD5H
@@ -18738,8 +19004,8 @@ definitions:
             severity_id: 01FH5TZRWMNAFB0DZ23FD1TV96
             slack_channel_name_override: inc-123-database-down
             summary: Our database is really really sad, and we don't know why yet.
-    IncidentMembershipResponseBody:
-        title: IncidentMembershipResponseBody
+    IncidentMembership:
+        title: IncidentMembership
         type: object
         properties:
             created_at:
@@ -18761,7 +19027,7 @@ definitions:
                 example: "2021-08-17T13:28:57.801578Z"
                 format: date-time
             user:
-                $ref: '#/definitions/UserV2ResponseBody'
+                $ref: '#/definitions/UserV2'
         example:
             created_at: "2021-08-17T13:28:57.801578Z"
             id: 01FCNDV6P870EA6S7TK1DSYD5H
@@ -18800,7 +19066,7 @@ definitions:
         type: object
         properties:
             incident_membership:
-                $ref: '#/definitions/IncidentMembershipResponseBody'
+                $ref: '#/definitions/IncidentMembership'
         example:
             incident_membership:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -18832,12 +19098,12 @@ definitions:
         required:
             - user_id
             - incident_id
-    IncidentRoleAssignmentPayloadV1RequestBody:
-        title: IncidentRoleAssignmentPayloadV1RequestBody
+    IncidentRoleAssignmentPayloadV1:
+        title: IncidentRoleAssignmentPayloadV1
         type: object
         properties:
             assignee:
-                $ref: '#/definitions/UserReferencePayloadV1RequestBody'
+                $ref: '#/definitions/UserReferencePayloadV1'
             incident_role_id:
                 type: string
                 description: Unique ID of an incident role. Note that the 'reporter' role can only be assigned when creating an incident.
@@ -18851,12 +19117,12 @@ definitions:
         required:
             - incident_role_id
             - assignee
-    IncidentRoleAssignmentPayloadV2RequestBody:
-        title: IncidentRoleAssignmentPayloadV2RequestBody
+    IncidentRoleAssignmentPayloadV2:
+        title: IncidentRoleAssignmentPayloadV2
         type: object
         properties:
             assignee:
-                $ref: '#/definitions/UserReferencePayloadV2RequestBody'
+                $ref: '#/definitions/UserReferencePayloadV2'
             incident_role_id:
                 type: string
                 description: Unique ID of an incident role
@@ -18869,14 +19135,14 @@ definitions:
             incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
         required:
             - incident_role_id
-    IncidentRoleAssignmentV1ResponseBody:
-        title: IncidentRoleAssignmentV1ResponseBody
+    IncidentRoleAssignmentV1:
+        title: IncidentRoleAssignmentV1
         type: object
         properties:
             assignee:
-                $ref: '#/definitions/UserV1ResponseBody'
+                $ref: '#/definitions/UserV1'
             role:
-                $ref: '#/definitions/IncidentRoleV1ResponseBody'
+                $ref: '#/definitions/IncidentRoleV1'
         example:
             assignee:
                 email: lisa@incident.io
@@ -18896,14 +19162,14 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - role
-    IncidentRoleAssignmentV2ResponseBody:
-        title: IncidentRoleAssignmentV2ResponseBody
+    IncidentRoleAssignmentV2:
+        title: IncidentRoleAssignmentV2
         type: object
         properties:
             assignee:
-                $ref: '#/definitions/UserV2ResponseBody'
+                $ref: '#/definitions/UserV2'
             role:
-                $ref: '#/definitions/EmbeddedIncidentRoleV2ResponseBody'
+                $ref: '#/definitions/EmbeddedIncidentRoleV2'
         example:
             assignee:
                 email: lisa@incident.io
@@ -18923,8 +19189,8 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - role
-    IncidentRoleV1ResponseBody:
-        title: IncidentRoleV1ResponseBody
+    IncidentRoleV1:
+        title: IncidentRoleV1
         type: object
         properties:
             created_at:
@@ -18991,8 +19257,8 @@ definitions:
             - role_type
             - created_at
             - updated_at
-    IncidentRoleV2ResponseBody:
-        title: IncidentRoleV2ResponseBody
+    IncidentRoleV2:
+        title: IncidentRoleV2
         type: object
         properties:
             created_at:
@@ -19102,7 +19368,7 @@ definitions:
         type: object
         properties:
             incident_role:
-                $ref: '#/definitions/IncidentRoleV1ResponseBody'
+                $ref: '#/definitions/IncidentRoleV1'
         example:
             incident_role:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -19123,7 +19389,7 @@ definitions:
             incident_roles:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentRoleV1ResponseBody'
+                    $ref: '#/definitions/IncidentRoleV1'
                 example:
                     - created_at: "2021-08-17T13:28:57.801578Z"
                       description: The person currently coordinating the incident
@@ -19152,7 +19418,7 @@ definitions:
         type: object
         properties:
             incident_role:
-                $ref: '#/definitions/IncidentRoleV1ResponseBody'
+                $ref: '#/definitions/IncidentRoleV1'
         example:
             incident_role:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -19212,7 +19478,7 @@ definitions:
         type: object
         properties:
             incident_role:
-                $ref: '#/definitions/IncidentRoleV1ResponseBody'
+                $ref: '#/definitions/IncidentRoleV1'
         example:
             incident_role:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -19268,7 +19534,7 @@ definitions:
         type: object
         properties:
             incident_role:
-                $ref: '#/definitions/IncidentRoleV2ResponseBody'
+                $ref: '#/definitions/IncidentRoleV2'
         example:
             incident_role:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -19288,7 +19554,7 @@ definitions:
             incident_roles:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentRoleV2ResponseBody'
+                    $ref: '#/definitions/IncidentRoleV2'
                 example:
                     - created_at: "2021-08-17T13:28:57.801578Z"
                       description: The person currently coordinating the incident
@@ -19315,7 +19581,7 @@ definitions:
         type: object
         properties:
             incident_role:
-                $ref: '#/definitions/IncidentRoleV2ResponseBody'
+                $ref: '#/definitions/IncidentRoleV2'
         example:
             incident_role:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -19369,7 +19635,7 @@ definitions:
         type: object
         properties:
             incident_role:
-                $ref: '#/definitions/IncidentRoleV2ResponseBody'
+                $ref: '#/definitions/IncidentRoleV2'
         example:
             incident_role:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -19382,8 +19648,8 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - incident_role
-    IncidentStatusV1ResponseBody:
-        title: IncidentStatusV1ResponseBody
+    IncidentStatusV1:
+        title: IncidentStatusV1
         type: object
         properties:
             category:
@@ -19440,8 +19706,8 @@ definitions:
             - category
             - created_at
             - updated_at
-    IncidentStatusV2ResponseBody:
-        title: IncidentStatusV2ResponseBody
+    IncidentStatusV2:
+        title: IncidentStatusV2
         type: object
         properties:
             category:
@@ -19535,7 +19801,7 @@ definitions:
         type: object
         properties:
             incident_status:
-                $ref: '#/definitions/IncidentStatusV1ResponseBody'
+                $ref: '#/definitions/IncidentStatusV1'
         example:
             incident_status:
                 category: triage
@@ -19554,7 +19820,7 @@ definitions:
             incident_statuses:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentStatusV1ResponseBody'
+                    $ref: '#/definitions/IncidentStatusV1'
                 example:
                     - category: triage
                       created_at: "2021-08-17T13:28:57.801578Z"
@@ -19579,7 +19845,7 @@ definitions:
         type: object
         properties:
             incident_status:
-                $ref: '#/definitions/IncidentStatusV1ResponseBody'
+                $ref: '#/definitions/IncidentStatusV1'
         example:
             incident_status:
                 category: triage
@@ -19618,7 +19884,7 @@ definitions:
         type: object
         properties:
             incident_status:
-                $ref: '#/definitions/IncidentStatusV1ResponseBody'
+                $ref: '#/definitions/IncidentStatusV1'
         example:
             incident_status:
                 category: triage
@@ -19630,8 +19896,8 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - incident_status
-    IncidentTimestampV1ResponseBody:
-        title: IncidentTimestampV1ResponseBody
+    IncidentTimestampV1:
+        title: IncidentTimestampV1
         type: object
         properties:
             last_occurred_at:
@@ -19648,8 +19914,8 @@ definitions:
             name: last_activity
         required:
             - name
-    IncidentTimestampV2ResponseBody:
-        title: IncidentTimestampV2ResponseBody
+    IncidentTimestampV2:
+        title: IncidentTimestampV2
         type: object
         properties:
             id:
@@ -19681,8 +19947,8 @@ definitions:
             - timestamp_type
             - created_at
             - updated_at
-    IncidentTimestampValuePayloadV2RequestBody:
-        title: IncidentTimestampValuePayloadV2RequestBody
+    IncidentTimestampValuePayloadV2:
+        title: IncidentTimestampValuePayloadV2
         type: object
         properties:
             incident_timestamp_id:
@@ -19702,8 +19968,8 @@ definitions:
             - id
             - incident_id
             - created_at
-    IncidentTimestampValueV2ResponseBody:
-        title: IncidentTimestampValueV2ResponseBody
+    IncidentTimestampValueV2:
+        title: IncidentTimestampValueV2
         type: object
         properties:
             value:
@@ -19718,14 +19984,14 @@ definitions:
             - incident_id
             - incident_timestamp_id
             - created_at
-    IncidentTimestampWithValueV2ResponseBody:
-        title: IncidentTimestampWithValueV2ResponseBody
+    IncidentTimestampWithValueV2:
+        title: IncidentTimestampWithValueV2
         type: object
         properties:
             incident_timestamp:
-                $ref: '#/definitions/IncidentTimestampV2ResponseBody'
+                $ref: '#/definitions/IncidentTimestampV2'
             value:
-                $ref: '#/definitions/IncidentTimestampValueV2ResponseBody'
+                $ref: '#/definitions/IncidentTimestampValueV2'
         example:
             incident_timestamp:
                 id: 01FCNDV6P870EA6S7TK1DSYD5H
@@ -19742,7 +20008,7 @@ definitions:
             incident_timestamps:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentTimestampV2ResponseBody'
+                    $ref: '#/definitions/IncidentTimestampV2'
                 example:
                     - id: 01FCNDV6P870EA6S7TK1DSYD5H
                       name: Impact started
@@ -19759,7 +20025,7 @@ definitions:
         type: object
         properties:
             incident_timestamp:
-                $ref: '#/definitions/IncidentTimestampV2ResponseBody'
+                $ref: '#/definitions/IncidentTimestampV2'
         example:
             incident_timestamp:
                 id: 01FCNDV6P870EA6S7TK1DSYD5H
@@ -19767,8 +20033,8 @@ definitions:
                 rank: 1
         required:
             - incident_timestamp
-    IncidentTypeV1ResponseBody:
-        title: IncidentTypeV1ResponseBody
+    IncidentTypeV1:
+        title: IncidentTypeV1
         type: object
         properties:
             create_in_triage:
@@ -19834,8 +20100,8 @@ definitions:
             - override_auto_archive_slack_channels
             - auto_archive_slack_channels
             - auto_archive_slack_channels_delay_days
-    IncidentTypeV2ResponseBody:
-        title: IncidentTypeV2ResponseBody
+    IncidentTypeV2:
+        title: IncidentTypeV2
         type: object
         properties:
             create_in_triage:
@@ -19908,7 +20174,7 @@ definitions:
             incident_types:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentTypeV1ResponseBody'
+                    $ref: '#/definitions/IncidentTypeV1'
                 example:
                     - create_in_triage: always
                       created_at: "2021-08-17T13:28:57.801578Z"
@@ -19935,7 +20201,7 @@ definitions:
         type: object
         properties:
             incident_type:
-                $ref: '#/definitions/IncidentTypeV1ResponseBody'
+                $ref: '#/definitions/IncidentTypeV1'
         example:
             incident_type:
                 create_in_triage: always
@@ -19948,8 +20214,8 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - incident_type
-    IncidentUpdateV2ResponseBody:
-        title: IncidentUpdateV2ResponseBody
+    IncidentUpdateV2:
+        title: IncidentUpdateV2
         type: object
         properties:
             created_at:
@@ -19974,11 +20240,11 @@ definitions:
                 description: Message that explains the context behind the update
                 example: We're working on a fix, hoping to ship in the next 30 minutes
             new_incident_status:
-                $ref: '#/definitions/IncidentStatusV2ResponseBody'
+                $ref: '#/definitions/IncidentStatusV2'
             new_severity:
-                $ref: '#/definitions/SeverityV2ResponseBody'
+                $ref: '#/definitions/SeverityV2'
             updater:
-                $ref: '#/definitions/ActorV2ResponseBody'
+                $ref: '#/definitions/ActorV2'
         example:
             created_at: "2021-08-17T13:28:57.801578Z"
             id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -20024,7 +20290,7 @@ definitions:
             incident_updates:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentUpdateV2ResponseBody'
+                    $ref: '#/definitions/IncidentUpdateV2'
                 example:
                     - created_at: "2021-08-17T13:28:57.801578Z"
                       id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -20057,7 +20323,7 @@ definitions:
                             role: viewer
                             slack_user_id: U02AYNF2XJM
             pagination_meta:
-                $ref: '#/definitions/PaginationMetaResultResponseBody'
+                $ref: '#/definitions/PaginationMetaResult'
         example:
             incident_updates:
                 - created_at: "2021-08-17T13:28:57.801578Z"
@@ -20095,8 +20361,8 @@ definitions:
                 page_size: 25
         required:
             - incident_updates
-    IncidentV1ResponseBody:
-        title: IncidentV1ResponseBody
+    IncidentV1:
+        title: IncidentV1
         type: object
         properties:
             call_url:
@@ -20109,11 +20375,11 @@ definitions:
                 example: "2021-08-17T13:28:57.801578Z"
                 format: date-time
             creator:
-                $ref: '#/definitions/ActorV1ResponseBody'
+                $ref: '#/definitions/ActorV1'
             custom_field_entries:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldEntryV1ResponseBody'
+                    $ref: '#/definitions/CustomFieldEntryV1'
                 description: Custom field entries for this incident
                 example:
                     - custom_field:
@@ -20149,7 +20415,7 @@ definitions:
             incident_role_assignments:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentRoleAssignmentV1ResponseBody'
+                    $ref: '#/definitions/IncidentRoleAssignmentV1'
                 description: A list of who is assigned to each role for this incident
                 example:
                     - assignee:
@@ -20169,7 +20435,7 @@ definitions:
                         shortform: lead
                         updated_at: "2021-08-17T13:28:57.801578Z"
             incident_type:
-                $ref: '#/definitions/IncidentTypeV1ResponseBody'
+                $ref: '#/definitions/IncidentTypeV1'
             mode:
                 type: string
                 description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
@@ -20195,7 +20461,7 @@ definitions:
                 description: Reference to this incident, as displayed across the product
                 example: INC-123
             severity:
-                $ref: '#/definitions/SeverityV1ResponseBody'
+                $ref: '#/definitions/SeverityV1'
             slack_channel_id:
                 type: string
                 description: ID of the Slack channel in the organisation Slack workspace. Note that the channel is sometimes created asynchronously, so may not be present when the incident is just created.
@@ -20226,7 +20492,7 @@ definitions:
             timestamps:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentTimestampV1ResponseBody'
+                    $ref: '#/definitions/IncidentTimestampV1'
                 description: Incident lifecycle events and when they last occurred
                 example:
                     - last_occurred_at: "2021-08-17T13:28:57.801578Z"
@@ -20353,8 +20619,8 @@ definitions:
             - created_at
             - updated_at
             - reported_at
-    IncidentV2ResponseBody:
-        title: IncidentV2ResponseBody
+    IncidentV2:
+        title: IncidentV2
         type: object
         properties:
             call_url:
@@ -20367,11 +20633,11 @@ definitions:
                 example: "2021-08-17T13:28:57.801578Z"
                 format: date-time
             creator:
-                $ref: '#/definitions/ActorV2ResponseBody'
+                $ref: '#/definitions/ActorV2'
             custom_field_entries:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldEntryV2ResponseBody'
+                    $ref: '#/definitions/CustomFieldEntryV2'
                 description: Custom field entries for this incident
                 example:
                     - custom_field:
@@ -20403,7 +20669,7 @@ definitions:
             duration_metrics:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentDurationMetricWithValueV2ResponseBody'
+                    $ref: '#/definitions/IncidentDurationMetricWithValueV2'
                 description: Incident duration metrics and their measurements for this incident
                 example:
                     - duration_metric:
@@ -20411,7 +20677,7 @@ definitions:
                         name: Lasted
                       value_seconds: 1
             external_issue_reference:
-                $ref: '#/definitions/ExternalIssueReferenceV2ResponseBody'
+                $ref: '#/definitions/ExternalIssueReferenceV2'
             id:
                 type: string
                 description: Unique identifier for the incident
@@ -20419,7 +20685,7 @@ definitions:
             incident_role_assignments:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentRoleAssignmentV2ResponseBody'
+                    $ref: '#/definitions/IncidentRoleAssignmentV2'
                 description: A list of who is assigned to each role for this incident
                 example:
                     - assignee:
@@ -20439,11 +20705,11 @@ definitions:
                         shortform: lead
                         updated_at: "2021-08-17T13:28:57.801578Z"
             incident_status:
-                $ref: '#/definitions/IncidentStatusV2ResponseBody'
+                $ref: '#/definitions/IncidentStatusV2'
             incident_timestamp_values:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentTimestampWithValueV2ResponseBody'
+                    $ref: '#/definitions/IncidentTimestampWithValueV2'
                 description: Incident lifecycle events and when they occurred
                 example:
                     - incident_timestamp:
@@ -20453,7 +20719,7 @@ definitions:
                       value:
                         value: "2021-08-17T13:28:57.801578Z"
             incident_type:
-                $ref: '#/definitions/IncidentTypeV2ResponseBody'
+                $ref: '#/definitions/IncidentTypeV2'
             mode:
                 type: string
                 description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
@@ -20480,7 +20746,7 @@ definitions:
                 description: Reference to this incident, as displayed across the product
                 example: INC-123
             severity:
-                $ref: '#/definitions/SeverityV2ResponseBody'
+                $ref: '#/definitions/SeverityV2'
             slack_channel_id:
                 type: string
                 description: ID of the Slack channel in the organisation Slack workspace. Note that the channel is sometimes created asynchronously, so may not be present when the incident is just created.
@@ -20662,16 +20928,16 @@ definitions:
             - created_at
             - updated_at
             - reported_at
-    IncidentWithStatusChangeV2ResponseBody:
-        title: IncidentWithStatusChangeV2ResponseBody
+    IncidentWithStatusChangeV2:
+        title: IncidentWithStatusChangeV2
         type: object
         properties:
             incident:
-                $ref: '#/definitions/IncidentV2ResponseBody'
+                $ref: '#/definitions/IncidentV2'
             new_status:
-                $ref: '#/definitions/IncidentStatusV2ResponseBody'
+                $ref: '#/definitions/IncidentStatusV2'
             previous_status:
-                $ref: '#/definitions/IncidentStatusV2ResponseBody'
+                $ref: '#/definitions/IncidentStatusV2'
         example:
             incident:
                 call_url: https://zoom.us/foo
@@ -20813,7 +21079,7 @@ definitions:
             custom_field_entries:
                 type: array
                 items:
-                    $ref: '#/definitions/CustomFieldEntryPayloadV1RequestBody'
+                    $ref: '#/definitions/CustomFieldEntryPayloadV1'
                 description: Set the incident's custom fields to these values
                 example:
                     - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -20832,7 +21098,7 @@ definitions:
             incident_role_assignments:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentRoleAssignmentPayloadV1RequestBody'
+                    $ref: '#/definitions/IncidentRoleAssignmentPayloadV1'
                 description: Assign incident roles to these people
                 example:
                     - assignee:
@@ -20929,7 +21195,7 @@ definitions:
         type: object
         properties:
             incident:
-                $ref: '#/definitions/IncidentV1ResponseBody'
+                $ref: '#/definitions/IncidentV1'
         example:
             incident:
                 call_url: https://zoom.us/foo
@@ -21029,7 +21295,7 @@ definitions:
             incidents:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentV1ResponseBody'
+                    $ref: '#/definitions/IncidentV1'
                 example:
                     - call_url: https://zoom.us/foo
                       created_at: "2021-08-17T13:28:57.801578Z"
@@ -21120,7 +21386,7 @@ definitions:
                       updated_at: "2021-08-17T13:28:57.801578Z"
                       visibility: public
             pagination_meta:
-                $ref: '#/definitions/PaginationMetaResultWithTotalResponseBody'
+                $ref: '#/definitions/PaginationMetaResultWithTotal'
         example:
             incidents:
                 - call_url: https://zoom.us/foo
@@ -21222,7 +21488,7 @@ definitions:
         type: object
         properties:
             incident:
-                $ref: '#/definitions/IncidentV1ResponseBody'
+                $ref: '#/definitions/IncidentV1'
         example:
             incident:
                 call_url: https://zoom.us/foo
@@ -21315,141 +21581,12 @@ definitions:
                 visibility: public
         required:
             - incident
-    IncidentsV2CreateRequestBody:
-        title: IncidentsV2CreateRequestBody
-        type: object
-        properties:
-            custom_field_entries:
-                type: array
-                items:
-                    $ref: '#/definitions/CustomFieldEntryPayloadV2RequestBody'
-                description: Set the incident's custom fields to these values
-                example:
-                    - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      values:
-                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          value_link: https://google.com/
-                          value_numeric: "123.456"
-                          value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          value_text: This is my text field, I hope you like it
-                          value_timestamp: ""
-            id:
-                type: string
-                description: Unique identifier for the incident
-                example: 01FDAG4SAP5TYPT98WGR2N7W91
-            idempotency_key:
-                type: string
-                description: Unique string used to de-duplicate incident create requests
-                example: alert-uuid
-            incident_role_assignments:
-                type: array
-                items:
-                    $ref: '#/definitions/IncidentRoleAssignmentPayloadV2RequestBody'
-                description: Assign incident roles to these people
-                example:
-                    - assignee:
-                        email: bob@example.com
-                        id: 01G0J1EXE7AXZ2C93K61WBPYEH
-                        slack_user_id: USER123
-                      incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-            incident_status_id:
-                type: string
-                description: Incident status to assign to the incident
-                example: 01G0J1EXE7AXZ2C93K61WBPYEH
-            incident_timestamp_values:
-                type: array
-                items:
-                    $ref: '#/definitions/IncidentTimestampValuePayloadV2RequestBody'
-                description: Assign the incident's timestamps to these values
-                example:
-                    - incident_timestamp_id: 01FCNDV6P870EA6S7TK1DSYD5H
-                      value: "2021-08-17T13:28:57.801578Z"
-            incident_type_id:
-                type: string
-                description: Incident type to create this incident as
-                example: 01FH5TZRWMNAFB0DZ23FD1TV96
-            mode:
-                type: string
-                description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
-                example: standard
-                enum:
-                    - standard
-                    - retrospective
-                    - test
-                    - tutorial
-            name:
-                type: string
-                description: Explanation of the incident
-                example: Our database is sad
-            retrospective_incident_options:
-                $ref: '#/definitions/RetrospectiveIncidentOptionsV2RequestBody'
-            severity_id:
-                type: string
-                description: Severity to create incident as
-                example: 01FH5TZRWMNAFB0DZ23FD1TV96
-            slack_channel_name_override:
-                type: string
-                description: Name of the Slack channel to create for this incident
-                example: inc-123-database-down
-            slack_team_id:
-                type: string
-                description: Slack Team to create the incident in
-                example: T02A1FSLE8J
-            summary:
-                type: string
-                description: Detailed description of the incident
-                example: Our database is really really sad, and we don't know why yet.
-            visibility:
-                type: string
-                description: Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-                example: public
-                enum:
-                    - public
-                    - private
-        example:
-            custom_field_entries:
-                - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                  values:
-                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      value_link: https://google.com/
-                      value_numeric: "123.456"
-                      value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      value_text: This is my text field, I hope you like it
-                      value_timestamp: ""
-            id: 01FDAG4SAP5TYPT98WGR2N7W91
-            idempotency_key: alert-uuid
-            incident_role_assignments:
-                - assignee:
-                    email: bob@example.com
-                    id: 01G0J1EXE7AXZ2C93K61WBPYEH
-                    slack_user_id: USER123
-                  incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-            incident_status_id: 01G0J1EXE7AXZ2C93K61WBPYEH
-            incident_timestamp_values:
-                - incident_timestamp_id: 01FCNDV6P870EA6S7TK1DSYD5H
-                  value: "2021-08-17T13:28:57.801578Z"
-            incident_type_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-            mode: standard
-            name: Our database is sad
-            retrospective_incident_options:
-                postmortem_document_url: https://docs.google.com/my_doc_id
-                slack_channel_id: abc123
-            severity_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-            slack_channel_name_override: inc-123-database-down
-            slack_team_id: T02A1FSLE8J
-            summary: Our database is really really sad, and we don't know why yet.
-            visibility: public
-        required:
-            - idempotency_key
-            - visibility
     IncidentsV2CreateResponseBody:
         title: IncidentsV2CreateResponseBody
         type: object
         properties:
             incident:
-                $ref: '#/definitions/IncidentV2ResponseBody'
+                $ref: '#/definitions/IncidentV2'
         example:
             incident:
                 call_url: https://zoom.us/foo
@@ -21571,7 +21708,7 @@ definitions:
         type: object
         properties:
             incident:
-                $ref: '#/definitions/IncidentEditPayloadV2RequestBody'
+                $ref: '#/definitions/IncidentEditPayloadV2'
             notify_incident_channel:
                 type: boolean
                 description: Should we send Slack channel notifications to inform responders of this update? Note that this won't work if the Slack channel has already been archived.
@@ -21612,7 +21749,7 @@ definitions:
         type: object
         properties:
             incident:
-                $ref: '#/definitions/IncidentV2ResponseBody'
+                $ref: '#/definitions/IncidentV2'
         example:
             incident:
                 call_url: https://zoom.us/foo
@@ -21736,7 +21873,7 @@ definitions:
             incidents:
                 type: array
                 items:
-                    $ref: '#/definitions/IncidentV2ResponseBody'
+                    $ref: '#/definitions/IncidentV2'
                 example:
                     - call_url: https://zoom.us/foo
                       created_at: "2021-08-17T13:28:57.801578Z"
@@ -21851,7 +21988,7 @@ definitions:
                       workload_minutes_total: 60.7
                       workload_minutes_working: 20
             pagination_meta:
-                $ref: '#/definitions/PaginationMetaResultWithTotalResponseBody'
+                $ref: '#/definitions/PaginationMetaResultWithTotal'
         example:
             incidents:
                 - call_url: https://zoom.us/foo
@@ -21977,7 +22114,7 @@ definitions:
         type: object
         properties:
             incident:
-                $ref: '#/definitions/IncidentV2ResponseBody'
+                $ref: '#/definitions/IncidentV2'
         example:
             incident:
                 call_url: https://zoom.us/foo
@@ -22094,8 +22231,8 @@ definitions:
                 workload_minutes_working: 20
         required:
             - incident
-    ManagedResourceV2ResponseBody:
-        title: ManagedResourceV2ResponseBody
+    ManagedResourceV2:
+        title: ManagedResourceV2
         type: object
         properties:
             annotations:
@@ -22179,7 +22316,7 @@ definitions:
         type: object
         properties:
             managed_resource:
-                $ref: '#/definitions/ManagedResourceV2ResponseBody'
+                $ref: '#/definitions/ManagedResourceV2'
         example:
             managed_resource:
                 annotations:
@@ -22190,8 +22327,8 @@ definitions:
                 source_url: https://github.com/my-company/infrastructure
         required:
             - managed_resource
-    ManagementMetaV2ResponseBody:
-        title: ManagementMetaV2ResponseBody
+    ManagementMetaV2:
+        title: ManagementMetaV2
         type: object
         properties:
             annotations:
@@ -22222,8 +22359,8 @@ definitions:
         required:
             - annotations
             - managed_by
-    PaginationMetaResultResponseBody:
-        title: PaginationMetaResultResponseBody
+    PaginationMetaResult:
+        title: PaginationMetaResult
         type: object
         properties:
             after:
@@ -22241,8 +22378,8 @@ definitions:
             page_size: 25
         required:
             - page_size
-    PaginationMetaResultWithTotalResponseBody:
-        title: PaginationMetaResultWithTotalResponseBody
+    PaginationMetaResultWithTotal:
+        title: PaginationMetaResultWithTotal
         type: object
         properties:
             after:
@@ -22266,8 +22403,8 @@ definitions:
             total_record_count: 238
         required:
             - page_size
-    RBACRoleV2ResponseBody:
-        title: RBACRoleV2ResponseBody
+    RBACRoleV2:
+        title: RBACRoleV2
         type: object
         properties:
             description:
@@ -22295,8 +22432,8 @@ definitions:
             - id
             - name
             - slug
-    RetrospectiveIncidentOptionsV2RequestBody:
-        title: RetrospectiveIncidentOptionsV2RequestBody
+    RetrospectiveIncidentOptionsV2:
+        title: RetrospectiveIncidentOptionsV2
         type: object
         properties:
             postmortem_document_url:
@@ -22310,8 +22447,8 @@ definitions:
         example:
             postmortem_document_url: https://docs.google.com/my_doc_id
             slack_channel_id: abc123
-    ReturnsMetaV2RequestBody:
-        title: ReturnsMetaV2RequestBody
+    ReturnsMetaV2:
+        title: ReturnsMetaV2
         type: object
         properties:
             array:
@@ -22328,32 +22465,14 @@ definitions:
         required:
             - type
             - array
-    ReturnsMetaV2ResponseBody:
-        title: ReturnsMetaV2ResponseBody
-        type: object
-        properties:
-            array:
-                type: boolean
-                description: Whether the return value should be single or multi-value
-                example: true
-            type:
-                type: string
-                description: Expected return type of this expression (what to try casting the result to)
-                example: IncidentStatus
-        example:
-            array: true
-            type: IncidentStatus
-        required:
-            - type
-            - array
-    ScheduleConfigCreatePayloadV2RequestBody:
-        title: ScheduleConfigCreatePayloadV2RequestBody
+    ScheduleConfigCreatePayloadV2:
+        title: ScheduleConfigCreatePayloadV2
         type: object
         properties:
             rotations:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleRotationCreatePayloadV2RequestBody'
+                    $ref: '#/definitions/ScheduleRotationCreatePayloadV2'
                 example:
                     - effective_from: "2021-08-17T13:28:57.801578Z"
                       handover_start_at: "2021-08-17T13:28:57.801578Z"
@@ -22393,14 +22512,14 @@ definitions:
                     - end_time: "17:00"
                       start_time: "09:00"
                       weekday: tuesday
-    ScheduleConfigUpdatePayloadV2RequestBody:
-        title: ScheduleConfigUpdatePayloadV2RequestBody
+    ScheduleConfigUpdatePayloadV2:
+        title: ScheduleConfigUpdatePayloadV2
         type: object
         properties:
             rotations:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleRotationUpdatePayloadV2RequestBody'
+                    $ref: '#/definitions/ScheduleRotationUpdatePayloadV2'
                 example:
                     - effective_from: "2021-08-17T13:28:57.801578Z"
                       handover_start_at: "2021-08-17T13:28:57.801578Z"
@@ -22440,14 +22559,14 @@ definitions:
                     - end_time: "17:00"
                       start_time: "09:00"
                       weekday: tuesday
-    ScheduleConfigV2ResponseBody:
-        title: ScheduleConfigV2ResponseBody
+    ScheduleConfigV2:
+        title: ScheduleConfigV2
         type: object
         properties:
             rotations:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleRotationV2ResponseBody'
+                    $ref: '#/definitions/ScheduleRotationV2'
                 description: Rotas in this schedule
                 example:
                     - effective_from: "2021-08-17T13:28:57.801578Z"
@@ -22495,8 +22614,8 @@ definitions:
         required:
             - rotations
             - version
-    ScheduleCreatePayloadV2RequestBody:
-        title: ScheduleCreatePayloadV2RequestBody
+    ScheduleCreatePayloadV2:
+        title: ScheduleCreatePayloadV2
         type: object
         properties:
             annotations:
@@ -22508,9 +22627,9 @@ definitions:
                     type: string
                     example: abc123
             config:
-                $ref: '#/definitions/ScheduleConfigCreatePayloadV2RequestBody'
+                $ref: '#/definitions/ScheduleConfigCreatePayloadV2'
             holidays_public_config:
-                $ref: '#/definitions/ScheduleHolidaysPublicConfigPayloadV2RequestBody'
+                $ref: '#/definitions/ScheduleHolidaysPublicConfigPayloadV2'
             name:
                 type: string
                 description: Name of the schedule
@@ -22547,14 +22666,14 @@ definitions:
                     - abc123
             name: My Schedule
             timezone: America/Los_Angeles
-    ScheduleEntriesListPayloadV2ResponseBody:
-        title: ScheduleEntriesListPayloadV2ResponseBody
+    ScheduleEntriesListPayloadV2:
+        title: ScheduleEntriesListPayloadV2
         type: object
         properties:
             final:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleEntryV2ResponseBody'
+                    $ref: '#/definitions/ScheduleEntryV2'
                 example:
                     - end_at: "2021-08-17T13:28:57.801578Z"
                       entry_id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22571,7 +22690,7 @@ definitions:
             overrides:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleEntryV2ResponseBody'
+                    $ref: '#/definitions/ScheduleEntryV2'
                 example:
                     - end_at: "2021-08-17T13:28:57.801578Z"
                       entry_id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22588,7 +22707,7 @@ definitions:
             scheduled:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleEntryV2ResponseBody'
+                    $ref: '#/definitions/ScheduleEntryV2'
                 example:
                     - end_at: "2021-08-17T13:28:57.801578Z"
                       entry_id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22646,8 +22765,8 @@ definitions:
             - scheduled
             - overrides
             - final
-    ScheduleEntryV2ResponseBody:
-        title: ScheduleEntryV2ResponseBody
+    ScheduleEntryV2:
+        title: ScheduleEntryV2
         type: object
         properties:
             end_at:
@@ -22675,7 +22794,7 @@ definitions:
                 example: "2021-08-17T13:28:57.801578Z"
                 format: date-time
             user:
-                $ref: '#/definitions/UserV2ResponseBody'
+                $ref: '#/definitions/UserV2'
         example:
             end_at: "2021-08-17T13:28:57.801578Z"
             entry_id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22693,8 +22812,8 @@ definitions:
             - external_user_id
             - start_at
             - end_at
-    ScheduleHolidaysPublicConfigPayloadV2RequestBody:
-        title: ScheduleHolidaysPublicConfigPayloadV2RequestBody
+    ScheduleHolidaysPublicConfigPayloadV2:
+        title: ScheduleHolidaysPublicConfigPayloadV2
         type: object
         properties:
             country_codes:
@@ -22710,8 +22829,8 @@ definitions:
                 - abc123
         required:
             - country_codes
-    ScheduleHolidaysPublicConfigV2ResponseBody:
-        title: ScheduleHolidaysPublicConfigV2ResponseBody
+    ScheduleHolidaysPublicConfigV2:
+        title: ScheduleHolidaysPublicConfigV2
         type: object
         properties:
             country_codes:
@@ -22729,8 +22848,8 @@ definitions:
                 - FR
         required:
             - country_codes
-    ScheduleLayerCreatePayloadV2RequestBody:
-        title: ScheduleLayerCreatePayloadV2RequestBody
+    ScheduleLayerCreatePayloadV2:
+        title: ScheduleLayerCreatePayloadV2
         type: object
         properties:
             id:
@@ -22746,8 +22865,8 @@ definitions:
             name: Layer 1
         required:
             - name
-    ScheduleLayerUpdatePayloadV2RequestBody:
-        title: ScheduleLayerUpdatePayloadV2RequestBody
+    ScheduleLayerUpdatePayloadV2:
+        title: ScheduleLayerUpdatePayloadV2
         type: object
         properties:
             id:
@@ -22761,8 +22880,8 @@ definitions:
         example:
             id: 01G0J1EXE7AXZ2C93K61WBPYEH
             name: Layer 1
-    ScheduleLayerV2ResponseBody:
-        title: ScheduleLayerV2ResponseBody
+    ScheduleLayerV2:
+        title: ScheduleLayerV2
         type: object
         properties:
             id:
@@ -22776,8 +22895,8 @@ definitions:
         example:
             id: 01G0J1EXE7AXZ2C93K61WBPYEH
             name: Layer 1
-    ScheduleRotationCreatePayloadV2RequestBody:
-        title: ScheduleRotationCreatePayloadV2RequestBody
+    ScheduleRotationCreatePayloadV2:
+        title: ScheduleRotationCreatePayloadV2
         type: object
         properties:
             effective_from:
@@ -22791,7 +22910,7 @@ definitions:
             handovers:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleRotationHandoverV2RequestBody'
+                    $ref: '#/definitions/ScheduleRotationHandoverV2'
                 example:
                     - interval: 1
                       interval_type: daily
@@ -22802,7 +22921,7 @@ definitions:
             layers:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleLayerCreatePayloadV2RequestBody'
+                    $ref: '#/definitions/ScheduleLayerCreatePayloadV2'
                 example:
                     - id: 01G0J1EXE7AXZ2C93K61WBPYEH
                       name: Layer 1
@@ -22813,7 +22932,7 @@ definitions:
             users:
                 type: array
                 items:
-                    $ref: '#/definitions/UserReferencePayloadV2RequestBody'
+                    $ref: '#/definitions/UserReferencePayloadV2'
                 example:
                     - email: bob@example.com
                       id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22821,7 +22940,7 @@ definitions:
             working_interval:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleRotationWorkingIntervalCreatePayloadV2RequestBody'
+                    $ref: '#/definitions/ScheduleRotationWorkingIntervalCreatePayloadV2'
                 example:
                     - end_time: "17:00"
                       start_time: "09:00"
@@ -22847,8 +22966,8 @@ definitions:
                   weekday: tuesday
         required:
             - name
-    ScheduleRotationHandoverV2RequestBody:
-        title: ScheduleRotationHandoverV2RequestBody
+    ScheduleRotationHandoverV2:
+        title: ScheduleRotationHandoverV2
         type: object
         properties:
             interval:
@@ -22865,26 +22984,8 @@ definitions:
         example:
             interval: 1
             interval_type: daily
-    ScheduleRotationHandoverV2ResponseBody:
-        title: ScheduleRotationHandoverV2ResponseBody
-        type: object
-        properties:
-            interval:
-                type: integer
-                example: 1
-                format: int64
-            interval_type:
-                type: string
-                example: daily
-                enum:
-                    - hourly
-                    - daily
-                    - weekly
-        example:
-            interval: 1
-            interval_type: daily
-    ScheduleRotationUpdatePayloadV2RequestBody:
-        title: ScheduleRotationUpdatePayloadV2RequestBody
+    ScheduleRotationUpdatePayloadV2:
+        title: ScheduleRotationUpdatePayloadV2
         type: object
         properties:
             effective_from:
@@ -22898,7 +22999,7 @@ definitions:
             handovers:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleRotationHandoverV2RequestBody'
+                    $ref: '#/definitions/ScheduleRotationHandoverV2'
                 example:
                     - interval: 1
                       interval_type: daily
@@ -22909,7 +23010,7 @@ definitions:
             layers:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleLayerUpdatePayloadV2RequestBody'
+                    $ref: '#/definitions/ScheduleLayerUpdatePayloadV2'
                 example:
                     - id: 01G0J1EXE7AXZ2C93K61WBPYEH
                       name: Layer 1
@@ -22920,7 +23021,7 @@ definitions:
             users:
                 type: array
                 items:
-                    $ref: '#/definitions/UserReferencePayloadV2RequestBody'
+                    $ref: '#/definitions/UserReferencePayloadV2'
                 example:
                     - email: bob@example.com
                       id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22928,7 +23029,7 @@ definitions:
             working_interval:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleRotationWorkingIntervalUpdatePayloadV2RequestBody'
+                    $ref: '#/definitions/ScheduleRotationWorkingIntervalUpdatePayloadV2'
                 example:
                     - end_time: "17:00"
                       start_time: "09:00"
@@ -22952,8 +23053,8 @@ definitions:
                 - end_time: "17:00"
                   start_time: "09:00"
                   weekday: tuesday
-    ScheduleRotationV2ResponseBody:
-        title: ScheduleRotationV2ResponseBody
+    ScheduleRotationV2:
+        title: ScheduleRotationV2
         type: object
         properties:
             effective_from:
@@ -22969,7 +23070,7 @@ definitions:
             handovers:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleRotationHandoverV2ResponseBody'
+                    $ref: '#/definitions/ScheduleRotationHandoverV2'
                 description: Defines the handover intervals for this rota, in order they should apply
                 example:
                     - interval: 1
@@ -22981,7 +23082,7 @@ definitions:
             layers:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleLayerV2ResponseBody'
+                    $ref: '#/definitions/ScheduleLayerV2'
                 description: Controls how many people are on-call concurrently
                 example:
                     - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22993,7 +23094,7 @@ definitions:
             users:
                 type: array
                 items:
-                    $ref: '#/definitions/UserV2ResponseBody'
+                    $ref: '#/definitions/UserV2'
                 example:
                     - email: lisa@incident.io
                       id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -23003,7 +23104,7 @@ definitions:
             working_interval:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleRotationWorkingIntervalV2ResponseBody'
+                    $ref: '#/definitions/ScheduleRotationWorkingIntervalV2'
                 example:
                     - end_time: "17:00"
                       start_time: "09:00"
@@ -23037,8 +23138,8 @@ definitions:
             - working_intervals
             - handover_start_at
             - handovers
-    ScheduleRotationWorkingIntervalCreatePayloadV2RequestBody:
-        title: ScheduleRotationWorkingIntervalCreatePayloadV2RequestBody
+    ScheduleRotationWorkingIntervalCreatePayloadV2:
+        title: ScheduleRotationWorkingIntervalCreatePayloadV2
         type: object
         properties:
             end_time:
@@ -23069,8 +23170,8 @@ definitions:
             - weekday
             - start_time
             - end_time
-    ScheduleRotationWorkingIntervalUpdatePayloadV2RequestBody:
-        title: ScheduleRotationWorkingIntervalUpdatePayloadV2RequestBody
+    ScheduleRotationWorkingIntervalUpdatePayloadV2:
+        title: ScheduleRotationWorkingIntervalUpdatePayloadV2
         type: object
         properties:
             end_time:
@@ -23097,8 +23198,8 @@ definitions:
             end_time: "17:00"
             start_time: "09:00"
             weekday: tuesday
-    ScheduleRotationWorkingIntervalV2ResponseBody:
-        title: ScheduleRotationWorkingIntervalV2ResponseBody
+    ScheduleRotationWorkingIntervalV2:
+        title: ScheduleRotationWorkingIntervalV2
         type: object
         properties:
             end_time:
@@ -23129,8 +23230,8 @@ definitions:
             - weekday
             - start_time
             - end_time
-    ScheduleUpdatePayloadV2RequestBody:
-        title: ScheduleUpdatePayloadV2RequestBody
+    ScheduleUpdatePayloadV2:
+        title: ScheduleUpdatePayloadV2
         type: object
         properties:
             annotations:
@@ -23142,9 +23243,9 @@ definitions:
                     type: string
                     example: abc123
             config:
-                $ref: '#/definitions/ScheduleConfigUpdatePayloadV2RequestBody'
+                $ref: '#/definitions/ScheduleConfigUpdatePayloadV2'
             holidays_public_config:
-                $ref: '#/definitions/ScheduleHolidaysPublicConfigPayloadV2RequestBody'
+                $ref: '#/definitions/ScheduleHolidaysPublicConfigPayloadV2'
             name:
                 type: string
                 description: Name of the schedule
@@ -23181,8 +23282,8 @@ definitions:
                     - abc123
             name: My Schedule
             timezone: America/Los_Angeles
-    ScheduleV2ResponseBody:
-        title: ScheduleV2ResponseBody
+    ScheduleV2:
+        title: ScheduleV2
         type: object
         properties:
             annotations:
@@ -23194,7 +23295,7 @@ definitions:
                     type: string
                     example: abc123
             config:
-                $ref: '#/definitions/ScheduleConfigV2ResponseBody'
+                $ref: '#/definitions/ScheduleConfigV2'
             created_at:
                 type: string
                 example: "2021-08-17T13:28:57.801578Z"
@@ -23202,7 +23303,7 @@ definitions:
             current_shifts:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleEntryV2ResponseBody'
+                    $ref: '#/definitions/ScheduleEntryV2'
                 description: Shifts that are on-going for this schedule, if a native schedule
                 example:
                     - end_at: "2021-08-17T13:28:57.801578Z"
@@ -23218,7 +23319,7 @@ definitions:
                         role: viewer
                         slack_user_id: U02AYNF2XJM
             holidays_public_config:
-                $ref: '#/definitions/ScheduleHolidaysPublicConfigV2ResponseBody'
+                $ref: '#/definitions/ScheduleHolidaysPublicConfigV2'
             id:
                 type: string
                 description: Unique internal ID of the schedule
@@ -23296,7 +23397,7 @@ definitions:
         type: object
         properties:
             schedule:
-                $ref: '#/definitions/ScheduleCreatePayloadV2RequestBody'
+                $ref: '#/definitions/ScheduleCreatePayloadV2'
         example:
             schedule:
                 annotations:
@@ -23333,7 +23434,7 @@ definitions:
         type: object
         properties:
             schedule:
-                $ref: '#/definitions/ScheduleV2ResponseBody'
+                $ref: '#/definitions/ScheduleV2'
         example:
             schedule:
                 annotations:
@@ -23389,11 +23490,11 @@ definitions:
         type: object
         properties:
             pagination_meta:
-                $ref: '#/definitions/PaginationMetaResultWithTotalResponseBody'
+                $ref: '#/definitions/PaginationMetaResultWithTotal'
             schedules:
                 type: array
                 items:
-                    $ref: '#/definitions/ScheduleV2ResponseBody'
+                    $ref: '#/definitions/ScheduleV2'
                 example:
                     - annotations:
                         incident.io/terraform/version: 3.0.0
@@ -23500,9 +23601,9 @@ definitions:
         type: object
         properties:
             pagination_meta:
-                $ref: '#/definitions/AfterPaginationMetaResultV2ResponseBody'
+                $ref: '#/definitions/AfterPaginationMetaResultV2'
             schedule_entries:
-                $ref: '#/definitions/ScheduleEntriesListPayloadV2ResponseBody'
+                $ref: '#/definitions/ScheduleEntriesListPayloadV2'
         example:
             pagination_meta:
                 after: abc123
@@ -23554,7 +23655,7 @@ definitions:
         type: object
         properties:
             schedule:
-                $ref: '#/definitions/ScheduleV2ResponseBody'
+                $ref: '#/definitions/ScheduleV2'
         example:
             schedule:
                 annotations:
@@ -23610,7 +23711,7 @@ definitions:
         type: object
         properties:
             schedule:
-                $ref: '#/definitions/ScheduleUpdatePayloadV2RequestBody'
+                $ref: '#/definitions/ScheduleUpdatePayloadV2'
         example:
             schedule:
                 annotations:
@@ -23654,7 +23755,7 @@ definitions:
         type: object
         properties:
             schedule:
-                $ref: '#/definitions/ScheduleV2ResponseBody'
+                $ref: '#/definitions/ScheduleV2'
         example:
             schedule:
                 annotations:
@@ -23735,7 +23836,7 @@ definitions:
         type: object
         properties:
             severity:
-                $ref: '#/definitions/SeverityV1ResponseBody'
+                $ref: '#/definitions/SeverityV1'
         example:
             severity:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -23753,7 +23854,7 @@ definitions:
             severities:
                 type: array
                 items:
-                    $ref: '#/definitions/SeverityV1ResponseBody'
+                    $ref: '#/definitions/SeverityV1'
                 example:
                     - created_at: "2021-08-17T13:28:57.801578Z"
                       description: Issues with **low impact**.
@@ -23776,7 +23877,7 @@ definitions:
         type: object
         properties:
             severity:
-                $ref: '#/definitions/SeverityV1ResponseBody'
+                $ref: '#/definitions/SeverityV1'
         example:
             severity:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -23817,7 +23918,7 @@ definitions:
         type: object
         properties:
             severity:
-                $ref: '#/definitions/SeverityV1ResponseBody'
+                $ref: '#/definitions/SeverityV1'
         example:
             severity:
                 created_at: "2021-08-17T13:28:57.801578Z"
@@ -23828,8 +23929,8 @@ definitions:
                 updated_at: "2021-08-17T13:28:57.801578Z"
         required:
             - severity
-    SeverityV1ResponseBody:
-        title: SeverityV1ResponseBody
+    SeverityV1:
+        title: SeverityV1
         type: object
         properties:
             created_at:
@@ -23874,8 +23975,8 @@ definitions:
             - rank
             - created_at
             - updated_at
-    SeverityV2ResponseBody:
-        title: SeverityV2ResponseBody
+    SeverityV2:
+        title: SeverityV2
         type: object
         properties:
             created_at:
@@ -23920,54 +24021,8 @@ definitions:
             - rank
             - created_at
             - updated_at
-    StepConfigPayloadRequestBody:
-        title: StepConfigPayloadRequestBody
-        type: object
-        properties:
-            for_each:
-                type: string
-                description: Reference to an expression that returns resources to run this step over
-                example: abc123
-            id:
-                type: string
-                description: Unique ID of this step in a workflow. This must be a valid ULID.
-                example: abc123
-            name:
-                type: string
-                description: Unique name of the step in the engine
-                example: pagerduty.escalate
-            param_bindings:
-                type: array
-                items:
-                    $ref: '#/definitions/EngineParamBindingPayloadV2RequestBody'
-                description: List of parameter bindings
-                example:
-                    - array_value:
-                        - literal: SEV123
-                          reference: incident.severity
-                      value:
-                        literal: SEV123
-                        reference: incident.severity
-        example:
-            for_each: abc123
-            id: abc123
-            name: pagerduty.escalate
-            param_bindings:
-                - array_value:
-                    - literal: SEV123
-                      reference: incident.severity
-                  value:
-                    literal: SEV123
-                    reference: incident.severity
-        required:
-            - id
-            - name
-            - param_bindings
-            - label
-            - description
-            - params
-    StepConfigResponseBody:
-        title: StepConfigResponseBody
+    StepConfig:
+        title: StepConfig
         type: object
         properties:
             for_each:
@@ -23989,7 +24044,7 @@ definitions:
             param_bindings:
                 type: array
                 items:
-                    $ref: '#/definitions/EngineParamBindingV2ResponseBody'
+                    $ref: '#/definitions/EngineParamBindingV2'
                 description: Bindings for the step parameters
                 example:
                     - array_value:
@@ -24021,8 +24076,54 @@ definitions:
             - description
             - param_bindings
             - params
-    StepConfigSlimResponseBody:
-        title: StepConfigSlimResponseBody
+    StepConfigPayload:
+        title: StepConfigPayload
+        type: object
+        properties:
+            for_each:
+                type: string
+                description: Reference to an expression that returns resources to run this step over
+                example: abc123
+            id:
+                type: string
+                description: Unique ID of this step in a workflow. This must be a valid ULID.
+                example: abc123
+            name:
+                type: string
+                description: Unique name of the step in the engine
+                example: pagerduty.escalate
+            param_bindings:
+                type: array
+                items:
+                    $ref: '#/definitions/EngineParamBindingPayloadV2'
+                description: List of parameter bindings
+                example:
+                    - array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                      value:
+                        literal: SEV123
+                        reference: incident.severity
+        example:
+            for_each: abc123
+            id: abc123
+            name: pagerduty.escalate
+            param_bindings:
+                - array_value:
+                    - literal: SEV123
+                      reference: incident.severity
+                  value:
+                    literal: SEV123
+                    reference: incident.severity
+        required:
+            - id
+            - name
+            - param_bindings
+            - label
+            - description
+            - params
+    StepConfigSlim:
+        title: StepConfigSlim
         type: object
         properties:
             label:
@@ -24041,8 +24142,8 @@ definitions:
             - label
             - description
             - params
-    TriggerSlimResponseBody:
-        title: TriggerSlimResponseBody
+    TriggerSlim:
+        title: TriggerSlim
         type: object
         properties:
             label:
@@ -24059,8 +24160,273 @@ definitions:
         required:
             - name
             - label
-    UserReferencePayloadV1RequestBody:
-        title: UserReferencePayloadV1RequestBody
+    UpdateWorkflowPayload:
+        title: UpdateWorkflowPayload
+        type: object
+        properties:
+            annotations:
+                type: object
+                description: Annotations that track metadata about this resource
+                example:
+                    incident.io/terraform/version: 3.0.0
+                additionalProperties:
+                    type: string
+                    example: abc123
+            condition_groups:
+                type: array
+                items:
+                    $ref: '#/definitions/ConditionGroupPayloadV2'
+                description: List of conditions to apply to the workflow
+                example:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+            continue_on_step_error:
+                type: boolean
+                description: Whether to continue executing the workflow if a step fails
+                example: true
+            delay:
+                $ref: '#/definitions/WorkflowDelay'
+            expressions:
+                type: array
+                items:
+                    $ref: '#/definitions/ExpressionPayloadV2'
+                description: The expressions used in the workflow
+                example:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                                  result:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                          navigate:
+                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                      reference: abc123
+                      root_reference: incident.status
+            folder:
+                type: string
+                description: Folder to display the workflow in
+                example: My folder 01
+            include_private_incidents:
+                type: boolean
+                description: Whether to include private incidents
+                example: true
+            name:
+                type: string
+                description: The human-readable name of the workflow
+                example: My workflow
+            once_for:
+                type: array
+                items:
+                    type: string
+                    example: incident.url
+                description: Once For strategy to apply to this workflow
+                example:
+                    - incident.url
+            runs_on_incident_modes:
+                type: array
+                items:
+                    type: string
+                    example: test
+                    enum:
+                        - standard
+                        - test
+                        - retrospective
+                description: Which modes of incident this should run on (defaults to just standard incidents)
+                example:
+                    - standard
+                    - retrospective
+            runs_on_incidents:
+                type: string
+                description: Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
+                example: newly_created
+                enum:
+                    - newly_created
+                    - newly_created_and_active
+            state:
+                type: string
+                description: The state of the workflow (e.g. is it draft, or disabled)
+                example: active
+                enum:
+                    - active
+                    - disabled
+                    - draft
+                    - error
+            steps:
+                type: array
+                items:
+                    $ref: '#/definitions/StepConfigPayload'
+                description: List of step to execute as part of the workflow
+                example:
+                    - for_each: abc123
+                      id: abc123
+                      name: pagerduty.escalate
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+        example:
+            annotations:
+                incident.io/terraform/version: 3.0.0
+            condition_groups:
+                - conditions:
+                    - operation: one_of
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+                      subject: incident.severity
+            continue_on_step_error: true
+            delay:
+                conditions_apply_over_delay: false
+                for_seconds: 60
+            expressions:
+                - else_branch:
+                    result:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                  label: Team Slack channel
+                  operations:
+                    - branches:
+                        branches:
+                            - condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                              result:
+                                array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                      filter:
+                        condition_groups:
+                            - conditions:
+                                - operation: one_of
+                                  param_bindings:
+                                    - array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject: incident.severity
+                      navigate:
+                        reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                      operation_type: navigate
+                      parse:
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                        source: metadata.annotations["github.com/repo"]
+                  reference: abc123
+                  root_reference: incident.status
+            folder: My folder 01
+            include_private_incidents: true
+            name: My workflow
+            once_for:
+                - incident.url
+            runs_on_incident_modes:
+                - standard
+                - retrospective
+            runs_on_incidents: newly_created
+            state: active
+            steps:
+                - for_each: abc123
+                  id: abc123
+                  name: pagerduty.escalate
+                  param_bindings:
+                    - array_value:
+                        - literal: SEV123
+                          reference: incident.severity
+                      value:
+                        literal: SEV123
+                        reference: incident.severity
+        required:
+            - name
+            - once_for
+            - condition_groups
+            - steps
+            - expressions
+            - include_private_incidents
+            - runs_on_incident_modes
+            - continue_on_step_error
+            - runs_on_incidents
+    UserReferencePayloadV1:
+        title: UserReferencePayloadV1
         type: object
         properties:
             email:
@@ -24079,8 +24445,8 @@ definitions:
             email: bob@example.com
             id: 01G0J1EXE7AXZ2C93K61WBPYEH
             slack_user_id: USER123
-    UserReferencePayloadV2RequestBody:
-        title: UserReferencePayloadV2RequestBody
+    UserReferencePayloadV2:
+        title: UserReferencePayloadV2
         type: object
         properties:
             email:
@@ -24099,8 +24465,8 @@ definitions:
             email: bob@example.com
             id: 01G0J1EXE7AXZ2C93K61WBPYEH
             slack_user_id: USER123
-    UserV1ResponseBody:
-        title: UserV1ResponseBody
+    UserV1:
+        title: UserV1
         type: object
         properties:
             email:
@@ -24142,8 +24508,8 @@ definitions:
             - name
             - deprecated_base_role
             - organisation_id
-    UserV2ResponseBody:
-        title: UserV2ResponseBody
+    UserV2:
+        title: UserV2
         type: object
         properties:
             email:
@@ -24185,16 +24551,16 @@ definitions:
             - name
             - deprecated_base_role
             - organisation_id
-    UserWithRolesV2ResponseBody:
-        title: UserWithRolesV2ResponseBody
+    UserWithRolesV2:
+        title: UserWithRolesV2
         type: object
         properties:
             base_role:
-                $ref: '#/definitions/RBACRoleV2ResponseBody'
+                $ref: '#/definitions/RBACRoleV2'
             custom_roles:
                 type: array
                 items:
-                    $ref: '#/definitions/RBACRoleV2ResponseBody'
+                    $ref: '#/definitions/RBACRoleV2'
                 example:
                     - description: Elevated permissions for the customer success team.
                       id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -24256,11 +24622,11 @@ definitions:
         type: object
         properties:
             pagination_meta:
-                $ref: '#/definitions/PaginationMetaResultResponseBody'
+                $ref: '#/definitions/PaginationMetaResult'
             users:
                 type: array
                 items:
-                    $ref: '#/definitions/UserWithRolesV2ResponseBody'
+                    $ref: '#/definitions/UserWithRolesV2'
                 example:
                     - base_role:
                         description: Elevated permissions for the customer success team.
@@ -24305,7 +24671,7 @@ definitions:
         type: object
         properties:
             user:
-                $ref: '#/definitions/UserWithRolesV2ResponseBody'
+                $ref: '#/definitions/UserWithRolesV2'
         example:
             user:
                 base_role:
@@ -24330,7 +24696,7 @@ definitions:
         type: object
         properties:
             identity:
-                $ref: '#/definitions/IdentityV1ResponseBody'
+                $ref: '#/definitions/IdentityV1'
         example:
             identity:
                 dashboard_url: https://app.incident.io/my-org
@@ -24339,6 +24705,360 @@ definitions:
                     - incident_creator
         required:
             - identity
+    WebhookIncidentUserV2:
+        title: WebhookIncidentUserV2
+        type: object
+        properties:
+            actor_user_id:
+                type: string
+                description: The ID of the user who performed this action. If the action was not taken by a user, for example it was taken by a Workflow, this will be empty.
+                example: abc123
+            incident_id:
+                type: string
+                description: The ID of the incident
+                example: abc123
+            user_id:
+                type: string
+                description: The ID of the user
+                example: abc123
+        example:
+            actor_user_id: abc123
+            incident_id: abc123
+            user_id: abc123
+        required:
+            - incident_id
+            - user_id
+    WebhookIncidentV2:
+        title: WebhookIncidentV2
+        type: object
+        properties:
+            call_url:
+                type: string
+                description: The call URL attached to this incident
+                example: https://zoom.us/foo
+            created_at:
+                type: string
+                description: When the incident was created
+                example: "2021-08-17T13:28:57.801578Z"
+                format: date-time
+            creator:
+                $ref: '#/definitions/ActorV2'
+            custom_field_entries:
+                type: array
+                items:
+                    $ref: '#/definitions/CustomFieldEntryV2'
+                description: Custom field entries for this incident
+                example:
+                    - custom_field:
+                        description: Which team is impacted by this issue
+                        field_type: single_select
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Affected Team
+                        options:
+                            - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              sort_key: 10
+                              value: Product
+                      values:
+                        - value_catalog_entry:
+                            aliases:
+                                - lawrence@incident.io
+                                - lawrence
+                            external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: Primary On-call
+                          value_link: https://google.com/
+                          value_numeric: "123.456"
+                          value_option:
+                            custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            sort_key: 10
+                            value: Product
+                          value_text: This is my text field, I hope you like it
+            duration_metrics:
+                type: array
+                items:
+                    $ref: '#/definitions/IncidentDurationMetricWithValueV2'
+                description: Incident duration metrics and their measurements for this incident
+                example:
+                    - duration_metric:
+                        id: 01FCNDV6P870EA6S7TK1DSYD5H
+                        name: Lasted
+                      value_seconds: 1
+            external_issue_reference:
+                $ref: '#/definitions/ExternalIssueReferenceV2'
+            id:
+                type: string
+                description: Unique identifier for the incident
+                example: 01FDAG4SAP5TYPT98WGR2N7W91
+            incident_role_assignments:
+                type: array
+                items:
+                    $ref: '#/definitions/IncidentRoleAssignmentV2'
+                description: A list of who is assigned to each role for this incident
+                example:
+                    - assignee:
+                        email: lisa@incident.io
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Lisa Karlin Curtis
+                        role: viewer
+                        slack_user_id: U02AYNF2XJM
+                      role:
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        description: The person currently coordinating the incident
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        instructions: Take point on the incident; Make sure people are clear on responsibilities
+                        name: Incident Lead
+                        required: false
+                        role_type: lead
+                        shortform: lead
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+            incident_status:
+                $ref: '#/definitions/IncidentStatusV2'
+            incident_timestamp_values:
+                type: array
+                items:
+                    $ref: '#/definitions/IncidentTimestampWithValueV2'
+                description: Incident lifecycle events and when they occurred
+                example:
+                    - incident_timestamp:
+                        id: 01FCNDV6P870EA6S7TK1DSYD5H
+                        name: Impact started
+                        rank: 1
+                      value:
+                        value: "2021-08-17T13:28:57.801578Z"
+            incident_type:
+                $ref: '#/definitions/IncidentTypeV2'
+            mode:
+                type: string
+                description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
+                example: standard
+                enum:
+                    - standard
+                    - retrospective
+                    - test
+                    - tutorial
+            name:
+                type: string
+                description: Explanation of the incident
+                example: Our database is sad
+            permalink:
+                type: string
+                description: A permanent link to the homepage for this incident
+                example: https://app.incident.io/incidents/123
+            postmortem_document_url:
+                type: string
+                description: Description of the incident
+                example: https://docs.google.com/my_doc_id
+            reference:
+                type: string
+                description: Reference to this incident, as displayed across the product
+                example: INC-123
+            related_incidents:
+                type: array
+                items:
+                    type: string
+                    example: abc123
+                description: Incident IDs of incidents related to this incident
+                example:
+                    - INC-237
+            severity:
+                $ref: '#/definitions/SeverityV2'
+            slack_channel_id:
+                type: string
+                description: ID of the Slack channel in the organisation Slack workspace. Note that the channel is sometimes created asynchronously, so may not be present when the incident is just created.
+                example: C02AW36C1M5
+            slack_channel_name:
+                type: string
+                description: Name of the slack channel
+                example: inc-165-green-parrot
+            slack_team_id:
+                type: string
+                description: ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
+                example: T02A1FSLE8J
+            summary:
+                type: string
+                description: Detailed description of the incident
+                example: Our database is really really sad, and we don't know why yet.
+            updated_at:
+                type: string
+                description: When the incident was last updated
+                example: "2021-08-17T13:28:57.801578Z"
+                format: date-time
+            visibility:
+                type: string
+                description: Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+                example: public
+                enum:
+                    - public
+                    - private
+            workload_minutes_late:
+                type: number
+                description: Amount of time spent on the incident in late hours
+                example: 40.7
+                format: double
+            workload_minutes_sleeping:
+                type: number
+                description: Amount of time spent on the incident in sleeping hours
+                example: 0
+                format: double
+            workload_minutes_total:
+                type: number
+                description: Amount of time spent on the incident in total
+                example: 60.7
+                format: double
+            workload_minutes_working:
+                type: number
+                description: Amount of time spent on the incident in working hours
+                example: 20
+                format: double
+        example:
+            call_url: https://zoom.us/foo
+            created_at: "2021-08-17T13:28:57.801578Z"
+            creator:
+                api_key:
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: My test API key
+                user:
+                    email: lisa@incident.io
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: Lisa Karlin Curtis
+                    role: viewer
+                    slack_user_id: U02AYNF2XJM
+            custom_field_entries:
+                - custom_field:
+                    description: Which team is impacted by this issue
+                    field_type: single_select
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: Affected Team
+                    options:
+                        - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          sort_key: 10
+                          value: Product
+                  values:
+                    - value_catalog_entry:
+                        aliases:
+                            - lawrence@incident.io
+                            - lawrence
+                        external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Primary On-call
+                      value_link: https://google.com/
+                      value_numeric: "123.456"
+                      value_option:
+                        custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        sort_key: 10
+                        value: Product
+                      value_text: This is my text field, I hope you like it
+            duration_metrics:
+                - duration_metric:
+                    id: 01FCNDV6P870EA6S7TK1DSYD5H
+                    name: Lasted
+                  value_seconds: 1
+            external_issue_reference:
+                issue_name: INC-123
+                issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider: asana
+            id: 01FDAG4SAP5TYPT98WGR2N7W91
+            incident_role_assignments:
+                - assignee:
+                    email: lisa@incident.io
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: Lisa Karlin Curtis
+                    role: viewer
+                    slack_user_id: U02AYNF2XJM
+                  role:
+                    created_at: "2021-08-17T13:28:57.801578Z"
+                    description: The person currently coordinating the incident
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    instructions: Take point on the incident; Make sure people are clear on responsibilities
+                    name: Incident Lead
+                    required: false
+                    role_type: lead
+                    shortform: lead
+                    updated_at: "2021-08-17T13:28:57.801578Z"
+            incident_status:
+                category: triage
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                id: 01FCNDV6P870EA6S7TK1DSYD5H
+                name: Closed
+                rank: 4
+                updated_at: "2021-08-17T13:28:57.801578Z"
+            incident_timestamp_values:
+                - incident_timestamp:
+                    id: 01FCNDV6P870EA6S7TK1DSYD5H
+                    name: Impact started
+                    rank: 1
+                  value:
+                    value: "2021-08-17T13:28:57.801578Z"
+            incident_type:
+                create_in_triage: always
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Customer facing production outages
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                is_default: false
+                name: Production Outage
+                private_incidents_only: false
+                updated_at: "2021-08-17T13:28:57.801578Z"
+            mode: standard
+            name: Our database is sad
+            permalink: https://app.incident.io/incidents/123
+            postmortem_document_url: https://docs.google.com/my_doc_id
+            reference: INC-123
+            related_incidents:
+                - INC-237
+            severity:
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Issues with **low impact**.
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Minor
+                rank: 1
+                updated_at: "2021-08-17T13:28:57.801578Z"
+            slack_channel_id: C02AW36C1M5
+            slack_channel_name: inc-165-green-parrot
+            slack_team_id: T02A1FSLE8J
+            summary: Our database is really really sad, and we don't know why yet.
+            updated_at: "2021-08-17T13:28:57.801578Z"
+            visibility: public
+            workload_minutes_late: 40.7
+            workload_minutes_sleeping: 0
+            workload_minutes_total: 60.7
+            workload_minutes_working: 20
+        required:
+            - incident_status
+            - id
+            - external_id
+            - reference
+            - name
+            - idempotency_key
+            - did_opt_out_of_post_incident_flow
+            - visibility
+            - mode
+            - organisation_id
+            - creator
+            - last_activity_at
+            - incident_role_assignments
+            - custom_field_entries
+            - slack_team_id
+            - slack_channel_id
+            - created_at
+            - updated_at
+            - reported_at
+    WebhookPrivateResourceV2:
+        title: WebhookPrivateResourceV2
+        type: object
+        properties:
+            id:
+                type: string
+                description: The ID of the resource
+                example: abc123
+        example:
+            id: abc123
+        required:
+            - id
     WebhooksAllResponseBody:
         title: WebhooksAllResponseBody
         type: object
@@ -24364,35 +25084,35 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             private_incident.action_created_v1:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
             private_incident.action_updated_v1:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
             private_incident.follow_up_created_v1:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
             private_incident.follow_up_updated_v1:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
             private_incident.incident_created_v2:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
             private_incident.incident_updated_v2:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
             private_incident.membership_granted_v1:
-                $ref: '#/definitions/webhook_incident_userV2ResponseBody'
+                $ref: '#/definitions/WebhookIncidentUserV2'
             private_incident.membership_revoked_v1:
-                $ref: '#/definitions/webhook_incident_userV2ResponseBody'
+                $ref: '#/definitions/WebhookIncidentUserV2'
             public_incident.action_created_v1:
-                $ref: '#/definitions/ActionV1ResponseBody'
+                $ref: '#/definitions/ActionV1'
             public_incident.action_updated_v1:
-                $ref: '#/definitions/ActionV1ResponseBody'
+                $ref: '#/definitions/ActionV1'
             public_incident.follow_up_created_v1:
-                $ref: '#/definitions/ActionV1ResponseBody'
+                $ref: '#/definitions/ActionV1'
             public_incident.follow_up_updated_v1:
-                $ref: '#/definitions/ActionV1ResponseBody'
+                $ref: '#/definitions/ActionV1'
             public_incident.incident_created_v2:
-                $ref: '#/definitions/webhook_incidentV2ResponseBody'
+                $ref: '#/definitions/WebhookIncidentV2'
             public_incident.incident_status_updated_v2:
-                $ref: '#/definitions/IncidentWithStatusChangeV2ResponseBody'
+                $ref: '#/definitions/IncidentWithStatusChangeV2'
             public_incident.incident_updated_v2:
-                $ref: '#/definitions/webhook_incidentV2ResponseBody'
+                $ref: '#/definitions/WebhookIncidentV2'
         example:
             event_type: public_incident.incident_created_v2
             private_incident.action_created_v1:
@@ -24878,7 +25598,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             private_incident.action_created_v1:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
         example:
             event_type: private_incident.action_created_v1
             private_incident.action_created_v1:
@@ -24911,7 +25631,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             private_incident.action_updated_v1:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
         example:
             event_type: private_incident.action_updated_v1
             private_incident.action_updated_v1:
@@ -24944,7 +25664,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             private_incident.follow_up_created_v1:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
         example:
             event_type: private_incident.follow_up_created_v1
             private_incident.follow_up_created_v1:
@@ -24977,7 +25697,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             private_incident.follow_up_updated_v1:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
         example:
             event_type: private_incident.follow_up_updated_v1
             private_incident.follow_up_updated_v1:
@@ -25010,7 +25730,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             private_incident.incident_created_v2:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
         example:
             event_type: private_incident.incident_created_v2
             private_incident.incident_created_v2:
@@ -25043,7 +25763,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             private_incident.incident_updated_v2:
-                $ref: '#/definitions/webhook_private_resourceV2ResponseBody'
+                $ref: '#/definitions/WebhookPrivateResourceV2'
         example:
             event_type: private_incident.incident_updated_v2
             private_incident.incident_updated_v2:
@@ -25076,7 +25796,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             private_incident.membership_granted_v1:
-                $ref: '#/definitions/webhook_incident_userV2ResponseBody'
+                $ref: '#/definitions/WebhookIncidentUserV2'
         example:
             event_type: private_incident.membership_granted_v1
             private_incident.membership_granted_v1:
@@ -25111,7 +25831,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             private_incident.membership_revoked_v1:
-                $ref: '#/definitions/webhook_incident_userV2ResponseBody'
+                $ref: '#/definitions/WebhookIncidentUserV2'
         example:
             event_type: private_incident.membership_revoked_v1
             private_incident.membership_revoked_v1:
@@ -25146,7 +25866,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             public_incident.action_created_v1:
-                $ref: '#/definitions/ActionV1ResponseBody'
+                $ref: '#/definitions/ActionV1'
         example:
             event_type: public_incident.action_created_v1
             public_incident.action_created_v1:
@@ -25196,7 +25916,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             public_incident.action_updated_v1:
-                $ref: '#/definitions/ActionV1ResponseBody'
+                $ref: '#/definitions/ActionV1'
         example:
             event_type: public_incident.action_updated_v1
             public_incident.action_updated_v1:
@@ -25246,7 +25966,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             public_incident.follow_up_created_v1:
-                $ref: '#/definitions/ActionV1ResponseBody'
+                $ref: '#/definitions/ActionV1'
         example:
             event_type: public_incident.follow_up_created_v1
             public_incident.follow_up_created_v1:
@@ -25296,7 +26016,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             public_incident.follow_up_updated_v1:
-                $ref: '#/definitions/ActionV1ResponseBody'
+                $ref: '#/definitions/ActionV1'
         example:
             event_type: public_incident.follow_up_updated_v1
             public_incident.follow_up_updated_v1:
@@ -25346,7 +26066,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             public_incident.incident_created_v2:
-                $ref: '#/definitions/webhook_incidentV2ResponseBody'
+                $ref: '#/definitions/WebhookIncidentV2'
         example:
             event_type: public_incident.incident_created_v2
             public_incident.incident_created_v2:
@@ -25492,7 +26212,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             public_incident.incident_status_updated_v2:
-                $ref: '#/definitions/IncidentWithStatusChangeV2ResponseBody'
+                $ref: '#/definitions/IncidentWithStatusChangeV2'
         example:
             event_type: public_incident.incident_status_updated_v2
             public_incident.incident_status_updated_v2:
@@ -25653,7 +26373,7 @@ definitions:
                     - private_incident.membership_granted_v1
                     - private_incident.membership_revoked_v1
             public_incident.incident_updated_v2:
-                $ref: '#/definitions/webhook_incidentV2ResponseBody'
+                $ref: '#/definitions/WebhookIncidentV2'
         example:
             event_type: public_incident.incident_updated_v2
             public_incident.incident_updated_v2:
@@ -25774,8 +26494,8 @@ definitions:
         required:
             - event_type
             - public_incident.incident_updated_v2
-    WeekdayIntervalConfigV2RequestBody:
-        title: WeekdayIntervalConfigV2RequestBody
+    WeekdayIntervalConfigV2:
+        title: WeekdayIntervalConfigV2
         type: object
         properties:
             id:
@@ -25793,7 +26513,7 @@ definitions:
             weekday_intervals:
                 type: array
                 items:
-                    $ref: '#/definitions/WeekdayIntervalV2RequestBody'
+                    $ref: '#/definitions/WeekdayIntervalV2'
                 example:
                     - end_time: "17:00"
                       start_time: "09:00"
@@ -25811,45 +26531,8 @@ definitions:
             - name
             - timezone
             - weekday_intervals
-    WeekdayIntervalConfigV2ResponseBody:
-        title: WeekdayIntervalConfigV2ResponseBody
-        type: object
-        properties:
-            id:
-                type: string
-                description: The unique identifier for this set of working intervals
-                example: abc123
-            name:
-                type: string
-                description: A human readable label for this set of working intervals
-                example: abc123
-            timezone:
-                type: string
-                description: How to interpret all the intervals
-                example: abc123
-            weekday_intervals:
-                type: array
-                items:
-                    $ref: '#/definitions/WeekdayIntervalV2ResponseBody'
-                example:
-                    - end_time: "17:00"
-                      start_time: "09:00"
-                      weekday: abc123
-        example:
-            id: abc123
-            name: abc123
-            timezone: abc123
-            weekday_intervals:
-                - end_time: "17:00"
-                  start_time: "09:00"
-                  weekday: abc123
-        required:
-            - id
-            - name
-            - timezone
-            - weekday_intervals
-    WeekdayIntervalV2RequestBody:
-        title: WeekdayIntervalV2RequestBody
+    WeekdayIntervalV2:
+        title: WeekdayIntervalV2
         type: object
         properties:
             end_time:
@@ -25872,76 +26555,14 @@ definitions:
             - weekday
             - start_time
             - end_time
-    WeekdayIntervalV2ResponseBody:
-        title: WeekdayIntervalV2ResponseBody
-        type: object
-        properties:
-            end_time:
-                type: string
-                description: End time of the interval, in 24hr format
-                example: "17:00"
-            start_time:
-                type: string
-                description: Start time of the interval, in 24hr format
-                example: "09:00"
-            weekday:
-                type: string
-                description: Weekday this interval applies to
-                example: abc123
-        example:
-            end_time: "17:00"
-            start_time: "09:00"
-            weekday: abc123
-        required:
-            - weekday
-            - start_time
-            - end_time
-    WorkflowDelayRequestBody:
-        title: WorkflowDelayRequestBody
-        type: object
-        properties:
-            conditions_apply_over_delay:
-                type: boolean
-                description: If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution
-                example: false
-            for_seconds:
-                type: integer
-                description: Delay in seconds between trigger firing and running the workflow
-                example: 60
-                format: int64
-        example:
-            conditions_apply_over_delay: false
-            for_seconds: 60
-        required:
-            - for_seconds
-            - conditions_apply_over_delay
-    WorkflowDelayResponseBody:
-        title: WorkflowDelayResponseBody
-        type: object
-        properties:
-            conditions_apply_over_delay:
-                type: boolean
-                description: If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution
-                example: false
-            for_seconds:
-                type: integer
-                description: Delay in seconds between trigger firing and running the workflow
-                example: 60
-                format: int64
-        example:
-            conditions_apply_over_delay: false
-            for_seconds: 60
-        required:
-            - for_seconds
-            - conditions_apply_over_delay
-    WorkflowResponseBody:
-        title: WorkflowResponseBody
+    Workflow:
+        title: Workflow
         type: object
         properties:
             condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupV2ResponseBody'
+                    $ref: '#/definitions/ConditionGroupV2'
                 description: Conditions that apply to the workflow trigger
                 example:
                     - conditions:
@@ -25965,11 +26586,11 @@ definitions:
                 description: Whether to continue executing the workflow if a step fails
                 example: true
             delay:
-                $ref: '#/definitions/WorkflowDelayResponseBody'
+                $ref: '#/definitions/WorkflowDelay'
             expressions:
                 type: array
                 items:
-                    $ref: '#/definitions/ExpressionV2ResponseBody'
+                    $ref: '#/definitions/ExpressionV2'
                 description: Expressions that make variables available in the scope
                 example:
                     - else_branch:
@@ -26069,7 +26690,7 @@ definitions:
             once_for:
                 type: array
                 items:
-                    $ref: '#/definitions/EngineReferenceV2ResponseBody'
+                    $ref: '#/definitions/EngineReferenceV2'
                 description: This workflow will run 'once for' a list of references
                 example:
                     - array: false
@@ -26113,7 +26734,7 @@ definitions:
             steps:
                 type: array
                 items:
-                    $ref: '#/definitions/StepConfigResponseBody'
+                    $ref: '#/definitions/StepConfig'
                 description: Steps that are executed as part of the workflow
                 example:
                     - for_each: abc123
@@ -26130,7 +26751,7 @@ definitions:
                             literal: SEV123
                             reference: incident.severity
             trigger:
-                $ref: '#/definitions/TriggerSlimResponseBody'
+                $ref: '#/definitions/TriggerSlim'
             version:
                 type: integer
                 description: Revision of the workflow, uniquely identifying its version
@@ -26284,14 +26905,33 @@ definitions:
             - runs_on_incidents
             - once_for
             - state
-    WorkflowSlimResponseBody:
-        title: WorkflowSlimResponseBody
+    WorkflowDelay:
+        title: WorkflowDelay
+        type: object
+        properties:
+            conditions_apply_over_delay:
+                type: boolean
+                description: If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution
+                example: false
+            for_seconds:
+                type: integer
+                description: Delay in seconds between trigger firing and running the workflow
+                example: 60
+                format: int64
+        example:
+            conditions_apply_over_delay: false
+            for_seconds: 60
+        required:
+            - for_seconds
+            - conditions_apply_over_delay
+    WorkflowSlim:
+        title: WorkflowSlim
         type: object
         properties:
             condition_groups:
                 type: array
                 items:
-                    $ref: '#/definitions/ConditionGroupV2ResponseBody'
+                    $ref: '#/definitions/ConditionGroupV2'
                 description: Conditions that apply to the workflow trigger
                 example:
                     - conditions:
@@ -26315,11 +26955,11 @@ definitions:
                 description: Whether to continue executing the workflow if a step fails
                 example: true
             delay:
-                $ref: '#/definitions/WorkflowDelayResponseBody'
+                $ref: '#/definitions/WorkflowDelay'
             expressions:
                 type: array
                 items:
-                    $ref: '#/definitions/ExpressionV2ResponseBody'
+                    $ref: '#/definitions/ExpressionV2'
                 description: Expressions that make variables available in the scope
                 example:
                     - else_branch:
@@ -26419,7 +27059,7 @@ definitions:
             once_for:
                 type: array
                 items:
-                    $ref: '#/definitions/EngineReferenceV2ResponseBody'
+                    $ref: '#/definitions/EngineReferenceV2'
                 description: This workflow will run 'once for' a list of references
                 example:
                     - array: false
@@ -26463,13 +27103,13 @@ definitions:
             steps:
                 type: array
                 items:
-                    $ref: '#/definitions/StepConfigSlimResponseBody'
+                    $ref: '#/definitions/StepConfigSlim'
                 description: Steps that are executed as part of the workflow
                 example:
                     - label: PagerDuty Escalate
                       name: pagerduty.escalate
             trigger:
-                $ref: '#/definitions/TriggerSlimResponseBody'
+                $ref: '#/definitions/TriggerSlim'
             version:
                 type: integer
                 description: Revision of the workflow, uniquely identifying its version
@@ -26612,285 +27252,14 @@ definitions:
             - runs_on_incidents
             - once_for
             - state
-    WorkflowsV2CreateWorkflowRequestBody:
-        title: WorkflowsV2CreateWorkflowRequestBody
-        type: object
-        properties:
-            annotations:
-                type: object
-                description: Annotations that track metadata about this resource
-                example:
-                    incident.io/terraform/version: 3.0.0
-                additionalProperties:
-                    type: string
-                    example: abc123
-            condition_groups:
-                type: array
-                items:
-                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
-                description: List of conditions to apply to the workflow
-                example:
-                    - conditions:
-                        - operation: one_of
-                          param_bindings:
-                            - array_value:
-                                - literal: SEV123
-                                  reference: incident.severity
-                              value:
-                                literal: SEV123
-                                reference: incident.severity
-                          subject: incident.severity
-            continue_on_step_error:
-                type: boolean
-                description: Whether to continue executing the workflow if a step fails
-                example: true
-            delay:
-                $ref: '#/definitions/WorkflowDelayRequestBody'
-            expressions:
-                type: array
-                items:
-                    $ref: '#/definitions/ExpressionPayloadV2RequestBody'
-                description: The expressions used in the workflow
-                example:
-                    - else_branch:
-                        result:
-                            array_value:
-                                - literal: SEV123
-                                  reference: incident.severity
-                            value:
-                                literal: SEV123
-                                reference: incident.severity
-                      label: Team Slack channel
-                      operations:
-                        - branches:
-                            branches:
-                                - condition_groups:
-                                    - conditions:
-                                        - operation: one_of
-                                          param_bindings:
-                                            - array_value:
-                                                - literal: SEV123
-                                                  reference: incident.severity
-                                              value:
-                                                literal: SEV123
-                                                reference: incident.severity
-                                          subject: incident.severity
-                                  result:
-                                    array_value:
-                                        - literal: SEV123
-                                          reference: incident.severity
-                                    value:
-                                        literal: SEV123
-                                        reference: incident.severity
-                            returns:
-                                array: true
-                                type: IncidentStatus
-                          filter:
-                            condition_groups:
-                                - conditions:
-                                    - operation: one_of
-                                      param_bindings:
-                                        - array_value:
-                                            - literal: SEV123
-                                              reference: incident.severity
-                                          value:
-                                            literal: SEV123
-                                            reference: incident.severity
-                                      subject: incident.severity
-                          navigate:
-                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
-                          operation_type: navigate
-                          parse:
-                            returns:
-                                array: true
-                                type: IncidentStatus
-                            source: metadata.annotations["github.com/repo"]
-                      reference: abc123
-                      root_reference: incident.status
-            folder:
-                type: string
-                description: Folder to display the workflow in
-                example: My folder 01
-            include_private_incidents:
-                type: boolean
-                description: Whether to include private incidents
-                example: true
-            name:
-                type: string
-                description: The human-readable name of the workflow
-                example: My workflow
-            once_for:
-                type: array
-                items:
-                    type: string
-                    example: incident.url
-                description: Once For strategy to apply to this workflow
-                example:
-                    - incident.url
-            runs_on_incident_modes:
-                type: array
-                items:
-                    type: string
-                    example: test
-                    enum:
-                        - standard
-                        - test
-                        - retrospective
-                description: Which modes of incident this should run on (defaults to just standard incidents)
-                example:
-                    - standard
-                    - retrospective
-            runs_on_incidents:
-                type: string
-                description: Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-                example: newly_created
-                enum:
-                    - newly_created
-                    - newly_created_and_active
-            state:
-                type: string
-                description: The state of the workflow (e.g. is it draft, or disabled)
-                example: active
-                enum:
-                    - active
-                    - disabled
-                    - draft
-                    - error
-            steps:
-                type: array
-                items:
-                    $ref: '#/definitions/StepConfigPayloadRequestBody'
-                description: List of step to execute as part of the workflow
-                example:
-                    - for_each: abc123
-                      id: abc123
-                      name: pagerduty.escalate
-                      param_bindings:
-                        - array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                          value:
-                            literal: SEV123
-                            reference: incident.severity
-            trigger:
-                type: string
-                description: Trigger to set on the workflow
-                example: incident.updated
-        example:
-            annotations:
-                incident.io/terraform/version: 3.0.0
-            condition_groups:
-                - conditions:
-                    - operation: one_of
-                      param_bindings:
-                        - array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                          value:
-                            literal: SEV123
-                            reference: incident.severity
-                      subject: incident.severity
-            continue_on_step_error: true
-            delay:
-                conditions_apply_over_delay: false
-                for_seconds: 60
-            expressions:
-                - else_branch:
-                    result:
-                        array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                        value:
-                            literal: SEV123
-                            reference: incident.severity
-                  label: Team Slack channel
-                  operations:
-                    - branches:
-                        branches:
-                            - condition_groups:
-                                - conditions:
-                                    - operation: one_of
-                                      param_bindings:
-                                        - array_value:
-                                            - literal: SEV123
-                                              reference: incident.severity
-                                          value:
-                                            literal: SEV123
-                                            reference: incident.severity
-                                      subject: incident.severity
-                              result:
-                                array_value:
-                                    - literal: SEV123
-                                      reference: incident.severity
-                                value:
-                                    literal: SEV123
-                                    reference: incident.severity
-                        returns:
-                            array: true
-                            type: IncidentStatus
-                      filter:
-                        condition_groups:
-                            - conditions:
-                                - operation: one_of
-                                  param_bindings:
-                                    - array_value:
-                                        - literal: SEV123
-                                          reference: incident.severity
-                                      value:
-                                        literal: SEV123
-                                        reference: incident.severity
-                                  subject: incident.severity
-                      navigate:
-                        reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
-                      operation_type: navigate
-                      parse:
-                        returns:
-                            array: true
-                            type: IncidentStatus
-                        source: metadata.annotations["github.com/repo"]
-                  reference: abc123
-                  root_reference: incident.status
-            folder: My folder 01
-            include_private_incidents: true
-            name: My workflow
-            once_for:
-                - incident.url
-            runs_on_incident_modes:
-                - standard
-                - retrospective
-            runs_on_incidents: newly_created
-            state: active
-            steps:
-                - for_each: abc123
-                  id: abc123
-                  name: pagerduty.escalate
-                  param_bindings:
-                    - array_value:
-                        - literal: SEV123
-                          reference: incident.severity
-                      value:
-                        literal: SEV123
-                        reference: incident.severity
-            trigger: incident.updated
-        required:
-            - name
-            - trigger
-            - once_for
-            - condition_groups
-            - steps
-            - expressions
-            - include_private_incidents
-            - runs_on_incident_modes
-            - continue_on_step_error
-            - runs_on_incidents
     WorkflowsV2CreateWorkflowResponseBody:
         title: WorkflowsV2CreateWorkflowResponseBody
         type: object
         properties:
             management_meta:
-                $ref: '#/definitions/ManagementMetaV2ResponseBody'
+                $ref: '#/definitions/ManagementMetaV2'
             workflow:
-                $ref: '#/definitions/WorkflowResponseBody'
+                $ref: '#/definitions/Workflow'
         example:
             management_meta:
                 annotations:
@@ -27041,7 +27410,7 @@ definitions:
             workflows:
                 type: array
                 items:
-                    $ref: '#/definitions/WorkflowSlimResponseBody'
+                    $ref: '#/definitions/WorkflowSlim'
                 example:
                     - condition_groups:
                         - conditions:
@@ -27296,9 +27665,9 @@ definitions:
         type: object
         properties:
             management_meta:
-                $ref: '#/definitions/ManagementMetaV2ResponseBody'
+                $ref: '#/definitions/ManagementMetaV2'
             workflow:
-                $ref: '#/definitions/WorkflowResponseBody'
+                $ref: '#/definitions/Workflow'
         example:
             management_meta:
                 annotations:
@@ -27442,279 +27811,14 @@ definitions:
         required:
             - workflow
             - management_meta
-    WorkflowsV2UpdateWorkflowRequestBody:
-        title: WorkflowsV2UpdateWorkflowRequestBody
-        type: object
-        properties:
-            annotations:
-                type: object
-                description: Annotations that track metadata about this resource
-                example:
-                    incident.io/terraform/version: 3.0.0
-                additionalProperties:
-                    type: string
-                    example: abc123
-            condition_groups:
-                type: array
-                items:
-                    $ref: '#/definitions/ConditionGroupPayloadV2RequestBody'
-                description: List of conditions to apply to the workflow
-                example:
-                    - conditions:
-                        - operation: one_of
-                          param_bindings:
-                            - array_value:
-                                - literal: SEV123
-                                  reference: incident.severity
-                              value:
-                                literal: SEV123
-                                reference: incident.severity
-                          subject: incident.severity
-            continue_on_step_error:
-                type: boolean
-                description: Whether to continue executing the workflow if a step fails
-                example: true
-            delay:
-                $ref: '#/definitions/WorkflowDelayRequestBody'
-            expressions:
-                type: array
-                items:
-                    $ref: '#/definitions/ExpressionPayloadV2RequestBody'
-                description: The expressions used in the workflow
-                example:
-                    - else_branch:
-                        result:
-                            array_value:
-                                - literal: SEV123
-                                  reference: incident.severity
-                            value:
-                                literal: SEV123
-                                reference: incident.severity
-                      label: Team Slack channel
-                      operations:
-                        - branches:
-                            branches:
-                                - condition_groups:
-                                    - conditions:
-                                        - operation: one_of
-                                          param_bindings:
-                                            - array_value:
-                                                - literal: SEV123
-                                                  reference: incident.severity
-                                              value:
-                                                literal: SEV123
-                                                reference: incident.severity
-                                          subject: incident.severity
-                                  result:
-                                    array_value:
-                                        - literal: SEV123
-                                          reference: incident.severity
-                                    value:
-                                        literal: SEV123
-                                        reference: incident.severity
-                            returns:
-                                array: true
-                                type: IncidentStatus
-                          filter:
-                            condition_groups:
-                                - conditions:
-                                    - operation: one_of
-                                      param_bindings:
-                                        - array_value:
-                                            - literal: SEV123
-                                              reference: incident.severity
-                                          value:
-                                            literal: SEV123
-                                            reference: incident.severity
-                                      subject: incident.severity
-                          navigate:
-                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
-                          operation_type: navigate
-                          parse:
-                            returns:
-                                array: true
-                                type: IncidentStatus
-                            source: metadata.annotations["github.com/repo"]
-                      reference: abc123
-                      root_reference: incident.status
-            folder:
-                type: string
-                description: Folder to display the workflow in
-                example: My folder 01
-            include_private_incidents:
-                type: boolean
-                description: Whether to include private incidents
-                example: true
-            name:
-                type: string
-                description: The human-readable name of the workflow
-                example: My workflow
-            once_for:
-                type: array
-                items:
-                    type: string
-                    example: incident.url
-                description: Once For strategy to apply to this workflow
-                example:
-                    - incident.url
-            runs_on_incident_modes:
-                type: array
-                items:
-                    type: string
-                    example: test
-                    enum:
-                        - standard
-                        - test
-                        - retrospective
-                description: Which modes of incident this should run on (defaults to just standard incidents)
-                example:
-                    - standard
-                    - retrospective
-            runs_on_incidents:
-                type: string
-                description: Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-                example: newly_created
-                enum:
-                    - newly_created
-                    - newly_created_and_active
-            state:
-                type: string
-                description: The state of the workflow (e.g. is it draft, or disabled)
-                example: active
-                enum:
-                    - active
-                    - disabled
-                    - draft
-                    - error
-            steps:
-                type: array
-                items:
-                    $ref: '#/definitions/StepConfigPayloadRequestBody'
-                description: List of step to execute as part of the workflow
-                example:
-                    - for_each: abc123
-                      id: abc123
-                      name: pagerduty.escalate
-                      param_bindings:
-                        - array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                          value:
-                            literal: SEV123
-                            reference: incident.severity
-        example:
-            annotations:
-                incident.io/terraform/version: 3.0.0
-            condition_groups:
-                - conditions:
-                    - operation: one_of
-                      param_bindings:
-                        - array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                          value:
-                            literal: SEV123
-                            reference: incident.severity
-                      subject: incident.severity
-            continue_on_step_error: true
-            delay:
-                conditions_apply_over_delay: false
-                for_seconds: 60
-            expressions:
-                - else_branch:
-                    result:
-                        array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                        value:
-                            literal: SEV123
-                            reference: incident.severity
-                  label: Team Slack channel
-                  operations:
-                    - branches:
-                        branches:
-                            - condition_groups:
-                                - conditions:
-                                    - operation: one_of
-                                      param_bindings:
-                                        - array_value:
-                                            - literal: SEV123
-                                              reference: incident.severity
-                                          value:
-                                            literal: SEV123
-                                            reference: incident.severity
-                                      subject: incident.severity
-                              result:
-                                array_value:
-                                    - literal: SEV123
-                                      reference: incident.severity
-                                value:
-                                    literal: SEV123
-                                    reference: incident.severity
-                        returns:
-                            array: true
-                            type: IncidentStatus
-                      filter:
-                        condition_groups:
-                            - conditions:
-                                - operation: one_of
-                                  param_bindings:
-                                    - array_value:
-                                        - literal: SEV123
-                                          reference: incident.severity
-                                      value:
-                                        literal: SEV123
-                                        reference: incident.severity
-                                  subject: incident.severity
-                      navigate:
-                        reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
-                      operation_type: navigate
-                      parse:
-                        returns:
-                            array: true
-                            type: IncidentStatus
-                        source: metadata.annotations["github.com/repo"]
-                  reference: abc123
-                  root_reference: incident.status
-            folder: My folder 01
-            include_private_incidents: true
-            name: My workflow
-            once_for:
-                - incident.url
-            runs_on_incident_modes:
-                - standard
-                - retrospective
-            runs_on_incidents: newly_created
-            state: active
-            steps:
-                - for_each: abc123
-                  id: abc123
-                  name: pagerduty.escalate
-                  param_bindings:
-                    - array_value:
-                        - literal: SEV123
-                          reference: incident.severity
-                      value:
-                        literal: SEV123
-                        reference: incident.severity
-        required:
-            - name
-            - once_for
-            - condition_groups
-            - steps
-            - expressions
-            - include_private_incidents
-            - runs_on_incident_modes
-            - continue_on_step_error
-            - runs_on_incidents
     WorkflowsV2UpdateWorkflowResponseBody:
         title: WorkflowsV2UpdateWorkflowResponseBody
         type: object
         properties:
             management_meta:
-                $ref: '#/definitions/ManagementMetaV2ResponseBody'
+                $ref: '#/definitions/ManagementMetaV2'
             workflow:
-                $ref: '#/definitions/WorkflowResponseBody'
+                $ref: '#/definitions/Workflow'
         example:
             management_meta:
                 annotations:
@@ -27858,357 +27962,3 @@ definitions:
         required:
             - workflow
             - management_meta
-    webhook_incident_userV2ResponseBody:
-        title: webhook_incident_userV2ResponseBody
-        type: object
-        properties:
-            actor_user_id:
-                type: string
-                description: The ID of the user who performed this action. If the action was not taken by a user, for example it was taken by a Workflow, this will be empty.
-                example: abc123
-            incident_id:
-                type: string
-                description: The ID of the incident
-                example: abc123
-            user_id:
-                type: string
-                description: The ID of the user
-                example: abc123
-        example:
-            actor_user_id: abc123
-            incident_id: abc123
-            user_id: abc123
-        required:
-            - incident_id
-            - user_id
-    webhook_incidentV2ResponseBody:
-        title: webhook_incidentV2ResponseBody
-        type: object
-        properties:
-            call_url:
-                type: string
-                description: The call URL attached to this incident
-                example: https://zoom.us/foo
-            created_at:
-                type: string
-                description: When the incident was created
-                example: "2021-08-17T13:28:57.801578Z"
-                format: date-time
-            creator:
-                $ref: '#/definitions/ActorV2ResponseBody'
-            custom_field_entries:
-                type: array
-                items:
-                    $ref: '#/definitions/CustomFieldEntryV2ResponseBody'
-                description: Custom field entries for this incident
-                example:
-                    - custom_field:
-                        description: Which team is impacted by this issue
-                        field_type: single_select
-                        id: 01FCNDV6P870EA6S7TK1DSYDG0
-                        name: Affected Team
-                        options:
-                            - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              sort_key: 10
-                              value: Product
-                      values:
-                        - value_catalog_entry:
-                            aliases:
-                                - lawrence@incident.io
-                                - lawrence
-                            external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
-                            id: 01FCNDV6P870EA6S7TK1DSYDG0
-                            name: Primary On-call
-                          value_link: https://google.com/
-                          value_numeric: "123.456"
-                          value_option:
-                            custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                            id: 01FCNDV6P870EA6S7TK1DSYDG0
-                            sort_key: 10
-                            value: Product
-                          value_text: This is my text field, I hope you like it
-            duration_metrics:
-                type: array
-                items:
-                    $ref: '#/definitions/IncidentDurationMetricWithValueV2ResponseBody'
-                description: Incident duration metrics and their measurements for this incident
-                example:
-                    - duration_metric:
-                        id: 01FCNDV6P870EA6S7TK1DSYD5H
-                        name: Lasted
-                      value_seconds: 1
-            external_issue_reference:
-                $ref: '#/definitions/ExternalIssueReferenceV2ResponseBody'
-            id:
-                type: string
-                description: Unique identifier for the incident
-                example: 01FDAG4SAP5TYPT98WGR2N7W91
-            incident_role_assignments:
-                type: array
-                items:
-                    $ref: '#/definitions/IncidentRoleAssignmentV2ResponseBody'
-                description: A list of who is assigned to each role for this incident
-                example:
-                    - assignee:
-                        email: lisa@incident.io
-                        id: 01FCNDV6P870EA6S7TK1DSYDG0
-                        name: Lisa Karlin Curtis
-                        role: viewer
-                        slack_user_id: U02AYNF2XJM
-                      role:
-                        created_at: "2021-08-17T13:28:57.801578Z"
-                        description: The person currently coordinating the incident
-                        id: 01FCNDV6P870EA6S7TK1DSYDG0
-                        instructions: Take point on the incident; Make sure people are clear on responsibilities
-                        name: Incident Lead
-                        required: false
-                        role_type: lead
-                        shortform: lead
-                        updated_at: "2021-08-17T13:28:57.801578Z"
-            incident_status:
-                $ref: '#/definitions/IncidentStatusV2ResponseBody'
-            incident_timestamp_values:
-                type: array
-                items:
-                    $ref: '#/definitions/IncidentTimestampWithValueV2ResponseBody'
-                description: Incident lifecycle events and when they occurred
-                example:
-                    - incident_timestamp:
-                        id: 01FCNDV6P870EA6S7TK1DSYD5H
-                        name: Impact started
-                        rank: 1
-                      value:
-                        value: "2021-08-17T13:28:57.801578Z"
-            incident_type:
-                $ref: '#/definitions/IncidentTypeV2ResponseBody'
-            mode:
-                type: string
-                description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
-                example: standard
-                enum:
-                    - standard
-                    - retrospective
-                    - test
-                    - tutorial
-            name:
-                type: string
-                description: Explanation of the incident
-                example: Our database is sad
-            permalink:
-                type: string
-                description: A permanent link to the homepage for this incident
-                example: https://app.incident.io/incidents/123
-            postmortem_document_url:
-                type: string
-                description: Description of the incident
-                example: https://docs.google.com/my_doc_id
-            reference:
-                type: string
-                description: Reference to this incident, as displayed across the product
-                example: INC-123
-            related_incidents:
-                type: array
-                items:
-                    type: string
-                    example: abc123
-                description: Incident IDs of incidents related to this incident
-                example:
-                    - INC-237
-            severity:
-                $ref: '#/definitions/SeverityV2ResponseBody'
-            slack_channel_id:
-                type: string
-                description: ID of the Slack channel in the organisation Slack workspace. Note that the channel is sometimes created asynchronously, so may not be present when the incident is just created.
-                example: C02AW36C1M5
-            slack_channel_name:
-                type: string
-                description: Name of the slack channel
-                example: inc-165-green-parrot
-            slack_team_id:
-                type: string
-                description: ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
-                example: T02A1FSLE8J
-            summary:
-                type: string
-                description: Detailed description of the incident
-                example: Our database is really really sad, and we don't know why yet.
-            updated_at:
-                type: string
-                description: When the incident was last updated
-                example: "2021-08-17T13:28:57.801578Z"
-                format: date-time
-            visibility:
-                type: string
-                description: Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-                example: public
-                enum:
-                    - public
-                    - private
-            workload_minutes_late:
-                type: number
-                description: Amount of time spent on the incident in late hours
-                example: 40.7
-                format: double
-            workload_minutes_sleeping:
-                type: number
-                description: Amount of time spent on the incident in sleeping hours
-                example: 0
-                format: double
-            workload_minutes_total:
-                type: number
-                description: Amount of time spent on the incident in total
-                example: 60.7
-                format: double
-            workload_minutes_working:
-                type: number
-                description: Amount of time spent on the incident in working hours
-                example: 20
-                format: double
-        example:
-            call_url: https://zoom.us/foo
-            created_at: "2021-08-17T13:28:57.801578Z"
-            creator:
-                api_key:
-                    id: 01FCNDV6P870EA6S7TK1DSYDG0
-                    name: My test API key
-                user:
-                    email: lisa@incident.io
-                    id: 01FCNDV6P870EA6S7TK1DSYDG0
-                    name: Lisa Karlin Curtis
-                    role: viewer
-                    slack_user_id: U02AYNF2XJM
-            custom_field_entries:
-                - custom_field:
-                    description: Which team is impacted by this issue
-                    field_type: single_select
-                    id: 01FCNDV6P870EA6S7TK1DSYDG0
-                    name: Affected Team
-                    options:
-                        - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          sort_key: 10
-                          value: Product
-                  values:
-                    - value_catalog_entry:
-                        aliases:
-                            - lawrence@incident.io
-                            - lawrence
-                        external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
-                        id: 01FCNDV6P870EA6S7TK1DSYDG0
-                        name: Primary On-call
-                      value_link: https://google.com/
-                      value_numeric: "123.456"
-                      value_option:
-                        custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                        id: 01FCNDV6P870EA6S7TK1DSYDG0
-                        sort_key: 10
-                        value: Product
-                      value_text: This is my text field, I hope you like it
-            duration_metrics:
-                - duration_metric:
-                    id: 01FCNDV6P870EA6S7TK1DSYD5H
-                    name: Lasted
-                  value_seconds: 1
-            external_issue_reference:
-                issue_name: INC-123
-                issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
-                provider: asana
-            id: 01FDAG4SAP5TYPT98WGR2N7W91
-            incident_role_assignments:
-                - assignee:
-                    email: lisa@incident.io
-                    id: 01FCNDV6P870EA6S7TK1DSYDG0
-                    name: Lisa Karlin Curtis
-                    role: viewer
-                    slack_user_id: U02AYNF2XJM
-                  role:
-                    created_at: "2021-08-17T13:28:57.801578Z"
-                    description: The person currently coordinating the incident
-                    id: 01FCNDV6P870EA6S7TK1DSYDG0
-                    instructions: Take point on the incident; Make sure people are clear on responsibilities
-                    name: Incident Lead
-                    required: false
-                    role_type: lead
-                    shortform: lead
-                    updated_at: "2021-08-17T13:28:57.801578Z"
-            incident_status:
-                category: triage
-                created_at: "2021-08-17T13:28:57.801578Z"
-                description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
-                id: 01FCNDV6P870EA6S7TK1DSYD5H
-                name: Closed
-                rank: 4
-                updated_at: "2021-08-17T13:28:57.801578Z"
-            incident_timestamp_values:
-                - incident_timestamp:
-                    id: 01FCNDV6P870EA6S7TK1DSYD5H
-                    name: Impact started
-                    rank: 1
-                  value:
-                    value: "2021-08-17T13:28:57.801578Z"
-            incident_type:
-                create_in_triage: always
-                created_at: "2021-08-17T13:28:57.801578Z"
-                description: Customer facing production outages
-                id: 01FCNDV6P870EA6S7TK1DSYDG0
-                is_default: false
-                name: Production Outage
-                private_incidents_only: false
-                updated_at: "2021-08-17T13:28:57.801578Z"
-            mode: standard
-            name: Our database is sad
-            permalink: https://app.incident.io/incidents/123
-            postmortem_document_url: https://docs.google.com/my_doc_id
-            reference: INC-123
-            related_incidents:
-                - INC-237
-            severity:
-                created_at: "2021-08-17T13:28:57.801578Z"
-                description: Issues with **low impact**.
-                id: 01FCNDV6P870EA6S7TK1DSYDG0
-                name: Minor
-                rank: 1
-                updated_at: "2021-08-17T13:28:57.801578Z"
-            slack_channel_id: C02AW36C1M5
-            slack_channel_name: inc-165-green-parrot
-            slack_team_id: T02A1FSLE8J
-            summary: Our database is really really sad, and we don't know why yet.
-            updated_at: "2021-08-17T13:28:57.801578Z"
-            visibility: public
-            workload_minutes_late: 40.7
-            workload_minutes_sleeping: 0
-            workload_minutes_total: 60.7
-            workload_minutes_working: 20
-        required:
-            - incident_status
-            - id
-            - external_id
-            - reference
-            - name
-            - idempotency_key
-            - did_opt_out_of_post_incident_flow
-            - visibility
-            - mode
-            - organisation_id
-            - creator
-            - last_activity_at
-            - incident_role_assignments
-            - custom_field_entries
-            - slack_team_id
-            - slack_channel_id
-            - created_at
-            - updated_at
-            - reported_at
-    webhook_private_resourceV2ResponseBody:
-        title: webhook_private_resourceV2ResponseBody
-        type: object
-        properties:
-            id:
-                type: string
-                description: The ID of the resource
-                example: abc123
-        example:
-            id: abc123
-        required:
-            - id

--- a/internal/apischema/openapi3-secret.json
+++ b/internal/apischema/openapi3-secret.json
@@ -257,7 +257,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody2"
+                "$ref": "#/components/schemas/CreateRequestBody"
               },
               "example": {
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -483,7 +483,7 @@
                 "show_in_announcement_post": true
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody3"
+                "$ref": "#/components/schemas/CreateRequestBody2"
               }
             }
           },
@@ -838,7 +838,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/CreateRequestBody4"
               },
               "example": {
                 "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
@@ -918,7 +918,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/CreateRequestBody5"
               },
               "example": {
                 "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
@@ -969,7 +969,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/CreateRequestBody5"
               },
               "example": {
                 "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
@@ -1036,7 +1036,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody7"
+                "$ref": "#/components/schemas/CreateRequestBody6"
               }
             }
           },
@@ -1263,7 +1263,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody9"
+                "$ref": "#/components/schemas/CreateRequestBody8"
               },
               "example": {
                 "category": "live",
@@ -1762,7 +1762,7 @@
                 "visibility": "public"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody10"
+                "$ref": "#/components/schemas/IncidentCreatePayloadV1"
               }
             }
           },
@@ -2074,9 +2074,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string",
-                  "example": "{}",
-                  "format": "binary"
+                  "example": "{}"
                 },
                 "example": "{}"
               }
@@ -2099,9 +2097,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string",
-                  "example": "{}",
-                  "format": "binary"
+                  "example": "{}"
                 },
                 "example": "{}"
               }
@@ -2155,7 +2151,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody13"
+                "$ref": "#/components/schemas/CreateRequestBody10"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2287,7 +2283,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody13"
+                "$ref": "#/components/schemas/CreateRequestBody10"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2544,7 +2540,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody"
+                "$ref": "#/components/schemas/AlertRoutePayloadV2"
               },
               "example": {
                 "alert_source_ids": [
@@ -4324,7 +4320,7 @@
           "Catalog V2"
         ],
         "summary": "CreateEntry Catalog V2",
-        "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.",
+        "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.\n\nIf you call this API with a payload where the external_id and catalog_type_id match an existing entry, the existing entry will be updated.",
         "operationId": "Catalog V2#CreateEntry",
         "requestBody": {
           "required": true,
@@ -5337,7 +5333,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody4"
+                "$ref": "#/components/schemas/CreateRequestBody3"
               },
               "example": {
                 "description": "Which team is impacted by this issue",
@@ -5518,7 +5514,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathRequestBody"
+                "$ref": "#/components/schemas/EscalationPathPayloadV2"
               },
               "example": {
                 "name": "Urgent Support",
@@ -5863,7 +5859,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathRequestBody"
+                "$ref": "#/components/schemas/EscalationPathPayloadV2"
               },
               "example": {
                 "name": "Urgent Support",
@@ -6237,7 +6233,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody8"
+                "$ref": "#/components/schemas/CreateRequestBody7"
               },
               "example": {
                 "description": "The person currently coordinating the incident",
@@ -7109,7 +7105,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody11"
+                "$ref": "#/components/schemas/IncidentCreatePayloadV2"
               },
               "example": {
                 "custom_field_entries": [
@@ -7808,7 +7804,7 @@
           "Schedules V2"
         ],
         "summary": "ListScheduleEntries Schedules V2",
-        "description": "Get a list of schedule entries.",
+        "description": "Get a list of schedule entries. The endpoint will return all entries that overlap with the given window, if one is provided.",
         "operationId": "Schedules V2#ListScheduleEntries",
         "parameters": [
           {
@@ -8065,7 +8061,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody12"
+                "$ref": "#/components/schemas/CreateRequestBody9"
               },
               "example": {
                 "schedule": {
@@ -8916,7 +8912,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateWorkflowRequestBody"
+                "$ref": "#/components/schemas/CreateWorkflowPayload"
               },
               "example": {
                 "annotations": {
@@ -9670,7 +9666,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateWorkflowRequestBody"
+                "$ref": "#/components/schemas/UpdateWorkflowPayload2"
               },
               "example": {
                 "annotations": {
@@ -10100,79 +10096,29 @@
   },
   "components": {
     "schemas": {
-      "APIKeyCreatedV1ResponseBody": {
+      "APIKeyV1": {
         "type": "object",
         "properties": {
-          "action": {
+          "id": {
             "type": "string",
-            "description": "The type of log entry that this is",
-            "example": "api_key.created"
+            "description": "Unique identifier for this API key",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
-          "actor": {
-            "$ref": "#/components/schemas/AuditLogActorV2"
-          },
-          "context": {
-            "$ref": "#/components/schemas/AuditLogEntryContextV2"
-          },
-          "occurred_at": {
+          "name": {
             "type": "string",
-            "description": "When the entry occurred",
-            "example": "2021-08-17T13:28:57.801578Z",
-            "format": "date-time"
-          },
-          "targets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AuditLogTargetV2"
-            },
-            "description": "The custom field that was created",
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Development API Key",
-                "type": "api_key"
-              }
-            ]
-          },
-          "version": {
-            "type": "integer",
-            "description": "Which version the event is",
-            "example": 1,
-            "format": "int64"
+            "description": "The name of the API key, for the user's reference",
+            "example": "My test API key"
           }
         },
         "example": {
-          "action": "api_key.created",
-          "actor": {
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "metadata": {
-              "user_base_role_slug": "admin",
-              "user_custom_role_slugs": "engineering,security"
-            },
-            "name": "John Doe",
-            "type": "user"
-          },
-          "context": {
-            "location": "1.2.3.4",
-            "user_agent": "Chrome/91.0.4472.114"
-          },
-          "occurred_at": "2021-08-17T13:28:57.801578Z",
-          "targets": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Development API Key",
-              "type": "api_key"
-            }
-          ],
-          "version": 1
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "My test API key"
         },
         "required": [
-          "action",
-          "occurred_at",
-          "version",
-          "actor",
-          "targets",
-          "context"
+          "id",
+          "name",
+          "roles",
+          "created_by"
         ]
       },
       "APIKeyV2": {
@@ -10224,7 +10170,7 @@
             "example": "Call the fire brigade"
           },
           "external_issue_reference": {
-            "$ref": "#/components/schemas/ExternalIssueReferenceV1"
+            "$ref": "#/components/schemas/ExternalIssueReferenceV2"
           },
           "follow_up": {
             "type": "boolean",
@@ -10294,7 +10240,7 @@
         "type": "object",
         "properties": {
           "assignee": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           },
           "completed_at": {
             "type": "string",
@@ -10366,6 +10312,30 @@
           "updated_at"
         ]
       },
+      "ActorV1": {
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "$ref": "#/components/schemas/APIKeyV1"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserV1"
+          }
+        },
+        "example": {
+          "api_key": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "My test API key"
+          },
+          "user": {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          }
+        }
+      },
       "ActorV2": {
         "type": "object",
         "properties": {
@@ -10373,7 +10343,7 @@
             "$ref": "#/components/schemas/APIKeyV2"
           },
           "user": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           }
         },
         "example": {
@@ -10413,6 +10383,415 @@
           "after_url"
         ]
       },
+      "AlertAttributeBinding": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertAttributeValue"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "catalog_entry": {
+                  "archived_at": "2021-08-17T14:28:57.801578Z",
+                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
+                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "helptext": "Collection of standalone automations like auto-closing incidents.",
+                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "is_image_slack_icon": false,
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "sort_key": "000020"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/AlertAttributeValue"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "catalog_entry": {
+                "archived_at": "2021-08-17T14:28:57.801578Z",
+                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "catalog_entry_name": "Primary escalation",
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "helptext": "Collection of standalone automations like auto-closing incidents.",
+              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+              "is_image_slack_icon": false,
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "sort_key": "000020"
+            }
+          ],
+          "value": {
+            "catalog_entry": {
+              "archived_at": "2021-08-17T14:28:57.801578Z",
+              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "catalog_entry_name": "Primary escalation",
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "helptext": "Collection of standalone automations like auto-closing incidents.",
+            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+            "is_image_slack_icon": false,
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "sort_key": "000020"
+          }
+        }
+      },
+      "AlertAttributeValue": {
+        "type": "object",
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryReference"
+          },
+          "helptext": {
+            "type": "string",
+            "description": "Gives a description of the option to the user",
+            "example": "Collection of standalone automations like auto-closing incidents."
+          },
+          "image_url": {
+            "type": "string",
+            "description": "If appropriate, URL to an image that can be displayed alongside the option",
+            "example": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg"
+          },
+          "is_image_slack_icon": {
+            "type": "boolean",
+            "description": "If true, the image_url is a Slack icon and should be displayed as such",
+            "example": false
+          },
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "sort_key": {
+            "type": "string",
+            "description": "Gives an indication of how to sort the options when displayed to the user",
+            "example": "000020"
+          }
+        },
+        "example": {
+          "catalog_entry": {
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "catalog_entry_name": "Primary escalation",
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "helptext": "Collection of standalone automations like auto-closing incidents.",
+          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+          "is_image_slack_icon": false,
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "sort_key": "000020"
+        },
+        "required": [
+          "label",
+          "sort_key"
+        ]
+      },
+      "AlertDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "alert_source_config": {
+            "$ref": "#/components/schemas/AlertSourceConfigSlim"
+          },
+          "alert_source_config_id": {
+            "type": "string",
+            "description": "Which alert source config produced this alert",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "attribute_values": {
+            "type": "object",
+            "description": "Attribute values parsed into the alert",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
+                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "helptext": "Collection of standalone automations like auto-closing incidents.",
+                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "is_image_slack_icon": false,
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "sort_key": "000020"
+                  }
+                ],
+                "value": {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "Collection of standalone automations like auto-closing incidents.",
+                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "sort_key": "000020"
+                }
+              }
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AlertAttributeBinding"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When this entry was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "dashboard_url": {
+            "type": "string",
+            "description": "If applicable, a link to the dashboard for this alert",
+            "example": "https://my-dashboard.com/alerts/123"
+          },
+          "deduplication_key": {
+            "type": "string",
+            "description": "A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.",
+            "example": "4293868629"
+          },
+          "description": {
+            "$ref": "#/components/schemas/TextDocument"
+          },
+          "evaluation_failures": {
+            "type": "object",
+            "description": "Attributes that we failed to evaluate and why",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of this alert",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "payload": {
+            "type": "string",
+            "description": "JSON payload that this alert was created from",
+            "example": "abc123"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/Priority"
+          },
+          "priority_id": {
+            "type": "string",
+            "description": "The priority of this alert",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "resolved_at": {
+            "type": "string",
+            "description": "When this alert was resolved",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "silence_url": {
+            "type": "string",
+            "description": "If applicable, a link to silence this alert",
+            "example": "https://my-dashboard.com/alerts/123/silence"
+          },
+          "source_type": {
+            "type": "string",
+            "description": "Type of alert source",
+            "example": "alertmanager",
+            "enum": [
+              "alertmanager",
+              "app_optics",
+              "azure_monitor",
+              "bugsnag",
+              "checkly",
+              "cloudwatch",
+              "cloudflare",
+              "cronitor",
+              "crowdstrike_falcon",
+              "chronosphere",
+              "datadog",
+              "dynatrace",
+              "elasticsearch",
+              "email",
+              "expel",
+              "github_issue",
+              "google_cloud",
+              "grafana",
+              "http",
+              "honeycomb",
+              "jira",
+              "monte_carlo",
+              "new_relic",
+              "opsgenie",
+              "pager_duty",
+              "panther",
+              "pingdom",
+              "runscope",
+              "sns",
+              "sentry",
+              "splunk",
+              "status_cake",
+              "status_page_views",
+              "sumo_logic",
+              "uptime",
+              "zendesk"
+            ]
+          },
+          "source_url": {
+            "type": "string",
+            "description": "If applicable, a link to the alert in the upstream system",
+            "example": "https://www.my-alerting-platform.com/alerts/my-alert-123"
+          },
+          "status": {
+            "type": "string",
+            "description": "Statuses of an alert",
+            "example": "firing",
+            "enum": [
+              "firing",
+              "resolved"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Alert title which is used when summarising the alert",
+            "example": "*errors.withMessage: PG::Error failed to connect"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When this alert was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "alert_source_config": {
+            "archived_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01GW2G3V0S59R238FAHPDS1R66",
+            "name": "Production Web Dashboard Alerts",
+            "source_type": "alertmanager"
+          },
+          "alert_source_config_id": "01GW2G3V0S59R238FAHPDS1R66",
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "Collection of standalone automations like auto-closing incidents.",
+                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "sort_key": "000020"
+                }
+              ],
+              "value": {
+                "catalog_entry": {
+                  "archived_at": "2021-08-17T14:28:57.801578Z",
+                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
+                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "helptext": "Collection of standalone automations like auto-closing incidents.",
+                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "is_image_slack_icon": false,
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "sort_key": "000020"
+              }
+            }
+          },
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "dashboard_url": "https://my-dashboard.com/alerts/123",
+          "deduplication_key": "4293868629",
+          "description": {
+            "markdown": "There's a snake in my boot",
+            "text_node": {
+              "attrs": {
+                "level": 3
+              },
+              "content": [
+                {}
+              ],
+              "marks": [
+                {
+                  "attrs": {
+                    "color": "blue"
+                  },
+                  "type": "em"
+                }
+              ],
+              "text": "some nice text",
+              "type": "text"
+            }
+          },
+          "evaluation_failures": {
+            "abc123": "abc123"
+          },
+          "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "payload": "abc123",
+          "priority": {
+            "archived_at": "2021-08-17T13:28:57.801578Z",
+            "description": {
+              "attrs": {
+                "level": 3
+              },
+              "content": [
+                {}
+              ],
+              "marks": [
+                {
+                  "attrs": {
+                    "color": "blue"
+                  },
+                  "type": "em"
+                }
+              ],
+              "text": "some nice text",
+              "type": "text"
+            },
+            "id": "01GW2G3V0S59R238FAHPDS1R66",
+            "is_default": true,
+            "name": "P1",
+            "rank": 1,
+            "slugs": [
+              "p1",
+              "priority-1"
+            ]
+          },
+          "priority_id": "01GW2G3V0S59R238FAHPDS1R66",
+          "resolved_at": "2021-08-17T14:28:57.801578Z",
+          "silence_url": "https://my-dashboard.com/alerts/123/silence",
+          "source_type": "alertmanager",
+          "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+          "status": "firing",
+          "title": "*errors.withMessage: PG::Error failed to connect",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        }
+      },
       "AlertResult": {
         "type": "object",
         "properties": {
@@ -10451,6 +10830,670 @@
           "message",
           "deduplication_key"
         ]
+      },
+      "AlertRouteDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "alert_source_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "Legacy field - the alert sources that will match this alert route",
+            "example": [
+              "02FCNDV6P870EA6S7TK1DSYDG2"
+            ]
+          },
+          "auto_decline_enabled": {
+            "type": "boolean",
+            "description": "Should triage incidents be declined when alerts are resolved?",
+            "example": false
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
+            "type": "integer",
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route is enabled or not",
+            "example": false
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this alert route config",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "incident_condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV2"
+            },
+            "description": "What condition groups must be true for this alert route to create an incident?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "incident_enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route will create incidents or not",
+            "example": false
+          },
+          "last_fired_at": {
+            "type": "string",
+            "description": "When did this alert route last create an incident?",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplateV2"
+          }
+        },
+        "example": {
+          "alert_source_ids": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ],
+          "auto_decline_enabled": false,
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "enabled": false,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "incident_enabled": false,
+          "last_fired_at": "2021-08-17T13:28:57.801578Z",
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "first-wins"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        }
       },
       "AlertRouteEscalationBindingPayloadV2": {
         "type": "object",
@@ -10844,6 +11887,549 @@
           "custom_field_priorities",
           "priority_severity"
         ]
+      },
+      "AlertRoutePayloadV2": {
+        "type": "object",
+        "properties": {
+          "alert_source_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "Legacy field - the alert sources that will match this alert route",
+            "example": [
+              "02FCNDV6P870EA6S7TK1DSYDG2"
+            ]
+          },
+          "auto_decline_enabled": {
+            "type": "boolean",
+            "description": "Should triage incidents be declined when alerts are resolved?",
+            "example": false
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
+            "type": "integer",
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route is enabled or not",
+            "example": false
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "incident_condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to create an incident?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "incident_enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route will create incidents or not",
+            "example": false
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
+          }
+        },
+        "example": {
+          "alert_source_ids": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ],
+          "auto_decline_enabled": false,
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "enabled": false,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "incident_condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "incident_enabled": false,
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "abc123"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        }
       },
       "AlertRouteV2": {
         "type": "object",
@@ -11410,8 +12996,84 @@
           "enabled",
           "incident_enabled",
           "incident_condition_groups",
+          "alert_sources",
           "alert_source_ids",
           "auto_cancel_escalations"
+        ]
+      },
+      "AlertSourceConfigSlim": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this type was archived",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of this alert source",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of the alert source",
+            "example": "Production Web Dashboard Alerts"
+          },
+          "source_type": {
+            "type": "string",
+            "description": "Type of alert source",
+            "example": "alertmanager",
+            "enum": [
+              "alertmanager",
+              "app_optics",
+              "azure_monitor",
+              "bugsnag",
+              "checkly",
+              "cloudwatch",
+              "cloudflare",
+              "cronitor",
+              "crowdstrike_falcon",
+              "chronosphere",
+              "datadog",
+              "dynatrace",
+              "elasticsearch",
+              "email",
+              "expel",
+              "github_issue",
+              "google_cloud",
+              "grafana",
+              "http",
+              "honeycomb",
+              "jira",
+              "monte_carlo",
+              "new_relic",
+              "opsgenie",
+              "pager_duty",
+              "panther",
+              "pingdom",
+              "runscope",
+              "sns",
+              "sentry",
+              "splunk",
+              "status_cake",
+              "status_page_views",
+              "sumo_logic",
+              "uptime",
+              "zendesk"
+            ]
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T13:28:57.801578Z",
+          "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "name": "Production Web Dashboard Alerts",
+          "source_type": "alertmanager"
+        },
+        "required": [
+          "id",
+          "name",
+          "source_type"
         ]
       },
       "AllResponseBody": {
@@ -11440,22 +13102,22 @@
             ]
           },
           "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.membership_granted_v1": {
             "$ref": "#/components/schemas/WebhookIncidentUserV2"
@@ -12078,6 +13740,19 @@
           "event_type"
         ]
       },
+      "AuditLogAPIKeyMetadataV2": {
+        "type": "object",
+        "properties": {
+          "api_key_roles": {
+            "type": "string",
+            "description": "The roles that the API key has, separated by commas (if it's an API key actor)",
+            "example": "abc123"
+          }
+        },
+        "example": {
+          "api_key_roles": "abc123"
+        }
+      },
       "AuditLogActorMetadataV2": {
         "type": "object",
         "properties": {
@@ -12158,6 +13833,81 @@
           "type"
         ]
       },
+      "AuditLogEntryBaseV2": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "The type of log entry that this is",
+            "example": "custom_field.created"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "type": "string",
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "description": "The target of the entry",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "John Doe",
+                "type": "user"
+              }
+            ]
+          },
+          "version": {
+            "type": "integer",
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64"
+          }
+        },
+        "example": {
+          "action": "custom_field.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "John Doe",
+              "type": "user"
+            }
+          ],
+          "version": 1
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ]
+      },
       "AuditLogEntryContextV2": {
         "type": "object",
         "properties": {
@@ -12179,6 +13929,25 @@
         "required": [
           "location"
         ]
+      },
+      "AuditLogExternalResourceMetadataV2": {
+        "type": "object",
+        "properties": {
+          "external_resource_external_id": {
+            "type": "string",
+            "description": "The ID of the external resource in the 3rd party system (if it's an external resource actor)",
+            "example": "q1234"
+          },
+          "external_resource_type": {
+            "type": "string",
+            "description": "The type of the external resource (if it's an external resource actor)",
+            "example": "pager_duty_incident"
+          }
+        },
+        "example": {
+          "external_resource_external_id": "q1234",
+          "external_resource_type": "pager_duty_incident"
+        }
       },
       "AuditLogPrivateIncidentAccessAttemptedMetadataV2": {
         "type": "object",
@@ -12260,6 +14029,25 @@
           "type"
         ]
       },
+      "AuditLogUserActorMetadataV2": {
+        "type": "object",
+        "properties": {
+          "user_base_role_slug": {
+            "type": "string",
+            "description": "The base role slug of the user (if it's a user actor)",
+            "example": "admin"
+          },
+          "user_custom_role_slugs": {
+            "type": "string",
+            "description": "The custom role slugs of the user, separated by commas (if it's a user actor)",
+            "example": "engineering,security"
+          }
+        },
+        "example": {
+          "user_base_role_slug": "admin",
+          "user_custom_role_slugs": "engineering,security"
+        }
+      },
       "AuditLogUserRoleMembershipChangedMetadataV2": {
         "type": "object",
         "properties": {
@@ -12326,6 +14114,168 @@
           "after_custom_role_slugs": "engineering,data",
           "before_base_role_slug": "admin",
           "before_custom_role_slugs": "engineering,security"
+        }
+      },
+      "CatalogEntryDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ]
+          },
+          "archived_at": {
+            "type": "string",
+            "description": "When this entry was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "attribute_values": {
+            "type": "object",
+            "description": "Values of this entry",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
+                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "helptext": "abc123",
+                    "image_url": "abc123",
+                    "is_image_slack_icon": false,
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity",
+                    "sort_key": "abc123",
+                    "unavailable": false,
+                    "value": "abc123"
+                  }
+                ],
+                "value": {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "abc123",
+                  "image_url": "abc123",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity",
+                  "sort_key": "abc123",
+                  "unavailable": false,
+                  "value": "abc123"
+                }
+              }
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CatalogEntryEngineParamBindingV2"
+            }
+          },
+          "catalog_type_id": {
+            "type": "string",
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When this entry was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "external_id": {
+            "type": "string",
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When this entry was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "archived_at": "2021-08-17T14:28:57.801578Z",
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "abc123",
+                  "image_url": "abc123",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity",
+                  "sort_key": "abc123",
+                  "unavailable": false,
+                  "value": "abc123"
+                }
+              ],
+              "value": {
+                "catalog_entry": {
+                  "archived_at": "2021-08-17T14:28:57.801578Z",
+                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
+                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "helptext": "abc123",
+                "image_url": "abc123",
+                "is_image_slack_icon": false,
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity",
+                "sort_key": "abc123",
+                "unavailable": false,
+                "value": "abc123"
+              }
+            }
+          },
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Primary On-call",
+          "rank": 3,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
         }
       },
       "CatalogEntryEngineParamBindingV2": {
@@ -12472,6 +14422,43 @@
         "required": [
           "label",
           "sort_key"
+        ]
+      },
+      "CatalogEntryReference": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this entry was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "catalog_entry_id": {
+            "type": "string",
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "catalog_entry_name": {
+            "type": "string",
+            "description": "The name of this entry",
+            "example": "Primary escalation"
+          },
+          "catalog_type_id": {
+            "type": "string",
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T14:28:57.801578Z",
+          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "catalog_entry_name": "Primary escalation",
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "required": [
+          "catalog_type_id",
+          "catalog_entry_id",
+          "catalog_entry_name"
         ]
       },
       "CatalogEntryReferenceV2": {
@@ -12794,7 +14781,7 @@
           "mode": {
             "type": "string",
             "description": "Controls how this attribute is modified",
-            "example": "manual",
+            "example": "",
             "enum": [
               "",
               "manual",
@@ -12832,7 +14819,7 @@
           "array": false,
           "backlink_attribute": "abc123",
           "id": "01GW2G3V0S59R238FAHPDS1R66",
-          "mode": "manual",
+          "mode": "",
           "name": "tier",
           "path": [
             {
@@ -12868,7 +14855,7 @@
           "mode": {
             "type": "string",
             "description": "Controls how this attribute is modified",
-            "example": "manual",
+            "example": "",
             "enum": [
               "",
               "manual",
@@ -12907,7 +14894,7 @@
           "array": false,
           "backlink_attribute": "abc123",
           "id": "01GW2G3V0S59R238FAHPDS1R66",
-          "mode": "manual",
+          "mode": "",
           "name": "tier",
           "path": [
             {
@@ -12925,6 +14912,273 @@
           "array"
         ]
       },
+      "CatalogTypeDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that can track metadata about this type",
+            "example": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "customer",
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-feature",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ]
+            },
+            "description": "What categories is this type considered part of",
+            "example": [
+              "customer"
+            ]
+          },
+          "color": {
+            "type": "string",
+            "description": "Sets the display color of this type in the dashboard",
+            "example": "yellow",
+            "enum": [
+              "yellow",
+              "green",
+              "blue",
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When this type was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human readble description of this type",
+            "example": "Represents Kubernetes clusters that we run inside of GKE."
+          },
+          "dynamic_resource_parameter": {
+            "type": "string",
+            "description": "If this is a dynamic catalog type, this will be the unique parameter for identitfying this resource externally.",
+            "example": "abc123"
+          },
+          "engine_resource_type": {
+            "type": "string",
+            "description": "The way this resource type is referenced in the engine",
+            "example": "CatalogType[\"PagerDutyService\"]"
+          },
+          "estimated_count": {
+            "type": "integer",
+            "description": "If populated, gives an estimated count of entries for this type",
+            "example": 7,
+            "format": "int64"
+          },
+          "icon": {
+            "type": "string",
+            "description": "Sets the display icon of this type in the dashboard",
+            "example": "alert",
+            "enum": [
+              "alert",
+              "bolt",
+              "box",
+              "briefcase",
+              "browser",
+              "bulb",
+              "calendar",
+              "clock",
+              "cog",
+              "components",
+              "database",
+              "doc",
+              "email",
+              "escalation-path",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
+              "server",
+              "severity",
+              "status-page",
+              "store",
+              "star",
+              "tag",
+              "user",
+              "users"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "is_editable": {
+            "type": "boolean",
+            "description": "Catalog types that are synced with external resources can't be edited",
+            "example": false
+          },
+          "last_synced_at": {
+            "type": "string",
+            "description": "When this type was last synced (if it's ever been sync'd)",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "mode": {
+            "type": "string",
+            "description": "What mode is this catalog type?",
+            "example": "manual",
+            "enum": [
+              "manual",
+              "external",
+              "internal"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is the human readable name of this type",
+            "example": "Kubernetes Cluster"
+          },
+          "native_resource_path": {
+            "type": "string",
+            "description": "If present, the path to view this resource natively in the web UI",
+            "example": "/on-call/escalation-paths"
+          },
+          "ranked": {
+            "type": "boolean",
+            "description": "If this type should be ranked",
+            "example": true
+          },
+          "registry_type": {
+            "type": "string",
+            "description": "The registry resource this type is synced from, if any",
+            "example": "PagerDutyService"
+          },
+          "required_integration": {
+            "type": "string",
+            "description": "If populated, the integration required for this type",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "statuspage",
+              "click_up",
+              "confluence",
+              "cortex",
+              "datadog",
+              "github",
+              "gitlab",
+              "google_docs",
+              "google_meet",
+              "google_calendar",
+              "google_workspace",
+              "jira",
+              "jira_server",
+              "linear",
+              "microsoft_teams",
+              "notion",
+              "opsgenie",
+              "opslevel",
+              "pagerduty",
+              "salesforce",
+              "sentry",
+              "shortcut",
+              "scim",
+              "slack",
+              "splunk_on_call",
+              "incident_io_status_pages",
+              "incident_io_on_call",
+              "vanta",
+              "webhooks",
+              "zendesk",
+              "zoom"
+            ]
+          },
+          "schema": {
+            "$ref": "#/components/schemas/CatalogTypeSchemaV2"
+          },
+          "source_repo_url": {
+            "type": "string",
+            "description": "The url of the external repository where this type is managed",
+            "example": "https://github.com/my-company/incident-io-catalog"
+          },
+          "type_name": {
+            "type": "string",
+            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName \"]",
+            "example": "Custom[\"BackstageGroup\"]"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When this type was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "use_name_as_identifier": {
+            "type": "boolean",
+            "description": "If populated, the name of the entry will be added to the list of identifiers for this type",
+            "example": true
+          }
+        },
+        "example": {
+          "annotations": {
+            "incident.io/catalog-importer/id": "id-of-config"
+          },
+          "categories": [
+            "customer"
+          ],
+          "color": "yellow",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "dynamic_resource_parameter": "abc123",
+          "engine_resource_type": "CatalogType[\"PagerDutyService\"]",
+          "estimated_count": 7,
+          "icon": "alert",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "is_editable": false,
+          "last_synced_at": "2021-08-17T13:28:57.801578Z",
+          "mode": "manual",
+          "name": "Kubernetes Cluster",
+          "native_resource_path": "/on-call/escalation-paths",
+          "ranked": true,
+          "registry_type": "PagerDutyService",
+          "required_integration": "asana",
+          "schema": {
+            "attributes": [
+              {
+                "array": false,
+                "backlink_attribute": "abc123",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "mode": "",
+                "name": "tier",
+                "path": [
+                  {
+                    "attribute_id": "abc123",
+                    "attribute_name": "abc123"
+                  }
+                ],
+                "type": "Custom[\"Service\"]"
+              }
+            ],
+            "version": 1
+          },
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+          "type_name": "Custom[\"BackstageGroup\"]",
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "use_name_as_identifier": true
+        }
+      },
       "CatalogTypeSchemaV2": {
         "type": "object",
         "properties": {
@@ -12939,7 +15193,7 @@
                 "array": false,
                 "backlink_attribute": "abc123",
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
-                "mode": "manual",
+                "mode": "",
                 "name": "tier",
                 "path": [
                   {
@@ -12964,7 +15218,7 @@
               "array": false,
               "backlink_attribute": "abc123",
               "id": "01GW2G3V0S59R238FAHPDS1R66",
-              "mode": "manual",
+              "mode": "",
               "name": "tier",
               "path": [
                 {
@@ -13000,7 +15254,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "issue-tracker",
+              "example": "customer",
               "enum": [
                 "customer",
                 "issue-tracker",
@@ -13013,7 +15267,7 @@
             },
             "description": "What categories is this type considered part of",
             "example": [
-              "issue-tracker"
+              "customer"
             ]
           },
           "color": {
@@ -13133,8 +15387,8 @@
           },
           "semantic_type": {
             "type": "string",
-            "description": "Semantic type of this resource (unused)",
-            "example": "custom"
+            "description": "What type of resource this catalog type should be understodd as",
+            "example": "abc123"
           },
           "source_repo_url": {
             "type": "string",
@@ -13158,7 +15412,7 @@
             "incident.io/catalog-importer/id": "id-of-config"
           },
           "categories": [
-            "issue-tracker"
+            "customer"
           ],
           "color": "yellow",
           "created_at": "2021-08-17T13:28:57.801578Z",
@@ -13181,7 +15435,7 @@
                 "array": false,
                 "backlink_attribute": "abc123",
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
-                "mode": "manual",
+                "mode": "",
                 "name": "tier",
                 "path": [
                   {
@@ -13422,6 +15676,371 @@
           "conditions"
         ]
       },
+      "ConditionGroupV4": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV4"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV5": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV5"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV6": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV6"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV7": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV7"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV8": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV8"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
       "ConditionOperationV2": {
         "type": "object",
         "properties": {
@@ -13447,6 +16066,121 @@
         ]
       },
       "ConditionOperationV3": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV4": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV5": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV6": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV7": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV8": {
         "type": "object",
         "properties": {
           "label": {
@@ -13575,6 +16309,121 @@
           "reference"
         ]
       },
+      "ConditionSubjectV4": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
+      "ConditionSubjectV5": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
+      "ConditionSubjectV6": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
+      "ConditionSubjectV7": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
+      "ConditionSubjectV8": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
       "ConditionV2": {
         "type": "object",
         "properties": {
@@ -13650,7 +16499,7 @@
           "param_bindings": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV3"
+              "$ref": "#/components/schemas/EngineParamBindingV4"
             },
             "description": "Bindings for the operation parameters",
             "example": [
@@ -13704,6 +16553,333 @@
           "subject",
           "operation",
           "param_bindings"
+        ]
+      },
+      "ConditionV4": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV4"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV5"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV4"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings"
+        ]
+      },
+      "ConditionV5": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV5"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV7"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV5"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings",
+          "params"
+        ]
+      },
+      "ConditionV6": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV6"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV9"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV6"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings"
+        ]
+      },
+      "ConditionV7": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV7"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV10"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV7"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings"
+        ]
+      },
+      "ConditionV8": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV8"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV12"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV8"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings",
+          "params"
         ]
       },
       "CreateEntryRequestBody": {
@@ -13988,175 +17164,6 @@
           "managed_resource"
         ]
       },
-      "CreatePathRequestBody": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of this escalation path, for the user's reference.",
-            "example": "Urgent Support"
-          },
-          "path": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
-            },
-            "description": "The nodes that form the levels and branches of this escalation path.",
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "if_else": {
-                  "conditions": [
-                    {
-                      "operation": "one_of",
-                      "param_bindings": [
-                        {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      ],
-                      "subject": "incident.severity"
-                    }
-                  ],
-                  "else_path": [
-                    {}
-                  ],
-                  "then_path": [
-                    {}
-                  ]
-                },
-                "level": {
-                  "round_robin_config": {
-                    "enabled": false,
-                    "rotate_after_seconds": 120
-                  },
-                  "targets": [
-                    {
-                      "id": "lawrencejones",
-                      "schedule_mode": "currently_on_call",
-                      "type": "user",
-                      "urgency": "high"
-                    }
-                  ],
-                  "time_to_ack_interval_condition": "active",
-                  "time_to_ack_seconds": 1800,
-                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "repeat": {
-                  "repeat_times": 3,
-                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "type": "if_else"
-              }
-            ]
-          },
-          "working_hours": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/WeekdayIntervalConfigV2"
-            },
-            "description": "The working hours for this escalation path.",
-            "example": [
-              {
-                "id": "abc123",
-                "name": "abc123",
-                "timezone": "abc123",
-                "weekday_intervals": [
-                  {
-                    "end_time": "17:00",
-                    "start_time": "09:00",
-                    "weekday": "abc123"
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        "example": {
-          "name": "Urgent Support",
-          "path": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "if_else": {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ],
-                "else_path": [
-                  {}
-                ],
-                "then_path": [
-                  {}
-                ]
-              },
-              "level": {
-                "round_robin_config": {
-                  "enabled": false,
-                  "rotate_after_seconds": 120
-                },
-                "targets": [
-                  {
-                    "id": "lawrencejones",
-                    "schedule_mode": "currently_on_call",
-                    "type": "user",
-                    "urgency": "high"
-                  }
-                ],
-                "time_to_ack_interval_condition": "active",
-                "time_to_ack_seconds": 1800,
-                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              },
-              "repeat": {
-                "repeat_times": 3,
-                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
-              },
-              "type": "if_else"
-            }
-          ],
-          "working_hours": [
-            {
-              "id": "abc123",
-              "name": "abc123",
-              "timezone": "abc123",
-              "weekday_intervals": [
-                {
-                  "end_time": "17:00",
-                  "start_time": "09:00",
-                  "weekday": "abc123"
-                }
-              ]
-            }
-          ]
-        },
-        "required": [
-          "name",
-          "path"
-        ]
-      },
       "CreatePathResponseBody": {
         "type": "object",
         "properties": {
@@ -14254,946 +17261,35 @@
       "CreateRequestBody": {
         "type": "object",
         "properties": {
-          "alert_source_ids": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "example": "abc123"
-            },
-            "description": "The alert sources that will match this alert route",
-            "example": [
-              "02FCNDV6P870EA6S7TK1DSYDG2"
-            ]
-          },
-          "auto_decline_enabled": {
-            "type": "boolean",
-            "description": "Should triage incidents be declined when alerts are resolved?",
-            "example": false
-          },
-          "condition_groups": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
-            },
-            "description": "What condition groups must be true for this alert route to fire?",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ]
-          },
-          "defer_time_seconds": {
-            "type": "integer",
-            "description": "How long should the escalation defer time be?",
-            "example": 1,
-            "format": "int64"
-          },
-          "enabled": {
-            "type": "boolean",
-            "description": "Whether this alert route is enabled or not",
-            "example": false
-          },
-          "escalation_bindings": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
-            },
-            "description": "Which escalation paths should this alert route escalate to?",
-            "example": [
-              {
-                "binding": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              }
-            ]
-          },
-          "expressions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExpressionPayloadV2"
-            },
-            "description": "The expressions used in this template",
-            "example": [
-              {
-                "else_branch": {
-                  "result": {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                },
-                "label": "Team Slack channel",
-                "operations": [
-                  {
-                    "branches": {
-                      "branches": [
-                        {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": "one_of",
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": "incident.severity"
-                                }
-                              ]
-                            }
-                          ],
-                          "result": {
-                            "array_value": [
-                              {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        }
-                      ],
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    },
-                    "filter": {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": "one_of",
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": "incident.severity"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "navigate": {
-                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                    },
-                    "operation_type": "navigate",
-                    "parse": {
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      },
-                      "source": "metadata.annotations[\"github.com/repo\"]"
-                    }
-                  }
-                ],
-                "reference": "abc123",
-                "root_reference": "incident.status"
-              }
-            ]
-          },
-          "grouping_keys": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/GroupingKeyV2"
-            },
-            "description": "Which attributes should this alert route use to group alerts?",
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              }
-            ]
-          },
-          "grouping_window_seconds": {
-            "type": "integer",
-            "description": "How large should the grouping window be?",
-            "example": 1,
-            "format": "int64"
-          },
-          "incident_condition_groups": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
-            },
-            "description": "What condition groups must be true for this alert route to create an incident?",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ]
-          },
-          "incident_enabled": {
-            "type": "boolean",
-            "description": "Whether this alert route will create incidents or not",
-            "example": false
-          },
-          "name": {
+          "custom_field_id": {
             "type": "string",
-            "description": "The name of this alert route config, for the user's reference",
-            "example": "Production incidents"
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
-          "template": {
-            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
           }
         },
         "example": {
-          "alert_source_ids": [
-            "02FCNDV6P870EA6S7TK1DSYDG2"
-          ],
-          "auto_decline_enabled": false,
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ],
-          "defer_time_seconds": 1,
-          "enabled": false,
-          "escalation_bindings": [
-            {
-              "binding": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            }
-          ],
-          "expressions": [
-            {
-              "else_branch": {
-                "result": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              },
-              "label": "Team Slack channel",
-              "operations": [
-                {
-                  "branches": {
-                    "branches": [
-                      {
-                        "condition_groups": [
-                          {
-                            "conditions": [
-                              {
-                                "operation": "one_of",
-                                "param_bindings": [
-                                  {
-                                    "array_value": [
-                                      {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    ],
-                                    "value": {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ],
-                                "subject": "incident.severity"
-                              }
-                            ]
-                          }
-                        ],
-                        "result": {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      }
-                    ],
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
-                  },
-                  "filter": {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": "one_of",
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": "incident.severity"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "navigate": {
-                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                  },
-                  "operation_type": "navigate",
-                  "parse": {
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    },
-                    "source": "metadata.annotations[\"github.com/repo\"]"
-                  }
-                }
-              ],
-              "reference": "abc123",
-              "root_reference": "incident.status"
-            }
-          ],
-          "grouping_keys": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
-            }
-          ],
-          "grouping_window_seconds": 1,
-          "incident_condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ],
-          "incident_enabled": false,
-          "name": "Production incidents",
-          "template": {
-            "custom_field_priorities": {
-              "abc123": "abc123"
-            },
-            "custom_fields": {
-              "custom_field_10014": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            },
-            "incident_mode": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "incident_type": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "name": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "priority_severity": "severity-first-wins",
-            "severity": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "summary": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "workspace": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          }
-        }
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        },
+        "required": [
+          "custom_field_id",
+          "value"
+        ]
       },
       "CreateRequestBody10": {
-        "type": "object",
-        "properties": {
-          "custom_field_entries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
-            },
-            "description": "Set the incident's custom fields to these values",
-            "example": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "values": [
-                  {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_text": "This is my text field, I hope you like it",
-                    "value_timestamp": ""
-                  }
-                ]
-              }
-            ]
-          },
-          "idempotency_key": {
-            "type": "string",
-            "description": "Unique string used to de-duplicate incident create requests",
-            "example": "alert-uuid"
-          },
-          "incident_role_assignments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
-            },
-            "description": "Assign incident roles to these people",
-            "example": [
-              {
-                "assignee": {
-                  "email": "bob@example.com",
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "slack_user_id": "USER123"
-                },
-                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-              }
-            ]
-          },
-          "incident_type_id": {
-            "type": "string",
-            "description": "Incident type to create this incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "mode": {
-            "type": "string",
-            "description": "Whether the incident is real or test",
-            "example": "real",
-            "enum": [
-              "real",
-              "test"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Explanation of the incident",
-            "example": "Our database is sad"
-          },
-          "severity_id": {
-            "type": "string",
-            "description": "Severity to create incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "slack_team_id": {
-            "type": "string",
-            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
-            "example": "T02A1FSLE8J"
-          },
-          "source_message_channel_id": {
-            "type": "string",
-            "description": "Channel ID of the source message, if this incident was created from one",
-            "example": "C02AW36C1M5"
-          },
-          "source_message_timestamp": {
-            "type": "string",
-            "description": "Timestamp of the source message, if this incident was created from one",
-            "example": "1653650280.526509"
-          },
-          "status": {
-            "type": "string",
-            "description": "Current status of the incident",
-            "example": "triage",
-            "enum": [
-              "triage",
-              "investigating",
-              "fixing",
-              "monitoring",
-              "closed",
-              "declined"
-            ]
-          },
-          "summary": {
-            "type": "string",
-            "description": "Detailed description of the incident",
-            "example": "Our database is really really sad, and we don't know why yet."
-          },
-          "visibility": {
-            "type": "string",
-            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-            "example": "public",
-            "enum": [
-              "public",
-              "private"
-            ]
-          }
-        },
-        "example": {
-          "custom_field_entries": [
-            {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "values": [
-                {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_text": "This is my text field, I hope you like it",
-                  "value_timestamp": ""
-                }
-              ]
-            }
-          ],
-          "idempotency_key": "alert-uuid",
-          "incident_role_assignments": [
-            {
-              "assignee": {
-                "email": "bob@example.com",
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                "slack_user_id": "USER123"
-              },
-              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-            }
-          ],
-          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "mode": "real",
-          "name": "Our database is sad",
-          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "slack_team_id": "T02A1FSLE8J",
-          "source_message_channel_id": "C02AW36C1M5",
-          "source_message_timestamp": "1653650280.526509",
-          "status": "triage",
-          "summary": "Our database is really really sad, and we don't know why yet.",
-          "visibility": "public"
-        },
-        "required": [
-          "idempotency_key",
-          "visibility"
-        ]
-      },
-      "CreateRequestBody11": {
-        "type": "object",
-        "properties": {
-          "custom_field_entries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
-            },
-            "description": "Set the incident's custom fields to these values",
-            "example": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "values": [
-                  {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_text": "This is my text field, I hope you like it",
-                    "value_timestamp": ""
-                  }
-                ]
-              }
-            ]
-          },
-          "id": {
-            "type": "string",
-            "description": "Unique identifier for the incident",
-            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
-          },
-          "idempotency_key": {
-            "type": "string",
-            "description": "Unique string used to de-duplicate incident create requests",
-            "example": "alert-uuid"
-          },
-          "incident_role_assignments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV2"
-            },
-            "description": "Assign incident roles to these people",
-            "example": [
-              {
-                "assignee": {
-                  "email": "bob@example.com",
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "slack_user_id": "USER123"
-                },
-                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-              }
-            ]
-          },
-          "incident_status_id": {
-            "type": "string",
-            "description": "Incident status to assign to the incident",
-            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
-          },
-          "incident_timestamp_values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentTimestampValuePayloadV2"
-            },
-            "description": "Assign the incident's timestamps to these values",
-            "example": [
-              {
-                "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "value": "2021-08-17T13:28:57.801578Z"
-              }
-            ]
-          },
-          "incident_type_id": {
-            "type": "string",
-            "description": "Incident type to create this incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "mode": {
-            "type": "string",
-            "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
-            "example": "standard",
-            "enum": [
-              "standard",
-              "retrospective",
-              "test",
-              "tutorial"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Explanation of the incident",
-            "example": "Our database is sad"
-          },
-          "retrospective_incident_options": {
-            "$ref": "#/components/schemas/RetrospectiveIncidentOptionsV2"
-          },
-          "severity_id": {
-            "type": "string",
-            "description": "Severity to create incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "slack_channel_name_override": {
-            "type": "string",
-            "description": "Name of the Slack channel to create for this incident",
-            "example": "inc-123-database-down"
-          },
-          "slack_team_id": {
-            "type": "string",
-            "description": "Slack Team to create the incident in",
-            "example": "T02A1FSLE8J"
-          },
-          "summary": {
-            "type": "string",
-            "description": "Detailed description of the incident",
-            "example": "Our database is really really sad, and we don't know why yet."
-          },
-          "visibility": {
-            "type": "string",
-            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-            "example": "public",
-            "enum": [
-              "public",
-              "private"
-            ]
-          }
-        },
-        "example": {
-          "custom_field_entries": [
-            {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "values": [
-                {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_text": "This is my text field, I hope you like it",
-                  "value_timestamp": ""
-                }
-              ]
-            }
-          ],
-          "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-          "idempotency_key": "alert-uuid",
-          "incident_role_assignments": [
-            {
-              "assignee": {
-                "email": "bob@example.com",
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                "slack_user_id": "USER123"
-              },
-              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-            }
-          ],
-          "incident_status_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-          "incident_timestamp_values": [
-            {
-              "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "value": "2021-08-17T13:28:57.801578Z"
-            }
-          ],
-          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "mode": "standard",
-          "name": "Our database is sad",
-          "retrospective_incident_options": {
-            "postmortem_document_url": "https://docs.google.com/my_doc_id",
-            "slack_channel_id": "abc123"
-          },
-          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "slack_channel_name_override": "inc-123-database-down",
-          "slack_team_id": "T02A1FSLE8J",
-          "summary": "Our database is really really sad, and we don't know why yet.",
-          "visibility": "public"
-        },
-        "required": [
-          "idempotency_key",
-          "visibility"
-        ]
-      },
-      "CreateRequestBody12": {
-        "type": "object",
-        "properties": {
-          "schedule": {
-            "$ref": "#/components/schemas/ScheduleCreatePayloadV2"
-          }
-        },
-        "example": {
-          "schedule": {
-            "annotations": {
-              "incident.io/terraform/version": "version-of-terraform"
-            },
-            "config": {
-              "rotations": [
-                {
-                  "effective_from": "2021-08-17T13:28:57.801578Z",
-                  "handover_start_at": "2021-08-17T13:28:57.801578Z",
-                  "handovers": [
-                    {
-                      "interval": 1,
-                      "interval_type": "daily"
-                    }
-                  ],
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "layers": [
-                    {
-                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                      "name": "Layer 1"
-                    }
-                  ],
-                  "name": "My Rotation",
-                  "users": [
-                    {
-                      "email": "bob@example.com",
-                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                      "slack_user_id": "USER123"
-                    }
-                  ],
-                  "working_interval": [
-                    {
-                      "end_time": "17:00",
-                      "start_time": "09:00",
-                      "weekday": "tuesday"
-                    }
-                  ]
-                }
-              ]
-            },
-            "holidays_public_config": {
-              "country_codes": [
-                "abc123"
-              ]
-            },
-            "name": "My Schedule",
-            "timezone": "America/Los_Angeles"
-          }
-        },
-        "required": [
-          "schedule"
-        ]
-      },
-      "CreateRequestBody13": {
         "type": "object",
         "properties": {
           "description": {
@@ -15225,37 +17321,6 @@
         ]
       },
       "CreateRequestBody2": {
-        "type": "object",
-        "properties": {
-          "custom_field_id": {
-            "type": "string",
-            "description": "ID of the custom field this option belongs to",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-          },
-          "sort_key": {
-            "type": "integer",
-            "description": "Sort key used to order the custom field options correctly",
-            "default": 1000,
-            "example": 10,
-            "format": "int64"
-          },
-          "value": {
-            "type": "string",
-            "description": "Human readable name for the custom field option",
-            "example": "Product"
-          }
-        },
-        "example": {
-          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "sort_key": 10,
-          "value": "Product"
-        },
-        "required": [
-          "custom_field_id",
-          "value"
-        ]
-      },
-      "CreateRequestBody3": {
         "type": "object",
         "properties": {
           "description": {
@@ -15346,7 +17411,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody4": {
+      "CreateRequestBody3": {
         "type": "object",
         "properties": {
           "description": {
@@ -15388,7 +17453,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody5": {
+      "CreateRequestBody4": {
         "type": "object",
         "properties": {
           "incident_id": {
@@ -15452,7 +17517,7 @@
           "resource"
         ]
       },
-      "CreateRequestBody6": {
+      "CreateRequestBody5": {
         "type": "object",
         "properties": {
           "incident_id": {
@@ -15473,7 +17538,7 @@
           "incident_id"
         ]
       },
-      "CreateRequestBody7": {
+      "CreateRequestBody6": {
         "type": "object",
         "properties": {
           "description": {
@@ -15524,7 +17589,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody8": {
+      "CreateRequestBody7": {
         "type": "object",
         "properties": {
           "description": {
@@ -15568,7 +17633,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody9": {
+      "CreateRequestBody8": {
         "type": "object",
         "properties": {
           "category": {
@@ -15605,6 +17670,67 @@
           "rank",
           "created_at",
           "updated_at"
+        ]
+      },
+      "CreateRequestBody9": {
+        "type": "object",
+        "properties": {
+          "schedule": {
+            "$ref": "#/components/schemas/ScheduleCreatePayloadV2"
+          }
+        },
+        "example": {
+          "schedule": {
+            "annotations": {
+              "incident.io/terraform/version": "version-of-terraform"
+            },
+            "config": {
+              "rotations": [
+                {
+                  "effective_from": "2021-08-17T13:28:57.801578Z",
+                  "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                  "handovers": [
+                    {
+                      "interval": 1,
+                      "interval_type": "daily"
+                    }
+                  ],
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "layers": [
+                    {
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "name": "Layer 1"
+                    }
+                  ],
+                  "name": "My Rotation",
+                  "users": [
+                    {
+                      "email": "bob@example.com",
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "slack_user_id": "USER123"
+                    }
+                  ],
+                  "working_interval": [
+                    {
+                      "end_time": "17:00",
+                      "start_time": "09:00",
+                      "weekday": "tuesday"
+                    }
+                  ]
+                }
+              ]
+            },
+            "holidays_public_config": {
+              "country_codes": [
+                "abc123"
+              ]
+            },
+            "name": "My Schedule",
+            "timezone": "America/Los_Angeles"
+          }
+        },
+        "required": [
+          "schedule"
         ]
       },
       "CreateResponseBody": {
@@ -16160,7 +18286,7 @@
           "catalog_type"
         ]
       },
-      "CreateWorkflowRequestBody": {
+      "CreateWorkflowPayload": {
         "type": "object",
         "properties": {
           "annotations": {
@@ -16358,7 +18484,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "test",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
               "enum": [
                 "standard",
                 "test",
@@ -16660,6 +18787,52 @@
           "values"
         ]
       },
+      "CustomFieldEntryPayloadV2": {
+        "type": "object",
+        "properties": {
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this entry is linked against",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldValuePayloadV2"
+            },
+            "description": "List of values to associate with this entry. Use an empty array to unset the value of the custom field.",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_link": "https://google.com/",
+                "value_numeric": "123.456",
+                "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_text": "This is my text field, I hope you like it",
+                "value_timestamp": ""
+              }
+            ]
+          }
+        },
+        "example": {
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "values": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "value_link": "https://google.com/",
+              "value_numeric": "123.456",
+              "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "value_text": "This is my text field, I hope you like it",
+              "value_timestamp": ""
+            }
+          ]
+        },
+        "required": [
+          "custom_field_id",
+          "values"
+        ]
+      },
       "CustomFieldEntryV1": {
         "type": "object",
         "properties": {
@@ -16739,7 +18912,221 @@
           "values"
         ]
       },
+      "CustomFieldEntryV2": {
+        "type": "object",
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldTypeInfoV2"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldValueV2"
+            },
+            "description": "List of custom field values set on this entry",
+            "example": [
+              {
+                "value_catalog_entry": {
+                  "aliases": [
+                    "lawrence@incident.io",
+                    "lawrence"
+                  ],
+                  "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Primary On-call"
+                },
+                "value_link": "https://google.com/",
+                "value_numeric": "123.456",
+                "value_option": {
+                  "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "sort_key": 10,
+                  "value": "Product"
+                },
+                "value_text": "This is my text field, I hope you like it"
+              }
+            ]
+          }
+        },
+        "example": {
+          "custom_field": {
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "options": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              }
+            ]
+          },
+          "values": [
+            {
+              "value_catalog_entry": {
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
+                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Primary On-call"
+              },
+              "value_link": "https://google.com/",
+              "value_numeric": "123.456",
+              "value_option": {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              },
+              "value_text": "This is my text field, I hope you like it"
+            }
+          ]
+        },
+        "required": [
+          "custom_field",
+          "values"
+        ]
+      },
+      "CustomFieldOptionDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this option was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T14:28:57.801578Z",
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        }
+      },
+      "CustomFieldOptionDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this option was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T14:28:57.801578Z",
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        }
+      },
+      "CustomFieldOptionPayloadV1": {
+        "type": "object",
+        "example": {},
+        "required": [
+          "custom_field_id",
+          "value"
+        ]
+      },
+      "CustomFieldOptionPayloadV2": {
+        "type": "object",
+        "example": {},
+        "required": [
+          "custom_field_id",
+          "value"
+        ]
+      },
       "CustomFieldOptionV1": {
+        "type": "object",
+        "properties": {
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
+          }
+        },
+        "example": {
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        },
+        "required": [
+          "id",
+          "custom_field_id",
+          "value",
+          "sort_key"
+        ]
+      },
+      "CustomFieldOptionV2": {
         "type": "object",
         "properties": {
           "custom_field_id": {
@@ -16813,6 +19200,84 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CustomFieldOptionV1"
+            },
+            "description": "What options are available for this custom field, if this field has options",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              }
+            ]
+          }
+        },
+        "example": {
+          "description": "Which team is impacted by this issue",
+          "field_type": "single_select",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Affected Team",
+          "options": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "sort_key": 10,
+              "value": "Product"
+            }
+          ]
+        },
+        "required": [
+          "id",
+          "organisation_id",
+          "name",
+          "description",
+          "dynamic_options",
+          "rank",
+          "field_type",
+          "cannot_be_unset",
+          "options",
+          "is_usable",
+          "condition_groups",
+          "field_mode",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CustomFieldTypeInfoV2": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue"
+          },
+          "field_type": {
+            "type": "string",
+            "description": "Type of custom field",
+            "example": "single_select",
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldOptionV2"
             },
             "description": "What options are available for this custom field, if this field has options",
             "example": [
@@ -17064,7 +19529,206 @@
           "updated_at"
         ]
       },
+      "CustomFieldValueDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the value was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field value",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "incident_id": {
+            "type": "string",
+            "description": "ID of the incident this value is defined on",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the value was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "value_catalog_entry_id": {
+            "type": "string",
+            "description": "ID of the catalog entry.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_link": {
+            "type": "string",
+            "description": "If the custom field type is 'link', this will contain the value assigned.",
+            "example": "https://google.com/"
+          },
+          "value_numeric": {
+            "type": "string",
+            "description": "If the custom field type is 'numeric', this will contain the value assigned.",
+            "example": "123.456"
+          },
+          "value_option_id": {
+            "type": "string",
+            "description": "ID of the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_option_value": {
+            "type": "string",
+            "description": "The value of a new option that should be created, if the field supports dynamic options. If this conflicts with an existing option label, you must use its ID instead.",
+            "example": "New option"
+          },
+          "value_text": {
+            "type": "string",
+            "description": "If the custom field type is 'text', this will contain the value assigned.",
+            "example": "This is my text field, I hope you like it"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_link": "https://google.com/",
+          "value_numeric": "123.456",
+          "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_option_value": "New option",
+          "value_text": "This is my text field, I hope you like it"
+        }
+      },
+      "CustomFieldValueDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the value was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field value",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "incident_id": {
+            "type": "string",
+            "description": "ID of the incident this value is defined on",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the value was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "value_catalog_entry_id": {
+            "type": "string",
+            "description": "ID of the catalog entry.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_link": {
+            "type": "string",
+            "description": "If the custom field type is 'link', this will contain the value assigned.",
+            "example": "https://google.com/"
+          },
+          "value_numeric": {
+            "type": "string",
+            "description": "If the custom field type is 'numeric', this will contain the value assigned.",
+            "example": "123.456"
+          },
+          "value_option_id": {
+            "type": "string",
+            "description": "ID of the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_option_value": {
+            "type": "string",
+            "description": "The value of a new option that should be created, if the field supports dynamic options. If this conflicts with an existing option label, you must use its ID instead.",
+            "example": "New option"
+          },
+          "value_text": {
+            "type": "string",
+            "description": "If the custom field type is 'text', this will contain the value assigned.",
+            "example": "This is my text field, I hope you like it"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_link": "https://google.com/",
+          "value_numeric": "123.456",
+          "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_option_value": "New option",
+          "value_text": "This is my text field, I hope you like it"
+        }
+      },
       "CustomFieldValuePayloadV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field value",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_catalog_entry_id": {
+            "type": "string",
+            "description": "ID of the catalog entry. You can also use an ExternalID or an Alias of the catalog entry.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_link": {
+            "type": "string",
+            "description": "If the custom field type is 'link', this will contain the value assigned.",
+            "example": "https://google.com/"
+          },
+          "value_numeric": {
+            "type": "string",
+            "description": "If the custom field type is 'numeric', this will contain the value assigned.",
+            "example": "123.456"
+          },
+          "value_option_id": {
+            "type": "string",
+            "description": "ID of the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_text": {
+            "type": "string",
+            "description": "If the custom field type is 'text', this will contain the value assigned.",
+            "example": "This is my text field, I hope you like it"
+          },
+          "value_timestamp": {
+            "type": "string",
+            "description": "Deprecated: please use incident timestamp values instead",
+            "example": ""
+          }
+        },
+        "example": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_link": "https://google.com/",
+          "value_numeric": "123.456",
+          "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_text": "This is my text field, I hope you like it",
+          "value_timestamp": ""
+        }
+      },
+      "CustomFieldValuePayloadV2": {
         "type": "object",
         "properties": {
           "id": {
@@ -17131,6 +19795,52 @@
           },
           "value_option": {
             "$ref": "#/components/schemas/CustomFieldOptionV1"
+          },
+          "value_text": {
+            "type": "string",
+            "description": "If the custom field type is 'text', this will contain the value assigned.",
+            "example": "This is my text field, I hope you like it"
+          }
+        },
+        "example": {
+          "value_catalog_entry": {
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Primary On-call"
+          },
+          "value_link": "https://google.com/",
+          "value_numeric": "123.456",
+          "value_option": {
+            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "sort_key": 10,
+            "value": "Product"
+          },
+          "value_text": "This is my text field, I hope you like it"
+        }
+      },
+      "CustomFieldValueV2": {
+        "type": "object",
+        "properties": {
+          "value_catalog_entry": {
+            "$ref": "#/components/schemas/EmbeddedCatalogEntryV2"
+          },
+          "value_link": {
+            "type": "string",
+            "description": "If the custom field type is 'link', this will contain the value assigned.",
+            "example": "https://google.com/"
+          },
+          "value_numeric": {
+            "type": "string",
+            "description": "If the custom field type is 'numeric', this will contain the value assigned.",
+            "example": "123.456"
+          },
+          "value_option": {
+            "$ref": "#/components/schemas/CustomFieldOptionV2"
           },
           "value_text": {
             "type": "string",
@@ -17265,6 +19975,133 @@
           "catalog_type_id"
         ]
       },
+      "EmbeddedCatalogEntryV2": {
+        "type": "object",
+        "properties": {
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ]
+          },
+          "external_id": {
+            "type": "string",
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call"
+          }
+        },
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Primary On-call"
+        },
+        "required": [
+          "id",
+          "name",
+          "catalog_type_id"
+        ]
+      },
+      "EmbeddedIncidentRoleV2": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the role was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the role",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1
+          },
+          "required": {
+            "type": "boolean",
+            "description": "This field is deprecated.",
+            "example": false
+          },
+          "role_type": {
+            "type": "string",
+            "description": "Type of incident role",
+            "example": "lead",
+            "enum": [
+              "lead",
+              "reporter",
+              "custom"
+            ]
+          },
+          "shortform": {
+            "type": "string",
+            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
+            "example": "lead"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the role was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "The person currently coordinating the incident",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "required": false,
+          "role_type": "lead",
+          "shortform": "lead",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "name",
+          "shortform",
+          "description",
+          "instructions",
+          "condition_groups",
+          "id",
+          "role_type",
+          "created_at",
+          "updated_at"
+        ]
+      },
       "EngineParamBindingPayloadV2": {
         "type": "object",
         "properties": {
@@ -17293,6 +20130,114 @@
             }
           ],
           "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV10": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV18"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV17"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV11": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV20"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV19"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV12": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV22"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV21"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
             "literal": "SEV123",
             "reference": "incident.severity"
           }
@@ -17340,7 +20285,7 @@
           "array_value": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV3"
+              "$ref": "#/components/schemas/EngineParamBindingValueV4"
             },
             "description": "If array_value is set, this helps render the values",
             "example": [
@@ -17353,6 +20298,222 @@
           },
           "value": {
             "$ref": "#/components/schemas/EngineParamBindingValueV3"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV4": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV6"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV5"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV5": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV8"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV7"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV6": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV10"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV9"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV7": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV12"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV11"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV8": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV14"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV13"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV9": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV16"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV15"
           }
         },
         "example": {
@@ -17389,6 +20550,286 @@
           "reference": "incident.severity"
         }
       },
+      "EngineParamBindingValueV10": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV11": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV12": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV13": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV14": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV15": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV16": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV17": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV18": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV19": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
       "EngineParamBindingValueV2": {
         "type": "object",
         "properties": {
@@ -17418,6 +20859,90 @@
           "sort_key"
         ]
       },
+      "EngineParamBindingValueV20": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV21": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV22": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
       "EngineParamBindingValueV3": {
         "type": "object",
         "properties": {
@@ -17444,6 +20969,249 @@
         },
         "required": [
           "label"
+        ]
+      },
+      "EngineParamBindingValueV4": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV5": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV6": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV7": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV8": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV9": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamV2": {
+        "type": "object",
+        "properties": {
+          "array": {
+            "type": "boolean",
+            "description": "Whether this parameter is an array",
+            "example": true
+          },
+          "default_value": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "description": {
+            "type": "string",
+            "description": "A string describing the param",
+            "example": "What slack channel should we send the message to?"
+          },
+          "infer_reference": {
+            "type": "boolean",
+            "description": "Whether this parameter should be inferred as a reference from the scope",
+            "example": true
+          },
+          "label": {
+            "type": "string",
+            "description": "Human readable label for this parameter",
+            "example": "To date"
+          },
+          "name": {
+            "type": "string",
+            "description": "The unique identifier for the parameter",
+            "example": "severity"
+          },
+          "optional": {
+            "type": "boolean",
+            "description": "Whether this parameter is optional",
+            "example": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the parameter",
+            "example": "IncidentSeverity"
+          }
+        },
+        "example": {
+          "array": true,
+          "default_value": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "description": "What slack channel should we send the message to?",
+          "infer_reference": true,
+          "label": "To date",
+          "name": "severity",
+          "optional": true,
+          "type": "IncidentSeverity"
+        },
+        "required": [
+          "name",
+          "label",
+          "type",
+          "array",
+          "optional",
+          "infer_reference",
+          "description"
         ]
       },
       "EngineReferenceV2": {
@@ -17483,6 +21251,133 @@
           "array",
           "node_label",
           "hide_filter"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorSingle"
+            },
+            "description": "List of errors that caused this request to fail",
+            "example": [
+              {
+                "code": "trial_expired",
+                "message": "Default incident call link must be a valid URL",
+                "source": {
+                  "field": "default_call_url",
+                  "pointer": "/settings/default_call_url"
+                }
+              }
+            ]
+          },
+          "request_id": {
+            "type": "string",
+            "description": "Unique identifier of the request",
+            "example": "FF1D889F-0741-6290-783B-66E606310D86",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status of the response",
+            "example": 429,
+            "format": "int64"
+          },
+          "type": {
+            "type": "string",
+            "description": "Machine-readable identifier for the general category of error",
+            "example": "invalid_request_error",
+            "enum": [
+              "invalid_request_error",
+              "authentication_error",
+              "resource_forbidden",
+              "not_found",
+              "not_acceptable",
+              "conflict",
+              "precondition_failed",
+              "payload_too_large",
+              "validation_error",
+              "too_many_requests",
+              "api_error",
+              "rate_limit_reached"
+            ]
+          }
+        },
+        "example": {
+          "errors": [
+            {
+              "code": "trial_expired",
+              "message": "Default incident call link must be a valid URL",
+              "source": {
+                "field": "default_call_url",
+                "pointer": "/settings/default_call_url"
+              }
+            }
+          ],
+          "request_id": "FF1D889F-0741-6290-783B-66E606310D86",
+          "status": 429,
+          "type": "invalid_request_error"
+        },
+        "required": [
+          "type",
+          "status",
+          "request_id",
+          "errors"
+        ]
+      },
+      "ErrorSingle": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable identifier for this specific error",
+            "example": "trial_expired"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human readable description of the error",
+            "example": "Default incident call link must be a valid URL"
+          },
+          "source": {
+            "$ref": "#/components/schemas/ErrorSource"
+          }
+        },
+        "example": {
+          "code": "trial_expired",
+          "message": "Default incident call link must be a valid URL",
+          "source": {
+            "field": "default_call_url",
+            "pointer": "/settings/default_call_url"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      },
+      "ErrorSource": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "Field name that is the source of the error",
+            "example": "default_call_url"
+          },
+          "pointer": {
+            "type": "string",
+            "description": "JSON pointer to the request field that is the source of the error",
+            "example": "/settings/default_call_url"
+          }
+        },
+        "example": {
+          "field": "default_call_url",
+          "pointer": "/settings/default_call_url"
+        },
+        "required": [
+          "field",
+          "pointer"
         ]
       },
       "EscalationPathNodeIfElsePayloadV2": {
@@ -17561,7 +21456,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -17623,7 +21518,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -17701,7 +21596,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -17756,7 +21651,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -17869,7 +21764,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -17939,7 +21834,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -18033,7 +21928,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -18096,7 +21991,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -18134,7 +22029,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
-                "type": "user",
+                "type": "schedule",
                 "urgency": "high"
               }
             ]
@@ -18169,7 +22064,7 @@
             {
               "id": "lawrencejones",
               "schedule_mode": "currently_on_call",
-              "type": "user",
+              "type": "schedule",
               "urgency": "high"
             }
           ],
@@ -18249,7 +22144,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
-                "type": "user",
+                "type": "schedule",
                 "urgency": "high"
               }
             ],
@@ -18368,7 +22263,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
-                "type": "user",
+                "type": "schedule",
                 "urgency": "high"
               }
             ],
@@ -18385,6 +22280,175 @@
         "required": [
           "id",
           "type"
+        ]
+      },
+      "EscalationPathPayloadV2": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of this escalation path, for the user's reference.",
+            "example": "Urgent Support"
+          },
+          "path": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
+            },
+            "description": "The nodes that form the levels and branches of this escalation path.",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": "one_of",
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": "incident.severity"
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "round_robin_config": {
+                    "enabled": false,
+                    "rotate_after_seconds": 120
+                  },
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "schedule_mode": "currently_on_call",
+                      "type": "schedule",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ]
+          },
+          "working_hours": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WeekdayIntervalConfigV2"
+            },
+            "description": "The working hours for this escalation path.",
+            "example": [
+              {
+                "id": "abc123",
+                "name": "abc123",
+                "timezone": "abc123",
+                "weekday_intervals": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "abc123"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "name": "Urgent Support",
+          "path": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "if_else": {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ],
+                "else_path": [
+                  {}
+                ],
+                "then_path": [
+                  {}
+                ]
+              },
+              "level": {
+                "round_robin_config": {
+                  "enabled": false,
+                  "rotate_after_seconds": 120
+                },
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "schedule_mode": "currently_on_call",
+                    "type": "schedule",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "repeat": {
+                "repeat_times": 3,
+                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "type": "if_else"
+            }
+          ],
+          "working_hours": [
+            {
+              "id": "abc123",
+              "name": "abc123",
+              "timezone": "abc123",
+              "weekday_intervals": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "abc123"
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "name",
+          "path"
         ]
       },
       "EscalationPathRoundRobinConfigV2": {
@@ -18431,8 +22495,7 @@
           },
           "type": {
             "type": "string",
-            "description": "Controls what type of entity this target identifies, such as EscalationPolicy or User",
-            "example": "user",
+            "example": "schedule",
             "enum": [
               "schedule",
               "user",
@@ -18452,7 +22515,7 @@
         "example": {
           "id": "lawrencejones",
           "schedule_mode": "currently_on_call",
-          "type": "user",
+          "type": "schedule",
           "urgency": "high"
         },
         "required": [
@@ -18528,7 +22591,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -18617,7 +22680,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -18841,7 +22904,7 @@
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV3"
+              "$ref": "#/components/schemas/ConditionGroupV4"
             },
             "description": "When one of these condition groups are satisfied, this branch will be evaluated",
             "example": [
@@ -18878,7 +22941,106 @@
             ]
           },
           "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV3"
+            "$ref": "#/components/schemas/EngineParamBindingV6"
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "result": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "condition_groups",
+          "result"
+        ]
+      },
+      "ExpressionBranchV4": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV7"
+            },
+            "description": "When one of these condition groups are satisfied, this branch will be evaluated",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "result": {
+            "$ref": "#/components/schemas/EngineParamBindingV11"
           }
         },
         "example": {
@@ -19289,6 +23451,414 @@
           "returns"
         ]
       },
+      "ExpressionBranchesOptsV4": {
+        "type": "object",
+        "properties": {
+          "branches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionBranchV4"
+            },
+            "description": "The branches to apply for this operation",
+            "example": [
+              {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          }
+        },
+        "example": {
+          "branches": [
+            {
+              "condition_groups": [
+                {
+                  "conditions": [
+                    {
+                      "operation": {
+                        "label": "Lawrence Jones",
+                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                      },
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": {
+                        "label": "Incident Severity",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "result": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "required": [
+          "branches",
+          "returns"
+        ]
+      },
+      "ExpressionDefinitions": {
+        "type": "object",
+        "properties": {
+          "else_branch": {
+            "$ref": "#/components/schemas/ExpressionElseBranchV2"
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of the expression",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "label": {
+            "type": "string",
+            "description": "The human readable label of the expression",
+            "example": "Team Slack channel"
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionOperationV2"
+            },
+            "example": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": {
+                            "label": "Lawrence Jones",
+                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                          },
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": {
+                            "label": "Incident Severity",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "1235",
+                  "reference_label": "Teams"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                },
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              }
+            ]
+          },
+          "reference": {
+            "type": "string",
+            "description": "A short ID that can be used to reference the expression",
+            "example": "abc123"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          },
+          "root_reference": {
+            "type": "string",
+            "description": "The root reference for this expression (i.e. where the expression starts)",
+            "example": "incident.status"
+          }
+        },
+        "example": {
+          "else_branch": {
+            "result": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "label": "Team Slack channel",
+          "operations": [
+            {
+              "branches": {
+                "branches": [
+                  {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "result": {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              },
+              "filter": {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "navigate": {
+                "reference": "1235",
+                "reference_label": "Teams"
+              },
+              "operation_type": "navigate",
+              "parse": {
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "source": "metadata.annotations[\"github.com/repo\"]"
+              },
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              }
+            }
+          ],
+          "reference": "abc123",
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          },
+          "root_reference": "incident.status"
+        }
+      },
       "ExpressionElseBranchPayloadV2": {
         "type": "object",
         "properties": {
@@ -19346,6 +23916,33 @@
         "properties": {
           "result": {
             "$ref": "#/components/schemas/EngineParamBindingV3"
+          }
+        },
+        "example": {
+          "result": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "ExpressionElseBranchV4": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/EngineParamBindingV8"
           }
         },
         "example": {
@@ -19521,6 +24118,87 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ConditionGroupV3"
+            },
+            "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "condition_groups"
+        ]
+      },
+      "ExpressionFilterOptsV4": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV6"
             },
             "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
             "example": [
@@ -19785,7 +24463,7 @@
             ]
           },
           "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
+            "$ref": "#/components/schemas/ExpressionParseOptsV2"
           },
           "returns": {
             "$ref": "#/components/schemas/ReturnsMetaV2"
@@ -19933,7 +24611,155 @@
             ]
           },
           "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
+            "$ref": "#/components/schemas/ExpressionParseOptsV2"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          }
+        },
+        "example": {
+          "branches": {
+            "branches": [
+              {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ],
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            }
+          },
+          "filter": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "navigate": {
+            "reference": "1235",
+            "reference_label": "Teams"
+          },
+          "operation_type": "navigate",
+          "parse": {
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            },
+            "source": "metadata.annotations[\"github.com/repo\"]"
+          },
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "required": [
+          "operation_type",
+          "returns"
+        ]
+      },
+      "ExpressionOperationV4": {
+        "type": "object",
+        "properties": {
+          "branches": {
+            "$ref": "#/components/schemas/ExpressionBranchesOptsV4"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/ExpressionFilterOptsV4"
+          },
+          "navigate": {
+            "$ref": "#/components/schemas/ExpressionNavigateOptsV2"
+          },
+          "operation_type": {
+            "type": "string",
+            "description": "The type of the operation",
+            "example": "navigate",
+            "enum": [
+              "navigate",
+              "filter",
+              "count",
+              "min",
+              "max",
+              "random",
+              "first",
+              "parse",
+              "branches"
+            ]
+          },
+          "parse": {
+            "$ref": "#/components/schemas/ExpressionParseOptsV2"
           },
           "returns": {
             "$ref": "#/components/schemas/ReturnsMetaV2"
@@ -20053,6 +24879,30 @@
         ]
       },
       "ExpressionParseOptsPayloadV2": {
+        "type": "object",
+        "properties": {
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          },
+          "source": {
+            "type": "string",
+            "description": "Source expression that is evaluated to a result",
+            "example": "metadata.annotations[\"github.com/repo\"]"
+          }
+        },
+        "example": {
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          },
+          "source": "metadata.annotations[\"github.com/repo\"]"
+        },
+        "required": [
+          "source",
+          "returns"
+        ]
+      },
+      "ExpressionParseOptsV2": {
         "type": "object",
         "properties": {
           "returns": {
@@ -20874,42 +25724,292 @@
           "id"
         ]
       },
-      "ExternalIssueReferenceV1": {
+      "ExpressionV4": {
         "type": "object",
         "properties": {
-          "issue_name": {
-            "type": "string",
-            "description": "Human readable ID for the issue",
-            "example": "INC-123"
+          "else_branch": {
+            "$ref": "#/components/schemas/ExpressionElseBranchV4"
           },
-          "issue_permalink": {
+          "label": {
             "type": "string",
-            "description": "URL linking directly to the action in the issue tracker",
-            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+            "description": "The human readable label of the expression",
+            "example": "Team Slack channel"
           },
-          "provider": {
-            "type": "string",
-            "description": "ID of the issue tracker provider",
-            "example": "asana",
-            "enum": [
-              "asana",
-              "click_up",
-              "linear",
-              "jira",
-              "jira_server",
-              "github",
-              "gitlab",
-              "shortcut"
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionOperationV4"
+            },
+            "example": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": {
+                            "label": "Lawrence Jones",
+                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                          },
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": {
+                            "label": "Incident Severity",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "1235",
+                  "reference_label": "Teams"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                },
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              }
             ]
+          },
+          "reference": {
+            "type": "string",
+            "description": "A short ID that can be used to reference the expression",
+            "example": "abc123"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          },
+          "root_reference": {
+            "type": "string",
+            "description": "The root reference for this expression (i.e. where the expression starts)",
+            "example": "incident.status"
           }
         },
         "example": {
-          "issue_name": "INC-123",
-          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-          "provider": "asana"
-        }
+          "else_branch": {
+            "result": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "label": "Team Slack channel",
+          "operations": [
+            {
+              "branches": {
+                "branches": [
+                  {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "result": {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              },
+              "filter": {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "navigate": {
+                "reference": "1235",
+                "reference_label": "Teams"
+              },
+              "operation_type": "navigate",
+              "parse": {
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "source": "metadata.annotations[\"github.com/repo\"]"
+              },
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              }
+            }
+          ],
+          "reference": "abc123",
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          },
+          "root_reference": "incident.status"
+        },
+        "required": [
+          "label",
+          "reference",
+          "returns",
+          "root_reference",
+          "operations",
+          "id"
+        ]
       },
-      "ExternalIssueReferenceV2": {
+      "ExternalIssueReferenceV1": {
         "type": "object",
         "properties": {
           "issue_name": {
@@ -20950,6 +26050,254 @@
           "issue_permalink",
           "issue_id"
         ]
+      },
+      "ExternalIssueReferenceV2": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        }
+      },
+      "ExternalIssueReferenceV3": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        },
+        "required": [
+          "provider",
+          "provider_instance_id",
+          "issue_name",
+          "issue_permalink",
+          "issue_id"
+        ]
+      },
+      "ExternalIssueReferenceV4": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        },
+        "required": [
+          "provider",
+          "provider_instance_id",
+          "issue_name",
+          "issue_permalink",
+          "issue_id"
+        ]
+      },
+      "ExternalIssueReferenceV5": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        },
+        "required": [
+          "provider",
+          "provider_instance_id",
+          "issue_name",
+          "issue_permalink",
+          "issue_id"
+        ]
+      },
+      "ExternalIssueReferenceV6": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        },
+        "required": [
+          "provider",
+          "provider_instance_id",
+          "issue_name",
+          "issue_permalink",
+          "issue_id"
+        ]
+      },
+      "ExternalResourceDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "external_id": {
+            "type": "string",
+            "description": "ID of the resource in the external system",
+            "example": "123"
+          },
+          "permalink": {
+            "type": "string",
+            "description": "URL of the resource",
+            "example": "https://my.pagerduty.com/incidents/ABC"
+          },
+          "resource_type": {
+            "type": "string",
+            "description": "E.g. PagerDuty: the external system that holds the resource",
+            "example": "pager_duty_incident",
+            "enum": [
+              "pager_duty_incident",
+              "opsgenie_alert",
+              "datadog_monitor_alert",
+              "github_pull_request",
+              "gitlab_merge_request",
+              "sentry_issue",
+              "jira_issue",
+              "atlassian_statuspage_incident",
+              "zendesk_ticket",
+              "google_calendar_event",
+              "scrubbed",
+              "statuspage_incident"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of resource",
+            "example": "The database has gone down"
+          }
+        },
+        "example": {
+          "external_id": "123",
+          "permalink": "https://my.pagerduty.com/incidents/ABC",
+          "resource_type": "pager_duty_incident",
+          "title": "The database has gone down"
+        }
       },
       "ExternalResourceV1": {
         "type": "object",
@@ -21047,7 +26395,7 @@
         "type": "object",
         "properties": {
           "assignee": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           },
           "completed_at": {
             "type": "string",
@@ -21067,7 +26415,7 @@
             "example": "Call the fire brigade"
           },
           "external_issue_reference": {
-            "$ref": "#/components/schemas/ExternalIssueReferenceV2"
+            "$ref": "#/components/schemas/ExternalIssueReferenceV5"
           },
           "id": {
             "type": "string",
@@ -21195,7 +26543,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "incident_creator",
+              "description": "API key roles",
+              "example": "viewer",
               "enum": [
                 "viewer",
                 "incident_creator",
@@ -21214,7 +26563,7 @@
             },
             "description": "Which roles have been enabled for this key",
             "example": [
-              "incident_creator"
+              "viewer"
             ]
           }
         },
@@ -21222,7 +26571,7 @@
           "dashboard_url": "https://app.incident.io/my-org",
           "name": "Alertmanager token",
           "roles": [
-            "incident_creator"
+            "viewer"
           ]
         },
         "required": [
@@ -21265,6 +26614,344 @@
           "resource",
           "creator",
           "created_at"
+        ]
+      },
+      "IncidentCreatePayloadV1": {
+        "type": "object",
+        "properties": {
+          "custom_field_entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+            },
+            "description": "Set the incident's custom fields to these values",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ]
+          },
+          "idempotency_key": {
+            "type": "string",
+            "description": "Unique string used to de-duplicate incident create requests",
+            "example": "alert-uuid"
+          },
+          "incident_role_assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
+            },
+            "description": "Assign incident roles to these people",
+            "example": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ]
+          },
+          "incident_type_id": {
+            "type": "string",
+            "description": "Incident type to create this incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Whether the incident is real or test",
+            "example": "real",
+            "enum": [
+              "real",
+              "test"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Explanation of the incident",
+            "example": "Our database is sad"
+          },
+          "severity_id": {
+            "type": "string",
+            "description": "Severity to create incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "slack_team_id": {
+            "type": "string",
+            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
+            "example": "T02A1FSLE8J"
+          },
+          "source_message_channel_id": {
+            "type": "string",
+            "description": "Channel ID of the source message, if this incident was created from one",
+            "example": "C02AW36C1M5"
+          },
+          "source_message_timestamp": {
+            "type": "string",
+            "description": "Timestamp of the source message, if this incident was created from one",
+            "example": "1653650280.526509"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the incident",
+            "example": "triage",
+            "enum": [
+              "triage",
+              "investigating",
+              "fixing",
+              "monitoring",
+              "closed",
+              "declined"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "description": "Detailed description of the incident",
+            "example": "Our database is really really sad, and we don't know why yet."
+          },
+          "visibility": {
+            "type": "string",
+            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+            "example": "public",
+            "enum": [
+              "public",
+              "private"
+            ]
+          }
+        },
+        "example": {
+          "custom_field_entries": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ],
+          "idempotency_key": "alert-uuid",
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ],
+          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "mode": "real",
+          "name": "Our database is sad",
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "slack_team_id": "T02A1FSLE8J",
+          "source_message_channel_id": "C02AW36C1M5",
+          "source_message_timestamp": "1653650280.526509",
+          "status": "triage",
+          "summary": "Our database is really really sad, and we don't know why yet.",
+          "visibility": "public"
+        },
+        "required": [
+          "idempotency_key",
+          "visibility"
+        ]
+      },
+      "IncidentCreatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "custom_field_entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV2"
+            },
+            "description": "Set the incident's custom fields to these values",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the incident",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+          },
+          "idempotency_key": {
+            "type": "string",
+            "description": "Unique string used to de-duplicate incident create requests",
+            "example": "alert-uuid"
+          },
+          "incident_role_assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV2"
+            },
+            "description": "Assign incident roles to these people",
+            "example": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ]
+          },
+          "incident_status_id": {
+            "type": "string",
+            "description": "Incident status to assign to the incident",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "incident_timestamp_values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentTimestampValuePayloadV2"
+            },
+            "description": "Assign the incident's timestamps to these values",
+            "example": [
+              {
+                "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "value": "2021-08-17T13:28:57.801578Z"
+              }
+            ]
+          },
+          "incident_type_id": {
+            "type": "string",
+            "description": "Incident type to create this incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
+            "example": "standard",
+            "enum": [
+              "standard",
+              "retrospective",
+              "test",
+              "tutorial"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Explanation of the incident",
+            "example": "Our database is sad"
+          },
+          "retrospective_incident_options": {
+            "$ref": "#/components/schemas/RetrospectiveIncidentOptionsV2"
+          },
+          "severity_id": {
+            "type": "string",
+            "description": "Severity to create incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "slack_channel_name_override": {
+            "type": "string",
+            "description": "Name of the Slack channel to create for this incident",
+            "example": "inc-123-database-down"
+          },
+          "slack_team_id": {
+            "type": "string",
+            "description": "Slack Team to create the incident in",
+            "example": "T02A1FSLE8J"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Detailed description of the incident",
+            "example": "Our database is really really sad, and we don't know why yet."
+          },
+          "visibility": {
+            "type": "string",
+            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+            "example": "public",
+            "enum": [
+              "public",
+              "private"
+            ]
+          }
+        },
+        "example": {
+          "custom_field_entries": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ],
+          "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+          "idempotency_key": "alert-uuid",
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ],
+          "incident_status_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "incident_timestamp_values": [
+            {
+              "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "value": "2021-08-17T13:28:57.801578Z"
+            }
+          ],
+          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "mode": "standard",
+          "name": "Our database is sad",
+          "retrospective_incident_options": {
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "slack_channel_id": "abc123"
+          },
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "slack_channel_name_override": "inc-123-database-down",
+          "slack_team_id": "T02A1FSLE8J",
+          "summary": "Our database is really really sad, and we don't know why yet.",
+          "visibility": "public"
+        },
+        "required": [
+          "idempotency_key",
+          "visibility"
         ]
       },
       "IncidentDurationMetricV2": {
@@ -21333,7 +27020,7 @@
           "custom_field_entries": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV2"
             },
             "description": "Set the incident's custom fields to these values",
             "example": [
@@ -21450,6 +27137,257 @@
           "summary": "Our database is really really sad, and we don't know why yet."
         }
       },
+      "IncidentFilterFieldsV2": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "object",
+            "description": "Filter on incident created at timestamp. The accepted operators are 'gte', 'lte' and 'date_range'.",
+            "example": {
+              "created_at[gte]": [
+                "2024-05-01"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "custom_field": {
+            "type": "object",
+            "description": "Filter on an incident custom field. Custom field ID should be sent, followed by the operator and values. Accepted operator will depend on the custom field type.",
+            "example": {
+              "01GBSQF3FHF7FWZQNWGHAVQ804": {
+                "one_of": [
+                  "01GBSQF3FHF7FWZQNWGHAVQ804",
+                  "01ET65M7ZARSFZ6TFDFVQDN9AA"
+                ]
+              }
+            },
+            "additionalProperties": {
+              "type": "object",
+              "example": {
+                "abc123": [
+                  "value"
+                ]
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "value"
+                },
+                "example": [
+                  "value"
+                ]
+              }
+            }
+          },
+          "incident_role": {
+            "type": "object",
+            "description": "Filter on an incident role. Role ID should be sent, followed by the operator and values. The accepted operators are 'one_of', 'is_blank'.",
+            "example": {
+              "01GBSQF3FHF7FWZQNWGHAVQ804": {
+                "one_of": [
+                  "01GBSQF3FHF7FWZQNWGHAVQ804",
+                  "01ET65M7ZARSFZ6TFDFVQDN9AA"
+                ]
+              }
+            },
+            "additionalProperties": {
+              "type": "object",
+              "example": {
+                "abc123": [
+                  "value"
+                ]
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "value"
+                },
+                "example": [
+                  "value"
+                ]
+              }
+            }
+          },
+          "incident_type": {
+            "type": "object",
+            "description": "Filter on incident type. The accepted operators are 'one_of, or 'not_in'.",
+            "example": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "mode": {
+            "type": "object",
+            "description": "Filter on incident mode. The accepted operator is 'one_of'.  If this is not provided, this value defaults to `{\"one_of\": [\"standard\", \"retrospective\"] }`, meaning that test and tutorial incidents are not included.",
+            "example": {
+              "one_of": [
+                "retrospective"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "severity": {
+            "type": "object",
+            "description": "Filter on incident severity. The accepted operators are 'one_of', 'not_in', 'gte', 'lte'.",
+            "example": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "status": {
+            "type": "object",
+            "description": "Filter on incident status. The accepted operators are 'one_of', or 'not_in'.",
+            "example": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "status_category": {
+            "type": "object",
+            "description": "Filter on the category of the incidents status. The accepted operators are 'one_of', or 'not_in'. If this is not provided, this value defaults to `{\"one_of\": [\"triage\", \"active\", \"post-incident\", \"closed\"] }`, meaning that canceled, declined and merged incidents are not included.",
+            "example": {
+              "one_of": [
+                "active"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "updated_at": {
+            "type": "object",
+            "description": "Filter on incident updated at timestamp. The accepted operators are 'gte', 'lte' and 'date_range'.",
+            "example": {
+              "updated_at[gte]": [
+                "2024-05-01"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          }
+        },
+        "example": {
+          "created_at": {
+            "created_at[gte]": [
+              "2024-05-01"
+            ]
+          },
+          "custom_field": {
+            "01GBSQF3FHF7FWZQNWGHAVQ804": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804",
+                "01ET65M7ZARSFZ6TFDFVQDN9AA"
+              ]
+            }
+          },
+          "incident_role": {
+            "01GBSQF3FHF7FWZQNWGHAVQ804": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804",
+                "01ET65M7ZARSFZ6TFDFVQDN9AA"
+              ]
+            }
+          },
+          "incident_type": {
+            "one_of": [
+              "01GBSQF3FHF7FWZQNWGHAVQ804"
+            ]
+          },
+          "mode": {
+            "one_of": [
+              "retrospective"
+            ]
+          },
+          "severity": {
+            "one_of": [
+              "01GBSQF3FHF7FWZQNWGHAVQ804"
+            ]
+          },
+          "status": {
+            "one_of": [
+              "01GBSQF3FHF7FWZQNWGHAVQ804"
+            ]
+          },
+          "status_category": {
+            "one_of": [
+              "active"
+            ]
+          },
+          "updated_at": {
+            "updated_at[gte]": [
+              "2024-05-01"
+            ]
+          }
+        }
+      },
       "IncidentMembership": {
         "type": "object",
         "properties": {
@@ -21476,7 +27414,7 @@
             "format": "date-time"
           },
           "user": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           }
         },
         "example": {
@@ -21529,7 +27467,7 @@
         "type": "object",
         "properties": {
           "assignee": {
-            "$ref": "#/components/schemas/UserReferencePayloadV1"
+            "$ref": "#/components/schemas/UserReferencePayloadV2"
           },
           "incident_role_id": {
             "type": "string",
@@ -21557,6 +27495,40 @@
           },
           "role": {
             "$ref": "#/components/schemas/IncidentRoleV1"
+          }
+        },
+        "example": {
+          "assignee": {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          },
+          "role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "required": false,
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "role"
+        ]
+      },
+      "IncidentRoleAssignmentV2": {
+        "type": "object",
+        "properties": {
+          "assignee": {
+            "$ref": "#/components/schemas/UserV2"
+          },
+          "role": {
+            "$ref": "#/components/schemas/EmbeddedIncidentRoleV2"
           }
         },
         "example": {
@@ -21739,7 +27711,145 @@
           "updated_at"
         ]
       },
+      "IncidentStatusDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured",
+            "example": "triage",
+            "enum": [
+              "triage",
+              "declined",
+              "merged",
+              "canceled",
+              "live",
+              "learning",
+              "closed",
+              "paused"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Rich text description of the incident status",
+            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique ID of this incident status",
+            "example": "01FCNDV6P870EA6S7TK1DSYD5H"
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of this status",
+            "example": "Closed"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Order of this incident status",
+            "example": 4,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "category": "triage",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+          "name": "Closed",
+          "rank": 4,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "rank",
+          "category",
+          "created_at",
+          "updated_at"
+        ]
+      },
       "IncidentStatusV1": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured",
+            "example": "triage",
+            "enum": [
+              "triage",
+              "declined",
+              "merged",
+              "canceled",
+              "live",
+              "learning",
+              "closed",
+              "paused"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Rich text description of the incident status",
+            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique ID of this incident status",
+            "example": "01FCNDV6P870EA6S7TK1DSYD5H"
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of this status",
+            "example": "Closed"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Order of this incident status",
+            "example": 4,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "category": "triage",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+          "name": "Closed",
+          "rank": 4,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "rank",
+          "category",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "IncidentStatusV2": {
         "type": "object",
         "properties": {
           "category": {
@@ -22019,6 +28129,85 @@
           "auto_archive_slack_channels_delay_days"
         ]
       },
+      "IncidentTypeV2": {
+        "type": "object",
+        "properties": {
+          "create_in_triage": {
+            "type": "string",
+            "description": "Whether incidents of this must always, or can optionally, be created in triage",
+            "example": "always",
+            "enum": [
+              "always",
+              "optional"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When this resource was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "What is this incident type for?",
+            "example": "Customer facing production outages"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this Incident Type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "is_default": {
+            "type": "boolean",
+            "description": "The default Incident Type is used when no other type is explicitly specified",
+            "example": false
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this Incident Type",
+            "example": "Production Outage"
+          },
+          "private_incidents_only": {
+            "type": "boolean",
+            "description": "Should all incidents created with this Incident Type be private?",
+            "example": false
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When this resource was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "create_in_triage": "always",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Customer facing production outages",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "is_default": false,
+          "name": "Production Outage",
+          "private_incidents_only": false,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "is_default",
+          "description",
+          "private_incidents_only",
+          "created_at",
+          "updated_at",
+          "create_in_triage",
+          "severity_aliases",
+          "rank",
+          "override_auto_close_incidents",
+          "auto_close_incidents",
+          "auto_close_incidents_delay_days",
+          "override_auto_archive_slack_channels",
+          "auto_archive_slack_channels",
+          "auto_archive_slack_channels_delay_days"
+        ]
+      },
       "IncidentUpdateV2": {
         "type": "object",
         "properties": {
@@ -22049,7 +28238,7 @@
             "example": "We're working on a fix, hoping to ship in the next 30 minutes"
           },
           "new_incident_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           },
           "new_severity": {
             "$ref": "#/components/schemas/SeverityV2"
@@ -22119,7 +28308,7 @@
             "format": "date-time"
           },
           "creator": {
-            "$ref": "#/components/schemas/ActorV2"
+            "$ref": "#/components/schemas/ActorV1"
           },
           "custom_field_entries": {
             "type": "array",
@@ -22236,7 +28425,7 @@
             "example": "INC-123"
           },
           "severity": {
-            "$ref": "#/components/schemas/SeverityV2"
+            "$ref": "#/components/schemas/SeverityV1"
           },
           "slack_channel_id": {
             "type": "string",
@@ -22459,7 +28648,7 @@
           "custom_field_entries": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryV1"
+              "$ref": "#/components/schemas/CustomFieldEntryV2"
             },
             "description": "Custom field entries for this incident",
             "example": [
@@ -22520,7 +28709,7 @@
             ]
           },
           "external_issue_reference": {
-            "$ref": "#/components/schemas/ExternalIssueReferenceV2"
+            "$ref": "#/components/schemas/ExternalIssueReferenceV4"
           },
           "id": {
             "type": "string",
@@ -22530,7 +28719,7 @@
           "incident_role_assignments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentV1"
+              "$ref": "#/components/schemas/IncidentRoleAssignmentV2"
             },
             "description": "A list of who is assigned to each role for this incident",
             "example": [
@@ -22557,7 +28746,7 @@
             ]
           },
           "incident_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           },
           "incident_timestamp_values": {
             "type": "array",
@@ -22579,7 +28768,7 @@
             ]
           },
           "incident_type": {
-            "$ref": "#/components/schemas/IncidentTypeV1"
+            "$ref": "#/components/schemas/IncidentTypeV2"
           },
           "mode": {
             "type": "string",
@@ -22852,10 +29041,10 @@
             "$ref": "#/components/schemas/IncidentV2"
           },
           "new_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           },
           "previous_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           }
         },
         "example": {
@@ -24285,7 +30474,7 @@
           "severities": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SeverityV2"
+              "$ref": "#/components/schemas/SeverityV1"
             },
             "example": [
               {
@@ -25427,8 +31616,7 @@
           },
           "resource_type": {
             "type": "string",
-            "description": "The type of the related resource",
-            "example": "schedule",
+            "example": "workflow",
             "enum": [
               "workflow",
               "schedule"
@@ -25446,7 +31634,7 @@
           },
           "managed_by": "dashboard",
           "resource_id": "abc123",
-          "resource_type": "schedule",
+          "resource_type": "workflow",
           "source_url": "https://github.com/my-company/infrastructure"
         },
         "required": [
@@ -25455,6 +31643,44 @@
           "managed_by",
           "annotations"
         ]
+      },
+      "ManagementMetaDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "managed_by": {
+            "type": "string",
+            "description": "How is this resource managed",
+            "example": "dashboard",
+            "enum": [
+              "dashboard",
+              "terraform",
+              "external"
+            ]
+          },
+          "source_url": {
+            "type": "string",
+            "description": "The url of the external repository where this resource is managed (if there is one)",
+            "example": "https://github.com/my-company/infrastructure"
+          }
+        },
+        "example": {
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          },
+          "managed_by": "dashboard",
+          "source_url": "https://github.com/my-company/infrastructure"
+        }
       },
       "ManagementMetaV2": {
         "type": "object",
@@ -25551,6 +31777,111 @@
         },
         "required": [
           "page_size"
+        ]
+      },
+      "PaginationParamDefinitions": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "type": "string",
+            "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+          },
+          "page_size": {
+            "type": "integer",
+            "description": "Integer number of records to return",
+            "default": 25,
+            "example": 25,
+            "format": "int64",
+            "maximum": 500
+          }
+        },
+        "example": {
+          "after": "01FDAG4SAP5TYPT98WGR2N7W91",
+          "page_size": 25
+        }
+      },
+      "Priority": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this type was archived",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "$ref": "#/components/schemas/TextNode"
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of this priority",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "is_default": {
+            "type": "boolean",
+            "description": "Whether this is the default priority",
+            "example": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The human readable label for this priority",
+            "example": "P1"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "The rank of the priority. Higher values are less urgent",
+            "example": 1,
+            "format": "int64"
+          },
+          "slugs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "All the slugs that this priority has",
+            "example": [
+              "p1",
+              "priority-1"
+            ]
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T13:28:57.801578Z",
+          "description": {
+            "attrs": {
+              "level": 3
+            },
+            "content": [
+              {}
+            ],
+            "marks": [
+              {
+                "attrs": {
+                  "color": "blue"
+                },
+                "type": "em"
+              }
+            ],
+            "text": "some nice text",
+            "type": "text"
+          },
+          "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "is_default": true,
+          "name": "P1",
+          "rank": 1,
+          "slugs": [
+            "p1",
+            "priority-1"
+          ]
+        },
+        "required": [
+          "id",
+          "rank",
+          "name",
+          "slugs",
+          "is_default"
         ]
       },
       "PrivateIncidentAccessAttemptedV1ResponseBody": {
@@ -25661,7 +31992,7 @@
             ]
           },
           "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25701,7 +32032,7 @@
             ]
           },
           "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25741,7 +32072,7 @@
             ]
           },
           "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25781,7 +32112,7 @@
             ]
           },
           "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25821,7 +32152,7 @@
             ]
           },
           "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25861,7 +32192,7 @@
             ]
           },
           "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -26854,6 +33185,93 @@
           "array"
         ]
       },
+      "RunscopeRequestAttribute": {
+        "type": "object",
+        "properties": {
+          "assertions": {
+            "type": "object",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": true
+          },
+          "method": {
+            "type": "string",
+            "description": "HTTP Method of request sent",
+            "example": "abc123"
+          },
+          "note": {
+            "type": "string",
+            "description": "A description or note of this request step",
+            "example": "abc123"
+          },
+          "response_size_bytes": {
+            "type": "integer",
+            "description": "Number of bytes of response",
+            "example": 1,
+            "format": "int64"
+          },
+          "response_status_code": {
+            "type": "string",
+            "description": "Status code of the response",
+            "example": "abc123"
+          },
+          "response_time_ms": {
+            "type": "integer",
+            "description": "Time in milliseconds for response",
+            "example": 1,
+            "format": "int64"
+          },
+          "result": {
+            "type": "string",
+            "description": "The result of the request",
+            "example": "abc123"
+          },
+          "scripts": {
+            "type": "object",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": true
+          },
+          "step_type": {
+            "type": "string",
+            "description": "The type of step in the request",
+            "example": "abc123"
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL of the request from Runscope",
+            "example": "abc123"
+          },
+          "variables": {
+            "type": "object",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": true
+          }
+        },
+        "example": {
+          "assertions": {
+            "abc123": "abc123"
+          },
+          "method": "abc123",
+          "note": "abc123",
+          "response_size_bytes": 1,
+          "response_status_code": "abc123",
+          "response_time_ms": 1,
+          "result": "abc123",
+          "scripts": {
+            "abc123": "abc123"
+          },
+          "step_type": "abc123",
+          "url": "abc123",
+          "variables": {
+            "abc123": "abc123"
+          }
+        }
+      },
       "ScheduleConfigCreatePayloadV2": {
         "type": "object",
         "properties": {
@@ -26869,7 +33287,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -26891,7 +33309,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -26906,7 +33324,7 @@
               "handovers": [
                 {
                   "interval": 1,
-                  "interval_type": "daily"
+                  "interval_type": "hourly"
                 }
               ],
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -26928,7 +33346,7 @@
                 {
                   "end_time": "17:00",
                   "start_time": "09:00",
-                  "weekday": "tuesday"
+                  "weekday": "monday"
                 }
               ]
             }
@@ -26950,7 +33368,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -26972,7 +33390,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -26987,7 +33405,7 @@
               "handovers": [
                 {
                   "interval": 1,
-                  "interval_type": "daily"
+                  "interval_type": "hourly"
                 }
               ],
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27009,7 +33427,7 @@
                 {
                   "end_time": "17:00",
                   "start_time": "09:00",
-                  "weekday": "tuesday"
+                  "weekday": "monday"
                 }
               ]
             }
@@ -27032,7 +33450,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27056,7 +33474,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -27071,7 +33489,7 @@
               "handovers": [
                 {
                   "interval": 1,
-                  "interval_type": "daily"
+                  "interval_type": "hourly"
                 }
               ],
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27095,7 +33513,7 @@
                 {
                   "end_time": "17:00",
                   "start_time": "09:00",
-                  "weekday": "tuesday"
+                  "weekday": "monday"
                 }
               ]
             }
@@ -27124,7 +33542,7 @@
             "$ref": "#/components/schemas/ScheduleConfigCreatePayloadV2"
           },
           "holidays_public_config": {
-            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigPayloadV2"
           },
           "name": {
             "type": "string",
@@ -27149,7 +33567,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27171,7 +33589,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -27352,7 +33770,7 @@
             "format": "date-time"
           },
           "user": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           }
         },
         "example": {
@@ -27374,6 +33792,30 @@
           "external_user_id",
           "start_at",
           "end_at"
+        ]
+      },
+      "ScheduleHolidaysPublicConfigPayloadV2": {
+        "type": "object",
+        "properties": {
+          "country_codes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for",
+            "example": [
+              "abc123"
+            ]
+          }
+        },
+        "example": {
+          "country_codes": [
+            "abc123"
+          ]
+        },
+        "required": [
+          "country_codes"
         ]
       },
       "ScheduleHolidaysPublicConfigV2": {
@@ -27424,6 +33866,25 @@
           "name"
         ]
       },
+      "ScheduleLayerUpdatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the layer",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the layer",
+            "example": "Layer 1"
+          }
+        },
+        "example": {
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "name": "Layer 1"
+        }
+      },
       "ScheduleLayerV2": {
         "type": "object",
         "properties": {
@@ -27464,7 +33925,7 @@
             "example": [
               {
                 "interval": 1,
-                "interval_type": "daily"
+                "interval_type": "hourly"
               }
             ]
           },
@@ -27493,7 +33954,7 @@
           "users": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserReferencePayloadV1"
+              "$ref": "#/components/schemas/UserReferencePayloadV2"
             },
             "example": [
               {
@@ -27506,13 +33967,13 @@
           "working_interval": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/WeekdayIntervalV2"
+              "$ref": "#/components/schemas/ScheduleRotationWorkingIntervalCreatePayloadV2"
             },
             "example": [
               {
                 "end_time": "17:00",
                 "start_time": "09:00",
-                "weekday": "tuesday"
+                "weekday": "monday"
               }
             ]
           }
@@ -27523,7 +33984,7 @@
           "handovers": [
             {
               "interval": 1,
-              "interval_type": "daily"
+              "interval_type": "hourly"
             }
           ],
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27545,7 +34006,7 @@
             {
               "end_time": "17:00",
               "start_time": "09:00",
-              "weekday": "tuesday"
+              "weekday": "monday"
             }
           ]
         },
@@ -27563,7 +34024,8 @@
           },
           "interval_type": {
             "type": "string",
-            "example": "daily",
+            "description": "How often a handover occurs",
+            "example": "hourly",
             "enum": [
               "hourly",
               "daily",
@@ -27573,7 +34035,7 @@
         },
         "example": {
           "interval": 1,
-          "interval_type": "daily"
+          "interval_type": "hourly"
         }
       },
       "ScheduleRotationUpdatePayloadV2": {
@@ -27597,7 +34059,7 @@
             "example": [
               {
                 "interval": 1,
-                "interval_type": "daily"
+                "interval_type": "hourly"
               }
             ]
           },
@@ -27609,7 +34071,7 @@
           "layers": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ScheduleLayerV2"
+              "$ref": "#/components/schemas/ScheduleLayerUpdatePayloadV2"
             },
             "example": [
               {
@@ -27626,7 +34088,7 @@
           "users": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserReferencePayloadV1"
+              "$ref": "#/components/schemas/UserReferencePayloadV2"
             },
             "example": [
               {
@@ -27645,7 +34107,7 @@
               {
                 "end_time": "17:00",
                 "start_time": "09:00",
-                "weekday": "tuesday"
+                "weekday": "monday"
               }
             ]
           }
@@ -27656,7 +34118,7 @@
           "handovers": [
             {
               "interval": 1,
-              "interval_type": "daily"
+              "interval_type": "hourly"
             }
           ],
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27678,7 +34140,7 @@
             {
               "end_time": "17:00",
               "start_time": "09:00",
-              "weekday": "tuesday"
+              "weekday": "monday"
             }
           ]
         }
@@ -27707,7 +34169,7 @@
             "example": [
               {
                 "interval": 1,
-                "interval_type": "daily"
+                "interval_type": "hourly"
               }
             ]
           },
@@ -27737,7 +34199,7 @@
           "users": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserV1"
+              "$ref": "#/components/schemas/UserV2"
             },
             "example": [
               {
@@ -27752,13 +34214,13 @@
           "working_interval": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/WeekdayIntervalV2"
+              "$ref": "#/components/schemas/ScheduleRotationWorkingIntervalV2"
             },
             "example": [
               {
                 "end_time": "17:00",
                 "start_time": "09:00",
-                "weekday": "tuesday"
+                "weekday": "monday"
               }
             ]
           }
@@ -27769,7 +34231,7 @@
           "handovers": [
             {
               "interval": 1,
-              "interval_type": "daily"
+              "interval_type": "hourly"
             }
           ],
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27793,7 +34255,7 @@
             {
               "end_time": "17:00",
               "start_time": "09:00",
-              "weekday": "tuesday"
+              "weekday": "monday"
             }
           ]
         },
@@ -27805,6 +34267,45 @@
           "working_intervals",
           "handover_start_at",
           "handovers"
+        ]
+      },
+      "ScheduleRotationWorkingIntervalCreatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "end_time": {
+            "type": "string",
+            "description": "End time of the interval, in 24hr format",
+            "example": "17:00"
+          },
+          "start_time": {
+            "type": "string",
+            "description": "Start time of the interval, in 24hr format",
+            "example": "09:00"
+          },
+          "weekday": {
+            "type": "string",
+            "description": "Weekdays for use with a schedule",
+            "example": "monday",
+            "enum": [
+              "monday",
+              "tuesday",
+              "wednesday",
+              "thursday",
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        },
+        "example": {
+          "end_time": "17:00",
+          "start_time": "09:00",
+          "weekday": "monday"
+        },
+        "required": [
+          "weekday",
+          "start_time",
+          "end_time"
         ]
       },
       "ScheduleRotationWorkingIntervalUpdatePayloadV2": {
@@ -27822,8 +34323,8 @@
           },
           "weekday": {
             "type": "string",
-            "description": "Weekday this interval applies to",
-            "example": "tuesday",
+            "description": "Weekdays for use with a schedule",
+            "example": "monday",
             "enum": [
               "monday",
               "tuesday",
@@ -27838,8 +34339,47 @@
         "example": {
           "end_time": "17:00",
           "start_time": "09:00",
-          "weekday": "tuesday"
+          "weekday": "monday"
         }
+      },
+      "ScheduleRotationWorkingIntervalV2": {
+        "type": "object",
+        "properties": {
+          "end_time": {
+            "type": "string",
+            "description": "End time of the interval, in 24hr format",
+            "example": "17:00"
+          },
+          "start_time": {
+            "type": "string",
+            "description": "Start time of the interval, in 24hr format",
+            "example": "09:00"
+          },
+          "weekday": {
+            "type": "string",
+            "description": "Weekdays for use with a schedule",
+            "example": "monday",
+            "enum": [
+              "monday",
+              "tuesday",
+              "wednesday",
+              "thursday",
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        },
+        "example": {
+          "end_time": "17:00",
+          "start_time": "09:00",
+          "weekday": "monday"
+        },
+        "required": [
+          "weekday",
+          "start_time",
+          "end_time"
+        ]
       },
       "ScheduleUpdatePayloadV2": {
         "type": "object",
@@ -27859,7 +34399,7 @@
             "$ref": "#/components/schemas/ScheduleConfigUpdatePayloadV2"
           },
           "holidays_public_config": {
-            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigPayloadV2"
           },
           "name": {
             "type": "string",
@@ -27884,7 +34424,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27906,7 +34446,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -28003,7 +34543,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -28027,7 +34567,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -28156,6 +34696,155 @@
           "targets",
           "context",
           "metadata"
+        ]
+      },
+      "SeverityDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the action was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the severity",
+            "example": "Issues with **low impact**."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the severity",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the severity",
+            "example": "Minor",
+            "maxLength": 50
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Rank to help sort severities (lower numbers are less severe)",
+            "example": 1,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the action was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Issues with **low impact**.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Minor",
+          "rank": 1,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        }
+      },
+      "SeverityDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the action was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the severity",
+            "example": "Issues with **low impact**."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the severity",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the severity",
+            "example": "Minor",
+            "maxLength": 50
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Rank to help sort severities (lower numbers are less severe)",
+            "example": 1,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the action was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Issues with **low impact**.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Minor",
+          "rank": 1,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        }
+      },
+      "SeverityV1": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the action was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the severity",
+            "example": "Issues with **low impact**."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the severity",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the severity",
+            "example": "Minor",
+            "maxLength": 50
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Rank to help sort severities (lower numbers are less severe)",
+            "example": 1,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the action was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Issues with **low impact**.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Minor",
+          "rank": 1,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "rank",
+          "created_at",
+          "updated_at"
         ]
       },
       "SeverityV2": {
@@ -28784,7 +35473,7 @@
         "type": "object",
         "properties": {
           "severity": {
-            "$ref": "#/components/schemas/SeverityV2"
+            "$ref": "#/components/schemas/SeverityV1"
           }
         },
         "example": {
@@ -29299,6 +35988,94 @@
           "management_meta"
         ]
       },
+      "Step": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Human readable description of what this step does",
+            "example": "Escalates a page to the default escalation policy of the configured PagerDuty service."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for this step",
+            "example": "PagerDuty Escalate"
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of the step in the engine",
+            "example": "pagerduty.escalate"
+          },
+          "params": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamV2"
+            },
+            "description": "Type information for the step parameters",
+            "example": [
+              {
+                "array": true,
+                "default_value": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                },
+                "description": "What slack channel should we send the message to?",
+                "infer_reference": true,
+                "label": "To date",
+                "name": "severity",
+                "optional": true,
+                "type": "IncidentSeverity"
+              }
+            ]
+          }
+        },
+        "example": {
+          "description": "Escalates a page to the default escalation policy of the configured PagerDuty service.",
+          "label": "PagerDuty Escalate",
+          "name": "pagerduty.escalate",
+          "params": [
+            {
+              "array": true,
+              "default_value": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "description": "What slack channel should we send the message to?",
+              "infer_reference": true,
+              "label": "To date",
+              "name": "severity",
+              "optional": true,
+              "type": "IncidentSeverity"
+            }
+          ]
+        },
+        "required": [
+          "name",
+          "label",
+          "description",
+          "params"
+        ]
+      },
       "StepConfig": {
         "type": "object",
         "properties": {
@@ -29325,7 +36102,7 @@
           "param_bindings": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV3"
+              "$ref": "#/components/schemas/EngineParamBindingV2"
             },
             "description": "Bindings for the step parameters",
             "example": [
@@ -29470,6 +36247,174 @@
           "params"
         ]
       },
+      "TextDocument": {
+        "type": "object",
+        "properties": {
+          "markdown": {
+            "type": "string",
+            "description": "the original Markdown string",
+            "example": "There's a snake in my boot"
+          },
+          "text_node": {
+            "$ref": "#/components/schemas/TextNode"
+          }
+        },
+        "example": {
+          "markdown": "There's a snake in my boot",
+          "text_node": {
+            "attrs": {
+              "level": 3
+            },
+            "content": [
+              {}
+            ],
+            "marks": [
+              {
+                "attrs": {
+                  "color": "blue"
+                },
+                "type": "em"
+              }
+            ],
+            "text": "some nice text",
+            "type": "text"
+          }
+        },
+        "required": [
+          "text_node",
+          "markdown"
+        ]
+      },
+      "TextMark": {
+        "type": "object",
+        "properties": {
+          "attrs": {
+            "type": "object",
+            "description": "type-specific mark attributes",
+            "example": {
+              "color": "blue"
+            },
+            "additionalProperties": true
+          },
+          "type": {
+            "type": "string",
+            "description": "the type of the node, eg 'text'",
+            "example": "em"
+          }
+        },
+        "example": {
+          "attrs": {
+            "color": "blue"
+          },
+          "type": "em"
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "TextNode": {
+        "type": "object",
+        "properties": {
+          "attrs": {
+            "type": "object",
+            "description": "type-specific node attributes",
+            "example": {
+              "level": 3
+            },
+            "additionalProperties": true
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TextNode"
+            },
+            "description": "children of this node",
+            "example": [
+              {
+                "attrs": {
+                  "level": 3
+                },
+                "content": [
+                  {}
+                ],
+                "marks": [
+                  {
+                    "attrs": {
+                      "color": "blue"
+                    },
+                    "type": "em"
+                  }
+                ],
+                "text": "some nice text",
+                "type": "text"
+              }
+            ]
+          },
+          "marks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TextMark"
+            },
+            "description": "marks that apply to this node, eg 'bold'",
+            "example": [
+              {
+                "attrs": {
+                  "color": "blue"
+                },
+                "type": "em"
+              }
+            ]
+          },
+          "text": {
+            "type": "string",
+            "description": "if this node doesn't have children, it has text content",
+            "example": "some nice text"
+          },
+          "type": {
+            "type": "string",
+            "description": "the type of the node",
+            "example": "text"
+          }
+        },
+        "example": {
+          "attrs": {
+            "level": 3
+          },
+          "content": [
+            {
+              "attrs": {
+                "level": 3
+              },
+              "content": [
+                {}
+              ],
+              "marks": [
+                {
+                  "attrs": {
+                    "color": "blue"
+                  },
+                  "type": "em"
+                }
+              ],
+              "text": "some nice text",
+              "type": "text"
+            }
+          ],
+          "marks": [
+            {
+              "attrs": {
+                "color": "blue"
+              },
+              "type": "em"
+            }
+          ],
+          "text": "some nice text",
+          "type": "text"
+        },
+        "required": [
+          "type"
+        ]
+      },
       "TriggerSlim": {
         "type": "object",
         "properties": {
@@ -29583,7 +36528,7 @@
               "type": "string",
               "example": "abc123"
             },
-            "description": "The alert sources that will match this alert route",
+            "description": "Legacy field - the alert sources that will match this alert route",
             "example": [
               "02FCNDV6P870EA6S7TK1DSYDG2"
             ]
@@ -30127,6 +37072,7 @@
           "enabled",
           "incident_enabled",
           "incident_condition_groups",
+          "alert_sources",
           "alert_source_ids",
           "auto_cancel_escalations"
         ]
@@ -30640,7 +37586,462 @@
           "use_name_as_identifier"
         ]
       },
-      "UpdateWorkflowRequestBody": {
+      "UpdateWorkflowPayload": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "List of conditions to apply to the workflow",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "continue_on_step_error": {
+            "type": "boolean",
+            "description": "Whether to continue executing the workflow if a step fails",
+            "example": true
+          },
+          "delay": {
+            "$ref": "#/components/schemas/WorkflowDelay"
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in the workflow",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "folder": {
+            "type": "string",
+            "description": "Folder to display the workflow in",
+            "example": "My folder 01"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of the workflow to update",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "include_private_incidents": {
+            "type": "boolean",
+            "description": "Whether to include private incidents",
+            "example": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The human-readable name of the workflow",
+            "example": "My workflow"
+          },
+          "once_for": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "incident.url"
+            },
+            "description": "Once For strategy to apply to this workflow",
+            "example": [
+              "incident.url"
+            ]
+          },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
+          "runs_on_incidents": {
+            "type": "string",
+            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+            "example": "newly_created",
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of the workflow (e.g. is it draft, or disabled)",
+            "example": "active",
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StepConfigPayload"
+            },
+            "description": "List of step to execute as part of the workflow",
+            "example": [
+              {
+                "for_each": "abc123",
+                "id": "abc123",
+                "name": "pagerduty.escalate",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          },
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "continue_on_step_error": true,
+          "delay": {
+            "conditions_apply_over_delay": false,
+            "for_seconds": 60
+          },
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "folder": "My folder 01",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "include_private_incidents": true,
+          "name": "My workflow",
+          "once_for": [
+            "incident.url"
+          ],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
+          "runs_on_incidents": "newly_created",
+          "state": "active",
+          "steps": [
+            {
+              "for_each": "abc123",
+              "id": "abc123",
+              "name": "pagerduty.escalate",
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "id",
+          "name",
+          "once_for",
+          "condition_groups",
+          "steps",
+          "expressions",
+          "include_private_incidents",
+          "runs_on_incident_modes",
+          "continue_on_step_error",
+          "runs_on_incidents"
+        ]
+      },
+      "UpdateWorkflowPayload2": {
         "type": "object",
         "properties": {
           "annotations": {
@@ -31112,6 +38513,31 @@
           "slack_user_id": "USER123"
         }
       },
+      "UserReferencePayloadV2": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "The user's email address, matching the email on their Slack account",
+            "example": "bob@example.com"
+          },
+          "id": {
+            "type": "string",
+            "description": "The incident.io ID of a user",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "slack_user_id": {
+            "type": "string",
+            "description": "The ID of the user's Slack account.",
+            "example": "USER123"
+          }
+        },
+        "example": {
+          "email": "bob@example.com",
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "slack_user_id": "USER123"
+        }
+      },
       "UserRoleMembershipsUpdatedV1ResponseBody": {
         "type": "object",
         "properties": {
@@ -31198,6 +38624,58 @@
         ]
       },
       "UserV1": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Email address of the user.",
+            "example": "lisa@incident.io"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the user",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the user",
+            "example": "Lisa Karlin Curtis"
+          },
+          "role": {
+            "type": "string",
+            "description": "DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.",
+            "example": "viewer",
+            "enum": [
+              "viewer",
+              "responder",
+              "administrator",
+              "owner",
+              "unset"
+            ]
+          },
+          "slack_user_id": {
+            "type": "string",
+            "description": "Slack ID of the user",
+            "example": "U02AYNF2XJM"
+          }
+        },
+        "example": {
+          "email": "lisa@incident.io",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Lisa Karlin Curtis",
+          "role": "viewer",
+          "slack_user_id": "U02AYNF2XJM"
+        },
+        "required": [
+          "role",
+          "id",
+          "slack_role",
+          "name",
+          "deprecated_base_role",
+          "organisation_id"
+        ]
+      },
+      "UserV2": {
         "type": "object",
         "properties": {
           "email": {
@@ -31383,7 +38861,7 @@
           "custom_field_entries": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryV1"
+              "$ref": "#/components/schemas/CustomFieldEntryV2"
             },
             "description": "Custom field entries for this incident",
             "example": [
@@ -31444,7 +38922,7 @@
             ]
           },
           "external_issue_reference": {
-            "$ref": "#/components/schemas/ExternalIssueReferenceV2"
+            "$ref": "#/components/schemas/ExternalIssueReferenceV6"
           },
           "id": {
             "type": "string",
@@ -31454,7 +38932,7 @@
           "incident_role_assignments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentV1"
+              "$ref": "#/components/schemas/IncidentRoleAssignmentV2"
             },
             "description": "A list of who is assigned to each role for this incident",
             "example": [
@@ -31481,7 +38959,7 @@
             ]
           },
           "incident_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           },
           "incident_timestamp_values": {
             "type": "array",
@@ -31503,7 +38981,7 @@
             ]
           },
           "incident_type": {
-            "$ref": "#/components/schemas/IncidentTypeV1"
+            "$ref": "#/components/schemas/IncidentTypeV2"
           },
           "mode": {
             "type": "string",
@@ -31783,6 +39261,683 @@
           "reported_at"
         ]
       },
+      "WebhookPayloadDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "description": "What type of event is this webhook for?",
+            "example": "public_incident.incident_created_v2",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ]
+          },
+          "private_incident.action_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.follow_up_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.follow_up_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.incident_created_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.incident_updated_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.membership_granted_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          },
+          "private_incident.membership_revoked_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          },
+          "public_incident.action_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.follow_up_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.follow_up_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.incident_created_v2": {
+            "$ref": "#/components/schemas/WebhookIncidentV2"
+          },
+          "public_incident.incident_status_updated_v2": {
+            "$ref": "#/components/schemas/IncidentWithStatusChangeV2"
+          },
+          "public_incident.incident_updated_v2": {
+            "$ref": "#/components/schemas/WebhookIncidentV2"
+          }
+        },
+        "example": {
+          "event_type": "public_incident.incident_created_v2",
+          "private_incident.action_created_v1": {
+            "id": "abc123"
+          },
+          "private_incident.action_updated_v1": {
+            "id": "abc123"
+          },
+          "private_incident.follow_up_created_v1": {
+            "id": "abc123"
+          },
+          "private_incident.follow_up_updated_v1": {
+            "id": "abc123"
+          },
+          "private_incident.incident_created_v2": {
+            "id": "abc123"
+          },
+          "private_incident.incident_updated_v2": {
+            "id": "abc123"
+          },
+          "private_incident.membership_granted_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          },
+          "private_incident.membership_revoked_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          },
+          "public_incident.action_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.action_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.follow_up_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.follow_up_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.incident_created_v2": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          },
+          "public_incident.incident_status_updated_v2": {
+            "incident": {
+              "call_url": "https://zoom.us/foo",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              },
+              "custom_field_entries": [
+                {
+                  "custom_field": {
+                    "description": "Which team is impacted by this issue",
+                    "field_type": "single_select",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Affected Team",
+                    "options": [
+                      {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      }
+                    ]
+                  },
+                  "values": [
+                    {
+                      "value_catalog_entry": {
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
+                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Primary On-call"
+                      },
+                      "value_link": "https://google.com/",
+                      "value_numeric": "123.456",
+                      "value_option": {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      },
+                      "value_text": "This is my text field, I hope you like it"
+                    }
+                  ]
+                }
+              ],
+              "duration_metrics": [
+                {
+                  "duration_metric": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Lasted"
+                  },
+                  "value_seconds": 1
+                }
+              ],
+              "external_issue_reference": {
+                "issue_name": "INC-123",
+                "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                "provider": "asana"
+              },
+              "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "incident_role_assignments": [
+                {
+                  "assignee": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "required": false,
+                    "role_type": "lead",
+                    "shortform": "lead",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_status": {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "incident_timestamp_values": [
+                {
+                  "incident_timestamp": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Impact started",
+                    "rank": 1
+                  },
+                  "value": {
+                    "value": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_type": {
+                "create_in_triage": "always",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Customer facing production outages",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_default": false,
+                "name": "Production Outage",
+                "private_incidents_only": false,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "mode": "standard",
+              "name": "Our database is sad",
+              "permalink": "https://app.incident.io/incidents/123",
+              "postmortem_document_url": "https://docs.google.com/my_doc_id",
+              "reference": "INC-123",
+              "severity": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "slack_channel_id": "C02AW36C1M5",
+              "slack_channel_name": "inc-165-green-parrot",
+              "slack_team_id": "T02A1FSLE8J",
+              "summary": "Our database is really really sad, and we don't know why yet.",
+              "updated_at": "2021-08-17T13:28:57.801578Z",
+              "visibility": "public",
+              "workload_minutes_late": 40.7,
+              "workload_minutes_sleeping": 0,
+              "workload_minutes_total": 60.7,
+              "workload_minutes_working": 20
+            },
+            "new_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "previous_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          },
+          "public_incident.incident_updated_v2": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          }
+        }
+      },
+      "WebhookPrivateResourceV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the resource",
+            "example": "abc123"
+          }
+        },
+        "example": {
+          "id": "abc123"
+        },
+        "required": [
+          "id"
+        ]
+      },
       "WeekdayIntervalConfigV2": {
         "type": "object",
         "properties": {
@@ -31849,7 +40004,6 @@
           },
           "weekday": {
             "type": "string",
-            "description": "Weekday this interval applies to",
             "example": "abc123"
           }
         },
@@ -31870,7 +40024,7 @@
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV3"
+              "$ref": "#/components/schemas/ConditionGroupV5"
             },
             "description": "Conditions that apply to the workflow trigger",
             "example": [
@@ -32103,7 +40257,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "test",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
               "enum": [
                 "standard",
                 "test",
@@ -32417,37 +40572,13 @@
           "state"
         ]
       },
-      "WorkflowDelay": {
-        "type": "object",
-        "properties": {
-          "conditions_apply_over_delay": {
-            "type": "boolean",
-            "description": "If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution",
-            "example": false
-          },
-          "for_seconds": {
-            "type": "integer",
-            "description": "Delay in seconds between trigger firing and running the workflow",
-            "example": 60,
-            "format": "int64"
-          }
-        },
-        "example": {
-          "conditions_apply_over_delay": false,
-          "for_seconds": 60
-        },
-        "required": [
-          "for_seconds",
-          "conditions_apply_over_delay"
-        ]
-      },
-      "WorkflowSlim": {
+      "WorkflowDefinitions": {
         "type": "object",
         "properties": {
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV3"
+              "$ref": "#/components/schemas/ConditionGroupV2"
             },
             "description": "Conditions that apply to the workflow trigger",
             "example": [
@@ -32494,7 +40625,7 @@
           "expressions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ExpressionV3"
+              "$ref": "#/components/schemas/ExpressionV2"
             },
             "description": "Expressions that make variables available in the scope",
             "example": [
@@ -32680,7 +40811,939 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "test",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
+          "runs_on_incidents": {
+            "type": "string",
+            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+            "example": "newly_created",
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of the workflow (e.g. is it draft, or disabled)",
+            "example": "active",
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/TriggerSlim"
+          },
+          "version": {
+            "type": "integer",
+            "description": "Revision of the workflow, uniquely identifying its version",
+            "example": 3,
+            "format": "int64"
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "continue_on_step_error": true,
+          "delay": {
+            "conditions_apply_over_delay": false,
+            "for_seconds": 60
+          },
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "folder": "My folder 01",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "include_private_incidents": true,
+          "name": "My workflow",
+          "once_for": [
+            {
+              "array": false,
+              "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+              "label": "Incident -> Affected Team",
+              "type": "IncidentSeverity"
+            }
+          ],
+          "runs_from": "2021-08-17T13:28:57.801578Z",
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
+          "runs_on_incidents": "newly_created",
+          "state": "active",
+          "trigger": {
+            "label": "Incident Updated",
+            "name": "incident.updated"
+          },
+          "version": 3
+        }
+      },
+      "WorkflowDelay": {
+        "type": "object",
+        "properties": {
+          "conditions_apply_over_delay": {
+            "type": "boolean",
+            "description": "If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution",
+            "example": false
+          },
+          "for_seconds": {
+            "type": "integer",
+            "description": "Delay in seconds between trigger firing and running the workflow",
+            "example": 60,
+            "format": "int64"
+          }
+        },
+        "example": {
+          "conditions_apply_over_delay": false,
+          "for_seconds": 60
+        },
+        "required": [
+          "for_seconds",
+          "conditions_apply_over_delay"
+        ]
+      },
+      "WorkflowPayload": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "List of conditions to apply to the workflow",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "continue_on_step_error": {
+            "type": "boolean",
+            "description": "Whether to continue executing the workflow if a step fails",
+            "example": true
+          },
+          "delay": {
+            "$ref": "#/components/schemas/WorkflowDelay"
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in the workflow",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "folder": {
+            "type": "string",
+            "description": "Folder to display the workflow in",
+            "example": "My folder 01"
+          },
+          "include_private_incidents": {
+            "type": "boolean",
+            "description": "Whether to include private incidents",
+            "example": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The human-readable name of the workflow",
+            "example": "My workflow"
+          },
+          "once_for": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "incident.url"
+            },
+            "description": "Once For strategy to apply to this workflow",
+            "example": [
+              "incident.url"
+            ]
+          },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
+          "runs_on_incidents": {
+            "type": "string",
+            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+            "example": "newly_created",
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of the workflow (e.g. is it draft, or disabled)",
+            "example": "active",
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StepConfigPayload"
+            },
+            "description": "List of step to execute as part of the workflow",
+            "example": [
+              {
+                "for_each": "abc123",
+                "id": "abc123",
+                "name": "pagerduty.escalate",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "continue_on_step_error": true,
+          "delay": {
+            "conditions_apply_over_delay": false,
+            "for_seconds": 60
+          },
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "folder": "My folder 01",
+          "include_private_incidents": true,
+          "name": "My workflow",
+          "once_for": [
+            "incident.url"
+          ],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
+          "runs_on_incidents": "newly_created",
+          "state": "active",
+          "steps": [
+            {
+              "for_each": "abc123",
+              "id": "abc123",
+              "name": "pagerduty.escalate",
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "WorkflowSlim": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV8"
+            },
+            "description": "Conditions that apply to the workflow trigger",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "continue_on_step_error": {
+            "type": "boolean",
+            "description": "Whether to continue executing the workflow if a step fails",
+            "example": true
+          },
+          "delay": {
+            "$ref": "#/components/schemas/WorkflowDelay"
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionV4"
+            },
+            "description": "Expressions that make variables available in the scope",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "folder": {
+            "type": "string",
+            "description": "Folder to display the workflow in",
+            "example": "My folder 01"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the workflow",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "include_private_incidents": {
+            "type": "boolean",
+            "description": "Whether to include private incidents",
+            "example": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The human-readable name of the workflow",
+            "example": "My workflow"
+          },
+          "once_for": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineReferenceV2"
+            },
+            "description": "This workflow will run 'once for' a list of references",
+            "example": [
+              {
+                "array": false,
+                "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                "label": "Incident -> Affected Team",
+                "type": "IncidentSeverity"
+              }
+            ]
+          },
+          "runs_from": {
+            "type": "string",
+            "description": "The time from which this workflow will run on incidents",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
               "enum": [
                 "standard",
                 "test",
@@ -34050,7 +43113,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_route.created",
@@ -34097,7 +43160,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_route.deleted",
@@ -34144,7 +43207,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_route.updated",
@@ -34191,7 +43254,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_schema.updated",
@@ -34238,7 +43301,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_source_config.created",
@@ -34285,7 +43348,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_source_config.deleted",
@@ -34332,7 +43395,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_source_config.updated",
@@ -34379,7 +43442,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "announcement_rule.created",
@@ -34426,7 +43489,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "announcement_rule.deleted",
@@ -34473,7 +43536,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "announcement_rule.updated",
@@ -34520,7 +43583,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "api_key.created",
@@ -34567,7 +43630,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "api_key.deleted",
@@ -34614,7 +43677,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "catalog_type.created",
@@ -34661,7 +43724,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "catalog_type.deleted",
@@ -34708,7 +43771,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "catalog_type.updated",
@@ -34755,7 +43818,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "custom_field.created",
@@ -34802,7 +43865,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "custom_field.deleted",
@@ -34849,7 +43912,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "custom_field.updated",
@@ -34896,7 +43959,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "debrief_invite_rule.created",
@@ -34943,7 +44006,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "debrief_invite_rule.deleted",
@@ -34990,7 +44053,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "debrief_invite_rule.updated",
@@ -35037,7 +44100,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "escalation_path.created",
@@ -35084,7 +44147,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "escalation_path.deleted",
@@ -35131,7 +44194,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "escalation_path.updated",
@@ -35178,7 +44241,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "follow_up_priority.created",
@@ -35225,7 +44288,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "follow_up_priority.deleted",
@@ -35272,7 +44335,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "follow_up_priority.updated",
@@ -35319,7 +44382,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "holiday_user_feed.created",
@@ -35366,7 +44429,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "holiday_user_feed.deleted",
@@ -35413,7 +44476,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "holiday_user_feed.updated",
@@ -35460,7 +44523,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_call_setting.updated",
@@ -35507,7 +44570,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_duration_metric.created",
@@ -35554,7 +44617,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_duration_metric.deleted",
@@ -35601,7 +44664,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_duration_metric.updated",
@@ -35648,7 +44711,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_role.created",
@@ -35695,7 +44758,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_role.deleted",
@@ -35742,7 +44805,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_role.updated",
@@ -35789,7 +44852,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_status.created",
@@ -35836,7 +44899,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_status.deleted",
@@ -35883,7 +44946,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_status.updated",
@@ -35930,7 +44993,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_timestamp.created",
@@ -35977,7 +45040,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_timestamp.deleted",
@@ -36024,7 +45087,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_timestamp.updated",
@@ -36071,7 +45134,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_type.created",
@@ -36118,7 +45181,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_type.deleted",
@@ -36165,7 +45228,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_type.updated",
@@ -36212,7 +45275,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "integration.installed",
@@ -36259,7 +45322,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "integration.uninstalled",
@@ -36306,7 +45369,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "internal_status_page.created",
@@ -36353,7 +45416,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "internal_status_page.deleted",
@@ -36400,7 +45463,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "internal_status_page.updated",
@@ -36447,7 +45510,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "nudge.created",
@@ -36494,7 +45557,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "nudge.deleted",
@@ -36541,7 +45604,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "nudge.updated",
@@ -36588,7 +45651,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "policy.created",
@@ -36635,7 +45698,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "policy.deleted",
@@ -36682,7 +45745,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "policy.updated",
@@ -36729,7 +45792,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "post_incident_task.created",
@@ -36776,7 +45839,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "post_incident_task.deleted",
@@ -36823,7 +45886,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "post_incident_task.updated",
@@ -36920,7 +45983,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "private_incident.access_requested",
@@ -36967,7 +46030,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "private_incident_membership.granted",
@@ -37019,7 +46082,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "private_incident_membership.revoked",
@@ -37071,7 +46134,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "rbac_role.created",
@@ -37118,7 +46181,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "rbac_role.deleted",
@@ -37165,7 +46228,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "rbac_role.updated",
@@ -37212,7 +46275,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "schedule.created",
@@ -37259,7 +46322,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "schedule.deleted",
@@ -37306,7 +46369,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "schedule.updated",
@@ -37406,7 +46469,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "severity.created",
@@ -37453,7 +46516,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "severity.deleted",
@@ -37500,7 +46563,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "severity.updated",
@@ -37547,7 +46610,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page.created",
@@ -37594,7 +46657,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page.deleted",
@@ -37641,7 +46704,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page.updated",
@@ -37688,7 +46751,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_sub_page.created",
@@ -37735,7 +46798,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_sub_page.deleted",
@@ -37782,7 +46845,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_sub_page.updated",
@@ -37829,7 +46892,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_template.created",
@@ -37876,7 +46939,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_template.deleted",
@@ -37923,7 +46986,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_template.updated",
@@ -37970,7 +47033,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "user.created",
@@ -38017,7 +47080,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "user.deactivated",
@@ -38064,7 +47127,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "user.reinstated",
@@ -38164,7 +47227,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "user.updated",
@@ -38211,7 +47274,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "workflow.created",
@@ -38258,7 +47321,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "workflow.deleted",
@@ -38305,7 +47368,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "workflow.updated",

--- a/internal/apischema/openapi3-secret.json
+++ b/internal/apischema/openapi3-secret.json
@@ -15094,6 +15094,7 @@
               "pagerduty",
               "salesforce",
               "sentry",
+              "service_now",
               "shortcut",
               "scim",
               "slack",

--- a/internal/apischema/openapi3.json
+++ b/internal/apischema/openapi3.json
@@ -257,7 +257,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody2"
+                "$ref": "#/components/schemas/CreateRequestBody"
               },
               "example": {
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -483,7 +483,7 @@
                 "show_in_announcement_post": true
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody3"
+                "$ref": "#/components/schemas/CreateRequestBody2"
               }
             }
           },
@@ -838,7 +838,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/CreateRequestBody4"
               },
               "example": {
                 "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
@@ -918,7 +918,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/CreateRequestBody5"
               },
               "example": {
                 "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
@@ -969,7 +969,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/CreateRequestBody5"
               },
               "example": {
                 "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
@@ -1036,7 +1036,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody7"
+                "$ref": "#/components/schemas/CreateRequestBody6"
               }
             }
           },
@@ -1263,7 +1263,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody9"
+                "$ref": "#/components/schemas/CreateRequestBody8"
               },
               "example": {
                 "category": "live",
@@ -1762,7 +1762,7 @@
                 "visibility": "public"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody10"
+                "$ref": "#/components/schemas/IncidentCreatePayloadV1"
               }
             }
           },
@@ -2074,9 +2074,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string",
-                  "example": "{}",
-                  "format": "binary"
+                  "example": "{}"
                 },
                 "example": "{}"
               }
@@ -2099,9 +2097,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string",
-                  "example": "{}",
-                  "format": "binary"
+                  "example": "{}"
                 },
                 "example": "{}"
               }
@@ -2155,7 +2151,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody13"
+                "$ref": "#/components/schemas/CreateRequestBody10"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2287,7 +2283,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody13"
+                "$ref": "#/components/schemas/CreateRequestBody10"
               },
               "example": {
                 "description": "Issues with **low impact**.",
@@ -2544,7 +2540,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody"
+                "$ref": "#/components/schemas/AlertRoutePayloadV2"
               },
               "example": {
                 "alert_source_ids": [
@@ -4324,7 +4320,7 @@
           "Catalog V2"
         ],
         "summary": "CreateEntry Catalog V2",
-        "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.",
+        "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.\n\nIf you call this API with a payload where the external_id and catalog_type_id match an existing entry, the existing entry will be updated.",
         "operationId": "Catalog V2#CreateEntry",
         "requestBody": {
           "required": true,
@@ -5337,7 +5333,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody4"
+                "$ref": "#/components/schemas/CreateRequestBody3"
               },
               "example": {
                 "description": "Which team is impacted by this issue",
@@ -5518,7 +5514,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathRequestBody"
+                "$ref": "#/components/schemas/EscalationPathPayloadV2"
               },
               "example": {
                 "name": "Urgent Support",
@@ -5863,7 +5859,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePathRequestBody"
+                "$ref": "#/components/schemas/EscalationPathPayloadV2"
               },
               "example": {
                 "name": "Urgent Support",
@@ -6237,7 +6233,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody8"
+                "$ref": "#/components/schemas/CreateRequestBody7"
               },
               "example": {
                 "description": "The person currently coordinating the incident",
@@ -7109,7 +7105,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody11"
+                "$ref": "#/components/schemas/IncidentCreatePayloadV2"
               },
               "example": {
                 "custom_field_entries": [
@@ -7758,7 +7754,7 @@
           "Schedules V2"
         ],
         "summary": "ListScheduleEntries Schedules V2",
-        "description": "Get a list of schedule entries.",
+        "description": "Get a list of schedule entries. The endpoint will return all entries that overlap with the given window, if one is provided.",
         "operationId": "Schedules V2#ListScheduleEntries",
         "parameters": [
           {
@@ -8015,7 +8011,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody12"
+                "$ref": "#/components/schemas/CreateRequestBody9"
               },
               "example": {
                 "schedule": {
@@ -8866,7 +8862,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateWorkflowRequestBody"
+                "$ref": "#/components/schemas/CreateWorkflowPayload"
               },
               "example": {
                 "annotations": {
@@ -9620,7 +9616,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateWorkflowRequestBody"
+                "$ref": "#/components/schemas/UpdateWorkflowPayload2"
               },
               "example": {
                 "annotations": {
@@ -10050,79 +10046,29 @@
   },
   "components": {
     "schemas": {
-      "APIKeyCreatedV1ResponseBody": {
+      "APIKeyV1": {
         "type": "object",
         "properties": {
-          "action": {
+          "id": {
             "type": "string",
-            "description": "The type of log entry that this is",
-            "example": "api_key.created"
+            "description": "Unique identifier for this API key",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
-          "actor": {
-            "$ref": "#/components/schemas/AuditLogActorV2"
-          },
-          "context": {
-            "$ref": "#/components/schemas/AuditLogEntryContextV2"
-          },
-          "occurred_at": {
+          "name": {
             "type": "string",
-            "description": "When the entry occurred",
-            "example": "2021-08-17T13:28:57.801578Z",
-            "format": "date-time"
-          },
-          "targets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AuditLogTargetV2"
-            },
-            "description": "The custom field that was created",
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Development API Key",
-                "type": "api_key"
-              }
-            ]
-          },
-          "version": {
-            "type": "integer",
-            "description": "Which version the event is",
-            "example": 1,
-            "format": "int64"
+            "description": "The name of the API key, for the user's reference",
+            "example": "My test API key"
           }
         },
         "example": {
-          "action": "api_key.created",
-          "actor": {
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "metadata": {
-              "user_base_role_slug": "admin",
-              "user_custom_role_slugs": "engineering,security"
-            },
-            "name": "John Doe",
-            "type": "user"
-          },
-          "context": {
-            "location": "1.2.3.4",
-            "user_agent": "Chrome/91.0.4472.114"
-          },
-          "occurred_at": "2021-08-17T13:28:57.801578Z",
-          "targets": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Development API Key",
-              "type": "api_key"
-            }
-          ],
-          "version": 1
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "My test API key"
         },
         "required": [
-          "action",
-          "occurred_at",
-          "version",
-          "actor",
-          "targets",
-          "context"
+          "id",
+          "name",
+          "roles",
+          "created_by"
         ]
       },
       "APIKeyV2": {
@@ -10174,7 +10120,7 @@
             "example": "Call the fire brigade"
           },
           "external_issue_reference": {
-            "$ref": "#/components/schemas/ExternalIssueReferenceV1"
+            "$ref": "#/components/schemas/ExternalIssueReferenceV2"
           },
           "follow_up": {
             "type": "boolean",
@@ -10244,7 +10190,7 @@
         "type": "object",
         "properties": {
           "assignee": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           },
           "completed_at": {
             "type": "string",
@@ -10316,6 +10262,30 @@
           "updated_at"
         ]
       },
+      "ActorV1": {
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "$ref": "#/components/schemas/APIKeyV1"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserV1"
+          }
+        },
+        "example": {
+          "api_key": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "My test API key"
+          },
+          "user": {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          }
+        }
+      },
       "ActorV2": {
         "type": "object",
         "properties": {
@@ -10323,7 +10293,7 @@
             "$ref": "#/components/schemas/APIKeyV2"
           },
           "user": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           }
         },
         "example": {
@@ -10363,6 +10333,415 @@
           "after_url"
         ]
       },
+      "AlertAttributeBinding": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertAttributeValue"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "catalog_entry": {
+                  "archived_at": "2021-08-17T14:28:57.801578Z",
+                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
+                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "helptext": "Collection of standalone automations like auto-closing incidents.",
+                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "is_image_slack_icon": false,
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "sort_key": "000020"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/AlertAttributeValue"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "catalog_entry": {
+                "archived_at": "2021-08-17T14:28:57.801578Z",
+                "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "catalog_entry_name": "Primary escalation",
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "helptext": "Collection of standalone automations like auto-closing incidents.",
+              "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+              "is_image_slack_icon": false,
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "sort_key": "000020"
+            }
+          ],
+          "value": {
+            "catalog_entry": {
+              "archived_at": "2021-08-17T14:28:57.801578Z",
+              "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "catalog_entry_name": "Primary escalation",
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            },
+            "helptext": "Collection of standalone automations like auto-closing incidents.",
+            "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+            "is_image_slack_icon": false,
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "sort_key": "000020"
+          }
+        }
+      },
+      "AlertAttributeValue": {
+        "type": "object",
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryReference"
+          },
+          "helptext": {
+            "type": "string",
+            "description": "Gives a description of the option to the user",
+            "example": "Collection of standalone automations like auto-closing incidents."
+          },
+          "image_url": {
+            "type": "string",
+            "description": "If appropriate, URL to an image that can be displayed alongside the option",
+            "example": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg"
+          },
+          "is_image_slack_icon": {
+            "type": "boolean",
+            "description": "If true, the image_url is a Slack icon and should be displayed as such",
+            "example": false
+          },
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "sort_key": {
+            "type": "string",
+            "description": "Gives an indication of how to sort the options when displayed to the user",
+            "example": "000020"
+          }
+        },
+        "example": {
+          "catalog_entry": {
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "catalog_entry_name": "Primary escalation",
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "helptext": "Collection of standalone automations like auto-closing incidents.",
+          "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+          "is_image_slack_icon": false,
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "sort_key": "000020"
+        },
+        "required": [
+          "label",
+          "sort_key"
+        ]
+      },
+      "AlertDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "alert_source_config": {
+            "$ref": "#/components/schemas/AlertSourceConfigSlim"
+          },
+          "alert_source_config_id": {
+            "type": "string",
+            "description": "Which alert source config produced this alert",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "attribute_values": {
+            "type": "object",
+            "description": "Attribute values parsed into the alert",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
+                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "helptext": "Collection of standalone automations like auto-closing incidents.",
+                    "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                    "is_image_slack_icon": false,
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "sort_key": "000020"
+                  }
+                ],
+                "value": {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "Collection of standalone automations like auto-closing incidents.",
+                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "sort_key": "000020"
+                }
+              }
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AlertAttributeBinding"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When this entry was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "dashboard_url": {
+            "type": "string",
+            "description": "If applicable, a link to the dashboard for this alert",
+            "example": "https://my-dashboard.com/alerts/123"
+          },
+          "deduplication_key": {
+            "type": "string",
+            "description": "A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.",
+            "example": "4293868629"
+          },
+          "description": {
+            "$ref": "#/components/schemas/TextDocument"
+          },
+          "evaluation_failures": {
+            "type": "object",
+            "description": "Attributes that we failed to evaluate and why",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of this alert",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "payload": {
+            "type": "string",
+            "description": "JSON payload that this alert was created from",
+            "example": "abc123"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/Priority"
+          },
+          "priority_id": {
+            "type": "string",
+            "description": "The priority of this alert",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "resolved_at": {
+            "type": "string",
+            "description": "When this alert was resolved",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "silence_url": {
+            "type": "string",
+            "description": "If applicable, a link to silence this alert",
+            "example": "https://my-dashboard.com/alerts/123/silence"
+          },
+          "source_type": {
+            "type": "string",
+            "description": "Type of alert source",
+            "example": "alertmanager",
+            "enum": [
+              "alertmanager",
+              "app_optics",
+              "azure_monitor",
+              "bugsnag",
+              "checkly",
+              "cloudwatch",
+              "cloudflare",
+              "cronitor",
+              "crowdstrike_falcon",
+              "chronosphere",
+              "datadog",
+              "dynatrace",
+              "elasticsearch",
+              "email",
+              "expel",
+              "github_issue",
+              "google_cloud",
+              "grafana",
+              "http",
+              "honeycomb",
+              "jira",
+              "monte_carlo",
+              "new_relic",
+              "opsgenie",
+              "pager_duty",
+              "panther",
+              "pingdom",
+              "runscope",
+              "sns",
+              "sentry",
+              "splunk",
+              "status_cake",
+              "status_page_views",
+              "sumo_logic",
+              "uptime",
+              "zendesk"
+            ]
+          },
+          "source_url": {
+            "type": "string",
+            "description": "If applicable, a link to the alert in the upstream system",
+            "example": "https://www.my-alerting-platform.com/alerts/my-alert-123"
+          },
+          "status": {
+            "type": "string",
+            "description": "Statuses of an alert",
+            "example": "firing",
+            "enum": [
+              "firing",
+              "resolved"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Alert title which is used when summarising the alert",
+            "example": "*errors.withMessage: PG::Error failed to connect"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When this alert was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "alert_source_config": {
+            "archived_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01GW2G3V0S59R238FAHPDS1R66",
+            "name": "Production Web Dashboard Alerts",
+            "source_type": "alertmanager"
+          },
+          "alert_source_config_id": "01GW2G3V0S59R238FAHPDS1R66",
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "Collection of standalone automations like auto-closing incidents.",
+                  "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "sort_key": "000020"
+                }
+              ],
+              "value": {
+                "catalog_entry": {
+                  "archived_at": "2021-08-17T14:28:57.801578Z",
+                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
+                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "helptext": "Collection of standalone automations like auto-closing incidents.",
+                "image_url": "https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg",
+                "is_image_slack_icon": false,
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "sort_key": "000020"
+              }
+            }
+          },
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "dashboard_url": "https://my-dashboard.com/alerts/123",
+          "deduplication_key": "4293868629",
+          "description": {
+            "markdown": "There's a snake in my boot",
+            "text_node": {
+              "attrs": {
+                "level": 3
+              },
+              "content": [
+                {}
+              ],
+              "marks": [
+                {
+                  "attrs": {
+                    "color": "blue"
+                  },
+                  "type": "em"
+                }
+              ],
+              "text": "some nice text",
+              "type": "text"
+            }
+          },
+          "evaluation_failures": {
+            "abc123": "abc123"
+          },
+          "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "payload": "abc123",
+          "priority": {
+            "archived_at": "2021-08-17T13:28:57.801578Z",
+            "description": {
+              "attrs": {
+                "level": 3
+              },
+              "content": [
+                {}
+              ],
+              "marks": [
+                {
+                  "attrs": {
+                    "color": "blue"
+                  },
+                  "type": "em"
+                }
+              ],
+              "text": "some nice text",
+              "type": "text"
+            },
+            "id": "01GW2G3V0S59R238FAHPDS1R66",
+            "is_default": true,
+            "name": "P1",
+            "rank": 1,
+            "slugs": [
+              "p1",
+              "priority-1"
+            ]
+          },
+          "priority_id": "01GW2G3V0S59R238FAHPDS1R66",
+          "resolved_at": "2021-08-17T14:28:57.801578Z",
+          "silence_url": "https://my-dashboard.com/alerts/123/silence",
+          "source_type": "alertmanager",
+          "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+          "status": "firing",
+          "title": "*errors.withMessage: PG::Error failed to connect",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        }
+      },
       "AlertResult": {
         "type": "object",
         "properties": {
@@ -10401,6 +10780,670 @@
           "message",
           "deduplication_key"
         ]
+      },
+      "AlertRouteDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "alert_source_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "Legacy field - the alert sources that will match this alert route",
+            "example": [
+              "02FCNDV6P870EA6S7TK1DSYDG2"
+            ]
+          },
+          "auto_decline_enabled": {
+            "type": "boolean",
+            "description": "Should triage incidents be declined when alerts are resolved?",
+            "example": false
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
+            "type": "integer",
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route is enabled or not",
+            "example": false
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this alert route config",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "incident_condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV2"
+            },
+            "description": "What condition groups must be true for this alert route to create an incident?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "incident_enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route will create incidents or not",
+            "example": false
+          },
+          "last_fired_at": {
+            "type": "string",
+            "description": "When did this alert route last create an incident?",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplateV2"
+          }
+        },
+        "example": {
+          "alert_source_ids": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ],
+          "auto_decline_enabled": false,
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "enabled": false,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "incident_enabled": false,
+          "last_fired_at": "2021-08-17T13:28:57.801578Z",
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "first-wins"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        }
       },
       "AlertRouteEscalationBindingPayloadV2": {
         "type": "object",
@@ -10794,6 +11837,549 @@
           "custom_field_priorities",
           "priority_severity"
         ]
+      },
+      "AlertRoutePayloadV2": {
+        "type": "object",
+        "properties": {
+          "alert_source_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "Legacy field - the alert sources that will match this alert route",
+            "example": [
+              "02FCNDV6P870EA6S7TK1DSYDG2"
+            ]
+          },
+          "auto_decline_enabled": {
+            "type": "boolean",
+            "description": "Should triage incidents be declined when alerts are resolved?",
+            "example": false
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "defer_time_seconds": {
+            "type": "integer",
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route is enabled or not",
+            "example": false
+          },
+          "escalation_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
+            },
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "grouping_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ]
+          },
+          "grouping_window_seconds": {
+            "type": "integer",
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64"
+          },
+          "incident_condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "What condition groups must be true for this alert route to create an incident?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "incident_enabled": {
+            "type": "boolean",
+            "description": "Whether this alert route will create incidents or not",
+            "example": false
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
+          }
+        },
+        "example": {
+          "alert_source_ids": [
+            "02FCNDV6P870EA6S7TK1DSYDG2"
+          ],
+          "auto_decline_enabled": false,
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "enabled": false,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "incident_condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "incident_enabled": false,
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "abc123"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        }
       },
       "AlertRouteV2": {
         "type": "object",
@@ -11360,8 +12946,84 @@
           "enabled",
           "incident_enabled",
           "incident_condition_groups",
+          "alert_sources",
           "alert_source_ids",
           "auto_cancel_escalations"
+        ]
+      },
+      "AlertSourceConfigSlim": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this type was archived",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of this alert source",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of the alert source",
+            "example": "Production Web Dashboard Alerts"
+          },
+          "source_type": {
+            "type": "string",
+            "description": "Type of alert source",
+            "example": "alertmanager",
+            "enum": [
+              "alertmanager",
+              "app_optics",
+              "azure_monitor",
+              "bugsnag",
+              "checkly",
+              "cloudwatch",
+              "cloudflare",
+              "cronitor",
+              "crowdstrike_falcon",
+              "chronosphere",
+              "datadog",
+              "dynatrace",
+              "elasticsearch",
+              "email",
+              "expel",
+              "github_issue",
+              "google_cloud",
+              "grafana",
+              "http",
+              "honeycomb",
+              "jira",
+              "monte_carlo",
+              "new_relic",
+              "opsgenie",
+              "pager_duty",
+              "panther",
+              "pingdom",
+              "runscope",
+              "sns",
+              "sentry",
+              "splunk",
+              "status_cake",
+              "status_page_views",
+              "sumo_logic",
+              "uptime",
+              "zendesk"
+            ]
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T13:28:57.801578Z",
+          "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "name": "Production Web Dashboard Alerts",
+          "source_type": "alertmanager"
+        },
+        "required": [
+          "id",
+          "name",
+          "source_type"
         ]
       },
       "AllResponseBody": {
@@ -11390,22 +13052,22 @@
             ]
           },
           "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.membership_granted_v1": {
             "$ref": "#/components/schemas/WebhookIncidentUserV2"
@@ -12028,6 +13690,19 @@
           "event_type"
         ]
       },
+      "AuditLogAPIKeyMetadataV2": {
+        "type": "object",
+        "properties": {
+          "api_key_roles": {
+            "type": "string",
+            "description": "The roles that the API key has, separated by commas (if it's an API key actor)",
+            "example": "abc123"
+          }
+        },
+        "example": {
+          "api_key_roles": "abc123"
+        }
+      },
       "AuditLogActorMetadataV2": {
         "type": "object",
         "properties": {
@@ -12108,6 +13783,81 @@
           "type"
         ]
       },
+      "AuditLogEntryBaseV2": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "The type of log entry that this is",
+            "example": "custom_field.created"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "type": "string",
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "description": "The target of the entry",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "John Doe",
+                "type": "user"
+              }
+            ]
+          },
+          "version": {
+            "type": "integer",
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64"
+          }
+        },
+        "example": {
+          "action": "custom_field.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "John Doe",
+              "type": "user"
+            }
+          ],
+          "version": 1
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ]
+      },
       "AuditLogEntryContextV2": {
         "type": "object",
         "properties": {
@@ -12129,6 +13879,25 @@
         "required": [
           "location"
         ]
+      },
+      "AuditLogExternalResourceMetadataV2": {
+        "type": "object",
+        "properties": {
+          "external_resource_external_id": {
+            "type": "string",
+            "description": "The ID of the external resource in the 3rd party system (if it's an external resource actor)",
+            "example": "q1234"
+          },
+          "external_resource_type": {
+            "type": "string",
+            "description": "The type of the external resource (if it's an external resource actor)",
+            "example": "pager_duty_incident"
+          }
+        },
+        "example": {
+          "external_resource_external_id": "q1234",
+          "external_resource_type": "pager_duty_incident"
+        }
       },
       "AuditLogPrivateIncidentAccessAttemptedMetadataV2": {
         "type": "object",
@@ -12210,6 +13979,25 @@
           "type"
         ]
       },
+      "AuditLogUserActorMetadataV2": {
+        "type": "object",
+        "properties": {
+          "user_base_role_slug": {
+            "type": "string",
+            "description": "The base role slug of the user (if it's a user actor)",
+            "example": "admin"
+          },
+          "user_custom_role_slugs": {
+            "type": "string",
+            "description": "The custom role slugs of the user, separated by commas (if it's a user actor)",
+            "example": "engineering,security"
+          }
+        },
+        "example": {
+          "user_base_role_slug": "admin",
+          "user_custom_role_slugs": "engineering,security"
+        }
+      },
       "AuditLogUserRoleMembershipChangedMetadataV2": {
         "type": "object",
         "properties": {
@@ -12276,6 +14064,168 @@
           "after_custom_role_slugs": "engineering,data",
           "before_base_role_slug": "admin",
           "before_custom_role_slugs": "engineering,security"
+        }
+      },
+      "CatalogEntryDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ]
+          },
+          "archived_at": {
+            "type": "string",
+            "description": "When this entry was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "attribute_values": {
+            "type": "object",
+            "description": "Values of this entry",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
+                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "helptext": "abc123",
+                    "image_url": "abc123",
+                    "is_image_slack_icon": false,
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity",
+                    "sort_key": "abc123",
+                    "unavailable": false,
+                    "value": "abc123"
+                  }
+                ],
+                "value": {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "abc123",
+                  "image_url": "abc123",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity",
+                  "sort_key": "abc123",
+                  "unavailable": false,
+                  "value": "abc123"
+                }
+              }
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CatalogEntryEngineParamBindingV2"
+            }
+          },
+          "catalog_type_id": {
+            "type": "string",
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When this entry was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "external_id": {
+            "type": "string",
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When this entry was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "archived_at": "2021-08-17T14:28:57.801578Z",
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "abc123",
+                  "image_url": "abc123",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity",
+                  "sort_key": "abc123",
+                  "unavailable": false,
+                  "value": "abc123"
+                }
+              ],
+              "value": {
+                "catalog_entry": {
+                  "archived_at": "2021-08-17T14:28:57.801578Z",
+                  "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "catalog_entry_name": "Primary escalation",
+                  "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "helptext": "abc123",
+                "image_url": "abc123",
+                "is_image_slack_icon": false,
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity",
+                "sort_key": "abc123",
+                "unavailable": false,
+                "value": "abc123"
+              }
+            }
+          },
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Primary On-call",
+          "rank": 3,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
         }
       },
       "CatalogEntryEngineParamBindingV2": {
@@ -12422,6 +14372,43 @@
         "required": [
           "label",
           "sort_key"
+        ]
+      },
+      "CatalogEntryReference": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this entry was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "catalog_entry_id": {
+            "type": "string",
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "catalog_entry_name": {
+            "type": "string",
+            "description": "The name of this entry",
+            "example": "Primary escalation"
+          },
+          "catalog_type_id": {
+            "type": "string",
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T14:28:57.801578Z",
+          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "catalog_entry_name": "Primary escalation",
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "required": [
+          "catalog_type_id",
+          "catalog_entry_id",
+          "catalog_entry_name"
         ]
       },
       "CatalogEntryReferenceV2": {
@@ -12744,7 +14731,7 @@
           "mode": {
             "type": "string",
             "description": "Controls how this attribute is modified",
-            "example": "manual",
+            "example": "",
             "enum": [
               "",
               "manual",
@@ -12782,7 +14769,7 @@
           "array": false,
           "backlink_attribute": "abc123",
           "id": "01GW2G3V0S59R238FAHPDS1R66",
-          "mode": "manual",
+          "mode": "",
           "name": "tier",
           "path": [
             {
@@ -12818,7 +14805,7 @@
           "mode": {
             "type": "string",
             "description": "Controls how this attribute is modified",
-            "example": "manual",
+            "example": "",
             "enum": [
               "",
               "manual",
@@ -12857,7 +14844,7 @@
           "array": false,
           "backlink_attribute": "abc123",
           "id": "01GW2G3V0S59R238FAHPDS1R66",
-          "mode": "manual",
+          "mode": "",
           "name": "tier",
           "path": [
             {
@@ -12875,6 +14862,273 @@
           "array"
         ]
       },
+      "CatalogTypeDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that can track metadata about this type",
+            "example": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "customer",
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-feature",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ]
+            },
+            "description": "What categories is this type considered part of",
+            "example": [
+              "customer"
+            ]
+          },
+          "color": {
+            "type": "string",
+            "description": "Sets the display color of this type in the dashboard",
+            "example": "yellow",
+            "enum": [
+              "yellow",
+              "green",
+              "blue",
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When this type was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human readble description of this type",
+            "example": "Represents Kubernetes clusters that we run inside of GKE."
+          },
+          "dynamic_resource_parameter": {
+            "type": "string",
+            "description": "If this is a dynamic catalog type, this will be the unique parameter for identitfying this resource externally.",
+            "example": "abc123"
+          },
+          "engine_resource_type": {
+            "type": "string",
+            "description": "The way this resource type is referenced in the engine",
+            "example": "CatalogType[\"PagerDutyService\"]"
+          },
+          "estimated_count": {
+            "type": "integer",
+            "description": "If populated, gives an estimated count of entries for this type",
+            "example": 7,
+            "format": "int64"
+          },
+          "icon": {
+            "type": "string",
+            "description": "Sets the display icon of this type in the dashboard",
+            "example": "alert",
+            "enum": [
+              "alert",
+              "bolt",
+              "box",
+              "briefcase",
+              "browser",
+              "bulb",
+              "calendar",
+              "clock",
+              "cog",
+              "components",
+              "database",
+              "doc",
+              "email",
+              "escalation-path",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
+              "server",
+              "severity",
+              "status-page",
+              "store",
+              "star",
+              "tag",
+              "user",
+              "users"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "is_editable": {
+            "type": "boolean",
+            "description": "Catalog types that are synced with external resources can't be edited",
+            "example": false
+          },
+          "last_synced_at": {
+            "type": "string",
+            "description": "When this type was last synced (if it's ever been sync'd)",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "mode": {
+            "type": "string",
+            "description": "What mode is this catalog type?",
+            "example": "manual",
+            "enum": [
+              "manual",
+              "external",
+              "internal"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is the human readable name of this type",
+            "example": "Kubernetes Cluster"
+          },
+          "native_resource_path": {
+            "type": "string",
+            "description": "If present, the path to view this resource natively in the web UI",
+            "example": "/on-call/escalation-paths"
+          },
+          "ranked": {
+            "type": "boolean",
+            "description": "If this type should be ranked",
+            "example": true
+          },
+          "registry_type": {
+            "type": "string",
+            "description": "The registry resource this type is synced from, if any",
+            "example": "PagerDutyService"
+          },
+          "required_integration": {
+            "type": "string",
+            "description": "If populated, the integration required for this type",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "statuspage",
+              "click_up",
+              "confluence",
+              "cortex",
+              "datadog",
+              "github",
+              "gitlab",
+              "google_docs",
+              "google_meet",
+              "google_calendar",
+              "google_workspace",
+              "jira",
+              "jira_server",
+              "linear",
+              "microsoft_teams",
+              "notion",
+              "opsgenie",
+              "opslevel",
+              "pagerduty",
+              "salesforce",
+              "sentry",
+              "shortcut",
+              "scim",
+              "slack",
+              "splunk_on_call",
+              "incident_io_status_pages",
+              "incident_io_on_call",
+              "vanta",
+              "webhooks",
+              "zendesk",
+              "zoom"
+            ]
+          },
+          "schema": {
+            "$ref": "#/components/schemas/CatalogTypeSchemaV2"
+          },
+          "source_repo_url": {
+            "type": "string",
+            "description": "The url of the external repository where this type is managed",
+            "example": "https://github.com/my-company/incident-io-catalog"
+          },
+          "type_name": {
+            "type": "string",
+            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName \"]",
+            "example": "Custom[\"BackstageGroup\"]"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When this type was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "use_name_as_identifier": {
+            "type": "boolean",
+            "description": "If populated, the name of the entry will be added to the list of identifiers for this type",
+            "example": true
+          }
+        },
+        "example": {
+          "annotations": {
+            "incident.io/catalog-importer/id": "id-of-config"
+          },
+          "categories": [
+            "customer"
+          ],
+          "color": "yellow",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "dynamic_resource_parameter": "abc123",
+          "engine_resource_type": "CatalogType[\"PagerDutyService\"]",
+          "estimated_count": 7,
+          "icon": "alert",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "is_editable": false,
+          "last_synced_at": "2021-08-17T13:28:57.801578Z",
+          "mode": "manual",
+          "name": "Kubernetes Cluster",
+          "native_resource_path": "/on-call/escalation-paths",
+          "ranked": true,
+          "registry_type": "PagerDutyService",
+          "required_integration": "asana",
+          "schema": {
+            "attributes": [
+              {
+                "array": false,
+                "backlink_attribute": "abc123",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "mode": "",
+                "name": "tier",
+                "path": [
+                  {
+                    "attribute_id": "abc123",
+                    "attribute_name": "abc123"
+                  }
+                ],
+                "type": "Custom[\"Service\"]"
+              }
+            ],
+            "version": 1
+          },
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+          "type_name": "Custom[\"BackstageGroup\"]",
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "use_name_as_identifier": true
+        }
+      },
       "CatalogTypeSchemaV2": {
         "type": "object",
         "properties": {
@@ -12889,7 +15143,7 @@
                 "array": false,
                 "backlink_attribute": "abc123",
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
-                "mode": "manual",
+                "mode": "",
                 "name": "tier",
                 "path": [
                   {
@@ -12914,7 +15168,7 @@
               "array": false,
               "backlink_attribute": "abc123",
               "id": "01GW2G3V0S59R238FAHPDS1R66",
-              "mode": "manual",
+              "mode": "",
               "name": "tier",
               "path": [
                 {
@@ -12950,7 +15204,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "issue-tracker",
+              "example": "customer",
               "enum": [
                 "customer",
                 "issue-tracker",
@@ -12963,7 +15217,7 @@
             },
             "description": "What categories is this type considered part of",
             "example": [
-              "issue-tracker"
+              "customer"
             ]
           },
           "color": {
@@ -13083,8 +15337,8 @@
           },
           "semantic_type": {
             "type": "string",
-            "description": "Semantic type of this resource (unused)",
-            "example": "custom"
+            "description": "What type of resource this catalog type should be understodd as",
+            "example": "abc123"
           },
           "source_repo_url": {
             "type": "string",
@@ -13108,7 +15362,7 @@
             "incident.io/catalog-importer/id": "id-of-config"
           },
           "categories": [
-            "issue-tracker"
+            "customer"
           ],
           "color": "yellow",
           "created_at": "2021-08-17T13:28:57.801578Z",
@@ -13131,7 +15385,7 @@
                 "array": false,
                 "backlink_attribute": "abc123",
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
-                "mode": "manual",
+                "mode": "",
                 "name": "tier",
                 "path": [
                   {
@@ -13372,6 +15626,371 @@
           "conditions"
         ]
       },
+      "ConditionGroupV4": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV4"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV5": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV5"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV6": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV6"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV7": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV7"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
+      "ConditionGroupV8": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionV8"
+            },
+            "description": "All conditions in this list must be satisfied for the group to be satisfied",
+            "example": [
+              {
+                "operation": {
+                  "label": "Lawrence Jones",
+                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                },
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ],
+                "subject": {
+                  "label": "Incident Severity",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          }
+        },
+        "example": {
+          "conditions": [
+            {
+              "operation": {
+                "label": "Lawrence Jones",
+                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+              },
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ],
+              "subject": {
+                "label": "Incident Severity",
+                "reference": "incident.severity"
+              }
+            }
+          ]
+        },
+        "required": [
+          "conditions"
+        ]
+      },
       "ConditionOperationV2": {
         "type": "object",
         "properties": {
@@ -13397,6 +16016,121 @@
         ]
       },
       "ConditionOperationV3": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV4": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV5": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV6": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV7": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "value": {
+            "type": "string",
+            "description": "Unique identifier for this option",
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "required": [
+          "label",
+          "value"
+        ]
+      },
+      "ConditionOperationV8": {
         "type": "object",
         "properties": {
           "label": {
@@ -13525,6 +16259,121 @@
           "reference"
         ]
       },
+      "ConditionSubjectV4": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
+      "ConditionSubjectV5": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
+      "ConditionSubjectV6": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
+      "ConditionSubjectV7": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
+      "ConditionSubjectV8": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for the subject",
+            "example": "Incident Severity"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Reference into the scope for the value of the subject",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Incident Severity",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label",
+          "reference"
+        ]
+      },
       "ConditionV2": {
         "type": "object",
         "properties": {
@@ -13600,7 +16449,7 @@
           "param_bindings": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV3"
+              "$ref": "#/components/schemas/EngineParamBindingV4"
             },
             "description": "Bindings for the operation parameters",
             "example": [
@@ -13654,6 +16503,333 @@
           "subject",
           "operation",
           "param_bindings"
+        ]
+      },
+      "ConditionV4": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV4"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV5"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV4"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings"
+        ]
+      },
+      "ConditionV5": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV5"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV7"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV5"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings",
+          "params"
+        ]
+      },
+      "ConditionV6": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV6"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV9"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV6"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings"
+        ]
+      },
+      "ConditionV7": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV7"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV10"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV7"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings"
+        ]
+      },
+      "ConditionV8": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "$ref": "#/components/schemas/ConditionOperationV8"
+          },
+          "param_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingV12"
+            },
+            "description": "Bindings for the operation parameters",
+            "example": [
+              {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            ]
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ConditionSubjectV8"
+          }
+        },
+        "example": {
+          "operation": {
+            "label": "Lawrence Jones",
+            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+          },
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ],
+          "subject": {
+            "label": "Incident Severity",
+            "reference": "incident.severity"
+          }
+        },
+        "required": [
+          "subject",
+          "operation",
+          "param_bindings",
+          "params"
         ]
       },
       "CreateEntryRequestBody": {
@@ -13938,175 +17114,6 @@
           "managed_resource"
         ]
       },
-      "CreatePathRequestBody": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of this escalation path, for the user's reference.",
-            "example": "Urgent Support"
-          },
-          "path": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
-            },
-            "description": "The nodes that form the levels and branches of this escalation path.",
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "if_else": {
-                  "conditions": [
-                    {
-                      "operation": "one_of",
-                      "param_bindings": [
-                        {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      ],
-                      "subject": "incident.severity"
-                    }
-                  ],
-                  "else_path": [
-                    {}
-                  ],
-                  "then_path": [
-                    {}
-                  ]
-                },
-                "level": {
-                  "round_robin_config": {
-                    "enabled": false,
-                    "rotate_after_seconds": 120
-                  },
-                  "targets": [
-                    {
-                      "id": "lawrencejones",
-                      "schedule_mode": "currently_on_call",
-                      "type": "user",
-                      "urgency": "high"
-                    }
-                  ],
-                  "time_to_ack_interval_condition": "active",
-                  "time_to_ack_seconds": 1800,
-                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "repeat": {
-                  "repeat_times": 3,
-                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
-                },
-                "type": "if_else"
-              }
-            ]
-          },
-          "working_hours": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/WeekdayIntervalConfigV2"
-            },
-            "description": "The working hours for this escalation path.",
-            "example": [
-              {
-                "id": "abc123",
-                "name": "abc123",
-                "timezone": "abc123",
-                "weekday_intervals": [
-                  {
-                    "end_time": "17:00",
-                    "start_time": "09:00",
-                    "weekday": "abc123"
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        "example": {
-          "name": "Urgent Support",
-          "path": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "if_else": {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ],
-                "else_path": [
-                  {}
-                ],
-                "then_path": [
-                  {}
-                ]
-              },
-              "level": {
-                "round_robin_config": {
-                  "enabled": false,
-                  "rotate_after_seconds": 120
-                },
-                "targets": [
-                  {
-                    "id": "lawrencejones",
-                    "schedule_mode": "currently_on_call",
-                    "type": "user",
-                    "urgency": "high"
-                  }
-                ],
-                "time_to_ack_interval_condition": "active",
-                "time_to_ack_seconds": 1800,
-                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              },
-              "repeat": {
-                "repeat_times": 3,
-                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
-              },
-              "type": "if_else"
-            }
-          ],
-          "working_hours": [
-            {
-              "id": "abc123",
-              "name": "abc123",
-              "timezone": "abc123",
-              "weekday_intervals": [
-                {
-                  "end_time": "17:00",
-                  "start_time": "09:00",
-                  "weekday": "abc123"
-                }
-              ]
-            }
-          ]
-        },
-        "required": [
-          "name",
-          "path"
-        ]
-      },
       "CreatePathResponseBody": {
         "type": "object",
         "properties": {
@@ -14204,946 +17211,35 @@
       "CreateRequestBody": {
         "type": "object",
         "properties": {
-          "alert_source_ids": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "example": "abc123"
-            },
-            "description": "The alert sources that will match this alert route",
-            "example": [
-              "02FCNDV6P870EA6S7TK1DSYDG2"
-            ]
-          },
-          "auto_decline_enabled": {
-            "type": "boolean",
-            "description": "Should triage incidents be declined when alerts are resolved?",
-            "example": false
-          },
-          "condition_groups": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
-            },
-            "description": "What condition groups must be true for this alert route to fire?",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ]
-          },
-          "defer_time_seconds": {
-            "type": "integer",
-            "description": "How long should the escalation defer time be?",
-            "example": 1,
-            "format": "int64"
-          },
-          "enabled": {
-            "type": "boolean",
-            "description": "Whether this alert route is enabled or not",
-            "example": false
-          },
-          "escalation_bindings": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
-            },
-            "description": "Which escalation paths should this alert route escalate to?",
-            "example": [
-              {
-                "binding": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              }
-            ]
-          },
-          "expressions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExpressionPayloadV2"
-            },
-            "description": "The expressions used in this template",
-            "example": [
-              {
-                "else_branch": {
-                  "result": {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                },
-                "label": "Team Slack channel",
-                "operations": [
-                  {
-                    "branches": {
-                      "branches": [
-                        {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": "one_of",
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": "incident.severity"
-                                }
-                              ]
-                            }
-                          ],
-                          "result": {
-                            "array_value": [
-                              {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        }
-                      ],
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    },
-                    "filter": {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": "one_of",
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": "incident.severity"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "navigate": {
-                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                    },
-                    "operation_type": "navigate",
-                    "parse": {
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      },
-                      "source": "metadata.annotations[\"github.com/repo\"]"
-                    }
-                  }
-                ],
-                "reference": "abc123",
-                "root_reference": "incident.status"
-              }
-            ]
-          },
-          "grouping_keys": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/GroupingKeyV2"
-            },
-            "description": "Which attributes should this alert route use to group alerts?",
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              }
-            ]
-          },
-          "grouping_window_seconds": {
-            "type": "integer",
-            "description": "How large should the grouping window be?",
-            "example": 1,
-            "format": "int64"
-          },
-          "incident_condition_groups": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
-            },
-            "description": "What condition groups must be true for this alert route to create an incident?",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ]
-          },
-          "incident_enabled": {
-            "type": "boolean",
-            "description": "Whether this alert route will create incidents or not",
-            "example": false
-          },
-          "name": {
+          "custom_field_id": {
             "type": "string",
-            "description": "The name of this alert route config, for the user's reference",
-            "example": "Production incidents"
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
           },
-          "template": {
-            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
           }
         },
         "example": {
-          "alert_source_ids": [
-            "02FCNDV6P870EA6S7TK1DSYDG2"
-          ],
-          "auto_decline_enabled": false,
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ],
-          "defer_time_seconds": 1,
-          "enabled": false,
-          "escalation_bindings": [
-            {
-              "binding": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            }
-          ],
-          "expressions": [
-            {
-              "else_branch": {
-                "result": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              },
-              "label": "Team Slack channel",
-              "operations": [
-                {
-                  "branches": {
-                    "branches": [
-                      {
-                        "condition_groups": [
-                          {
-                            "conditions": [
-                              {
-                                "operation": "one_of",
-                                "param_bindings": [
-                                  {
-                                    "array_value": [
-                                      {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    ],
-                                    "value": {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ],
-                                "subject": "incident.severity"
-                              }
-                            ]
-                          }
-                        ],
-                        "result": {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      }
-                    ],
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
-                  },
-                  "filter": {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": "one_of",
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": "incident.severity"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "navigate": {
-                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                  },
-                  "operation_type": "navigate",
-                  "parse": {
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    },
-                    "source": "metadata.annotations[\"github.com/repo\"]"
-                  }
-                }
-              ],
-              "reference": "abc123",
-              "root_reference": "incident.status"
-            }
-          ],
-          "grouping_keys": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
-            }
-          ],
-          "grouping_window_seconds": 1,
-          "incident_condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ],
-          "incident_enabled": false,
-          "name": "Production incidents",
-          "template": {
-            "custom_field_priorities": {
-              "abc123": "abc123"
-            },
-            "custom_fields": {
-              "custom_field_10014": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            },
-            "incident_mode": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "incident_type": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "name": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "priority_severity": "severity-first-wins",
-            "severity": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "summary": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "workspace": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          }
-        }
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        },
+        "required": [
+          "custom_field_id",
+          "value"
+        ]
       },
       "CreateRequestBody10": {
-        "type": "object",
-        "properties": {
-          "custom_field_entries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
-            },
-            "description": "Set the incident's custom fields to these values",
-            "example": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "values": [
-                  {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_text": "This is my text field, I hope you like it",
-                    "value_timestamp": ""
-                  }
-                ]
-              }
-            ]
-          },
-          "idempotency_key": {
-            "type": "string",
-            "description": "Unique string used to de-duplicate incident create requests",
-            "example": "alert-uuid"
-          },
-          "incident_role_assignments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
-            },
-            "description": "Assign incident roles to these people",
-            "example": [
-              {
-                "assignee": {
-                  "email": "bob@example.com",
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "slack_user_id": "USER123"
-                },
-                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-              }
-            ]
-          },
-          "incident_type_id": {
-            "type": "string",
-            "description": "Incident type to create this incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "mode": {
-            "type": "string",
-            "description": "Whether the incident is real or test",
-            "example": "real",
-            "enum": [
-              "real",
-              "test"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Explanation of the incident",
-            "example": "Our database is sad"
-          },
-          "severity_id": {
-            "type": "string",
-            "description": "Severity to create incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "slack_team_id": {
-            "type": "string",
-            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
-            "example": "T02A1FSLE8J"
-          },
-          "source_message_channel_id": {
-            "type": "string",
-            "description": "Channel ID of the source message, if this incident was created from one",
-            "example": "C02AW36C1M5"
-          },
-          "source_message_timestamp": {
-            "type": "string",
-            "description": "Timestamp of the source message, if this incident was created from one",
-            "example": "1653650280.526509"
-          },
-          "status": {
-            "type": "string",
-            "description": "Current status of the incident",
-            "example": "triage",
-            "enum": [
-              "triage",
-              "investigating",
-              "fixing",
-              "monitoring",
-              "closed",
-              "declined"
-            ]
-          },
-          "summary": {
-            "type": "string",
-            "description": "Detailed description of the incident",
-            "example": "Our database is really really sad, and we don't know why yet."
-          },
-          "visibility": {
-            "type": "string",
-            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-            "example": "public",
-            "enum": [
-              "public",
-              "private"
-            ]
-          }
-        },
-        "example": {
-          "custom_field_entries": [
-            {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "values": [
-                {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_text": "This is my text field, I hope you like it",
-                  "value_timestamp": ""
-                }
-              ]
-            }
-          ],
-          "idempotency_key": "alert-uuid",
-          "incident_role_assignments": [
-            {
-              "assignee": {
-                "email": "bob@example.com",
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                "slack_user_id": "USER123"
-              },
-              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-            }
-          ],
-          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "mode": "real",
-          "name": "Our database is sad",
-          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "slack_team_id": "T02A1FSLE8J",
-          "source_message_channel_id": "C02AW36C1M5",
-          "source_message_timestamp": "1653650280.526509",
-          "status": "triage",
-          "summary": "Our database is really really sad, and we don't know why yet.",
-          "visibility": "public"
-        },
-        "required": [
-          "idempotency_key",
-          "visibility"
-        ]
-      },
-      "CreateRequestBody11": {
-        "type": "object",
-        "properties": {
-          "custom_field_entries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
-            },
-            "description": "Set the incident's custom fields to these values",
-            "example": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "values": [
-                  {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_text": "This is my text field, I hope you like it",
-                    "value_timestamp": ""
-                  }
-                ]
-              }
-            ]
-          },
-          "id": {
-            "type": "string",
-            "description": "Unique identifier for the incident",
-            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
-          },
-          "idempotency_key": {
-            "type": "string",
-            "description": "Unique string used to de-duplicate incident create requests",
-            "example": "alert-uuid"
-          },
-          "incident_role_assignments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV2"
-            },
-            "description": "Assign incident roles to these people",
-            "example": [
-              {
-                "assignee": {
-                  "email": "bob@example.com",
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "slack_user_id": "USER123"
-                },
-                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-              }
-            ]
-          },
-          "incident_status_id": {
-            "type": "string",
-            "description": "Incident status to assign to the incident",
-            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
-          },
-          "incident_timestamp_values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IncidentTimestampValuePayloadV2"
-            },
-            "description": "Assign the incident's timestamps to these values",
-            "example": [
-              {
-                "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "value": "2021-08-17T13:28:57.801578Z"
-              }
-            ]
-          },
-          "incident_type_id": {
-            "type": "string",
-            "description": "Incident type to create this incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "mode": {
-            "type": "string",
-            "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
-            "example": "standard",
-            "enum": [
-              "standard",
-              "retrospective",
-              "test",
-              "tutorial"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Explanation of the incident",
-            "example": "Our database is sad"
-          },
-          "retrospective_incident_options": {
-            "$ref": "#/components/schemas/RetrospectiveIncidentOptionsV2"
-          },
-          "severity_id": {
-            "type": "string",
-            "description": "Severity to create incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
-          },
-          "slack_channel_name_override": {
-            "type": "string",
-            "description": "Name of the Slack channel to create for this incident",
-            "example": "inc-123-database-down"
-          },
-          "slack_team_id": {
-            "type": "string",
-            "description": "Slack Team to create the incident in",
-            "example": "T02A1FSLE8J"
-          },
-          "summary": {
-            "type": "string",
-            "description": "Detailed description of the incident",
-            "example": "Our database is really really sad, and we don't know why yet."
-          },
-          "visibility": {
-            "type": "string",
-            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-            "example": "public",
-            "enum": [
-              "public",
-              "private"
-            ]
-          }
-        },
-        "example": {
-          "custom_field_entries": [
-            {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "values": [
-                {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_text": "This is my text field, I hope you like it",
-                  "value_timestamp": ""
-                }
-              ]
-            }
-          ],
-          "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-          "idempotency_key": "alert-uuid",
-          "incident_role_assignments": [
-            {
-              "assignee": {
-                "email": "bob@example.com",
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                "slack_user_id": "USER123"
-              },
-              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-            }
-          ],
-          "incident_status_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-          "incident_timestamp_values": [
-            {
-              "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "value": "2021-08-17T13:28:57.801578Z"
-            }
-          ],
-          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "mode": "standard",
-          "name": "Our database is sad",
-          "retrospective_incident_options": {
-            "postmortem_document_url": "https://docs.google.com/my_doc_id",
-            "slack_channel_id": "abc123"
-          },
-          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "slack_channel_name_override": "inc-123-database-down",
-          "slack_team_id": "T02A1FSLE8J",
-          "summary": "Our database is really really sad, and we don't know why yet.",
-          "visibility": "public"
-        },
-        "required": [
-          "idempotency_key",
-          "visibility"
-        ]
-      },
-      "CreateRequestBody12": {
-        "type": "object",
-        "properties": {
-          "schedule": {
-            "$ref": "#/components/schemas/ScheduleCreatePayloadV2"
-          }
-        },
-        "example": {
-          "schedule": {
-            "annotations": {
-              "incident.io/terraform/version": "version-of-terraform"
-            },
-            "config": {
-              "rotations": [
-                {
-                  "effective_from": "2021-08-17T13:28:57.801578Z",
-                  "handover_start_at": "2021-08-17T13:28:57.801578Z",
-                  "handovers": [
-                    {
-                      "interval": 1,
-                      "interval_type": "daily"
-                    }
-                  ],
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "layers": [
-                    {
-                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                      "name": "Layer 1"
-                    }
-                  ],
-                  "name": "My Rotation",
-                  "users": [
-                    {
-                      "email": "bob@example.com",
-                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                      "slack_user_id": "USER123"
-                    }
-                  ],
-                  "working_interval": [
-                    {
-                      "end_time": "17:00",
-                      "start_time": "09:00",
-                      "weekday": "tuesday"
-                    }
-                  ]
-                }
-              ]
-            },
-            "holidays_public_config": {
-              "country_codes": [
-                "abc123"
-              ]
-            },
-            "name": "My Schedule",
-            "timezone": "America/Los_Angeles"
-          }
-        },
-        "required": [
-          "schedule"
-        ]
-      },
-      "CreateRequestBody13": {
         "type": "object",
         "properties": {
           "description": {
@@ -15175,37 +17271,6 @@
         ]
       },
       "CreateRequestBody2": {
-        "type": "object",
-        "properties": {
-          "custom_field_id": {
-            "type": "string",
-            "description": "ID of the custom field this option belongs to",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
-          },
-          "sort_key": {
-            "type": "integer",
-            "description": "Sort key used to order the custom field options correctly",
-            "default": 1000,
-            "example": 10,
-            "format": "int64"
-          },
-          "value": {
-            "type": "string",
-            "description": "Human readable name for the custom field option",
-            "example": "Product"
-          }
-        },
-        "example": {
-          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "sort_key": 10,
-          "value": "Product"
-        },
-        "required": [
-          "custom_field_id",
-          "value"
-        ]
-      },
-      "CreateRequestBody3": {
         "type": "object",
         "properties": {
           "description": {
@@ -15296,7 +17361,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody4": {
+      "CreateRequestBody3": {
         "type": "object",
         "properties": {
           "description": {
@@ -15338,7 +17403,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody5": {
+      "CreateRequestBody4": {
         "type": "object",
         "properties": {
           "incident_id": {
@@ -15402,7 +17467,7 @@
           "resource"
         ]
       },
-      "CreateRequestBody6": {
+      "CreateRequestBody5": {
         "type": "object",
         "properties": {
           "incident_id": {
@@ -15423,7 +17488,7 @@
           "incident_id"
         ]
       },
-      "CreateRequestBody7": {
+      "CreateRequestBody6": {
         "type": "object",
         "properties": {
           "description": {
@@ -15474,7 +17539,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody8": {
+      "CreateRequestBody7": {
         "type": "object",
         "properties": {
           "description": {
@@ -15518,7 +17583,7 @@
           "updated_at"
         ]
       },
-      "CreateRequestBody9": {
+      "CreateRequestBody8": {
         "type": "object",
         "properties": {
           "category": {
@@ -15555,6 +17620,67 @@
           "rank",
           "created_at",
           "updated_at"
+        ]
+      },
+      "CreateRequestBody9": {
+        "type": "object",
+        "properties": {
+          "schedule": {
+            "$ref": "#/components/schemas/ScheduleCreatePayloadV2"
+          }
+        },
+        "example": {
+          "schedule": {
+            "annotations": {
+              "incident.io/terraform/version": "version-of-terraform"
+            },
+            "config": {
+              "rotations": [
+                {
+                  "effective_from": "2021-08-17T13:28:57.801578Z",
+                  "handover_start_at": "2021-08-17T13:28:57.801578Z",
+                  "handovers": [
+                    {
+                      "interval": 1,
+                      "interval_type": "daily"
+                    }
+                  ],
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "layers": [
+                    {
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "name": "Layer 1"
+                    }
+                  ],
+                  "name": "My Rotation",
+                  "users": [
+                    {
+                      "email": "bob@example.com",
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "slack_user_id": "USER123"
+                    }
+                  ],
+                  "working_interval": [
+                    {
+                      "end_time": "17:00",
+                      "start_time": "09:00",
+                      "weekday": "tuesday"
+                    }
+                  ]
+                }
+              ]
+            },
+            "holidays_public_config": {
+              "country_codes": [
+                "abc123"
+              ]
+            },
+            "name": "My Schedule",
+            "timezone": "America/Los_Angeles"
+          }
+        },
+        "required": [
+          "schedule"
         ]
       },
       "CreateResponseBody": {
@@ -16110,7 +18236,7 @@
           "catalog_type"
         ]
       },
-      "CreateWorkflowRequestBody": {
+      "CreateWorkflowPayload": {
         "type": "object",
         "properties": {
           "annotations": {
@@ -16308,7 +18434,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "test",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
               "enum": [
                 "standard",
                 "test",
@@ -16610,6 +18737,52 @@
           "values"
         ]
       },
+      "CustomFieldEntryPayloadV2": {
+        "type": "object",
+        "properties": {
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this entry is linked against",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldValuePayloadV2"
+            },
+            "description": "List of values to associate with this entry. Use an empty array to unset the value of the custom field.",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_link": "https://google.com/",
+                "value_numeric": "123.456",
+                "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "value_text": "This is my text field, I hope you like it",
+                "value_timestamp": ""
+              }
+            ]
+          }
+        },
+        "example": {
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "values": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "value_link": "https://google.com/",
+              "value_numeric": "123.456",
+              "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "value_text": "This is my text field, I hope you like it",
+              "value_timestamp": ""
+            }
+          ]
+        },
+        "required": [
+          "custom_field_id",
+          "values"
+        ]
+      },
       "CustomFieldEntryV1": {
         "type": "object",
         "properties": {
@@ -16689,7 +18862,221 @@
           "values"
         ]
       },
+      "CustomFieldEntryV2": {
+        "type": "object",
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldTypeInfoV2"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldValueV2"
+            },
+            "description": "List of custom field values set on this entry",
+            "example": [
+              {
+                "value_catalog_entry": {
+                  "aliases": [
+                    "lawrence@incident.io",
+                    "lawrence"
+                  ],
+                  "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Primary On-call"
+                },
+                "value_link": "https://google.com/",
+                "value_numeric": "123.456",
+                "value_option": {
+                  "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "sort_key": 10,
+                  "value": "Product"
+                },
+                "value_text": "This is my text field, I hope you like it"
+              }
+            ]
+          }
+        },
+        "example": {
+          "custom_field": {
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "options": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              }
+            ]
+          },
+          "values": [
+            {
+              "value_catalog_entry": {
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
+                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Primary On-call"
+              },
+              "value_link": "https://google.com/",
+              "value_numeric": "123.456",
+              "value_option": {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              },
+              "value_text": "This is my text field, I hope you like it"
+            }
+          ]
+        },
+        "required": [
+          "custom_field",
+          "values"
+        ]
+      },
+      "CustomFieldOptionDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this option was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T14:28:57.801578Z",
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        }
+      },
+      "CustomFieldOptionDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this option was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time"
+          },
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T14:28:57.801578Z",
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        }
+      },
+      "CustomFieldOptionPayloadV1": {
+        "type": "object",
+        "example": {},
+        "required": [
+          "custom_field_id",
+          "value"
+        ]
+      },
+      "CustomFieldOptionPayloadV2": {
+        "type": "object",
+        "example": {},
+        "required": [
+          "custom_field_id",
+          "value"
+        ]
+      },
       "CustomFieldOptionV1": {
+        "type": "object",
+        "properties": {
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "sort_key": {
+            "type": "integer",
+            "description": "Sort key used to order the custom field options correctly",
+            "default": 1000,
+            "example": 10,
+            "format": "int64"
+          },
+          "value": {
+            "type": "string",
+            "description": "Human readable name for the custom field option",
+            "example": "Product"
+          }
+        },
+        "example": {
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        },
+        "required": [
+          "id",
+          "custom_field_id",
+          "value",
+          "sort_key"
+        ]
+      },
+      "CustomFieldOptionV2": {
         "type": "object",
         "properties": {
           "custom_field_id": {
@@ -16763,6 +19150,84 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CustomFieldOptionV1"
+            },
+            "description": "What options are available for this custom field, if this field has options",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              }
+            ]
+          }
+        },
+        "example": {
+          "description": "Which team is impacted by this issue",
+          "field_type": "single_select",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Affected Team",
+          "options": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "sort_key": 10,
+              "value": "Product"
+            }
+          ]
+        },
+        "required": [
+          "id",
+          "organisation_id",
+          "name",
+          "description",
+          "dynamic_options",
+          "rank",
+          "field_type",
+          "cannot_be_unset",
+          "options",
+          "is_usable",
+          "condition_groups",
+          "field_mode",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CustomFieldTypeInfoV2": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue"
+          },
+          "field_type": {
+            "type": "string",
+            "description": "Type of custom field",
+            "example": "single_select",
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldOptionV2"
             },
             "description": "What options are available for this custom field, if this field has options",
             "example": [
@@ -17014,7 +19479,206 @@
           "updated_at"
         ]
       },
+      "CustomFieldValueDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the value was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field value",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "incident_id": {
+            "type": "string",
+            "description": "ID of the incident this value is defined on",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the value was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "value_catalog_entry_id": {
+            "type": "string",
+            "description": "ID of the catalog entry.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_link": {
+            "type": "string",
+            "description": "If the custom field type is 'link', this will contain the value assigned.",
+            "example": "https://google.com/"
+          },
+          "value_numeric": {
+            "type": "string",
+            "description": "If the custom field type is 'numeric', this will contain the value assigned.",
+            "example": "123.456"
+          },
+          "value_option_id": {
+            "type": "string",
+            "description": "ID of the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_option_value": {
+            "type": "string",
+            "description": "The value of a new option that should be created, if the field supports dynamic options. If this conflicts with an existing option label, you must use its ID instead.",
+            "example": "New option"
+          },
+          "value_text": {
+            "type": "string",
+            "description": "If the custom field type is 'text', this will contain the value assigned.",
+            "example": "This is my text field, I hope you like it"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_link": "https://google.com/",
+          "value_numeric": "123.456",
+          "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_option_value": "New option",
+          "value_text": "This is my text field, I hope you like it"
+        }
+      },
+      "CustomFieldValueDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the value was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "custom_field_id": {
+            "type": "string",
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field value",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "incident_id": {
+            "type": "string",
+            "description": "ID of the incident this value is defined on",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the value was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "value_catalog_entry_id": {
+            "type": "string",
+            "description": "ID of the catalog entry.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_link": {
+            "type": "string",
+            "description": "If the custom field type is 'link', this will contain the value assigned.",
+            "example": "https://google.com/"
+          },
+          "value_numeric": {
+            "type": "string",
+            "description": "If the custom field type is 'numeric', this will contain the value assigned.",
+            "example": "123.456"
+          },
+          "value_option_id": {
+            "type": "string",
+            "description": "ID of the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_option_value": {
+            "type": "string",
+            "description": "The value of a new option that should be created, if the field supports dynamic options. If this conflicts with an existing option label, you must use its ID instead.",
+            "example": "New option"
+          },
+          "value_text": {
+            "type": "string",
+            "description": "If the custom field type is 'text', this will contain the value assigned.",
+            "example": "This is my text field, I hope you like it"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_link": "https://google.com/",
+          "value_numeric": "123.456",
+          "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_option_value": "New option",
+          "value_text": "This is my text field, I hope you like it"
+        }
+      },
       "CustomFieldValuePayloadV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the custom field value",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_catalog_entry_id": {
+            "type": "string",
+            "description": "ID of the catalog entry. You can also use an ExternalID or an Alias of the catalog entry.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_link": {
+            "type": "string",
+            "description": "If the custom field type is 'link', this will contain the value assigned.",
+            "example": "https://google.com/"
+          },
+          "value_numeric": {
+            "type": "string",
+            "description": "If the custom field type is 'numeric', this will contain the value assigned.",
+            "example": "123.456"
+          },
+          "value_option_id": {
+            "type": "string",
+            "description": "ID of the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "value_text": {
+            "type": "string",
+            "description": "If the custom field type is 'text', this will contain the value assigned.",
+            "example": "This is my text field, I hope you like it"
+          },
+          "value_timestamp": {
+            "type": "string",
+            "description": "Deprecated: please use incident timestamp values instead",
+            "example": ""
+          }
+        },
+        "example": {
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_link": "https://google.com/",
+          "value_numeric": "123.456",
+          "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "value_text": "This is my text field, I hope you like it",
+          "value_timestamp": ""
+        }
+      },
+      "CustomFieldValuePayloadV2": {
         "type": "object",
         "properties": {
           "id": {
@@ -17081,6 +19745,52 @@
           },
           "value_option": {
             "$ref": "#/components/schemas/CustomFieldOptionV1"
+          },
+          "value_text": {
+            "type": "string",
+            "description": "If the custom field type is 'text', this will contain the value assigned.",
+            "example": "This is my text field, I hope you like it"
+          }
+        },
+        "example": {
+          "value_catalog_entry": {
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Primary On-call"
+          },
+          "value_link": "https://google.com/",
+          "value_numeric": "123.456",
+          "value_option": {
+            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "sort_key": 10,
+            "value": "Product"
+          },
+          "value_text": "This is my text field, I hope you like it"
+        }
+      },
+      "CustomFieldValueV2": {
+        "type": "object",
+        "properties": {
+          "value_catalog_entry": {
+            "$ref": "#/components/schemas/EmbeddedCatalogEntryV2"
+          },
+          "value_link": {
+            "type": "string",
+            "description": "If the custom field type is 'link', this will contain the value assigned.",
+            "example": "https://google.com/"
+          },
+          "value_numeric": {
+            "type": "string",
+            "description": "If the custom field type is 'numeric', this will contain the value assigned.",
+            "example": "123.456"
+          },
+          "value_option": {
+            "$ref": "#/components/schemas/CustomFieldOptionV2"
           },
           "value_text": {
             "type": "string",
@@ -17215,6 +19925,133 @@
           "catalog_type_id"
         ]
       },
+      "EmbeddedCatalogEntryV2": {
+        "type": "object",
+        "properties": {
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ]
+          },
+          "external_id": {
+            "type": "string",
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call"
+          }
+        },
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Primary On-call"
+        },
+        "required": [
+          "id",
+          "name",
+          "catalog_type_id"
+        ]
+      },
+      "EmbeddedIncidentRoleV2": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the role was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the role",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "instructions": {
+            "type": "string",
+            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1
+          },
+          "required": {
+            "type": "boolean",
+            "description": "This field is deprecated.",
+            "example": false
+          },
+          "role_type": {
+            "type": "string",
+            "description": "Type of incident role",
+            "example": "lead",
+            "enum": [
+              "lead",
+              "reporter",
+              "custom"
+            ]
+          },
+          "shortform": {
+            "type": "string",
+            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
+            "example": "lead"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the role was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "The person currently coordinating the incident",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "required": false,
+          "role_type": "lead",
+          "shortform": "lead",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "name",
+          "shortform",
+          "description",
+          "instructions",
+          "condition_groups",
+          "id",
+          "role_type",
+          "created_at",
+          "updated_at"
+        ]
+      },
       "EngineParamBindingPayloadV2": {
         "type": "object",
         "properties": {
@@ -17243,6 +20080,114 @@
             }
           ],
           "value": {
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV10": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV18"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV17"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV11": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV20"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV19"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV12": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV22"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV21"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
             "literal": "SEV123",
             "reference": "incident.severity"
           }
@@ -17290,7 +20235,7 @@
           "array_value": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV3"
+              "$ref": "#/components/schemas/EngineParamBindingValueV4"
             },
             "description": "If array_value is set, this helps render the values",
             "example": [
@@ -17303,6 +20248,222 @@
           },
           "value": {
             "$ref": "#/components/schemas/EngineParamBindingValueV3"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV4": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV6"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV5"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV5": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV8"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV7"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV6": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV10"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV9"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV7": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV12"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV11"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV8": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV14"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV13"
+          }
+        },
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123",
+            "reference": "incident.severity"
+          }
+        }
+      },
+      "EngineParamBindingV9": {
+        "type": "object",
+        "properties": {
+          "array_value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingValueV16"
+            },
+            "description": "If array_value is set, this helps render the values",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/EngineParamBindingValueV15"
           }
         },
         "example": {
@@ -17339,6 +20500,286 @@
           "reference": "incident.severity"
         }
       },
+      "EngineParamBindingValueV10": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV11": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV12": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV13": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV14": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV15": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV16": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV17": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV18": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV19": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
       "EngineParamBindingValueV2": {
         "type": "object",
         "properties": {
@@ -17368,6 +20809,90 @@
           "sort_key"
         ]
       },
+      "EngineParamBindingValueV20": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV21": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV22": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
       "EngineParamBindingValueV3": {
         "type": "object",
         "properties": {
@@ -17394,6 +20919,249 @@
         },
         "required": [
           "label"
+        ]
+      },
+      "EngineParamBindingValueV4": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV5": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV6": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV7": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV8": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamBindingValueV9": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Human readable label to be displayed for user to select",
+            "example": "Lawrence Jones"
+          },
+          "literal": {
+            "type": "string",
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123"
+          },
+          "reference": {
+            "type": "string",
+            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
+            "example": "incident.severity"
+          }
+        },
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123",
+          "reference": "incident.severity"
+        },
+        "required": [
+          "label"
+        ]
+      },
+      "EngineParamV2": {
+        "type": "object",
+        "properties": {
+          "array": {
+            "type": "boolean",
+            "description": "Whether this parameter is an array",
+            "example": true
+          },
+          "default_value": {
+            "$ref": "#/components/schemas/EngineParamBindingV2"
+          },
+          "description": {
+            "type": "string",
+            "description": "A string describing the param",
+            "example": "What slack channel should we send the message to?"
+          },
+          "infer_reference": {
+            "type": "boolean",
+            "description": "Whether this parameter should be inferred as a reference from the scope",
+            "example": true
+          },
+          "label": {
+            "type": "string",
+            "description": "Human readable label for this parameter",
+            "example": "To date"
+          },
+          "name": {
+            "type": "string",
+            "description": "The unique identifier for the parameter",
+            "example": "severity"
+          },
+          "optional": {
+            "type": "boolean",
+            "description": "Whether this parameter is optional",
+            "example": true
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of the parameter",
+            "example": "IncidentSeverity"
+          }
+        },
+        "example": {
+          "array": true,
+          "default_value": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          },
+          "description": "What slack channel should we send the message to?",
+          "infer_reference": true,
+          "label": "To date",
+          "name": "severity",
+          "optional": true,
+          "type": "IncidentSeverity"
+        },
+        "required": [
+          "name",
+          "label",
+          "type",
+          "array",
+          "optional",
+          "infer_reference",
+          "description"
         ]
       },
       "EngineReferenceV2": {
@@ -17433,6 +21201,133 @@
           "array",
           "node_label",
           "hide_filter"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ErrorSingle"
+            },
+            "description": "List of errors that caused this request to fail",
+            "example": [
+              {
+                "code": "trial_expired",
+                "message": "Default incident call link must be a valid URL",
+                "source": {
+                  "field": "default_call_url",
+                  "pointer": "/settings/default_call_url"
+                }
+              }
+            ]
+          },
+          "request_id": {
+            "type": "string",
+            "description": "Unique identifier of the request",
+            "example": "FF1D889F-0741-6290-783B-66E606310D86",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status of the response",
+            "example": 429,
+            "format": "int64"
+          },
+          "type": {
+            "type": "string",
+            "description": "Machine-readable identifier for the general category of error",
+            "example": "invalid_request_error",
+            "enum": [
+              "invalid_request_error",
+              "authentication_error",
+              "resource_forbidden",
+              "not_found",
+              "not_acceptable",
+              "conflict",
+              "precondition_failed",
+              "payload_too_large",
+              "validation_error",
+              "too_many_requests",
+              "api_error",
+              "rate_limit_reached"
+            ]
+          }
+        },
+        "example": {
+          "errors": [
+            {
+              "code": "trial_expired",
+              "message": "Default incident call link must be a valid URL",
+              "source": {
+                "field": "default_call_url",
+                "pointer": "/settings/default_call_url"
+              }
+            }
+          ],
+          "request_id": "FF1D889F-0741-6290-783B-66E606310D86",
+          "status": 429,
+          "type": "invalid_request_error"
+        },
+        "required": [
+          "type",
+          "status",
+          "request_id",
+          "errors"
+        ]
+      },
+      "ErrorSingle": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Machine-readable identifier for this specific error",
+            "example": "trial_expired"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human readable description of the error",
+            "example": "Default incident call link must be a valid URL"
+          },
+          "source": {
+            "$ref": "#/components/schemas/ErrorSource"
+          }
+        },
+        "example": {
+          "code": "trial_expired",
+          "message": "Default incident call link must be a valid URL",
+          "source": {
+            "field": "default_call_url",
+            "pointer": "/settings/default_call_url"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      },
+      "ErrorSource": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "Field name that is the source of the error",
+            "example": "default_call_url"
+          },
+          "pointer": {
+            "type": "string",
+            "description": "JSON pointer to the request field that is the source of the error",
+            "example": "/settings/default_call_url"
+          }
+        },
+        "example": {
+          "field": "default_call_url",
+          "pointer": "/settings/default_call_url"
+        },
+        "required": [
+          "field",
+          "pointer"
         ]
       },
       "EscalationPathNodeIfElsePayloadV2": {
@@ -17511,7 +21406,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -17573,7 +21468,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -17651,7 +21546,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -17706,7 +21601,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -17819,7 +21714,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -17889,7 +21784,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -17983,7 +21878,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -18046,7 +21941,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -18084,7 +21979,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
-                "type": "user",
+                "type": "schedule",
                 "urgency": "high"
               }
             ]
@@ -18119,7 +22014,7 @@
             {
               "id": "lawrencejones",
               "schedule_mode": "currently_on_call",
-              "type": "user",
+              "type": "schedule",
               "urgency": "high"
             }
           ],
@@ -18199,7 +22094,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
-                "type": "user",
+                "type": "schedule",
                 "urgency": "high"
               }
             ],
@@ -18318,7 +22213,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
-                "type": "user",
+                "type": "schedule",
                 "urgency": "high"
               }
             ],
@@ -18335,6 +22230,175 @@
         "required": [
           "id",
           "type"
+        ]
+      },
+      "EscalationPathPayloadV2": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of this escalation path, for the user's reference.",
+            "example": "Urgent Support"
+          },
+          "path": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
+            },
+            "description": "The nodes that form the levels and branches of this escalation path.",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "if_else": {
+                  "conditions": [
+                    {
+                      "operation": "one_of",
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": "incident.severity"
+                    }
+                  ],
+                  "else_path": [
+                    {}
+                  ],
+                  "then_path": [
+                    {}
+                  ]
+                },
+                "level": {
+                  "round_robin_config": {
+                    "enabled": false,
+                    "rotate_after_seconds": 120
+                  },
+                  "targets": [
+                    {
+                      "id": "lawrencejones",
+                      "schedule_mode": "currently_on_call",
+                      "type": "schedule",
+                      "urgency": "high"
+                    }
+                  ],
+                  "time_to_ack_interval_condition": "active",
+                  "time_to_ack_seconds": 1800,
+                  "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "repeat": {
+                  "repeat_times": 3,
+                  "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+                },
+                "type": "if_else"
+              }
+            ]
+          },
+          "working_hours": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WeekdayIntervalConfigV2"
+            },
+            "description": "The working hours for this escalation path.",
+            "example": [
+              {
+                "id": "abc123",
+                "name": "abc123",
+                "timezone": "abc123",
+                "weekday_intervals": [
+                  {
+                    "end_time": "17:00",
+                    "start_time": "09:00",
+                    "weekday": "abc123"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "name": "Urgent Support",
+          "path": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "if_else": {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ],
+                "else_path": [
+                  {}
+                ],
+                "then_path": [
+                  {}
+                ]
+              },
+              "level": {
+                "round_robin_config": {
+                  "enabled": false,
+                  "rotate_after_seconds": 120
+                },
+                "targets": [
+                  {
+                    "id": "lawrencejones",
+                    "schedule_mode": "currently_on_call",
+                    "type": "schedule",
+                    "urgency": "high"
+                  }
+                ],
+                "time_to_ack_interval_condition": "active",
+                "time_to_ack_seconds": 1800,
+                "time_to_ack_weekday_interval_config_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "repeat": {
+                "repeat_times": 3,
+                "to_node": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "type": "if_else"
+            }
+          ],
+          "working_hours": [
+            {
+              "id": "abc123",
+              "name": "abc123",
+              "timezone": "abc123",
+              "weekday_intervals": [
+                {
+                  "end_time": "17:00",
+                  "start_time": "09:00",
+                  "weekday": "abc123"
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "name",
+          "path"
         ]
       },
       "EscalationPathRoundRobinConfigV2": {
@@ -18381,8 +22445,7 @@
           },
           "type": {
             "type": "string",
-            "description": "Controls what type of entity this target identifies, such as EscalationPolicy or User",
-            "example": "user",
+            "example": "schedule",
             "enum": [
               "schedule",
               "user",
@@ -18402,7 +22465,7 @@
         "example": {
           "id": "lawrencejones",
           "schedule_mode": "currently_on_call",
-          "type": "user",
+          "type": "schedule",
           "urgency": "high"
         },
         "required": [
@@ -18478,7 +22541,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -18567,7 +22630,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -18791,7 +22854,7 @@
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV3"
+              "$ref": "#/components/schemas/ConditionGroupV4"
             },
             "description": "When one of these condition groups are satisfied, this branch will be evaluated",
             "example": [
@@ -18828,7 +22891,106 @@
             ]
           },
           "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV3"
+            "$ref": "#/components/schemas/EngineParamBindingV6"
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "result": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "condition_groups",
+          "result"
+        ]
+      },
+      "ExpressionBranchV4": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV7"
+            },
+            "description": "When one of these condition groups are satisfied, this branch will be evaluated",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "result": {
+            "$ref": "#/components/schemas/EngineParamBindingV11"
           }
         },
         "example": {
@@ -19239,6 +23401,414 @@
           "returns"
         ]
       },
+      "ExpressionBranchesOptsV4": {
+        "type": "object",
+        "properties": {
+          "branches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionBranchV4"
+            },
+            "description": "The branches to apply for this operation",
+            "example": [
+              {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ]
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          }
+        },
+        "example": {
+          "branches": [
+            {
+              "condition_groups": [
+                {
+                  "conditions": [
+                    {
+                      "operation": {
+                        "label": "Lawrence Jones",
+                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                      },
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": {
+                        "label": "Incident Severity",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "result": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "required": [
+          "branches",
+          "returns"
+        ]
+      },
+      "ExpressionDefinitions": {
+        "type": "object",
+        "properties": {
+          "else_branch": {
+            "$ref": "#/components/schemas/ExpressionElseBranchV2"
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of the expression",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "label": {
+            "type": "string",
+            "description": "The human readable label of the expression",
+            "example": "Team Slack channel"
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionOperationV2"
+            },
+            "example": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": {
+                            "label": "Lawrence Jones",
+                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                          },
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": {
+                            "label": "Incident Severity",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "1235",
+                  "reference_label": "Teams"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                },
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              }
+            ]
+          },
+          "reference": {
+            "type": "string",
+            "description": "A short ID that can be used to reference the expression",
+            "example": "abc123"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          },
+          "root_reference": {
+            "type": "string",
+            "description": "The root reference for this expression (i.e. where the expression starts)",
+            "example": "incident.status"
+          }
+        },
+        "example": {
+          "else_branch": {
+            "result": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "label": "Team Slack channel",
+          "operations": [
+            {
+              "branches": {
+                "branches": [
+                  {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "result": {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              },
+              "filter": {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "navigate": {
+                "reference": "1235",
+                "reference_label": "Teams"
+              },
+              "operation_type": "navigate",
+              "parse": {
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "source": "metadata.annotations[\"github.com/repo\"]"
+              },
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              }
+            }
+          ],
+          "reference": "abc123",
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          },
+          "root_reference": "incident.status"
+        }
+      },
       "ExpressionElseBranchPayloadV2": {
         "type": "object",
         "properties": {
@@ -19296,6 +23866,33 @@
         "properties": {
           "result": {
             "$ref": "#/components/schemas/EngineParamBindingV3"
+          }
+        },
+        "example": {
+          "result": {
+            "array_value": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            ],
+            "value": {
+              "label": "Lawrence Jones",
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            }
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "ExpressionElseBranchV4": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/EngineParamBindingV8"
           }
         },
         "example": {
@@ -19471,6 +24068,87 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ConditionGroupV3"
+            },
+            "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "condition_groups"
+        ]
+      },
+      "ExpressionFilterOptsV4": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV6"
             },
             "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
             "example": [
@@ -19735,7 +24413,7 @@
             ]
           },
           "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
+            "$ref": "#/components/schemas/ExpressionParseOptsV2"
           },
           "returns": {
             "$ref": "#/components/schemas/ReturnsMetaV2"
@@ -19883,7 +24561,155 @@
             ]
           },
           "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsPayloadV2"
+            "$ref": "#/components/schemas/ExpressionParseOptsV2"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          }
+        },
+        "example": {
+          "branches": {
+            "branches": [
+              {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ],
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            }
+          },
+          "filter": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "navigate": {
+            "reference": "1235",
+            "reference_label": "Teams"
+          },
+          "operation_type": "navigate",
+          "parse": {
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            },
+            "source": "metadata.annotations[\"github.com/repo\"]"
+          },
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "required": [
+          "operation_type",
+          "returns"
+        ]
+      },
+      "ExpressionOperationV4": {
+        "type": "object",
+        "properties": {
+          "branches": {
+            "$ref": "#/components/schemas/ExpressionBranchesOptsV4"
+          },
+          "filter": {
+            "$ref": "#/components/schemas/ExpressionFilterOptsV4"
+          },
+          "navigate": {
+            "$ref": "#/components/schemas/ExpressionNavigateOptsV2"
+          },
+          "operation_type": {
+            "type": "string",
+            "description": "The type of the operation",
+            "example": "navigate",
+            "enum": [
+              "navigate",
+              "filter",
+              "count",
+              "min",
+              "max",
+              "random",
+              "first",
+              "parse",
+              "branches"
+            ]
+          },
+          "parse": {
+            "$ref": "#/components/schemas/ExpressionParseOptsV2"
           },
           "returns": {
             "$ref": "#/components/schemas/ReturnsMetaV2"
@@ -20003,6 +24829,30 @@
         ]
       },
       "ExpressionParseOptsPayloadV2": {
+        "type": "object",
+        "properties": {
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          },
+          "source": {
+            "type": "string",
+            "description": "Source expression that is evaluated to a result",
+            "example": "metadata.annotations[\"github.com/repo\"]"
+          }
+        },
+        "example": {
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          },
+          "source": "metadata.annotations[\"github.com/repo\"]"
+        },
+        "required": [
+          "source",
+          "returns"
+        ]
+      },
+      "ExpressionParseOptsV2": {
         "type": "object",
         "properties": {
           "returns": {
@@ -20824,42 +25674,292 @@
           "id"
         ]
       },
-      "ExternalIssueReferenceV1": {
+      "ExpressionV4": {
         "type": "object",
         "properties": {
-          "issue_name": {
-            "type": "string",
-            "description": "Human readable ID for the issue",
-            "example": "INC-123"
+          "else_branch": {
+            "$ref": "#/components/schemas/ExpressionElseBranchV4"
           },
-          "issue_permalink": {
+          "label": {
             "type": "string",
-            "description": "URL linking directly to the action in the issue tracker",
-            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+            "description": "The human readable label of the expression",
+            "example": "Team Slack channel"
           },
-          "provider": {
-            "type": "string",
-            "description": "ID of the issue tracker provider",
-            "example": "asana",
-            "enum": [
-              "asana",
-              "click_up",
-              "linear",
-              "jira",
-              "jira_server",
-              "github",
-              "gitlab",
-              "shortcut"
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionOperationV4"
+            },
+            "example": [
+              {
+                "branches": {
+                  "branches": [
+                    {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "result": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "filter": {
+                  "condition_groups": [
+                    {
+                      "conditions": [
+                        {
+                          "operation": {
+                            "label": "Lawrence Jones",
+                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                          },
+                          "param_bindings": [
+                            {
+                              "array_value": [
+                                {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ],
+                          "subject": {
+                            "label": "Incident Severity",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "navigate": {
+                  "reference": "1235",
+                  "reference_label": "Teams"
+                },
+                "operation_type": "navigate",
+                "parse": {
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "source": "metadata.annotations[\"github.com/repo\"]"
+                },
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              }
             ]
+          },
+          "reference": {
+            "type": "string",
+            "description": "A short ID that can be used to reference the expression",
+            "example": "abc123"
+          },
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          },
+          "root_reference": {
+            "type": "string",
+            "description": "The root reference for this expression (i.e. where the expression starts)",
+            "example": "incident.status"
           }
         },
         "example": {
-          "issue_name": "INC-123",
-          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-          "provider": "asana"
-        }
+          "else_branch": {
+            "result": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "label": "Team Slack channel",
+          "operations": [
+            {
+              "branches": {
+                "branches": [
+                  {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "result": {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  }
+                ],
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              },
+              "filter": {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "navigate": {
+                "reference": "1235",
+                "reference_label": "Teams"
+              },
+              "operation_type": "navigate",
+              "parse": {
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "source": "metadata.annotations[\"github.com/repo\"]"
+              },
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              }
+            }
+          ],
+          "reference": "abc123",
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          },
+          "root_reference": "incident.status"
+        },
+        "required": [
+          "label",
+          "reference",
+          "returns",
+          "root_reference",
+          "operations",
+          "id"
+        ]
       },
-      "ExternalIssueReferenceV2": {
+      "ExternalIssueReferenceV1": {
         "type": "object",
         "properties": {
           "issue_name": {
@@ -20900,6 +26000,254 @@
           "issue_permalink",
           "issue_id"
         ]
+      },
+      "ExternalIssueReferenceV2": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        }
+      },
+      "ExternalIssueReferenceV3": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        },
+        "required": [
+          "provider",
+          "provider_instance_id",
+          "issue_name",
+          "issue_permalink",
+          "issue_id"
+        ]
+      },
+      "ExternalIssueReferenceV4": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        },
+        "required": [
+          "provider",
+          "provider_instance_id",
+          "issue_name",
+          "issue_permalink",
+          "issue_id"
+        ]
+      },
+      "ExternalIssueReferenceV5": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        },
+        "required": [
+          "provider",
+          "provider_instance_id",
+          "issue_name",
+          "issue_permalink",
+          "issue_id"
+        ]
+      },
+      "ExternalIssueReferenceV6": {
+        "type": "object",
+        "properties": {
+          "issue_name": {
+            "type": "string",
+            "description": "Human readable ID for the issue",
+            "example": "INC-123"
+          },
+          "issue_permalink": {
+            "type": "string",
+            "description": "URL linking directly to the action in the issue tracker",
+            "example": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up"
+          },
+          "provider": {
+            "type": "string",
+            "description": "ID of the issue tracker provider",
+            "example": "asana",
+            "enum": [
+              "asana",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "shortcut"
+            ]
+          }
+        },
+        "example": {
+          "issue_name": "INC-123",
+          "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+          "provider": "asana"
+        },
+        "required": [
+          "provider",
+          "provider_instance_id",
+          "issue_name",
+          "issue_permalink",
+          "issue_id"
+        ]
+      },
+      "ExternalResourceDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "external_id": {
+            "type": "string",
+            "description": "ID of the resource in the external system",
+            "example": "123"
+          },
+          "permalink": {
+            "type": "string",
+            "description": "URL of the resource",
+            "example": "https://my.pagerduty.com/incidents/ABC"
+          },
+          "resource_type": {
+            "type": "string",
+            "description": "E.g. PagerDuty: the external system that holds the resource",
+            "example": "pager_duty_incident",
+            "enum": [
+              "pager_duty_incident",
+              "opsgenie_alert",
+              "datadog_monitor_alert",
+              "github_pull_request",
+              "gitlab_merge_request",
+              "sentry_issue",
+              "jira_issue",
+              "atlassian_statuspage_incident",
+              "zendesk_ticket",
+              "google_calendar_event",
+              "scrubbed",
+              "statuspage_incident"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of resource",
+            "example": "The database has gone down"
+          }
+        },
+        "example": {
+          "external_id": "123",
+          "permalink": "https://my.pagerduty.com/incidents/ABC",
+          "resource_type": "pager_duty_incident",
+          "title": "The database has gone down"
+        }
       },
       "ExternalResourceV1": {
         "type": "object",
@@ -20997,7 +26345,7 @@
         "type": "object",
         "properties": {
           "assignee": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           },
           "completed_at": {
             "type": "string",
@@ -21017,7 +26365,7 @@
             "example": "Call the fire brigade"
           },
           "external_issue_reference": {
-            "$ref": "#/components/schemas/ExternalIssueReferenceV2"
+            "$ref": "#/components/schemas/ExternalIssueReferenceV5"
           },
           "id": {
             "type": "string",
@@ -21145,7 +26493,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "incident_creator",
+              "description": "API key roles",
+              "example": "viewer",
               "enum": [
                 "viewer",
                 "incident_creator",
@@ -21164,7 +26513,7 @@
             },
             "description": "Which roles have been enabled for this key",
             "example": [
-              "incident_creator"
+              "viewer"
             ]
           }
         },
@@ -21172,7 +26521,7 @@
           "dashboard_url": "https://app.incident.io/my-org",
           "name": "Alertmanager token",
           "roles": [
-            "incident_creator"
+            "viewer"
           ]
         },
         "required": [
@@ -21215,6 +26564,344 @@
           "resource",
           "creator",
           "created_at"
+        ]
+      },
+      "IncidentCreatePayloadV1": {
+        "type": "object",
+        "properties": {
+          "custom_field_entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+            },
+            "description": "Set the incident's custom fields to these values",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ]
+          },
+          "idempotency_key": {
+            "type": "string",
+            "description": "Unique string used to de-duplicate incident create requests",
+            "example": "alert-uuid"
+          },
+          "incident_role_assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
+            },
+            "description": "Assign incident roles to these people",
+            "example": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ]
+          },
+          "incident_type_id": {
+            "type": "string",
+            "description": "Incident type to create this incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Whether the incident is real or test",
+            "example": "real",
+            "enum": [
+              "real",
+              "test"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Explanation of the incident",
+            "example": "Our database is sad"
+          },
+          "severity_id": {
+            "type": "string",
+            "description": "Severity to create incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "slack_team_id": {
+            "type": "string",
+            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
+            "example": "T02A1FSLE8J"
+          },
+          "source_message_channel_id": {
+            "type": "string",
+            "description": "Channel ID of the source message, if this incident was created from one",
+            "example": "C02AW36C1M5"
+          },
+          "source_message_timestamp": {
+            "type": "string",
+            "description": "Timestamp of the source message, if this incident was created from one",
+            "example": "1653650280.526509"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current status of the incident",
+            "example": "triage",
+            "enum": [
+              "triage",
+              "investigating",
+              "fixing",
+              "monitoring",
+              "closed",
+              "declined"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "description": "Detailed description of the incident",
+            "example": "Our database is really really sad, and we don't know why yet."
+          },
+          "visibility": {
+            "type": "string",
+            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+            "example": "public",
+            "enum": [
+              "public",
+              "private"
+            ]
+          }
+        },
+        "example": {
+          "custom_field_entries": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ],
+          "idempotency_key": "alert-uuid",
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ],
+          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "mode": "real",
+          "name": "Our database is sad",
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "slack_team_id": "T02A1FSLE8J",
+          "source_message_channel_id": "C02AW36C1M5",
+          "source_message_timestamp": "1653650280.526509",
+          "status": "triage",
+          "summary": "Our database is really really sad, and we don't know why yet.",
+          "visibility": "public"
+        },
+        "required": [
+          "idempotency_key",
+          "visibility"
+        ]
+      },
+      "IncidentCreatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "custom_field_entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV2"
+            },
+            "description": "Set the incident's custom fields to these values",
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the incident",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+          },
+          "idempotency_key": {
+            "type": "string",
+            "description": "Unique string used to de-duplicate incident create requests",
+            "example": "alert-uuid"
+          },
+          "incident_role_assignments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV2"
+            },
+            "description": "Assign incident roles to these people",
+            "example": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ]
+          },
+          "incident_status_id": {
+            "type": "string",
+            "description": "Incident status to assign to the incident",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "incident_timestamp_values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncidentTimestampValuePayloadV2"
+            },
+            "description": "Assign the incident's timestamps to these values",
+            "example": [
+              {
+                "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "value": "2021-08-17T13:28:57.801578Z"
+              }
+            ]
+          },
+          "incident_type_id": {
+            "type": "string",
+            "description": "Incident type to create this incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "mode": {
+            "type": "string",
+            "description": "Whether the incident is real, a test, a tutorial, or importing as a retrospective incident",
+            "example": "standard",
+            "enum": [
+              "standard",
+              "retrospective",
+              "test",
+              "tutorial"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Explanation of the incident",
+            "example": "Our database is sad"
+          },
+          "retrospective_incident_options": {
+            "$ref": "#/components/schemas/RetrospectiveIncidentOptionsV2"
+          },
+          "severity_id": {
+            "type": "string",
+            "description": "Severity to create incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96"
+          },
+          "slack_channel_name_override": {
+            "type": "string",
+            "description": "Name of the Slack channel to create for this incident",
+            "example": "inc-123-database-down"
+          },
+          "slack_team_id": {
+            "type": "string",
+            "description": "Slack Team to create the incident in",
+            "example": "T02A1FSLE8J"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Detailed description of the incident",
+            "example": "Our database is really really sad, and we don't know why yet."
+          },
+          "visibility": {
+            "type": "string",
+            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+            "example": "public",
+            "enum": [
+              "public",
+              "private"
+            ]
+          }
+        },
+        "example": {
+          "custom_field_entries": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
+            }
+          ],
+          "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+          "idempotency_key": "alert-uuid",
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ],
+          "incident_status_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "incident_timestamp_values": [
+            {
+              "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "value": "2021-08-17T13:28:57.801578Z"
+            }
+          ],
+          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "mode": "standard",
+          "name": "Our database is sad",
+          "retrospective_incident_options": {
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "slack_channel_id": "abc123"
+          },
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "slack_channel_name_override": "inc-123-database-down",
+          "slack_team_id": "T02A1FSLE8J",
+          "summary": "Our database is really really sad, and we don't know why yet.",
+          "visibility": "public"
+        },
+        "required": [
+          "idempotency_key",
+          "visibility"
         ]
       },
       "IncidentDurationMetricV2": {
@@ -21283,7 +26970,7 @@
           "custom_field_entries": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV2"
             },
             "description": "Set the incident's custom fields to these values",
             "example": [
@@ -21400,6 +27087,257 @@
           "summary": "Our database is really really sad, and we don't know why yet."
         }
       },
+      "IncidentFilterFieldsV2": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "object",
+            "description": "Filter on incident created at timestamp. The accepted operators are 'gte', 'lte' and 'date_range'.",
+            "example": {
+              "created_at[gte]": [
+                "2024-05-01"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "custom_field": {
+            "type": "object",
+            "description": "Filter on an incident custom field. Custom field ID should be sent, followed by the operator and values. Accepted operator will depend on the custom field type.",
+            "example": {
+              "01GBSQF3FHF7FWZQNWGHAVQ804": {
+                "one_of": [
+                  "01GBSQF3FHF7FWZQNWGHAVQ804",
+                  "01ET65M7ZARSFZ6TFDFVQDN9AA"
+                ]
+              }
+            },
+            "additionalProperties": {
+              "type": "object",
+              "example": {
+                "abc123": [
+                  "value"
+                ]
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "value"
+                },
+                "example": [
+                  "value"
+                ]
+              }
+            }
+          },
+          "incident_role": {
+            "type": "object",
+            "description": "Filter on an incident role. Role ID should be sent, followed by the operator and values. The accepted operators are 'one_of', 'is_blank'.",
+            "example": {
+              "01GBSQF3FHF7FWZQNWGHAVQ804": {
+                "one_of": [
+                  "01GBSQF3FHF7FWZQNWGHAVQ804",
+                  "01ET65M7ZARSFZ6TFDFVQDN9AA"
+                ]
+              }
+            },
+            "additionalProperties": {
+              "type": "object",
+              "example": {
+                "abc123": [
+                  "value"
+                ]
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "example": "value"
+                },
+                "example": [
+                  "value"
+                ]
+              }
+            }
+          },
+          "incident_type": {
+            "type": "object",
+            "description": "Filter on incident type. The accepted operators are 'one_of, or 'not_in'.",
+            "example": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "mode": {
+            "type": "object",
+            "description": "Filter on incident mode. The accepted operator is 'one_of'.  If this is not provided, this value defaults to `{\"one_of\": [\"standard\", \"retrospective\"] }`, meaning that test and tutorial incidents are not included.",
+            "example": {
+              "one_of": [
+                "retrospective"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "severity": {
+            "type": "object",
+            "description": "Filter on incident severity. The accepted operators are 'one_of', 'not_in', 'gte', 'lte'.",
+            "example": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "status": {
+            "type": "object",
+            "description": "Filter on incident status. The accepted operators are 'one_of', or 'not_in'.",
+            "example": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "status_category": {
+            "type": "object",
+            "description": "Filter on the category of the incidents status. The accepted operators are 'one_of', or 'not_in'. If this is not provided, this value defaults to `{\"one_of\": [\"triage\", \"active\", \"post-incident\", \"closed\"] }`, meaning that canceled, declined and merged incidents are not included.",
+            "example": {
+              "one_of": [
+                "active"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          },
+          "updated_at": {
+            "type": "object",
+            "description": "Filter on incident updated at timestamp. The accepted operators are 'gte', 'lte' and 'date_range'.",
+            "example": {
+              "updated_at[gte]": [
+                "2024-05-01"
+              ]
+            },
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "example": "some_value"
+              },
+              "example": [
+                "some_value"
+              ]
+            }
+          }
+        },
+        "example": {
+          "created_at": {
+            "created_at[gte]": [
+              "2024-05-01"
+            ]
+          },
+          "custom_field": {
+            "01GBSQF3FHF7FWZQNWGHAVQ804": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804",
+                "01ET65M7ZARSFZ6TFDFVQDN9AA"
+              ]
+            }
+          },
+          "incident_role": {
+            "01GBSQF3FHF7FWZQNWGHAVQ804": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804",
+                "01ET65M7ZARSFZ6TFDFVQDN9AA"
+              ]
+            }
+          },
+          "incident_type": {
+            "one_of": [
+              "01GBSQF3FHF7FWZQNWGHAVQ804"
+            ]
+          },
+          "mode": {
+            "one_of": [
+              "retrospective"
+            ]
+          },
+          "severity": {
+            "one_of": [
+              "01GBSQF3FHF7FWZQNWGHAVQ804"
+            ]
+          },
+          "status": {
+            "one_of": [
+              "01GBSQF3FHF7FWZQNWGHAVQ804"
+            ]
+          },
+          "status_category": {
+            "one_of": [
+              "active"
+            ]
+          },
+          "updated_at": {
+            "updated_at[gte]": [
+              "2024-05-01"
+            ]
+          }
+        }
+      },
       "IncidentMembership": {
         "type": "object",
         "properties": {
@@ -21426,7 +27364,7 @@
             "format": "date-time"
           },
           "user": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           }
         },
         "example": {
@@ -21479,7 +27417,7 @@
         "type": "object",
         "properties": {
           "assignee": {
-            "$ref": "#/components/schemas/UserReferencePayloadV1"
+            "$ref": "#/components/schemas/UserReferencePayloadV2"
           },
           "incident_role_id": {
             "type": "string",
@@ -21507,6 +27445,40 @@
           },
           "role": {
             "$ref": "#/components/schemas/IncidentRoleV1"
+          }
+        },
+        "example": {
+          "assignee": {
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          },
+          "role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "required": false,
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "required": [
+          "role"
+        ]
+      },
+      "IncidentRoleAssignmentV2": {
+        "type": "object",
+        "properties": {
+          "assignee": {
+            "$ref": "#/components/schemas/UserV2"
+          },
+          "role": {
+            "$ref": "#/components/schemas/EmbeddedIncidentRoleV2"
           }
         },
         "example": {
@@ -21689,7 +27661,145 @@
           "updated_at"
         ]
       },
+      "IncidentStatusDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured",
+            "example": "triage",
+            "enum": [
+              "triage",
+              "declined",
+              "merged",
+              "canceled",
+              "live",
+              "learning",
+              "closed",
+              "paused"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Rich text description of the incident status",
+            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique ID of this incident status",
+            "example": "01FCNDV6P870EA6S7TK1DSYD5H"
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of this status",
+            "example": "Closed"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Order of this incident status",
+            "example": 4,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "category": "triage",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+          "name": "Closed",
+          "rank": 4,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "rank",
+          "category",
+          "created_at",
+          "updated_at"
+        ]
+      },
       "IncidentStatusV1": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured",
+            "example": "triage",
+            "enum": [
+              "triage",
+              "declined",
+              "merged",
+              "canceled",
+              "live",
+              "learning",
+              "closed",
+              "paused"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Rich text description of the incident status",
+            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique ID of this incident status",
+            "example": "01FCNDV6P870EA6S7TK1DSYD5H"
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of this status",
+            "example": "Closed"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Order of this incident status",
+            "example": 4,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "category": "triage",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+          "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+          "name": "Closed",
+          "rank": 4,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "rank",
+          "category",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "IncidentStatusV2": {
         "type": "object",
         "properties": {
           "category": {
@@ -21969,6 +28079,85 @@
           "auto_archive_slack_channels_delay_days"
         ]
       },
+      "IncidentTypeV2": {
+        "type": "object",
+        "properties": {
+          "create_in_triage": {
+            "type": "string",
+            "description": "Whether incidents of this must always, or can optionally, be created in triage",
+            "example": "always",
+            "enum": [
+              "always",
+              "optional"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "description": "When this resource was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "What is this incident type for?",
+            "example": "Customer facing production outages"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this Incident Type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "is_default": {
+            "type": "boolean",
+            "description": "The default Incident Type is used when no other type is explicitly specified",
+            "example": false
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of this Incident Type",
+            "example": "Production Outage"
+          },
+          "private_incidents_only": {
+            "type": "boolean",
+            "description": "Should all incidents created with this Incident Type be private?",
+            "example": false
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When this resource was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "create_in_triage": "always",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Customer facing production outages",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "is_default": false,
+          "name": "Production Outage",
+          "private_incidents_only": false,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "is_default",
+          "description",
+          "private_incidents_only",
+          "created_at",
+          "updated_at",
+          "create_in_triage",
+          "severity_aliases",
+          "rank",
+          "override_auto_close_incidents",
+          "auto_close_incidents",
+          "auto_close_incidents_delay_days",
+          "override_auto_archive_slack_channels",
+          "auto_archive_slack_channels",
+          "auto_archive_slack_channels_delay_days"
+        ]
+      },
       "IncidentUpdateV2": {
         "type": "object",
         "properties": {
@@ -21999,7 +28188,7 @@
             "example": "We're working on a fix, hoping to ship in the next 30 minutes"
           },
           "new_incident_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           },
           "new_severity": {
             "$ref": "#/components/schemas/SeverityV2"
@@ -22069,7 +28258,7 @@
             "format": "date-time"
           },
           "creator": {
-            "$ref": "#/components/schemas/ActorV2"
+            "$ref": "#/components/schemas/ActorV1"
           },
           "custom_field_entries": {
             "type": "array",
@@ -22186,7 +28375,7 @@
             "example": "INC-123"
           },
           "severity": {
-            "$ref": "#/components/schemas/SeverityV2"
+            "$ref": "#/components/schemas/SeverityV1"
           },
           "slack_channel_id": {
             "type": "string",
@@ -22409,7 +28598,7 @@
           "custom_field_entries": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryV1"
+              "$ref": "#/components/schemas/CustomFieldEntryV2"
             },
             "description": "Custom field entries for this incident",
             "example": [
@@ -22470,7 +28659,7 @@
             ]
           },
           "external_issue_reference": {
-            "$ref": "#/components/schemas/ExternalIssueReferenceV2"
+            "$ref": "#/components/schemas/ExternalIssueReferenceV4"
           },
           "id": {
             "type": "string",
@@ -22480,7 +28669,7 @@
           "incident_role_assignments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentV1"
+              "$ref": "#/components/schemas/IncidentRoleAssignmentV2"
             },
             "description": "A list of who is assigned to each role for this incident",
             "example": [
@@ -22507,7 +28696,7 @@
             ]
           },
           "incident_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           },
           "incident_timestamp_values": {
             "type": "array",
@@ -22529,7 +28718,7 @@
             ]
           },
           "incident_type": {
-            "$ref": "#/components/schemas/IncidentTypeV1"
+            "$ref": "#/components/schemas/IncidentTypeV2"
           },
           "mode": {
             "type": "string",
@@ -22802,10 +28991,10 @@
             "$ref": "#/components/schemas/IncidentV2"
           },
           "new_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           },
           "previous_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           }
         },
         "example": {
@@ -24235,7 +30424,7 @@
           "severities": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SeverityV2"
+              "$ref": "#/components/schemas/SeverityV1"
             },
             "example": [
               {
@@ -25377,8 +31566,7 @@
           },
           "resource_type": {
             "type": "string",
-            "description": "The type of the related resource",
-            "example": "schedule",
+            "example": "workflow",
             "enum": [
               "workflow",
               "schedule"
@@ -25396,7 +31584,7 @@
           },
           "managed_by": "dashboard",
           "resource_id": "abc123",
-          "resource_type": "schedule",
+          "resource_type": "workflow",
           "source_url": "https://github.com/my-company/infrastructure"
         },
         "required": [
@@ -25405,6 +31593,44 @@
           "managed_by",
           "annotations"
         ]
+      },
+      "ManagementMetaDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "managed_by": {
+            "type": "string",
+            "description": "How is this resource managed",
+            "example": "dashboard",
+            "enum": [
+              "dashboard",
+              "terraform",
+              "external"
+            ]
+          },
+          "source_url": {
+            "type": "string",
+            "description": "The url of the external repository where this resource is managed (if there is one)",
+            "example": "https://github.com/my-company/infrastructure"
+          }
+        },
+        "example": {
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          },
+          "managed_by": "dashboard",
+          "source_url": "https://github.com/my-company/infrastructure"
+        }
       },
       "ManagementMetaV2": {
         "type": "object",
@@ -25501,6 +31727,111 @@
         },
         "required": [
           "page_size"
+        ]
+      },
+      "PaginationParamDefinitions": {
+        "type": "object",
+        "properties": {
+          "after": {
+            "type": "string",
+            "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91"
+          },
+          "page_size": {
+            "type": "integer",
+            "description": "Integer number of records to return",
+            "default": 25,
+            "example": 25,
+            "format": "int64",
+            "maximum": 500
+          }
+        },
+        "example": {
+          "after": "01FDAG4SAP5TYPT98WGR2N7W91",
+          "page_size": 25
+        }
+      },
+      "Priority": {
+        "type": "object",
+        "properties": {
+          "archived_at": {
+            "type": "string",
+            "description": "When this type was archived",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "$ref": "#/components/schemas/TextNode"
+          },
+          "id": {
+            "type": "string",
+            "description": "The ID of this priority",
+            "example": "01GW2G3V0S59R238FAHPDS1R66"
+          },
+          "is_default": {
+            "type": "boolean",
+            "description": "Whether this is the default priority",
+            "example": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The human readable label for this priority",
+            "example": "P1"
+          },
+          "rank": {
+            "type": "integer",
+            "description": "The rank of the priority. Higher values are less urgent",
+            "example": 1,
+            "format": "int64"
+          },
+          "slugs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "All the slugs that this priority has",
+            "example": [
+              "p1",
+              "priority-1"
+            ]
+          }
+        },
+        "example": {
+          "archived_at": "2021-08-17T13:28:57.801578Z",
+          "description": {
+            "attrs": {
+              "level": 3
+            },
+            "content": [
+              {}
+            ],
+            "marks": [
+              {
+                "attrs": {
+                  "color": "blue"
+                },
+                "type": "em"
+              }
+            ],
+            "text": "some nice text",
+            "type": "text"
+          },
+          "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "is_default": true,
+          "name": "P1",
+          "rank": 1,
+          "slugs": [
+            "p1",
+            "priority-1"
+          ]
+        },
+        "required": [
+          "id",
+          "rank",
+          "name",
+          "slugs",
+          "is_default"
         ]
       },
       "PrivateIncidentAccessAttemptedV1ResponseBody": {
@@ -25611,7 +31942,7 @@
             ]
           },
           "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25651,7 +31982,7 @@
             ]
           },
           "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25691,7 +32022,7 @@
             ]
           },
           "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25731,7 +32062,7 @@
             ]
           },
           "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25771,7 +32102,7 @@
             ]
           },
           "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -25811,7 +32142,7 @@
             ]
           },
           "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/GroupingKeyV2"
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           }
         },
         "example": {
@@ -26804,6 +33135,93 @@
           "array"
         ]
       },
+      "RunscopeRequestAttribute": {
+        "type": "object",
+        "properties": {
+          "assertions": {
+            "type": "object",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": true
+          },
+          "method": {
+            "type": "string",
+            "description": "HTTP Method of request sent",
+            "example": "abc123"
+          },
+          "note": {
+            "type": "string",
+            "description": "A description or note of this request step",
+            "example": "abc123"
+          },
+          "response_size_bytes": {
+            "type": "integer",
+            "description": "Number of bytes of response",
+            "example": 1,
+            "format": "int64"
+          },
+          "response_status_code": {
+            "type": "string",
+            "description": "Status code of the response",
+            "example": "abc123"
+          },
+          "response_time_ms": {
+            "type": "integer",
+            "description": "Time in milliseconds for response",
+            "example": 1,
+            "format": "int64"
+          },
+          "result": {
+            "type": "string",
+            "description": "The result of the request",
+            "example": "abc123"
+          },
+          "scripts": {
+            "type": "object",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": true
+          },
+          "step_type": {
+            "type": "string",
+            "description": "The type of step in the request",
+            "example": "abc123"
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL of the request from Runscope",
+            "example": "abc123"
+          },
+          "variables": {
+            "type": "object",
+            "example": {
+              "abc123": "abc123"
+            },
+            "additionalProperties": true
+          }
+        },
+        "example": {
+          "assertions": {
+            "abc123": "abc123"
+          },
+          "method": "abc123",
+          "note": "abc123",
+          "response_size_bytes": 1,
+          "response_status_code": "abc123",
+          "response_time_ms": 1,
+          "result": "abc123",
+          "scripts": {
+            "abc123": "abc123"
+          },
+          "step_type": "abc123",
+          "url": "abc123",
+          "variables": {
+            "abc123": "abc123"
+          }
+        }
+      },
       "ScheduleConfigCreatePayloadV2": {
         "type": "object",
         "properties": {
@@ -26819,7 +33237,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -26841,7 +33259,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -26856,7 +33274,7 @@
               "handovers": [
                 {
                   "interval": 1,
-                  "interval_type": "daily"
+                  "interval_type": "hourly"
                 }
               ],
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -26878,7 +33296,7 @@
                 {
                   "end_time": "17:00",
                   "start_time": "09:00",
-                  "weekday": "tuesday"
+                  "weekday": "monday"
                 }
               ]
             }
@@ -26900,7 +33318,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -26922,7 +33340,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -26937,7 +33355,7 @@
               "handovers": [
                 {
                   "interval": 1,
-                  "interval_type": "daily"
+                  "interval_type": "hourly"
                 }
               ],
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -26959,7 +33377,7 @@
                 {
                   "end_time": "17:00",
                   "start_time": "09:00",
-                  "weekday": "tuesday"
+                  "weekday": "monday"
                 }
               ]
             }
@@ -26982,7 +33400,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27006,7 +33424,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -27021,7 +33439,7 @@
               "handovers": [
                 {
                   "interval": 1,
-                  "interval_type": "daily"
+                  "interval_type": "hourly"
                 }
               ],
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27045,7 +33463,7 @@
                 {
                   "end_time": "17:00",
                   "start_time": "09:00",
-                  "weekday": "tuesday"
+                  "weekday": "monday"
                 }
               ]
             }
@@ -27074,7 +33492,7 @@
             "$ref": "#/components/schemas/ScheduleConfigCreatePayloadV2"
           },
           "holidays_public_config": {
-            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigPayloadV2"
           },
           "name": {
             "type": "string",
@@ -27099,7 +33517,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27121,7 +33539,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -27302,7 +33720,7 @@
             "format": "date-time"
           },
           "user": {
-            "$ref": "#/components/schemas/UserV1"
+            "$ref": "#/components/schemas/UserV2"
           }
         },
         "example": {
@@ -27324,6 +33742,30 @@
           "external_user_id",
           "start_at",
           "end_at"
+        ]
+      },
+      "ScheduleHolidaysPublicConfigPayloadV2": {
+        "type": "object",
+        "properties": {
+          "country_codes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "abc123"
+            },
+            "description": "ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for",
+            "example": [
+              "abc123"
+            ]
+          }
+        },
+        "example": {
+          "country_codes": [
+            "abc123"
+          ]
+        },
+        "required": [
+          "country_codes"
         ]
       },
       "ScheduleHolidaysPublicConfigV2": {
@@ -27374,6 +33816,25 @@
           "name"
         ]
       },
+      "ScheduleLayerUpdatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the layer",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the layer",
+            "example": "Layer 1"
+          }
+        },
+        "example": {
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "name": "Layer 1"
+        }
+      },
       "ScheduleLayerV2": {
         "type": "object",
         "properties": {
@@ -27414,7 +33875,7 @@
             "example": [
               {
                 "interval": 1,
-                "interval_type": "daily"
+                "interval_type": "hourly"
               }
             ]
           },
@@ -27443,7 +33904,7 @@
           "users": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserReferencePayloadV1"
+              "$ref": "#/components/schemas/UserReferencePayloadV2"
             },
             "example": [
               {
@@ -27456,13 +33917,13 @@
           "working_interval": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/WeekdayIntervalV2"
+              "$ref": "#/components/schemas/ScheduleRotationWorkingIntervalCreatePayloadV2"
             },
             "example": [
               {
                 "end_time": "17:00",
                 "start_time": "09:00",
-                "weekday": "tuesday"
+                "weekday": "monday"
               }
             ]
           }
@@ -27473,7 +33934,7 @@
           "handovers": [
             {
               "interval": 1,
-              "interval_type": "daily"
+              "interval_type": "hourly"
             }
           ],
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27495,7 +33956,7 @@
             {
               "end_time": "17:00",
               "start_time": "09:00",
-              "weekday": "tuesday"
+              "weekday": "monday"
             }
           ]
         },
@@ -27513,7 +33974,8 @@
           },
           "interval_type": {
             "type": "string",
-            "example": "daily",
+            "description": "How often a handover occurs",
+            "example": "hourly",
             "enum": [
               "hourly",
               "daily",
@@ -27523,7 +33985,7 @@
         },
         "example": {
           "interval": 1,
-          "interval_type": "daily"
+          "interval_type": "hourly"
         }
       },
       "ScheduleRotationUpdatePayloadV2": {
@@ -27547,7 +34009,7 @@
             "example": [
               {
                 "interval": 1,
-                "interval_type": "daily"
+                "interval_type": "hourly"
               }
             ]
           },
@@ -27559,7 +34021,7 @@
           "layers": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ScheduleLayerV2"
+              "$ref": "#/components/schemas/ScheduleLayerUpdatePayloadV2"
             },
             "example": [
               {
@@ -27576,7 +34038,7 @@
           "users": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserReferencePayloadV1"
+              "$ref": "#/components/schemas/UserReferencePayloadV2"
             },
             "example": [
               {
@@ -27595,7 +34057,7 @@
               {
                 "end_time": "17:00",
                 "start_time": "09:00",
-                "weekday": "tuesday"
+                "weekday": "monday"
               }
             ]
           }
@@ -27606,7 +34068,7 @@
           "handovers": [
             {
               "interval": 1,
-              "interval_type": "daily"
+              "interval_type": "hourly"
             }
           ],
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27628,7 +34090,7 @@
             {
               "end_time": "17:00",
               "start_time": "09:00",
-              "weekday": "tuesday"
+              "weekday": "monday"
             }
           ]
         }
@@ -27657,7 +34119,7 @@
             "example": [
               {
                 "interval": 1,
-                "interval_type": "daily"
+                "interval_type": "hourly"
               }
             ]
           },
@@ -27687,7 +34149,7 @@
           "users": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserV1"
+              "$ref": "#/components/schemas/UserV2"
             },
             "example": [
               {
@@ -27702,13 +34164,13 @@
           "working_interval": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/WeekdayIntervalV2"
+              "$ref": "#/components/schemas/ScheduleRotationWorkingIntervalV2"
             },
             "example": [
               {
                 "end_time": "17:00",
                 "start_time": "09:00",
-                "weekday": "tuesday"
+                "weekday": "monday"
               }
             ]
           }
@@ -27719,7 +34181,7 @@
           "handovers": [
             {
               "interval": 1,
-              "interval_type": "daily"
+              "interval_type": "hourly"
             }
           ],
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27743,7 +34205,7 @@
             {
               "end_time": "17:00",
               "start_time": "09:00",
-              "weekday": "tuesday"
+              "weekday": "monday"
             }
           ]
         },
@@ -27755,6 +34217,45 @@
           "working_intervals",
           "handover_start_at",
           "handovers"
+        ]
+      },
+      "ScheduleRotationWorkingIntervalCreatePayloadV2": {
+        "type": "object",
+        "properties": {
+          "end_time": {
+            "type": "string",
+            "description": "End time of the interval, in 24hr format",
+            "example": "17:00"
+          },
+          "start_time": {
+            "type": "string",
+            "description": "Start time of the interval, in 24hr format",
+            "example": "09:00"
+          },
+          "weekday": {
+            "type": "string",
+            "description": "Weekdays for use with a schedule",
+            "example": "monday",
+            "enum": [
+              "monday",
+              "tuesday",
+              "wednesday",
+              "thursday",
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        },
+        "example": {
+          "end_time": "17:00",
+          "start_time": "09:00",
+          "weekday": "monday"
+        },
+        "required": [
+          "weekday",
+          "start_time",
+          "end_time"
         ]
       },
       "ScheduleRotationWorkingIntervalUpdatePayloadV2": {
@@ -27772,8 +34273,8 @@
           },
           "weekday": {
             "type": "string",
-            "description": "Weekday this interval applies to",
-            "example": "tuesday",
+            "description": "Weekdays for use with a schedule",
+            "example": "monday",
             "enum": [
               "monday",
               "tuesday",
@@ -27788,8 +34289,47 @@
         "example": {
           "end_time": "17:00",
           "start_time": "09:00",
-          "weekday": "tuesday"
+          "weekday": "monday"
         }
+      },
+      "ScheduleRotationWorkingIntervalV2": {
+        "type": "object",
+        "properties": {
+          "end_time": {
+            "type": "string",
+            "description": "End time of the interval, in 24hr format",
+            "example": "17:00"
+          },
+          "start_time": {
+            "type": "string",
+            "description": "Start time of the interval, in 24hr format",
+            "example": "09:00"
+          },
+          "weekday": {
+            "type": "string",
+            "description": "Weekdays for use with a schedule",
+            "example": "monday",
+            "enum": [
+              "monday",
+              "tuesday",
+              "wednesday",
+              "thursday",
+              "friday",
+              "saturday",
+              "sunday"
+            ]
+          }
+        },
+        "example": {
+          "end_time": "17:00",
+          "start_time": "09:00",
+          "weekday": "monday"
+        },
+        "required": [
+          "weekday",
+          "start_time",
+          "end_time"
+        ]
       },
       "ScheduleUpdatePayloadV2": {
         "type": "object",
@@ -27809,7 +34349,7 @@
             "$ref": "#/components/schemas/ScheduleConfigUpdatePayloadV2"
           },
           "holidays_public_config": {
-            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigV2"
+            "$ref": "#/components/schemas/ScheduleHolidaysPublicConfigPayloadV2"
           },
           "name": {
             "type": "string",
@@ -27834,7 +34374,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27856,7 +34396,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -27953,7 +34493,7 @@
                 "handovers": [
                   {
                     "interval": 1,
-                    "interval_type": "daily"
+                    "interval_type": "hourly"
                   }
                 ],
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -27977,7 +34517,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -28106,6 +34646,155 @@
           "targets",
           "context",
           "metadata"
+        ]
+      },
+      "SeverityDefinitionsV1": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the action was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the severity",
+            "example": "Issues with **low impact**."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the severity",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the severity",
+            "example": "Minor",
+            "maxLength": 50
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Rank to help sort severities (lower numbers are less severe)",
+            "example": 1,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the action was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Issues with **low impact**.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Minor",
+          "rank": 1,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        }
+      },
+      "SeverityDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the action was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the severity",
+            "example": "Issues with **low impact**."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the severity",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the severity",
+            "example": "Minor",
+            "maxLength": 50
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Rank to help sort severities (lower numbers are less severe)",
+            "example": 1,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the action was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Issues with **low impact**.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Minor",
+          "rank": 1,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        }
+      },
+      "SeverityV1": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When the action was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the severity",
+            "example": "Issues with **low impact**."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the severity",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable name of the severity",
+            "example": "Minor",
+            "maxLength": 50
+          },
+          "rank": {
+            "type": "integer",
+            "description": "Rank to help sort severities (lower numbers are less severe)",
+            "example": 1,
+            "format": "int64"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "When the action was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Issues with **low impact**.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Minor",
+          "rank": 1,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "rank",
+          "created_at",
+          "updated_at"
         ]
       },
       "SeverityV2": {
@@ -28734,7 +35423,7 @@
         "type": "object",
         "properties": {
           "severity": {
-            "$ref": "#/components/schemas/SeverityV2"
+            "$ref": "#/components/schemas/SeverityV1"
           }
         },
         "example": {
@@ -29249,6 +35938,94 @@
           "management_meta"
         ]
       },
+      "Step": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Human readable description of what this step does",
+            "example": "Escalates a page to the default escalation policy of the configured PagerDuty service."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human readable identifier for this step",
+            "example": "PagerDuty Escalate"
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique name of the step in the engine",
+            "example": "pagerduty.escalate"
+          },
+          "params": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineParamV2"
+            },
+            "description": "Type information for the step parameters",
+            "example": [
+              {
+                "array": true,
+                "default_value": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                },
+                "description": "What slack channel should we send the message to?",
+                "infer_reference": true,
+                "label": "To date",
+                "name": "severity",
+                "optional": true,
+                "type": "IncidentSeverity"
+              }
+            ]
+          }
+        },
+        "example": {
+          "description": "Escalates a page to the default escalation policy of the configured PagerDuty service.",
+          "label": "PagerDuty Escalate",
+          "name": "pagerduty.escalate",
+          "params": [
+            {
+              "array": true,
+              "default_value": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "description": "What slack channel should we send the message to?",
+              "infer_reference": true,
+              "label": "To date",
+              "name": "severity",
+              "optional": true,
+              "type": "IncidentSeverity"
+            }
+          ]
+        },
+        "required": [
+          "name",
+          "label",
+          "description",
+          "params"
+        ]
+      },
       "StepConfig": {
         "type": "object",
         "properties": {
@@ -29275,7 +36052,7 @@
           "param_bindings": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV3"
+              "$ref": "#/components/schemas/EngineParamBindingV2"
             },
             "description": "Bindings for the step parameters",
             "example": [
@@ -29420,6 +36197,174 @@
           "params"
         ]
       },
+      "TextDocument": {
+        "type": "object",
+        "properties": {
+          "markdown": {
+            "type": "string",
+            "description": "the original Markdown string",
+            "example": "There's a snake in my boot"
+          },
+          "text_node": {
+            "$ref": "#/components/schemas/TextNode"
+          }
+        },
+        "example": {
+          "markdown": "There's a snake in my boot",
+          "text_node": {
+            "attrs": {
+              "level": 3
+            },
+            "content": [
+              {}
+            ],
+            "marks": [
+              {
+                "attrs": {
+                  "color": "blue"
+                },
+                "type": "em"
+              }
+            ],
+            "text": "some nice text",
+            "type": "text"
+          }
+        },
+        "required": [
+          "text_node",
+          "markdown"
+        ]
+      },
+      "TextMark": {
+        "type": "object",
+        "properties": {
+          "attrs": {
+            "type": "object",
+            "description": "type-specific mark attributes",
+            "example": {
+              "color": "blue"
+            },
+            "additionalProperties": true
+          },
+          "type": {
+            "type": "string",
+            "description": "the type of the node, eg 'text'",
+            "example": "em"
+          }
+        },
+        "example": {
+          "attrs": {
+            "color": "blue"
+          },
+          "type": "em"
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "TextNode": {
+        "type": "object",
+        "properties": {
+          "attrs": {
+            "type": "object",
+            "description": "type-specific node attributes",
+            "example": {
+              "level": 3
+            },
+            "additionalProperties": true
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TextNode"
+            },
+            "description": "children of this node",
+            "example": [
+              {
+                "attrs": {
+                  "level": 3
+                },
+                "content": [
+                  {}
+                ],
+                "marks": [
+                  {
+                    "attrs": {
+                      "color": "blue"
+                    },
+                    "type": "em"
+                  }
+                ],
+                "text": "some nice text",
+                "type": "text"
+              }
+            ]
+          },
+          "marks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TextMark"
+            },
+            "description": "marks that apply to this node, eg 'bold'",
+            "example": [
+              {
+                "attrs": {
+                  "color": "blue"
+                },
+                "type": "em"
+              }
+            ]
+          },
+          "text": {
+            "type": "string",
+            "description": "if this node doesn't have children, it has text content",
+            "example": "some nice text"
+          },
+          "type": {
+            "type": "string",
+            "description": "the type of the node",
+            "example": "text"
+          }
+        },
+        "example": {
+          "attrs": {
+            "level": 3
+          },
+          "content": [
+            {
+              "attrs": {
+                "level": 3
+              },
+              "content": [
+                {}
+              ],
+              "marks": [
+                {
+                  "attrs": {
+                    "color": "blue"
+                  },
+                  "type": "em"
+                }
+              ],
+              "text": "some nice text",
+              "type": "text"
+            }
+          ],
+          "marks": [
+            {
+              "attrs": {
+                "color": "blue"
+              },
+              "type": "em"
+            }
+          ],
+          "text": "some nice text",
+          "type": "text"
+        },
+        "required": [
+          "type"
+        ]
+      },
       "TriggerSlim": {
         "type": "object",
         "properties": {
@@ -29533,7 +36478,7 @@
               "type": "string",
               "example": "abc123"
             },
-            "description": "The alert sources that will match this alert route",
+            "description": "Legacy field - the alert sources that will match this alert route",
             "example": [
               "02FCNDV6P870EA6S7TK1DSYDG2"
             ]
@@ -30077,6 +37022,7 @@
           "enabled",
           "incident_enabled",
           "incident_condition_groups",
+          "alert_sources",
           "alert_source_ids",
           "auto_cancel_escalations"
         ]
@@ -30590,7 +37536,462 @@
           "use_name_as_identifier"
         ]
       },
-      "UpdateWorkflowRequestBody": {
+      "UpdateWorkflowPayload": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "additionalProperties": {
+              "type": "string",
+              "example": "abc123"
+            }
+          },
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "List of conditions to apply to the workflow",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "continue_on_step_error": {
+            "type": "boolean",
+            "description": "Whether to continue executing the workflow if a step fails",
+            "example": true
+          },
+          "delay": {
+            "$ref": "#/components/schemas/WorkflowDelay"
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in the workflow",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "folder": {
+            "type": "string",
+            "description": "Folder to display the workflow in",
+            "example": "My folder 01"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of the workflow to update",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "include_private_incidents": {
+            "type": "boolean",
+            "description": "Whether to include private incidents",
+            "example": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The human-readable name of the workflow",
+            "example": "My workflow"
+          },
+          "once_for": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "incident.url"
+            },
+            "description": "Once For strategy to apply to this workflow",
+            "example": [
+              "incident.url"
+            ]
+          },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
+          "runs_on_incidents": {
+            "type": "string",
+            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+            "example": "newly_created",
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of the workflow (e.g. is it draft, or disabled)",
+            "example": "active",
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StepConfigPayload"
+            },
+            "description": "List of step to execute as part of the workflow",
+            "example": [
+              {
+                "for_each": "abc123",
+                "id": "abc123",
+                "name": "pagerduty.escalate",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          },
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "continue_on_step_error": true,
+          "delay": {
+            "conditions_apply_over_delay": false,
+            "for_seconds": 60
+          },
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "folder": "My folder 01",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "include_private_incidents": true,
+          "name": "My workflow",
+          "once_for": [
+            "incident.url"
+          ],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
+          "runs_on_incidents": "newly_created",
+          "state": "active",
+          "steps": [
+            {
+              "for_each": "abc123",
+              "id": "abc123",
+              "name": "pagerduty.escalate",
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "required": [
+          "id",
+          "name",
+          "once_for",
+          "condition_groups",
+          "steps",
+          "expressions",
+          "include_private_incidents",
+          "runs_on_incident_modes",
+          "continue_on_step_error",
+          "runs_on_incidents"
+        ]
+      },
+      "UpdateWorkflowPayload2": {
         "type": "object",
         "properties": {
           "annotations": {
@@ -31062,6 +38463,31 @@
           "slack_user_id": "USER123"
         }
       },
+      "UserReferencePayloadV2": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "The user's email address, matching the email on their Slack account",
+            "example": "bob@example.com"
+          },
+          "id": {
+            "type": "string",
+            "description": "The incident.io ID of a user",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "slack_user_id": {
+            "type": "string",
+            "description": "The ID of the user's Slack account.",
+            "example": "USER123"
+          }
+        },
+        "example": {
+          "email": "bob@example.com",
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "slack_user_id": "USER123"
+        }
+      },
       "UserRoleMembershipsUpdatedV1ResponseBody": {
         "type": "object",
         "properties": {
@@ -31148,6 +38574,58 @@
         ]
       },
       "UserV1": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Email address of the user.",
+            "example": "lisa@incident.io"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the user",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the user",
+            "example": "Lisa Karlin Curtis"
+          },
+          "role": {
+            "type": "string",
+            "description": "DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.",
+            "example": "viewer",
+            "enum": [
+              "viewer",
+              "responder",
+              "administrator",
+              "owner",
+              "unset"
+            ]
+          },
+          "slack_user_id": {
+            "type": "string",
+            "description": "Slack ID of the user",
+            "example": "U02AYNF2XJM"
+          }
+        },
+        "example": {
+          "email": "lisa@incident.io",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Lisa Karlin Curtis",
+          "role": "viewer",
+          "slack_user_id": "U02AYNF2XJM"
+        },
+        "required": [
+          "role",
+          "id",
+          "slack_role",
+          "name",
+          "deprecated_base_role",
+          "organisation_id"
+        ]
+      },
+      "UserV2": {
         "type": "object",
         "properties": {
           "email": {
@@ -31333,7 +38811,7 @@
           "custom_field_entries": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryV1"
+              "$ref": "#/components/schemas/CustomFieldEntryV2"
             },
             "description": "Custom field entries for this incident",
             "example": [
@@ -31394,7 +38872,7 @@
             ]
           },
           "external_issue_reference": {
-            "$ref": "#/components/schemas/ExternalIssueReferenceV2"
+            "$ref": "#/components/schemas/ExternalIssueReferenceV6"
           },
           "id": {
             "type": "string",
@@ -31404,7 +38882,7 @@
           "incident_role_assignments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentV1"
+              "$ref": "#/components/schemas/IncidentRoleAssignmentV2"
             },
             "description": "A list of who is assigned to each role for this incident",
             "example": [
@@ -31431,7 +38909,7 @@
             ]
           },
           "incident_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
+            "$ref": "#/components/schemas/IncidentStatusV2"
           },
           "incident_timestamp_values": {
             "type": "array",
@@ -31453,7 +38931,7 @@
             ]
           },
           "incident_type": {
-            "$ref": "#/components/schemas/IncidentTypeV1"
+            "$ref": "#/components/schemas/IncidentTypeV2"
           },
           "mode": {
             "type": "string",
@@ -31733,6 +39211,683 @@
           "reported_at"
         ]
       },
+      "WebhookPayloadDefinitionsV2": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "description": "What type of event is this webhook for?",
+            "example": "public_incident.incident_created_v2",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ]
+          },
+          "private_incident.action_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.follow_up_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.follow_up_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.incident_created_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.incident_updated_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.membership_granted_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          },
+          "private_incident.membership_revoked_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          },
+          "public_incident.action_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.follow_up_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.follow_up_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.incident_created_v2": {
+            "$ref": "#/components/schemas/WebhookIncidentV2"
+          },
+          "public_incident.incident_status_updated_v2": {
+            "$ref": "#/components/schemas/IncidentWithStatusChangeV2"
+          },
+          "public_incident.incident_updated_v2": {
+            "$ref": "#/components/schemas/WebhookIncidentV2"
+          }
+        },
+        "example": {
+          "event_type": "public_incident.incident_created_v2",
+          "private_incident.action_created_v1": {
+            "id": "abc123"
+          },
+          "private_incident.action_updated_v1": {
+            "id": "abc123"
+          },
+          "private_incident.follow_up_created_v1": {
+            "id": "abc123"
+          },
+          "private_incident.follow_up_updated_v1": {
+            "id": "abc123"
+          },
+          "private_incident.incident_created_v2": {
+            "id": "abc123"
+          },
+          "private_incident.incident_updated_v2": {
+            "id": "abc123"
+          },
+          "private_incident.membership_granted_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          },
+          "private_incident.membership_revoked_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          },
+          "public_incident.action_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.action_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.follow_up_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.follow_up_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.incident_created_v2": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          },
+          "public_incident.incident_status_updated_v2": {
+            "incident": {
+              "call_url": "https://zoom.us/foo",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              },
+              "custom_field_entries": [
+                {
+                  "custom_field": {
+                    "description": "Which team is impacted by this issue",
+                    "field_type": "single_select",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Affected Team",
+                    "options": [
+                      {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      }
+                    ]
+                  },
+                  "values": [
+                    {
+                      "value_catalog_entry": {
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
+                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Primary On-call"
+                      },
+                      "value_link": "https://google.com/",
+                      "value_numeric": "123.456",
+                      "value_option": {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      },
+                      "value_text": "This is my text field, I hope you like it"
+                    }
+                  ]
+                }
+              ],
+              "duration_metrics": [
+                {
+                  "duration_metric": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Lasted"
+                  },
+                  "value_seconds": 1
+                }
+              ],
+              "external_issue_reference": {
+                "issue_name": "INC-123",
+                "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                "provider": "asana"
+              },
+              "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "incident_role_assignments": [
+                {
+                  "assignee": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "required": false,
+                    "role_type": "lead",
+                    "shortform": "lead",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_status": {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "incident_timestamp_values": [
+                {
+                  "incident_timestamp": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Impact started",
+                    "rank": 1
+                  },
+                  "value": {
+                    "value": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_type": {
+                "create_in_triage": "always",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Customer facing production outages",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_default": false,
+                "name": "Production Outage",
+                "private_incidents_only": false,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "mode": "standard",
+              "name": "Our database is sad",
+              "permalink": "https://app.incident.io/incidents/123",
+              "postmortem_document_url": "https://docs.google.com/my_doc_id",
+              "reference": "INC-123",
+              "severity": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "slack_channel_id": "C02AW36C1M5",
+              "slack_channel_name": "inc-165-green-parrot",
+              "slack_team_id": "T02A1FSLE8J",
+              "summary": "Our database is really really sad, and we don't know why yet.",
+              "updated_at": "2021-08-17T13:28:57.801578Z",
+              "visibility": "public",
+              "workload_minutes_late": 40.7,
+              "workload_minutes_sleeping": 0,
+              "workload_minutes_total": 60.7,
+              "workload_minutes_working": 20
+            },
+            "new_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "previous_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          },
+          "public_incident.incident_updated_v2": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          }
+        }
+      },
+      "WebhookPrivateResourceV2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the resource",
+            "example": "abc123"
+          }
+        },
+        "example": {
+          "id": "abc123"
+        },
+        "required": [
+          "id"
+        ]
+      },
       "WeekdayIntervalConfigV2": {
         "type": "object",
         "properties": {
@@ -31799,7 +39954,6 @@
           },
           "weekday": {
             "type": "string",
-            "description": "Weekday this interval applies to",
             "example": "abc123"
           }
         },
@@ -31820,7 +39974,7 @@
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV3"
+              "$ref": "#/components/schemas/ConditionGroupV5"
             },
             "description": "Conditions that apply to the workflow trigger",
             "example": [
@@ -32053,7 +40207,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "test",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
               "enum": [
                 "standard",
                 "test",
@@ -32367,37 +40522,13 @@
           "state"
         ]
       },
-      "WorkflowDelay": {
-        "type": "object",
-        "properties": {
-          "conditions_apply_over_delay": {
-            "type": "boolean",
-            "description": "If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution",
-            "example": false
-          },
-          "for_seconds": {
-            "type": "integer",
-            "description": "Delay in seconds between trigger firing and running the workflow",
-            "example": 60,
-            "format": "int64"
-          }
-        },
-        "example": {
-          "conditions_apply_over_delay": false,
-          "for_seconds": 60
-        },
-        "required": [
-          "for_seconds",
-          "conditions_apply_over_delay"
-        ]
-      },
-      "WorkflowSlim": {
+      "WorkflowDefinitions": {
         "type": "object",
         "properties": {
           "condition_groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV3"
+              "$ref": "#/components/schemas/ConditionGroupV2"
             },
             "description": "Conditions that apply to the workflow trigger",
             "example": [
@@ -32444,7 +40575,7 @@
           "expressions": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ExpressionV3"
+              "$ref": "#/components/schemas/ExpressionV2"
             },
             "description": "Expressions that make variables available in the scope",
             "example": [
@@ -32630,7 +40761,939 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "test",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
+          "runs_on_incidents": {
+            "type": "string",
+            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+            "example": "newly_created",
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of the workflow (e.g. is it draft, or disabled)",
+            "example": "active",
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/TriggerSlim"
+          },
+          "version": {
+            "type": "integer",
+            "description": "Revision of the workflow, uniquely identifying its version",
+            "example": 3,
+            "format": "int64"
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "continue_on_step_error": true,
+          "delay": {
+            "conditions_apply_over_delay": false,
+            "for_seconds": 60
+          },
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "folder": "My folder 01",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "include_private_incidents": true,
+          "name": "My workflow",
+          "once_for": [
+            {
+              "array": false,
+              "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+              "label": "Incident -> Affected Team",
+              "type": "IncidentSeverity"
+            }
+          ],
+          "runs_from": "2021-08-17T13:28:57.801578Z",
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
+          "runs_on_incidents": "newly_created",
+          "state": "active",
+          "trigger": {
+            "label": "Incident Updated",
+            "name": "incident.updated"
+          },
+          "version": 3
+        }
+      },
+      "WorkflowDelay": {
+        "type": "object",
+        "properties": {
+          "conditions_apply_over_delay": {
+            "type": "boolean",
+            "description": "If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution",
+            "example": false
+          },
+          "for_seconds": {
+            "type": "integer",
+            "description": "Delay in seconds between trigger firing and running the workflow",
+            "example": 60,
+            "format": "int64"
+          }
+        },
+        "example": {
+          "conditions_apply_over_delay": false,
+          "for_seconds": 60
+        },
+        "required": [
+          "for_seconds",
+          "conditions_apply_over_delay"
+        ]
+      },
+      "WorkflowPayload": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "description": "List of conditions to apply to the workflow",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ]
+          },
+          "continue_on_step_error": {
+            "type": "boolean",
+            "description": "Whether to continue executing the workflow if a step fails",
+            "example": true
+          },
+          "delay": {
+            "$ref": "#/components/schemas/WorkflowDelay"
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "description": "The expressions used in the workflow",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "folder": {
+            "type": "string",
+            "description": "Folder to display the workflow in",
+            "example": "My folder 01"
+          },
+          "include_private_incidents": {
+            "type": "boolean",
+            "description": "Whether to include private incidents",
+            "example": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The human-readable name of the workflow",
+            "example": "My workflow"
+          },
+          "once_for": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "incident.url"
+            },
+            "description": "Once For strategy to apply to this workflow",
+            "example": [
+              "incident.url"
+            ]
+          },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ]
+            },
+            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "example": [
+              "standard",
+              "retrospective"
+            ]
+          },
+          "runs_on_incidents": {
+            "type": "string",
+            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+            "example": "newly_created",
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of the workflow (e.g. is it draft, or disabled)",
+            "example": "active",
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ]
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StepConfigPayload"
+            },
+            "description": "List of step to execute as part of the workflow",
+            "example": [
+              {
+                "for_each": "abc123",
+                "id": "abc123",
+                "name": "pagerduty.escalate",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "continue_on_step_error": true,
+          "delay": {
+            "conditions_apply_over_delay": false,
+            "for_seconds": 60
+          },
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "folder": "My folder 01",
+          "include_private_incidents": true,
+          "name": "My workflow",
+          "once_for": [
+            "incident.url"
+          ],
+          "runs_on_incident_modes": [
+            "standard",
+            "retrospective"
+          ],
+          "runs_on_incidents": "newly_created",
+          "state": "active",
+          "steps": [
+            {
+              "for_each": "abc123",
+              "id": "abc123",
+              "name": "pagerduty.escalate",
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "WorkflowSlim": {
+        "type": "object",
+        "properties": {
+          "condition_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV8"
+            },
+            "description": "Conditions that apply to the workflow trigger",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "continue_on_step_error": {
+            "type": "boolean",
+            "description": "Whether to continue executing the workflow if a step fails",
+            "example": true
+          },
+          "delay": {
+            "$ref": "#/components/schemas/WorkflowDelay"
+          },
+          "expressions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExpressionV4"
+            },
+            "description": "Expressions that make variables available in the scope",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ]
+          },
+          "folder": {
+            "type": "string",
+            "description": "Folder to display the workflow in",
+            "example": "My folder 01"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the workflow",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0"
+          },
+          "include_private_incidents": {
+            "type": "boolean",
+            "description": "Whether to include private incidents",
+            "example": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The human-readable name of the workflow",
+            "example": "My workflow"
+          },
+          "once_for": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngineReferenceV2"
+            },
+            "description": "This workflow will run 'once for' a list of references",
+            "example": [
+              {
+                "array": false,
+                "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                "label": "Incident -> Affected Team",
+                "type": "IncidentSeverity"
+              }
+            ]
+          },
+          "runs_from": {
+            "type": "string",
+            "description": "The time from which this workflow will run on incidents",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time"
+          },
+          "runs_on_incident_modes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Incident mode that workflows can run on",
+              "example": "standard",
               "enum": [
                 "standard",
                 "test",
@@ -33996,7 +43059,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_route.created",
@@ -34043,7 +43106,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_route.deleted",
@@ -34090,7 +43153,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_route.updated",
@@ -34137,7 +43200,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_schema.updated",
@@ -34184,7 +43247,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_source_config.created",
@@ -34231,7 +43294,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_source_config.deleted",
@@ -34278,7 +43341,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "alert_source_config.updated",
@@ -34325,7 +43388,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "announcement_rule.created",
@@ -34372,7 +43435,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "announcement_rule.deleted",
@@ -34419,7 +43482,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "announcement_rule.updated",
@@ -34466,7 +43529,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "api_key.created",
@@ -34513,7 +43576,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "api_key.deleted",
@@ -34560,7 +43623,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "catalog_type.created",
@@ -34607,7 +43670,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "catalog_type.deleted",
@@ -34654,7 +43717,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "catalog_type.updated",
@@ -34701,7 +43764,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "custom_field.created",
@@ -34748,7 +43811,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "custom_field.deleted",
@@ -34795,7 +43858,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "custom_field.updated",
@@ -34842,7 +43905,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "debrief_invite_rule.created",
@@ -34889,7 +43952,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "debrief_invite_rule.deleted",
@@ -34936,7 +43999,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "debrief_invite_rule.updated",
@@ -34983,7 +44046,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "escalation_path.created",
@@ -35030,7 +44093,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "escalation_path.deleted",
@@ -35077,7 +44140,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "escalation_path.updated",
@@ -35124,7 +44187,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "follow_up_priority.created",
@@ -35171,7 +44234,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "follow_up_priority.deleted",
@@ -35218,7 +44281,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "follow_up_priority.updated",
@@ -35265,7 +44328,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "holiday_user_feed.created",
@@ -35312,7 +44375,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "holiday_user_feed.deleted",
@@ -35359,7 +44422,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "holiday_user_feed.updated",
@@ -35406,7 +44469,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_call_setting.updated",
@@ -35453,7 +44516,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_duration_metric.created",
@@ -35500,7 +44563,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_duration_metric.deleted",
@@ -35547,7 +44610,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_duration_metric.updated",
@@ -35594,7 +44657,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_role.created",
@@ -35641,7 +44704,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_role.deleted",
@@ -35688,7 +44751,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_role.updated",
@@ -35735,7 +44798,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_status.created",
@@ -35782,7 +44845,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_status.deleted",
@@ -35829,7 +44892,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_status.updated",
@@ -35876,7 +44939,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_timestamp.created",
@@ -35923,7 +44986,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_timestamp.deleted",
@@ -35970,7 +45033,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_timestamp.updated",
@@ -36017,7 +45080,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_type.created",
@@ -36064,7 +45127,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_type.deleted",
@@ -36111,7 +45174,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "incident_type.updated",
@@ -36158,7 +45221,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "integration.installed",
@@ -36205,7 +45268,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "integration.uninstalled",
@@ -36252,7 +45315,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "internal_status_page.created",
@@ -36299,7 +45362,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "internal_status_page.deleted",
@@ -36346,7 +45409,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "internal_status_page.updated",
@@ -36393,7 +45456,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "nudge.created",
@@ -36440,7 +45503,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "nudge.deleted",
@@ -36487,7 +45550,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "nudge.updated",
@@ -36534,7 +45597,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "policy.created",
@@ -36581,7 +45644,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "policy.deleted",
@@ -36628,7 +45691,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "policy.updated",
@@ -36675,7 +45738,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "post_incident_task.created",
@@ -36722,7 +45785,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "post_incident_task.deleted",
@@ -36769,7 +45832,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "post_incident_task.updated",
@@ -36866,7 +45929,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "private_incident.access_requested",
@@ -36913,7 +45976,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "private_incident_membership.granted",
@@ -36965,7 +46028,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "private_incident_membership.revoked",
@@ -37017,7 +46080,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "rbac_role.created",
@@ -37064,7 +46127,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "rbac_role.deleted",
@@ -37111,7 +46174,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "rbac_role.updated",
@@ -37158,7 +46221,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "schedule.created",
@@ -37205,7 +46268,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "schedule.deleted",
@@ -37252,7 +46315,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "schedule.updated",
@@ -37352,7 +46415,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "severity.created",
@@ -37399,7 +46462,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "severity.deleted",
@@ -37446,7 +46509,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "severity.updated",
@@ -37493,7 +46556,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page.created",
@@ -37540,7 +46603,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page.deleted",
@@ -37587,7 +46650,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page.updated",
@@ -37634,7 +46697,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_sub_page.created",
@@ -37681,7 +46744,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_sub_page.deleted",
@@ -37728,7 +46791,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_sub_page.updated",
@@ -37775,7 +46838,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_template.created",
@@ -37822,7 +46885,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_template.deleted",
@@ -37869,7 +46932,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "status_page_template.updated",
@@ -37916,7 +46979,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "user.created",
@@ -37963,7 +47026,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "user.deactivated",
@@ -38010,7 +47073,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "user.reinstated",
@@ -38110,7 +47173,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "user.updated",
@@ -38157,7 +47220,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "workflow.created",
@@ -38204,7 +47267,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "workflow.deleted",
@@ -38251,7 +47314,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/APIKeyCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/AuditLogEntryBaseV2"
                 },
                 "example": {
                   "action": "workflow.updated",

--- a/internal/apischema/openapi3.json
+++ b/internal/apischema/openapi3.json
@@ -15044,6 +15044,7 @@
               "pagerduty",
               "salesforce",
               "sentry",
+              "service_now",
               "shortcut",
               "scim",
               "slack",

--- a/internal/apischema/openapi3.yaml
+++ b/internal/apischema/openapi3.yaml
@@ -14666,6 +14666,7 @@ components:
                         - pagerduty
                         - salesforce
                         - sentry
+                        - service_now
                         - shortcut
                         - scim
                         - slack

--- a/internal/apischema/openapi3.yaml
+++ b/internal/apischema/openapi3.yaml
@@ -309,7 +309,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody2'
+                            $ref: '#/components/schemas/CreateRequestBody'
                         example:
                             custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
                             sort_key: 10
@@ -466,7 +466,7 @@ paths:
                             show_before_update: true
                             show_in_announcement_post: true
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody3'
+                            $ref: '#/components/schemas/CreateRequestBody2'
                 required: true
             responses:
                 "201":
@@ -721,7 +721,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody5'
+                            $ref: '#/components/schemas/CreateRequestBody4'
                         example:
                             incident_id: 01FDAG4SAP5TYPT98WGR2N7W91
                             resource:
@@ -775,7 +775,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody6'
+                            $ref: '#/components/schemas/CreateRequestBody5'
                         example:
                             incident_id: 01ET65M7ZADYFCKD4K1AE2QNMC
                             user_id: 01FCQSP07Z74QMMYPDDGQB9FTG
@@ -810,7 +810,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody6'
+                            $ref: '#/components/schemas/CreateRequestBody5'
                         example:
                             incident_id: 01FCNDV6P870EA6S7TK1DSYD5H
                             user_id: 01FCQSP07Z74QMMYPDDGQB9FTG
@@ -856,7 +856,7 @@ paths:
                             required: false
                             shortform: lead
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody7'
+                            $ref: '#/components/schemas/CreateRequestBody6'
                 required: true
             responses:
                 "201":
@@ -1017,7 +1017,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody9'
+                            $ref: '#/components/schemas/CreateRequestBody8'
                         example:
                             category: live
                             description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
@@ -1372,7 +1372,7 @@ paths:
                             summary: Our database is really really sad, and we don't know why yet.
                             visibility: public
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody10'
+                            $ref: '#/components/schemas/IncidentCreatePayloadV1'
                 required: true
             responses:
                 "200":
@@ -1603,9 +1603,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                type: string
                                 example: '{}'
-                                format: binary
                             example: '{}'
     /v1/openapiV3.json:
         get:
@@ -1620,9 +1618,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                type: string
                                 example: '{}'
-                                format: binary
                             example: '{}'
     /v1/severities:
         get:
@@ -1657,7 +1653,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody13'
+                            $ref: '#/components/schemas/CreateRequestBody10'
                         example:
                             description: Issues with **low impact**.
                             name: Minor
@@ -1749,7 +1745,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody13'
+                            $ref: '#/components/schemas/CreateRequestBody10'
                         example:
                             description: Issues with **low impact**.
                             name: Minor
@@ -1934,7 +1930,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody'
+                            $ref: '#/components/schemas/AlertRoutePayloadV2'
                         example:
                             alert_source_ids:
                                 - 02FCNDV6P870EA6S7TK1DSYDG2
@@ -3007,7 +3003,10 @@ paths:
             tags:
                 - Catalog V2
             summary: CreateEntry Catalog V2
-            description: Create an entry within the catalog. We support a maximum of 50,000 entries per type.
+            description: |-
+                Create an entry within the catalog. We support a maximum of 50,000 entries per type.
+
+                If you call this API with a payload where the external_id and catalog_type_id match an existing entry, the existing entry will be updated.
             operationId: Catalog V2#CreateEntry
             requestBody:
                 required: true
@@ -3747,7 +3746,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody4'
+                            $ref: '#/components/schemas/CreateRequestBody3'
                         example:
                             description: Which team is impacted by this issue
                             field_type: single_select
@@ -3881,7 +3880,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreatePathRequestBody'
+                            $ref: '#/components/schemas/EscalationPathPayloadV2'
                         example:
                             name: Urgent Support
                             path:
@@ -4110,7 +4109,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreatePathRequestBody'
+                            $ref: '#/components/schemas/EscalationPathPayloadV2'
                         example:
                             name: Urgent Support
                             path:
@@ -4360,7 +4359,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody8'
+                            $ref: '#/components/schemas/CreateRequestBody7'
                         example:
                             description: The person currently coordinating the incident
                             instructions: Take point on the incident; Make sure people are clear on responsibilities
@@ -5103,7 +5102,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody11'
+                            $ref: '#/components/schemas/IncidentCreatePayloadV2'
                         example:
                             custom_field_entries:
                                 - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -5620,7 +5619,7 @@ paths:
             tags:
                 - Schedules V2
             summary: ListScheduleEntries Schedules V2
-            description: Get a list of schedule entries.
+            description: Get a list of schedule entries. The endpoint will return all entries that overlap with the given window, if one is provided.
             operationId: Schedules V2#ListScheduleEntries
             parameters:
                 - name: schedule_id
@@ -5802,7 +5801,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateRequestBody12'
+                            $ref: '#/components/schemas/CreateRequestBody9'
                         example:
                             schedule:
                                 annotations:
@@ -6348,7 +6347,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/CreateWorkflowRequestBody'
+                            $ref: '#/components/schemas/CreateWorkflowPayload'
                         example:
                             annotations:
                                 incident.io/terraform/version: 3.0.0
@@ -6799,7 +6798,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/UpdateWorkflowRequestBody'
+                            $ref: '#/components/schemas/UpdateWorkflowPayload2'
                         example:
                             annotations:
                                 incident.io/terraform/version: 3.0.0
@@ -7055,7 +7054,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: alert_route.created
                                 actor:
@@ -7087,7 +7086,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: alert_route.deleted
                                 actor:
@@ -7119,7 +7118,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: alert_route.updated
                                 actor:
@@ -7151,7 +7150,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: alert_schema.updated
                                 actor:
@@ -7183,7 +7182,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: alert_source_config.created
                                 actor:
@@ -7215,7 +7214,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: alert_source_config.deleted
                                 actor:
@@ -7247,7 +7246,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: alert_source_config.updated
                                 actor:
@@ -7279,7 +7278,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: announcement_rule.created
                                 actor:
@@ -7311,7 +7310,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: announcement_rule.deleted
                                 actor:
@@ -7343,7 +7342,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: announcement_rule.updated
                                 actor:
@@ -7375,7 +7374,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: api_key.created
                                 actor:
@@ -7407,7 +7406,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: api_key.deleted
                                 actor:
@@ -7439,7 +7438,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: catalog_type.created
                                 actor:
@@ -7471,7 +7470,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: catalog_type.deleted
                                 actor:
@@ -7503,7 +7502,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: catalog_type.updated
                                 actor:
@@ -7535,7 +7534,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: custom_field.created
                                 actor:
@@ -7567,7 +7566,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: custom_field.deleted
                                 actor:
@@ -7599,7 +7598,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: custom_field.updated
                                 actor:
@@ -7631,7 +7630,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: debrief_invite_rule.created
                                 actor:
@@ -7663,7 +7662,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: debrief_invite_rule.deleted
                                 actor:
@@ -7695,7 +7694,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: debrief_invite_rule.updated
                                 actor:
@@ -7727,7 +7726,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: escalation_path.created
                                 actor:
@@ -7759,7 +7758,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: escalation_path.deleted
                                 actor:
@@ -7791,7 +7790,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: escalation_path.updated
                                 actor:
@@ -7823,7 +7822,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: follow_up_priority.created
                                 actor:
@@ -7855,7 +7854,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: follow_up_priority.deleted
                                 actor:
@@ -7887,7 +7886,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: follow_up_priority.updated
                                 actor:
@@ -7919,7 +7918,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: holiday_user_feed.created
                                 actor:
@@ -7951,7 +7950,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: holiday_user_feed.deleted
                                 actor:
@@ -7983,7 +7982,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: holiday_user_feed.updated
                                 actor:
@@ -8015,7 +8014,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_call_setting.updated
                                 actor:
@@ -8047,7 +8046,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_duration_metric.created
                                 actor:
@@ -8079,7 +8078,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_duration_metric.deleted
                                 actor:
@@ -8111,7 +8110,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_duration_metric.updated
                                 actor:
@@ -8143,7 +8142,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_role.created
                                 actor:
@@ -8175,7 +8174,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_role.deleted
                                 actor:
@@ -8207,7 +8206,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_role.updated
                                 actor:
@@ -8239,7 +8238,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_status.created
                                 actor:
@@ -8271,7 +8270,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_status.deleted
                                 actor:
@@ -8303,7 +8302,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_status.updated
                                 actor:
@@ -8335,7 +8334,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_timestamp.created
                                 actor:
@@ -8367,7 +8366,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_timestamp.deleted
                                 actor:
@@ -8399,7 +8398,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_timestamp.updated
                                 actor:
@@ -8431,7 +8430,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_type.created
                                 actor:
@@ -8463,7 +8462,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_type.deleted
                                 actor:
@@ -8495,7 +8494,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: incident_type.updated
                                 actor:
@@ -8527,7 +8526,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: integration.installed
                                 actor:
@@ -8559,7 +8558,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: integration.uninstalled
                                 actor:
@@ -8591,7 +8590,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: internal_status_page.created
                                 actor:
@@ -8623,7 +8622,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: internal_status_page.deleted
                                 actor:
@@ -8655,7 +8654,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: internal_status_page.updated
                                 actor:
@@ -8687,7 +8686,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: nudge.created
                                 actor:
@@ -8719,7 +8718,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: nudge.deleted
                                 actor:
@@ -8751,7 +8750,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: nudge.updated
                                 actor:
@@ -8783,7 +8782,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: policy.created
                                 actor:
@@ -8815,7 +8814,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: policy.deleted
                                 actor:
@@ -8847,7 +8846,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: policy.updated
                                 actor:
@@ -8879,7 +8878,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: post_incident_task.created
                                 actor:
@@ -8911,7 +8910,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: post_incident_task.deleted
                                 actor:
@@ -8943,7 +8942,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: post_incident_task.updated
                                 actor:
@@ -9009,7 +9008,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: private_incident.access_requested
                                 actor:
@@ -9041,7 +9040,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: private_incident_membership.granted
                                 actor:
@@ -9076,7 +9075,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: private_incident_membership.revoked
                                 actor:
@@ -9111,7 +9110,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: rbac_role.created
                                 actor:
@@ -9143,7 +9142,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: rbac_role.deleted
                                 actor:
@@ -9175,7 +9174,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: rbac_role.updated
                                 actor:
@@ -9207,7 +9206,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: schedule.created
                                 actor:
@@ -9239,7 +9238,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: schedule.deleted
                                 actor:
@@ -9271,7 +9270,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: schedule.updated
                                 actor:
@@ -9340,7 +9339,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: severity.created
                                 actor:
@@ -9372,7 +9371,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: severity.deleted
                                 actor:
@@ -9404,7 +9403,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: severity.updated
                                 actor:
@@ -9436,7 +9435,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: status_page.created
                                 actor:
@@ -9468,7 +9467,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: status_page.deleted
                                 actor:
@@ -9500,7 +9499,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: status_page.updated
                                 actor:
@@ -9532,7 +9531,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: status_page_sub_page.created
                                 actor:
@@ -9564,7 +9563,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: status_page_sub_page.deleted
                                 actor:
@@ -9596,7 +9595,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: status_page_sub_page.updated
                                 actor:
@@ -9628,7 +9627,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: status_page_template.created
                                 actor:
@@ -9660,7 +9659,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: status_page_template.deleted
                                 actor:
@@ -9692,7 +9691,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: status_page_template.updated
                                 actor:
@@ -9724,7 +9723,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: user.created
                                 actor:
@@ -9756,7 +9755,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: user.deactivated
                                 actor:
@@ -9788,7 +9787,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: user.reinstated
                                 actor:
@@ -9857,7 +9856,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: user.updated
                                 actor:
@@ -9889,7 +9888,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: workflow.created
                                 actor:
@@ -9921,7 +9920,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: workflow.deleted
                                 actor:
@@ -9953,7 +9952,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/APIKeyCreatedV1ResponseBody'
+                                $ref: '#/components/schemas/AuditLogEntryBaseV2'
                             example:
                                 action: workflow.updated
                                 actor:
@@ -11142,61 +11141,25 @@ paths:
                                     workload_minutes_working: 20
 components:
     schemas:
-        APIKeyCreatedV1ResponseBody:
+        APIKeyV1:
             type: object
             properties:
-                action:
+                id:
                     type: string
-                    description: The type of log entry that this is
-                    example: api_key.created
-                actor:
-                    $ref: '#/components/schemas/AuditLogActorV2'
-                context:
-                    $ref: '#/components/schemas/AuditLogEntryContextV2'
-                occurred_at:
+                    description: Unique identifier for this API key
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                name:
                     type: string
-                    description: When the entry occurred
-                    example: "2021-08-17T13:28:57.801578Z"
-                    format: date-time
-                targets:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/AuditLogTargetV2'
-                    description: The custom field that was created
-                    example:
-                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          name: Development API Key
-                          type: api_key
-                version:
-                    type: integer
-                    description: Which version the event is
-                    example: 1
-                    format: int64
+                    description: The name of the API key, for the user's reference
+                    example: My test API key
             example:
-                action: api_key.created
-                actor:
-                    id: 01FCNDV6P870EA6S7TK1DSYDG0
-                    metadata:
-                        user_base_role_slug: admin
-                        user_custom_role_slugs: engineering,security
-                    name: John Doe
-                    type: user
-                context:
-                    location: 1.2.3.4
-                    user_agent: Chrome/91.0.4472.114
-                occurred_at: "2021-08-17T13:28:57.801578Z"
-                targets:
-                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      name: Development API Key
-                      type: api_key
-                version: 1
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: My test API key
             required:
-                - action
-                - occurred_at
-                - version
-                - actor
-                - targets
-                - context
+                - id
+                - name
+                - roles
+                - created_by
         APIKeyV2:
             type: object
             properties:
@@ -11236,7 +11199,7 @@ components:
                     description: Description of the action
                     example: Call the fire brigade
                 external_issue_reference:
-                    $ref: '#/components/schemas/ExternalIssueReferenceV1'
+                    $ref: '#/components/schemas/ExternalIssueReferenceV2'
                 follow_up:
                     type: boolean
                     description: Whether an action is marked as follow-up
@@ -11293,7 +11256,7 @@ components:
             type: object
             properties:
                 assignee:
-                    $ref: '#/components/schemas/UserV1'
+                    $ref: '#/components/schemas/UserV2'
                 completed_at:
                     type: string
                     description: When the action was completed
@@ -11351,13 +11314,30 @@ components:
                 - status
                 - created_at
                 - updated_at
+        ActorV1:
+            type: object
+            properties:
+                api_key:
+                    $ref: '#/components/schemas/APIKeyV1'
+                user:
+                    $ref: '#/components/schemas/UserV1'
+            example:
+                api_key:
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: My test API key
+                user:
+                    email: lisa@incident.io
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: Lisa Karlin Curtis
+                    role: viewer
+                    slack_user_id: U02AYNF2XJM
         ActorV2:
             type: object
             properties:
                 api_key:
                     $ref: '#/components/schemas/APIKeyV2'
                 user:
-                    $ref: '#/components/schemas/UserV1'
+                    $ref: '#/components/schemas/UserV2'
             example:
                 api_key:
                     id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -11385,6 +11365,325 @@ components:
             required:
                 - after
                 - after_url
+        AlertAttributeBinding:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AlertAttributeValue'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - catalog_entry:
+                            archived_at: "2021-08-17T14:28:57.801578Z"
+                            catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            catalog_entry_name: Primary escalation
+                            catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          helptext: Collection of standalone automations like auto-closing incidents.
+                          image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                          is_image_slack_icon: false
+                          label: Lawrence Jones
+                          literal: SEV123
+                          sort_key: "000020"
+                value:
+                    $ref: '#/components/schemas/AlertAttributeValue'
+            example:
+                array_value:
+                    - catalog_entry:
+                        archived_at: "2021-08-17T14:28:57.801578Z"
+                        catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        catalog_entry_name: Primary escalation
+                        catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      helptext: Collection of standalone automations like auto-closing incidents.
+                      image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                      is_image_slack_icon: false
+                      label: Lawrence Jones
+                      literal: SEV123
+                      sort_key: "000020"
+                value:
+                    catalog_entry:
+                        archived_at: "2021-08-17T14:28:57.801578Z"
+                        catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        catalog_entry_name: Primary escalation
+                        catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    helptext: Collection of standalone automations like auto-closing incidents.
+                    image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                    is_image_slack_icon: false
+                    label: Lawrence Jones
+                    literal: SEV123
+                    sort_key: "000020"
+        AlertAttributeValue:
+            type: object
+            properties:
+                catalog_entry:
+                    $ref: '#/components/schemas/CatalogEntryReference'
+                helptext:
+                    type: string
+                    description: Gives a description of the option to the user
+                    example: Collection of standalone automations like auto-closing incidents.
+                image_url:
+                    type: string
+                    description: If appropriate, URL to an image that can be displayed alongside the option
+                    example: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                is_image_slack_icon:
+                    type: boolean
+                    description: If true, the image_url is a Slack icon and should be displayed as such
+                    example: false
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                sort_key:
+                    type: string
+                    description: Gives an indication of how to sort the options when displayed to the user
+                    example: "000020"
+            example:
+                catalog_entry:
+                    archived_at: "2021-08-17T14:28:57.801578Z"
+                    catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    catalog_entry_name: Primary escalation
+                    catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                helptext: Collection of standalone automations like auto-closing incidents.
+                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                is_image_slack_icon: false
+                label: Lawrence Jones
+                literal: SEV123
+                sort_key: "000020"
+            required:
+                - label
+                - sort_key
+        AlertDefinitionsV2:
+            type: object
+            properties:
+                alert_source_config:
+                    $ref: '#/components/schemas/AlertSourceConfigSlim'
+                alert_source_config_id:
+                    type: string
+                    description: Which alert source config produced this alert
+                    example: 01GW2G3V0S59R238FAHPDS1R66
+                attribute_values:
+                    type: object
+                    description: Attribute values parsed into the alert
+                    example:
+                        abc123:
+                            array_value:
+                                - catalog_entry:
+                                    archived_at: "2021-08-17T14:28:57.801578Z"
+                                    catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    catalog_entry_name: Primary escalation
+                                    catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                  helptext: Collection of standalone automations like auto-closing incidents.
+                                  image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                  is_image_slack_icon: false
+                                  label: Lawrence Jones
+                                  literal: SEV123
+                                  sort_key: "000020"
+                            value:
+                                catalog_entry:
+                                    archived_at: "2021-08-17T14:28:57.801578Z"
+                                    catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    catalog_entry_name: Primary escalation
+                                    catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                helptext: Collection of standalone automations like auto-closing incidents.
+                                image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                                is_image_slack_icon: false
+                                label: Lawrence Jones
+                                literal: SEV123
+                                sort_key: "000020"
+                    additionalProperties:
+                        $ref: '#/components/schemas/AlertAttributeBinding'
+                created_at:
+                    type: string
+                    description: When this entry was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                dashboard_url:
+                    type: string
+                    description: If applicable, a link to the dashboard for this alert
+                    example: https://my-dashboard.com/alerts/123
+                deduplication_key:
+                    type: string
+                    description: A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.
+                    example: "4293868629"
+                description:
+                    $ref: '#/components/schemas/TextDocument'
+                evaluation_failures:
+                    type: object
+                    description: Attributes that we failed to evaluate and why
+                    example:
+                        abc123: abc123
+                    additionalProperties:
+                        type: string
+                        example: abc123
+                id:
+                    type: string
+                    description: The ID of this alert
+                    example: 01GW2G3V0S59R238FAHPDS1R66
+                payload:
+                    type: string
+                    description: JSON payload that this alert was created from
+                    example: abc123
+                priority:
+                    $ref: '#/components/schemas/Priority'
+                priority_id:
+                    type: string
+                    description: The priority of this alert
+                    example: 01GW2G3V0S59R238FAHPDS1R66
+                resolved_at:
+                    type: string
+                    description: When this alert was resolved
+                    example: "2021-08-17T14:28:57.801578Z"
+                    format: date-time
+                silence_url:
+                    type: string
+                    description: If applicable, a link to silence this alert
+                    example: https://my-dashboard.com/alerts/123/silence
+                source_type:
+                    type: string
+                    description: Type of alert source
+                    example: alertmanager
+                    enum:
+                        - alertmanager
+                        - app_optics
+                        - azure_monitor
+                        - bugsnag
+                        - checkly
+                        - cloudwatch
+                        - cloudflare
+                        - cronitor
+                        - crowdstrike_falcon
+                        - chronosphere
+                        - datadog
+                        - dynatrace
+                        - elasticsearch
+                        - email
+                        - expel
+                        - github_issue
+                        - google_cloud
+                        - grafana
+                        - http
+                        - honeycomb
+                        - jira
+                        - monte_carlo
+                        - new_relic
+                        - opsgenie
+                        - pager_duty
+                        - panther
+                        - pingdom
+                        - runscope
+                        - sns
+                        - sentry
+                        - splunk
+                        - status_cake
+                        - status_page_views
+                        - sumo_logic
+                        - uptime
+                        - zendesk
+                source_url:
+                    type: string
+                    description: If applicable, a link to the alert in the upstream system
+                    example: https://www.my-alerting-platform.com/alerts/my-alert-123
+                status:
+                    type: string
+                    description: Statuses of an alert
+                    example: firing
+                    enum:
+                        - firing
+                        - resolved
+                title:
+                    type: string
+                    description: Alert title which is used when summarising the alert
+                    example: '*errors.withMessage: PG::Error failed to connect'
+                updated_at:
+                    type: string
+                    description: When this alert was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+            example:
+                alert_source_config:
+                    archived_at: "2021-08-17T13:28:57.801578Z"
+                    id: 01GW2G3V0S59R238FAHPDS1R66
+                    name: Production Web Dashboard Alerts
+                    source_type: alertmanager
+                alert_source_config_id: 01GW2G3V0S59R238FAHPDS1R66
+                attribute_values:
+                    abc123:
+                        array_value:
+                            - catalog_entry:
+                                archived_at: "2021-08-17T14:28:57.801578Z"
+                                catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                catalog_entry_name: Primary escalation
+                                catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              helptext: Collection of standalone automations like auto-closing incidents.
+                              image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                              is_image_slack_icon: false
+                              label: Lawrence Jones
+                              literal: SEV123
+                              sort_key: "000020"
+                        value:
+                            catalog_entry:
+                                archived_at: "2021-08-17T14:28:57.801578Z"
+                                catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                catalog_entry_name: Primary escalation
+                                catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            helptext: Collection of standalone automations like auto-closing incidents.
+                            image_url: https://avatars.slack-edge.com/2021-08-09/2372763167857_6f65d94928b0a0ac590b_192.jpg
+                            is_image_slack_icon: false
+                            label: Lawrence Jones
+                            literal: SEV123
+                            sort_key: "000020"
+                created_at: "2021-08-17T13:28:57.801578Z"
+                dashboard_url: https://my-dashboard.com/alerts/123
+                deduplication_key: "4293868629"
+                description:
+                    markdown: There's a snake in my boot
+                    text_node:
+                        attrs:
+                            level: 3
+                        content:
+                            - {}
+                        marks:
+                            - attrs:
+                                color: blue
+                              type: em
+                        text: some nice text
+                        type: text
+                evaluation_failures:
+                    abc123: abc123
+                id: 01GW2G3V0S59R238FAHPDS1R66
+                payload: abc123
+                priority:
+                    archived_at: "2021-08-17T13:28:57.801578Z"
+                    description:
+                        attrs:
+                            level: 3
+                        content:
+                            - {}
+                        marks:
+                            - attrs:
+                                color: blue
+                              type: em
+                        text: some nice text
+                        type: text
+                    id: 01GW2G3V0S59R238FAHPDS1R66
+                    is_default: true
+                    name: P1
+                    rank: 1
+                    slugs:
+                        - p1
+                        - priority-1
+                priority_id: 01GW2G3V0S59R238FAHPDS1R66
+                resolved_at: "2021-08-17T14:28:57.801578Z"
+                silence_url: https://my-dashboard.com/alerts/123/silence
+                source_type: alertmanager
+                source_url: https://www.my-alerting-platform.com/alerts/my-alert-123
+                status: firing
+                title: '*errors.withMessage: PG::Error failed to connect'
+                updated_at: "2021-08-17T13:28:57.801578Z"
         AlertResult:
             type: object
             properties:
@@ -11414,6 +11713,408 @@ components:
                 - status
                 - message
                 - deduplication_key
+        AlertRouteDefinitionsV2:
+            type: object
+            properties:
+                alert_source_ids:
+                    type: array
+                    items:
+                        type: string
+                        example: abc123
+                    description: Legacy field - the alert sources that will match this alert route
+                    example:
+                        - 02FCNDV6P870EA6S7TK1DSYDG2
+                auto_decline_enabled:
+                    type: boolean
+                    description: Should triage incidents be declined when alerts are resolved?
+                    example: false
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupV2'
+                    description: What condition groups must be true for this alert route to fire?
+                    example:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                defer_time_seconds:
+                    type: integer
+                    description: How long should the escalation defer time be?
+                    example: 1
+                    format: int64
+                enabled:
+                    type: boolean
+                    description: Whether this alert route is enabled or not
+                    example: false
+                escalation_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AlertRouteEscalationBindingV2'
+                    description: Which escalation paths should this alert route escalate to?
+                    example:
+                        - binding:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                expressions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionV2'
+                    description: The expressions used in this template
+                    example:
+                        - else_branch:
+                            result:
+                                array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                          label: Team Slack channel
+                          operations:
+                            - branches:
+                                branches:
+                                    - condition_groups:
+                                        - conditions:
+                                            - operation:
+                                                label: Lawrence Jones
+                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                              param_bindings:
+                                                - array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject:
+                                                label: Incident Severity
+                                                reference: incident.severity
+                                      result:
+                                        array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                              filter:
+                                condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                              navigate:
+                                reference: "1235"
+                                reference_label: Teams
+                              operation_type: navigate
+                              parse:
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                                source: metadata.annotations["github.com/repo"]
+                              returns:
+                                array: true
+                                type: IncidentStatus
+                          reference: abc123
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                          root_reference: incident.status
+                grouping_keys:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GroupingKeyV2'
+                    description: Which attributes should this alert route use to group alerts?
+                    example:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds:
+                    type: integer
+                    description: How large should the grouping window be?
+                    example: 1
+                    format: int64
+                id:
+                    type: string
+                    description: Unique identifier for this alert route config
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                incident_condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupV2'
+                    description: What condition groups must be true for this alert route to create an incident?
+                    example:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                incident_enabled:
+                    type: boolean
+                    description: Whether this alert route will create incidents or not
+                    example: false
+                last_fired_at:
+                    type: string
+                    description: When did this alert route last create an incident?
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                name:
+                    type: string
+                    description: The name of this alert route config, for the user's reference
+                    example: Production incidents
+                template:
+                    $ref: '#/components/schemas/AlertRouteIncidentTemplateV2'
+            example:
+                alert_source_ids:
+                    - 02FCNDV6P870EA6S7TK1DSYDG2
+                auto_decline_enabled: false
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+                defer_time_seconds: 1
+                enabled: false
+                escalation_bindings:
+                    - binding:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                      reference: abc123
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                      root_reference: incident.status
+                grouping_keys:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds: 1
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                incident_condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+                incident_enabled: false
+                last_fired_at: "2021-08-17T13:28:57.801578Z"
+                name: Production incidents
+                template:
+                    custom_field_priorities:
+                        abc123: first-wins
+                    custom_fields:
+                        custom_field_10014:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                    incident_mode:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    incident_type:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    name:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    priority_severity: severity-first-wins
+                    severity:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    summary:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                    workspace:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
         AlertRouteEscalationBindingPayloadV2:
             type: object
             properties:
@@ -11666,6 +12367,309 @@ components:
             required:
                 - custom_field_priorities
                 - priority_severity
+        AlertRoutePayloadV2:
+            type: object
+            properties:
+                alert_source_ids:
+                    type: array
+                    items:
+                        type: string
+                        example: abc123
+                    description: Legacy field - the alert sources that will match this alert route
+                    example:
+                        - 02FCNDV6P870EA6S7TK1DSYDG2
+                auto_decline_enabled:
+                    type: boolean
+                    description: Should triage incidents be declined when alerts are resolved?
+                    example: false
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
+                    description: What condition groups must be true for this alert route to fire?
+                    example:
+                        - conditions:
+                            - operation: one_of
+                              param_bindings:
+                                - array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject: incident.severity
+                defer_time_seconds:
+                    type: integer
+                    description: How long should the escalation defer time be?
+                    example: 1
+                    format: int64
+                enabled:
+                    type: boolean
+                    description: Whether this alert route is enabled or not
+                    example: false
+                escalation_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AlertRouteEscalationBindingPayloadV2'
+                    description: Which escalation paths should this alert route escalate to?
+                    example:
+                        - binding:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                expressions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionPayloadV2'
+                    description: The expressions used in this template
+                    example:
+                        - else_branch:
+                            result:
+                                array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                          label: Team Slack channel
+                          operations:
+                            - branches:
+                                branches:
+                                    - condition_groups:
+                                        - conditions:
+                                            - operation: one_of
+                                              param_bindings:
+                                                - array_value:
+                                                    - literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject: incident.severity
+                                      result:
+                                        array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                              filter:
+                                condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                              navigate:
+                                reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                              operation_type: navigate
+                              parse:
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                                source: metadata.annotations["github.com/repo"]
+                          reference: abc123
+                          root_reference: incident.status
+                grouping_keys:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GroupingKeyV2'
+                    description: Which attributes should this alert route use to group alerts?
+                    example:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds:
+                    type: integer
+                    description: How large should the grouping window be?
+                    example: 1
+                    format: int64
+                incident_condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
+                    description: What condition groups must be true for this alert route to create an incident?
+                    example:
+                        - conditions:
+                            - operation: one_of
+                              param_bindings:
+                                - array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject: incident.severity
+                incident_enabled:
+                    type: boolean
+                    description: Whether this alert route will create incidents or not
+                    example: false
+                name:
+                    type: string
+                    description: The name of this alert route config, for the user's reference
+                    example: Production incidents
+                template:
+                    $ref: '#/components/schemas/AlertRouteIncidentTemplatePayloadV2'
+            example:
+                alert_source_ids:
+                    - 02FCNDV6P870EA6S7TK1DSYDG2
+                auto_decline_enabled: false
+                condition_groups:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+                defer_time_seconds: 1
+                enabled: false
+                escalation_bindings:
+                    - binding:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                                  result:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                          navigate:
+                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                      reference: abc123
+                      root_reference: incident.status
+                grouping_keys:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                grouping_window_seconds: 1
+                incident_condition_groups:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+                incident_enabled: false
+                name: Production incidents
+                template:
+                    custom_field_priorities:
+                        abc123: abc123
+                    custom_fields:
+                        custom_field_10014:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                    incident_mode:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    incident_type:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    name:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    priority_severity: severity-first-wins
+                    severity:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    summary:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
+                    workspace:
+                        array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                        value:
+                            literal: SEV123
+                            reference: incident.severity
         AlertRouteV2:
             type: object
             properties:
@@ -12010,8 +13014,75 @@ components:
                 - enabled
                 - incident_enabled
                 - incident_condition_groups
+                - alert_sources
                 - alert_source_ids
                 - auto_cancel_escalations
+        AlertSourceConfigSlim:
+            type: object
+            properties:
+                archived_at:
+                    type: string
+                    description: When this type was archived
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                id:
+                    type: string
+                    description: The ID of this alert source
+                    example: 01GW2G3V0S59R238FAHPDS1R66
+                name:
+                    type: string
+                    description: Unique name of the alert source
+                    example: Production Web Dashboard Alerts
+                source_type:
+                    type: string
+                    description: Type of alert source
+                    example: alertmanager
+                    enum:
+                        - alertmanager
+                        - app_optics
+                        - azure_monitor
+                        - bugsnag
+                        - checkly
+                        - cloudwatch
+                        - cloudflare
+                        - cronitor
+                        - crowdstrike_falcon
+                        - chronosphere
+                        - datadog
+                        - dynatrace
+                        - elasticsearch
+                        - email
+                        - expel
+                        - github_issue
+                        - google_cloud
+                        - grafana
+                        - http
+                        - honeycomb
+                        - jira
+                        - monte_carlo
+                        - new_relic
+                        - opsgenie
+                        - pager_duty
+                        - panther
+                        - pingdom
+                        - runscope
+                        - sns
+                        - sentry
+                        - splunk
+                        - status_cake
+                        - status_page_views
+                        - sumo_logic
+                        - uptime
+                        - zendesk
+            example:
+                archived_at: "2021-08-17T13:28:57.801578Z"
+                id: 01GW2G3V0S59R238FAHPDS1R66
+                name: Production Web Dashboard Alerts
+                source_type: alertmanager
+            required:
+                - id
+                - name
+                - source_type
         AllResponseBody:
             type: object
             properties:
@@ -12036,17 +13107,17 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.action_created_v1:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
                 private_incident.action_updated_v1:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
                 private_incident.follow_up_created_v1:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
                 private_incident.follow_up_updated_v1:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
                 private_incident.incident_created_v2:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
                 private_incident.incident_updated_v2:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
                 private_incident.membership_granted_v1:
                     $ref: '#/components/schemas/WebhookIncidentUserV2'
                 private_incident.membership_revoked_v1:
@@ -12525,6 +13596,15 @@ components:
                     workload_minutes_working: 20
             required:
                 - event_type
+        AuditLogAPIKeyMetadataV2:
+            type: object
+            properties:
+                api_key_roles:
+                    type: string
+                    description: The roles that the API key has, separated by commas (if it's an API key actor)
+                    example: abc123
+            example:
+                api_key_roles: abc123
         AuditLogActorMetadataV2:
             type: object
             properties:
@@ -12587,6 +13667,61 @@ components:
             required:
                 - id
                 - type
+        AuditLogEntryBaseV2:
+            type: object
+            properties:
+                action:
+                    type: string
+                    description: The type of log entry that this is
+                    example: custom_field.created
+                actor:
+                    $ref: '#/components/schemas/AuditLogActorV2'
+                context:
+                    $ref: '#/components/schemas/AuditLogEntryContextV2'
+                occurred_at:
+                    type: string
+                    description: When the entry occurred
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                targets:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AuditLogTargetV2'
+                    description: The target of the entry
+                    example:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          name: John Doe
+                          type: user
+                version:
+                    type: integer
+                    description: Which version the event is
+                    example: 1
+                    format: int64
+            example:
+                action: custom_field.created
+                actor:
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    metadata:
+                        user_base_role_slug: admin
+                        user_custom_role_slugs: engineering,security
+                    name: John Doe
+                    type: user
+                context:
+                    location: 1.2.3.4
+                    user_agent: Chrome/91.0.4472.114
+                occurred_at: "2021-08-17T13:28:57.801578Z"
+                targets:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      name: John Doe
+                      type: user
+                version: 1
+            required:
+                - action
+                - occurred_at
+                - version
+                - actor
+                - targets
+                - context
         AuditLogEntryContextV2:
             type: object
             properties:
@@ -12603,6 +13738,20 @@ components:
                 user_agent: Chrome/91.0.4472.114
             required:
                 - location
+        AuditLogExternalResourceMetadataV2:
+            type: object
+            properties:
+                external_resource_external_id:
+                    type: string
+                    description: The ID of the external resource in the 3rd party system (if it's an external resource actor)
+                    example: q1234
+                external_resource_type:
+                    type: string
+                    description: The type of the external resource (if it's an external resource actor)
+                    example: pager_duty_incident
+            example:
+                external_resource_external_id: q1234
+                external_resource_type: pager_duty_incident
         AuditLogPrivateIncidentAccessAttemptedMetadataV2:
             type: object
             properties:
@@ -12670,6 +13819,20 @@ components:
             required:
                 - id
                 - type
+        AuditLogUserActorMetadataV2:
+            type: object
+            properties:
+                user_base_role_slug:
+                    type: string
+                    description: The base role slug of the user (if it's a user actor)
+                    example: admin
+                user_custom_role_slugs:
+                    type: string
+                    description: The custom role slugs of the user, separated by commas (if it's a user actor)
+                    example: engineering,security
+            example:
+                user_base_role_slug: admin
+                user_custom_role_slugs: engineering,security
         AuditLogUserRoleMembershipChangedMetadataV2:
             type: object
             properties:
@@ -12723,6 +13886,135 @@ components:
                 after_custom_role_slugs: engineering,data
                 before_base_role_slug: admin
                 before_custom_role_slugs: engineering,security
+        CatalogEntryDefinitionsV2:
+            type: object
+            properties:
+                aliases:
+                    type: array
+                    items:
+                        type: string
+                        example: abc123
+                    description: Optional aliases that can be used to reference this entry
+                    example:
+                        - lawrence@incident.io
+                        - lawrence
+                archived_at:
+                    type: string
+                    description: When this entry was archived
+                    example: "2021-08-17T14:28:57.801578Z"
+                    format: date-time
+                attribute_values:
+                    type: object
+                    description: Values of this entry
+                    example:
+                        abc123:
+                            array_value:
+                                - catalog_entry:
+                                    archived_at: "2021-08-17T14:28:57.801578Z"
+                                    catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    catalog_entry_name: Primary escalation
+                                    catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                  helptext: abc123
+                                  image_url: abc123
+                                  is_image_slack_icon: false
+                                  label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                                  sort_key: abc123
+                                  unavailable: false
+                                  value: abc123
+                            value:
+                                catalog_entry:
+                                    archived_at: "2021-08-17T14:28:57.801578Z"
+                                    catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    catalog_entry_name: Primary escalation
+                                    catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                helptext: abc123
+                                image_url: abc123
+                                is_image_slack_icon: false
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                                sort_key: abc123
+                                unavailable: false
+                                value: abc123
+                    additionalProperties:
+                        $ref: '#/components/schemas/CatalogEntryEngineParamBindingV2'
+                catalog_type_id:
+                    type: string
+                    description: ID of this catalog type
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                created_at:
+                    type: string
+                    description: When this entry was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                external_id:
+                    type: string
+                    description: An optional alternative ID for this entry, which is ensured to be unique for the type
+                    example: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                id:
+                    type: string
+                    description: ID of this catalog entry
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                name:
+                    type: string
+                    description: Name is the human readable name of this entry
+                    example: Primary On-call
+                rank:
+                    type: integer
+                    description: When catalog type is ranked, this is used to help order things
+                    example: 3
+                    format: int32
+                updated_at:
+                    type: string
+                    description: When this entry was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+            example:
+                aliases:
+                    - lawrence@incident.io
+                    - lawrence
+                archived_at: "2021-08-17T14:28:57.801578Z"
+                attribute_values:
+                    abc123:
+                        array_value:
+                            - catalog_entry:
+                                archived_at: "2021-08-17T14:28:57.801578Z"
+                                catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                catalog_entry_name: Primary escalation
+                                catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              helptext: abc123
+                              image_url: abc123
+                              is_image_slack_icon: false
+                              label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                              sort_key: abc123
+                              unavailable: false
+                              value: abc123
+                        value:
+                            catalog_entry:
+                                archived_at: "2021-08-17T14:28:57.801578Z"
+                                catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                catalog_entry_name: Primary escalation
+                                catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            helptext: abc123
+                            image_url: abc123
+                            is_image_slack_icon: false
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                            sort_key: abc123
+                            unavailable: false
+                            value: abc123
+                catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                created_at: "2021-08-17T13:28:57.801578Z"
+                external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Primary On-call
+                rank: 3
+                updated_at: "2021-08-17T13:28:57.801578Z"
         CatalogEntryEngineParamBindingV2:
             type: object
             properties:
@@ -12838,6 +14130,35 @@ components:
             required:
                 - label
                 - sort_key
+        CatalogEntryReference:
+            type: object
+            properties:
+                archived_at:
+                    type: string
+                    description: When this entry was archived
+                    example: "2021-08-17T14:28:57.801578Z"
+                    format: date-time
+                catalog_entry_id:
+                    type: string
+                    description: ID of this catalog entry
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                catalog_entry_name:
+                    type: string
+                    description: The name of this entry
+                    example: Primary escalation
+                catalog_type_id:
+                    type: string
+                    description: ID of this catalog type
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+            example:
+                archived_at: "2021-08-17T14:28:57.801578Z"
+                catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                catalog_entry_name: Primary escalation
+                catalog_type_id: 01FCNDV6P870EA6S7TK1DSYDG0
+            required:
+                - catalog_type_id
+                - catalog_entry_id
+                - catalog_entry_name
         CatalogEntryReferenceV2:
             type: object
             properties:
@@ -13092,7 +14413,7 @@ components:
                 mode:
                     type: string
                     description: Controls how this attribute is modified
-                    example: manual
+                    example: ""
                     enum:
                         - ""
                         - manual
@@ -13120,7 +14441,7 @@ components:
                 array: false
                 backlink_attribute: abc123
                 id: 01GW2G3V0S59R238FAHPDS1R66
-                mode: manual
+                mode: ""
                 name: tier
                 path:
                     - attribute_id: abc123
@@ -13147,7 +14468,7 @@ components:
                 mode:
                     type: string
                     description: Controls how this attribute is modified
-                    example: manual
+                    example: ""
                     enum:
                         - ""
                         - manual
@@ -13176,7 +14497,7 @@ components:
                 array: false
                 backlink_attribute: abc123
                 id: 01GW2G3V0S59R238FAHPDS1R66
-                mode: manual
+                mode: ""
                 name: tier
                 path:
                     - attribute_id: abc123
@@ -13188,6 +14509,229 @@ components:
                 - name
                 - type
                 - array
+        CatalogTypeDefinitionsV2:
+            type: object
+            properties:
+                annotations:
+                    type: object
+                    description: Annotations that can track metadata about this type
+                    example:
+                        incident.io/catalog-importer/id: id-of-config
+                    additionalProperties:
+                        type: string
+                        example: abc123
+                categories:
+                    type: array
+                    items:
+                        type: string
+                        example: customer
+                        enum:
+                            - customer
+                            - issue-tracker
+                            - product-feature
+                            - service
+                            - on-call
+                            - team
+                            - user
+                    description: What categories is this type considered part of
+                    example:
+                        - customer
+                color:
+                    type: string
+                    description: Sets the display color of this type in the dashboard
+                    example: yellow
+                    enum:
+                        - yellow
+                        - green
+                        - blue
+                        - violet
+                        - pink
+                        - cyan
+                        - orange
+                created_at:
+                    type: string
+                    description: When this type was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                description:
+                    type: string
+                    description: Human readble description of this type
+                    example: Represents Kubernetes clusters that we run inside of GKE.
+                dynamic_resource_parameter:
+                    type: string
+                    description: If this is a dynamic catalog type, this will be the unique parameter for identitfying this resource externally.
+                    example: abc123
+                engine_resource_type:
+                    type: string
+                    description: The way this resource type is referenced in the engine
+                    example: CatalogType["PagerDutyService"]
+                estimated_count:
+                    type: integer
+                    description: If populated, gives an estimated count of entries for this type
+                    example: 7
+                    format: int64
+                icon:
+                    type: string
+                    description: Sets the display icon of this type in the dashboard
+                    example: alert
+                    enum:
+                        - alert
+                        - bolt
+                        - box
+                        - briefcase
+                        - browser
+                        - bulb
+                        - calendar
+                        - clock
+                        - cog
+                        - components
+                        - database
+                        - doc
+                        - email
+                        - escalation-path
+                        - files
+                        - flag
+                        - folder
+                        - globe
+                        - money
+                        - server
+                        - severity
+                        - status-page
+                        - store
+                        - star
+                        - tag
+                        - user
+                        - users
+                id:
+                    type: string
+                    description: ID of this catalog type
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                is_editable:
+                    type: boolean
+                    description: Catalog types that are synced with external resources can't be edited
+                    example: false
+                last_synced_at:
+                    type: string
+                    description: When this type was last synced (if it's ever been sync'd)
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                mode:
+                    type: string
+                    description: What mode is this catalog type?
+                    example: manual
+                    enum:
+                        - manual
+                        - external
+                        - internal
+                name:
+                    type: string
+                    description: Name is the human readable name of this type
+                    example: Kubernetes Cluster
+                native_resource_path:
+                    type: string
+                    description: If present, the path to view this resource natively in the web UI
+                    example: /on-call/escalation-paths
+                ranked:
+                    type: boolean
+                    description: If this type should be ranked
+                    example: true
+                registry_type:
+                    type: string
+                    description: The registry resource this type is synced from, if any
+                    example: PagerDutyService
+                required_integration:
+                    type: string
+                    description: If populated, the integration required for this type
+                    example: asana
+                    enum:
+                        - asana
+                        - statuspage
+                        - click_up
+                        - confluence
+                        - cortex
+                        - datadog
+                        - github
+                        - gitlab
+                        - google_docs
+                        - google_meet
+                        - google_calendar
+                        - google_workspace
+                        - jira
+                        - jira_server
+                        - linear
+                        - microsoft_teams
+                        - notion
+                        - opsgenie
+                        - opslevel
+                        - pagerduty
+                        - salesforce
+                        - sentry
+                        - shortcut
+                        - scim
+                        - slack
+                        - splunk_on_call
+                        - incident_io_status_pages
+                        - incident_io_on_call
+                        - vanta
+                        - webhooks
+                        - zendesk
+                        - zoom
+                schema:
+                    $ref: '#/components/schemas/CatalogTypeSchemaV2'
+                source_repo_url:
+                    type: string
+                    description: The url of the external repository where this type is managed
+                    example: https://github.com/my-company/incident-io-catalog
+                type_name:
+                    type: string
+                    description: The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName "]
+                    example: Custom["BackstageGroup"]
+                updated_at:
+                    type: string
+                    description: When this type was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                use_name_as_identifier:
+                    type: boolean
+                    description: If populated, the name of the entry will be added to the list of identifiers for this type
+                    example: true
+            example:
+                annotations:
+                    incident.io/catalog-importer/id: id-of-config
+                categories:
+                    - customer
+                color: yellow
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Represents Kubernetes clusters that we run inside of GKE.
+                dynamic_resource_parameter: abc123
+                engine_resource_type: CatalogType["PagerDutyService"]
+                estimated_count: 7
+                icon: alert
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                is_editable: false
+                last_synced_at: "2021-08-17T13:28:57.801578Z"
+                mode: manual
+                name: Kubernetes Cluster
+                native_resource_path: /on-call/escalation-paths
+                ranked: true
+                registry_type: PagerDutyService
+                required_integration: asana
+                schema:
+                    attributes:
+                        - array: false
+                          backlink_attribute: abc123
+                          id: 01GW2G3V0S59R238FAHPDS1R66
+                          mode: ""
+                          name: tier
+                          path:
+                            - attribute_id: abc123
+                              attribute_name: abc123
+                          type: Custom["Service"]
+                    version: 1
+                source_repo_url: https://github.com/my-company/incident-io-catalog
+                type_name: Custom["BackstageGroup"]
+                updated_at: "2021-08-17T13:28:57.801578Z"
+                use_name_as_identifier: true
         CatalogTypeSchemaV2:
             type: object
             properties:
@@ -13200,7 +14744,7 @@ components:
                         - array: false
                           backlink_attribute: abc123
                           id: 01GW2G3V0S59R238FAHPDS1R66
-                          mode: manual
+                          mode: ""
                           name: tier
                           path:
                             - attribute_id: abc123
@@ -13216,7 +14760,7 @@ components:
                     - array: false
                       backlink_attribute: abc123
                       id: 01GW2G3V0S59R238FAHPDS1R66
-                      mode: manual
+                      mode: ""
                       name: tier
                       path:
                         - attribute_id: abc123
@@ -13241,7 +14785,7 @@ components:
                     type: array
                     items:
                         type: string
-                        example: issue-tracker
+                        example: customer
                         enum:
                             - customer
                             - issue-tracker
@@ -13252,7 +14796,7 @@ components:
                             - user
                     description: What categories is this type considered part of
                     example:
-                        - issue-tracker
+                        - customer
                 color:
                     type: string
                     description: Sets the display color of this type in the dashboard
@@ -13352,8 +14896,8 @@ components:
                     $ref: '#/components/schemas/CatalogTypeSchemaV2'
                 semantic_type:
                     type: string
-                    description: Semantic type of this resource (unused)
-                    example: custom
+                    description: What type of resource this catalog type should be understodd as
+                    example: abc123
                 source_repo_url:
                     type: string
                     description: The url of the external repository where this type is managed
@@ -13371,7 +14915,7 @@ components:
                 annotations:
                     incident.io/catalog-importer/id: id-of-config
                 categories:
-                    - issue-tracker
+                    - customer
                 color: yellow
                 created_at: "2021-08-17T13:28:57.801578Z"
                 description: Represents Kubernetes clusters that we run inside of GKE.
@@ -13391,7 +14935,7 @@ components:
                         - array: false
                           backlink_attribute: abc123
                           id: 01GW2G3V0S59R238FAHPDS1R66
-                          mode: manual
+                          mode: ""
                           name: tier
                           path:
                             - attribute_id: abc123
@@ -13537,6 +15081,221 @@ components:
                         reference: incident.severity
             required:
                 - conditions
+        ConditionGroupV4:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionV4'
+                    description: All conditions in this list must be satisfied for the group to be satisfied
+                    example:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+            example:
+                conditions:
+                    - operation:
+                        label: Lawrence Jones
+                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                      param_bindings:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                      subject:
+                        label: Incident Severity
+                        reference: incident.severity
+            required:
+                - conditions
+        ConditionGroupV5:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionV5'
+                    description: All conditions in this list must be satisfied for the group to be satisfied
+                    example:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+            example:
+                conditions:
+                    - operation:
+                        label: Lawrence Jones
+                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                      param_bindings:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                      subject:
+                        label: Incident Severity
+                        reference: incident.severity
+            required:
+                - conditions
+        ConditionGroupV6:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionV6'
+                    description: All conditions in this list must be satisfied for the group to be satisfied
+                    example:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+            example:
+                conditions:
+                    - operation:
+                        label: Lawrence Jones
+                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                      param_bindings:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                      subject:
+                        label: Incident Severity
+                        reference: incident.severity
+            required:
+                - conditions
+        ConditionGroupV7:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionV7'
+                    description: All conditions in this list must be satisfied for the group to be satisfied
+                    example:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+            example:
+                conditions:
+                    - operation:
+                        label: Lawrence Jones
+                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                      param_bindings:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                      subject:
+                        label: Incident Severity
+                        reference: incident.severity
+            required:
+                - conditions
+        ConditionGroupV8:
+            type: object
+            properties:
+                conditions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionV8'
+                    description: All conditions in this list must be satisfied for the group to be satisfied
+                    example:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+            example:
+                conditions:
+                    - operation:
+                        label: Lawrence Jones
+                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                      param_bindings:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                      subject:
+                        label: Incident Severity
+                        reference: incident.severity
+            required:
+                - conditions
         ConditionOperationV2:
             type: object
             properties:
@@ -13556,6 +15315,91 @@ components:
                 - value
                 - sort_key
         ConditionOperationV3:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                value:
+                    type: string
+                    description: Unique identifier for this option
+                    example: 01FCQSP07Z74QMMYPDDGQB9FTG
+            example:
+                label: Lawrence Jones
+                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+            required:
+                - label
+                - value
+        ConditionOperationV4:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                value:
+                    type: string
+                    description: Unique identifier for this option
+                    example: 01FCQSP07Z74QMMYPDDGQB9FTG
+            example:
+                label: Lawrence Jones
+                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+            required:
+                - label
+                - value
+        ConditionOperationV5:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                value:
+                    type: string
+                    description: Unique identifier for this option
+                    example: 01FCQSP07Z74QMMYPDDGQB9FTG
+            example:
+                label: Lawrence Jones
+                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+            required:
+                - label
+                - value
+        ConditionOperationV6:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                value:
+                    type: string
+                    description: Unique identifier for this option
+                    example: 01FCQSP07Z74QMMYPDDGQB9FTG
+            example:
+                label: Lawrence Jones
+                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+            required:
+                - label
+                - value
+        ConditionOperationV7:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                value:
+                    type: string
+                    description: Unique identifier for this option
+                    example: 01FCQSP07Z74QMMYPDDGQB9FTG
+            example:
+                label: Lawrence Jones
+                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+            required:
+                - label
+                - value
+        ConditionOperationV8:
             type: object
             properties:
                 label:
@@ -13644,6 +15488,91 @@ components:
             required:
                 - label
                 - reference
+        ConditionSubjectV4:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable identifier for the subject
+                    example: Incident Severity
+                reference:
+                    type: string
+                    description: Reference into the scope for the value of the subject
+                    example: incident.severity
+            example:
+                label: Incident Severity
+                reference: incident.severity
+            required:
+                - label
+                - reference
+        ConditionSubjectV5:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable identifier for the subject
+                    example: Incident Severity
+                reference:
+                    type: string
+                    description: Reference into the scope for the value of the subject
+                    example: incident.severity
+            example:
+                label: Incident Severity
+                reference: incident.severity
+            required:
+                - label
+                - reference
+        ConditionSubjectV6:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable identifier for the subject
+                    example: Incident Severity
+                reference:
+                    type: string
+                    description: Reference into the scope for the value of the subject
+                    example: incident.severity
+            example:
+                label: Incident Severity
+                reference: incident.severity
+            required:
+                - label
+                - reference
+        ConditionSubjectV7:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable identifier for the subject
+                    example: Incident Severity
+                reference:
+                    type: string
+                    description: Reference into the scope for the value of the subject
+                    example: incident.severity
+            example:
+                label: Incident Severity
+                reference: incident.severity
+            required:
+                - label
+                - reference
+        ConditionSubjectV8:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable identifier for the subject
+                    example: Incident Severity
+                reference:
+                    type: string
+                    description: Reference into the scope for the value of the subject
+                    example: incident.severity
+            example:
+                label: Incident Severity
+                reference: incident.severity
+            required:
+                - label
+                - reference
         ConditionV2:
             type: object
             properties:
@@ -13694,7 +15623,7 @@ components:
                 param_bindings:
                     type: array
                     items:
-                        $ref: '#/components/schemas/EngineParamBindingV3'
+                        $ref: '#/components/schemas/EngineParamBindingV4'
                     description: Bindings for the operation parameters
                     example:
                         - array_value:
@@ -13727,6 +15656,213 @@ components:
                 - subject
                 - operation
                 - param_bindings
+        ConditionV4:
+            type: object
+            properties:
+                operation:
+                    $ref: '#/components/schemas/ConditionOperationV4'
+                param_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingV5'
+                    description: Bindings for the operation parameters
+                    example:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                subject:
+                    $ref: '#/components/schemas/ConditionSubjectV4'
+            example:
+                operation:
+                    label: Lawrence Jones
+                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                param_bindings:
+                    - array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                      value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                subject:
+                    label: Incident Severity
+                    reference: incident.severity
+            required:
+                - subject
+                - operation
+                - param_bindings
+        ConditionV5:
+            type: object
+            properties:
+                operation:
+                    $ref: '#/components/schemas/ConditionOperationV5'
+                param_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingV7'
+                    description: Bindings for the operation parameters
+                    example:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                subject:
+                    $ref: '#/components/schemas/ConditionSubjectV5'
+            example:
+                operation:
+                    label: Lawrence Jones
+                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                param_bindings:
+                    - array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                      value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                subject:
+                    label: Incident Severity
+                    reference: incident.severity
+            required:
+                - subject
+                - operation
+                - param_bindings
+                - params
+        ConditionV6:
+            type: object
+            properties:
+                operation:
+                    $ref: '#/components/schemas/ConditionOperationV6'
+                param_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingV9'
+                    description: Bindings for the operation parameters
+                    example:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                subject:
+                    $ref: '#/components/schemas/ConditionSubjectV6'
+            example:
+                operation:
+                    label: Lawrence Jones
+                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                param_bindings:
+                    - array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                      value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                subject:
+                    label: Incident Severity
+                    reference: incident.severity
+            required:
+                - subject
+                - operation
+                - param_bindings
+        ConditionV7:
+            type: object
+            properties:
+                operation:
+                    $ref: '#/components/schemas/ConditionOperationV7'
+                param_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingV10'
+                    description: Bindings for the operation parameters
+                    example:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                subject:
+                    $ref: '#/components/schemas/ConditionSubjectV7'
+            example:
+                operation:
+                    label: Lawrence Jones
+                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                param_bindings:
+                    - array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                      value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                subject:
+                    label: Incident Severity
+                    reference: incident.severity
+            required:
+                - subject
+                - operation
+                - param_bindings
+        ConditionV8:
+            type: object
+            properties:
+                operation:
+                    $ref: '#/components/schemas/ConditionOperationV8'
+                param_bindings:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingV12'
+                    description: Bindings for the operation parameters
+                    example:
+                        - array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                          value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                subject:
+                    $ref: '#/components/schemas/ConditionSubjectV8'
+            example:
+                operation:
+                    label: Lawrence Jones
+                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                param_bindings:
+                    - array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                      value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                subject:
+                    label: Incident Severity
+                    reference: incident.severity
+            required:
+                - subject
+                - operation
+                - param_bindings
+                - params
         CreateEntryRequestBody:
             type: object
             properties:
@@ -13935,110 +16071,6 @@ components:
                     source_url: https://github.com/my-company/infrastructure
             required:
                 - managed_resource
-        CreatePathRequestBody:
-            type: object
-            properties:
-                name:
-                    type: string
-                    description: The name of this escalation path, for the user's reference.
-                    example: Urgent Support
-                path:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/EscalationPathNodePayloadV2'
-                    description: The nodes that form the levels and branches of this escalation path.
-                    example:
-                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          if_else:
-                            conditions:
-                                - operation: one_of
-                                  param_bindings:
-                                    - array_value:
-                                        - literal: SEV123
-                                          reference: incident.severity
-                                      value:
-                                        literal: SEV123
-                                        reference: incident.severity
-                                  subject: incident.severity
-                            else_path:
-                                - {}
-                            then_path:
-                                - {}
-                          level:
-                            round_robin_config:
-                                enabled: false
-                                rotate_after_seconds: 120
-                            targets:
-                                - id: lawrencejones
-                                  schedule_mode: currently_on_call
-                                  type: user
-                                  urgency: high
-                            time_to_ack_interval_condition: active
-                            time_to_ack_seconds: 1800
-                            time_to_ack_weekday_interval_config_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          repeat:
-                            repeat_times: 3
-                            to_node: 01FCNDV6P870EA6S7TK1DSYDG0
-                          type: if_else
-                working_hours:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/WeekdayIntervalConfigV2'
-                    description: The working hours for this escalation path.
-                    example:
-                        - id: abc123
-                          name: abc123
-                          timezone: abc123
-                          weekday_intervals:
-                            - end_time: "17:00"
-                              start_time: "09:00"
-                              weekday: abc123
-            example:
-                name: Urgent Support
-                path:
-                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      if_else:
-                        conditions:
-                            - operation: one_of
-                              param_bindings:
-                                - array_value:
-                                    - literal: SEV123
-                                      reference: incident.severity
-                                  value:
-                                    literal: SEV123
-                                    reference: incident.severity
-                              subject: incident.severity
-                        else_path:
-                            - {}
-                        then_path:
-                            - {}
-                      level:
-                        round_robin_config:
-                            enabled: false
-                            rotate_after_seconds: 120
-                        targets:
-                            - id: lawrencejones
-                              schedule_mode: currently_on_call
-                              type: user
-                              urgency: high
-                        time_to_ack_interval_condition: active
-                        time_to_ack_seconds: 1800
-                        time_to_ack_weekday_interval_config_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      repeat:
-                        repeat_times: 3
-                        to_node: 01FCNDV6P870EA6S7TK1DSYDG0
-                      type: if_else
-                working_hours:
-                    - id: abc123
-                      name: abc123
-                      timezone: abc123
-                      weekday_intervals:
-                        - end_time: "17:00"
-                          start_time: "09:00"
-                          weekday: abc123
-            required:
-                - name
-                - path
         CreatePathResponseBody:
             type: object
             properties:
@@ -14100,309 +16132,6 @@ components:
         CreateRequestBody:
             type: object
             properties:
-                alert_source_ids:
-                    type: array
-                    items:
-                        type: string
-                        example: abc123
-                    description: The alert sources that will match this alert route
-                    example:
-                        - 02FCNDV6P870EA6S7TK1DSYDG2
-                auto_decline_enabled:
-                    type: boolean
-                    description: Should triage incidents be declined when alerts are resolved?
-                    example: false
-                condition_groups:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
-                    description: What condition groups must be true for this alert route to fire?
-                    example:
-                        - conditions:
-                            - operation: one_of
-                              param_bindings:
-                                - array_value:
-                                    - literal: SEV123
-                                      reference: incident.severity
-                                  value:
-                                    literal: SEV123
-                                    reference: incident.severity
-                              subject: incident.severity
-                defer_time_seconds:
-                    type: integer
-                    description: How long should the escalation defer time be?
-                    example: 1
-                    format: int64
-                enabled:
-                    type: boolean
-                    description: Whether this alert route is enabled or not
-                    example: false
-                escalation_bindings:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/AlertRouteEscalationBindingPayloadV2'
-                    description: Which escalation paths should this alert route escalate to?
-                    example:
-                        - binding:
-                            array_value:
-                                - literal: SEV123
-                                  reference: incident.severity
-                            value:
-                                literal: SEV123
-                                reference: incident.severity
-                expressions:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/ExpressionPayloadV2'
-                    description: The expressions used in this template
-                    example:
-                        - else_branch:
-                            result:
-                                array_value:
-                                    - literal: SEV123
-                                      reference: incident.severity
-                                value:
-                                    literal: SEV123
-                                    reference: incident.severity
-                          label: Team Slack channel
-                          operations:
-                            - branches:
-                                branches:
-                                    - condition_groups:
-                                        - conditions:
-                                            - operation: one_of
-                                              param_bindings:
-                                                - array_value:
-                                                    - literal: SEV123
-                                                      reference: incident.severity
-                                                  value:
-                                                    literal: SEV123
-                                                    reference: incident.severity
-                                              subject: incident.severity
-                                      result:
-                                        array_value:
-                                            - literal: SEV123
-                                              reference: incident.severity
-                                        value:
-                                            literal: SEV123
-                                            reference: incident.severity
-                                returns:
-                                    array: true
-                                    type: IncidentStatus
-                              filter:
-                                condition_groups:
-                                    - conditions:
-                                        - operation: one_of
-                                          param_bindings:
-                                            - array_value:
-                                                - literal: SEV123
-                                                  reference: incident.severity
-                                              value:
-                                                literal: SEV123
-                                                reference: incident.severity
-                                          subject: incident.severity
-                              navigate:
-                                reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
-                              operation_type: navigate
-                              parse:
-                                returns:
-                                    array: true
-                                    type: IncidentStatus
-                                source: metadata.annotations["github.com/repo"]
-                          reference: abc123
-                          root_reference: incident.status
-                grouping_keys:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/GroupingKeyV2'
-                    description: Which attributes should this alert route use to group alerts?
-                    example:
-                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                grouping_window_seconds:
-                    type: integer
-                    description: How large should the grouping window be?
-                    example: 1
-                    format: int64
-                incident_condition_groups:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
-                    description: What condition groups must be true for this alert route to create an incident?
-                    example:
-                        - conditions:
-                            - operation: one_of
-                              param_bindings:
-                                - array_value:
-                                    - literal: SEV123
-                                      reference: incident.severity
-                                  value:
-                                    literal: SEV123
-                                    reference: incident.severity
-                              subject: incident.severity
-                incident_enabled:
-                    type: boolean
-                    description: Whether this alert route will create incidents or not
-                    example: false
-                name:
-                    type: string
-                    description: The name of this alert route config, for the user's reference
-                    example: Production incidents
-                template:
-                    $ref: '#/components/schemas/AlertRouteIncidentTemplatePayloadV2'
-            example:
-                alert_source_ids:
-                    - 02FCNDV6P870EA6S7TK1DSYDG2
-                auto_decline_enabled: false
-                condition_groups:
-                    - conditions:
-                        - operation: one_of
-                          param_bindings:
-                            - array_value:
-                                - literal: SEV123
-                                  reference: incident.severity
-                              value:
-                                literal: SEV123
-                                reference: incident.severity
-                          subject: incident.severity
-                defer_time_seconds: 1
-                enabled: false
-                escalation_bindings:
-                    - binding:
-                        array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                        value:
-                            literal: SEV123
-                            reference: incident.severity
-                expressions:
-                    - else_branch:
-                        result:
-                            array_value:
-                                - literal: SEV123
-                                  reference: incident.severity
-                            value:
-                                literal: SEV123
-                                reference: incident.severity
-                      label: Team Slack channel
-                      operations:
-                        - branches:
-                            branches:
-                                - condition_groups:
-                                    - conditions:
-                                        - operation: one_of
-                                          param_bindings:
-                                            - array_value:
-                                                - literal: SEV123
-                                                  reference: incident.severity
-                                              value:
-                                                literal: SEV123
-                                                reference: incident.severity
-                                          subject: incident.severity
-                                  result:
-                                    array_value:
-                                        - literal: SEV123
-                                          reference: incident.severity
-                                    value:
-                                        literal: SEV123
-                                        reference: incident.severity
-                            returns:
-                                array: true
-                                type: IncidentStatus
-                          filter:
-                            condition_groups:
-                                - conditions:
-                                    - operation: one_of
-                                      param_bindings:
-                                        - array_value:
-                                            - literal: SEV123
-                                              reference: incident.severity
-                                          value:
-                                            literal: SEV123
-                                            reference: incident.severity
-                                      subject: incident.severity
-                          navigate:
-                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
-                          operation_type: navigate
-                          parse:
-                            returns:
-                                array: true
-                                type: IncidentStatus
-                            source: metadata.annotations["github.com/repo"]
-                      reference: abc123
-                      root_reference: incident.status
-                grouping_keys:
-                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                grouping_window_seconds: 1
-                incident_condition_groups:
-                    - conditions:
-                        - operation: one_of
-                          param_bindings:
-                            - array_value:
-                                - literal: SEV123
-                                  reference: incident.severity
-                              value:
-                                literal: SEV123
-                                reference: incident.severity
-                          subject: incident.severity
-                incident_enabled: false
-                name: Production incidents
-                template:
-                    custom_field_priorities:
-                        abc123: abc123
-                    custom_fields:
-                        custom_field_10014:
-                            array_value:
-                                - literal: SEV123
-                                  reference: incident.severity
-                            value:
-                                literal: SEV123
-                                reference: incident.severity
-                    incident_mode:
-                        array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                        value:
-                            literal: SEV123
-                            reference: incident.severity
-                    incident_type:
-                        array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                        value:
-                            literal: SEV123
-                            reference: incident.severity
-                    name:
-                        array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                        value:
-                            literal: SEV123
-                            reference: incident.severity
-                    priority_severity: severity-first-wins
-                    severity:
-                        array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                        value:
-                            literal: SEV123
-                            reference: incident.severity
-                    summary:
-                        array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                        value:
-                            literal: SEV123
-                            reference: incident.severity
-                    workspace:
-                        array_value:
-                            - literal: SEV123
-                              reference: incident.severity
-                        value:
-                            literal: SEV123
-                            reference: incident.severity
-        CreateRequestBody2:
-            type: object
-            properties:
                 custom_field_id:
                     type: string
                     description: ID of the custom field this option belongs to
@@ -14424,7 +16153,7 @@ components:
             required:
                 - custom_field_id
                 - value
-        CreateRequestBody3:
+        CreateRequestBody2:
             type: object
             properties:
                 description:
@@ -14499,7 +16228,7 @@ components:
                 - options
                 - created_at
                 - updated_at
-        CreateRequestBody4:
+        CreateRequestBody3:
             type: object
             properties:
                 description:
@@ -14533,7 +16262,7 @@ components:
                 - cannot_be_unset
                 - created_at
                 - updated_at
-        CreateRequestBody5:
+        CreateRequestBody4:
             type: object
             properties:
                 incident_id:
@@ -14584,7 +16313,7 @@ components:
             required:
                 - incident_id
                 - resource
-        CreateRequestBody6:
+        CreateRequestBody5:
             type: object
             properties:
                 incident_id:
@@ -14599,7 +16328,7 @@ components:
             required:
                 - user_id
                 - incident_id
-        CreateRequestBody7:
+        CreateRequestBody6:
             type: object
             properties:
                 description:
@@ -14641,7 +16370,7 @@ components:
                 - role_type
                 - created_at
                 - updated_at
-        CreateRequestBody8:
+        CreateRequestBody7:
             type: object
             properties:
                 description:
@@ -14677,7 +16406,7 @@ components:
                 - role_type
                 - created_at
                 - updated_at
-        CreateRequestBody9:
+        CreateRequestBody8:
             type: object
             properties:
                 category:
@@ -14708,252 +16437,7 @@ components:
                 - rank
                 - created_at
                 - updated_at
-        CreateRequestBody10:
-            type: object
-            properties:
-                custom_field_entries:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/CustomFieldEntryPayloadV1'
-                    description: Set the incident's custom fields to these values
-                    example:
-                        - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          values:
-                            - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              value_link: https://google.com/
-                              value_numeric: "123.456"
-                              value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              value_text: This is my text field, I hope you like it
-                              value_timestamp: ""
-                idempotency_key:
-                    type: string
-                    description: Unique string used to de-duplicate incident create requests
-                    example: alert-uuid
-                incident_role_assignments:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/IncidentRoleAssignmentPayloadV1'
-                    description: Assign incident roles to these people
-                    example:
-                        - assignee:
-                            email: bob@example.com
-                            id: 01G0J1EXE7AXZ2C93K61WBPYEH
-                            slack_user_id: USER123
-                          incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-                incident_type_id:
-                    type: string
-                    description: Incident type to create this incident as
-                    example: 01FH5TZRWMNAFB0DZ23FD1TV96
-                mode:
-                    type: string
-                    description: Whether the incident is real or test
-                    example: real
-                    enum:
-                        - real
-                        - test
-                name:
-                    type: string
-                    description: Explanation of the incident
-                    example: Our database is sad
-                severity_id:
-                    type: string
-                    description: Severity to create incident as
-                    example: 01FH5TZRWMNAFB0DZ23FD1TV96
-                slack_team_id:
-                    type: string
-                    description: ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
-                    example: T02A1FSLE8J
-                source_message_channel_id:
-                    type: string
-                    description: Channel ID of the source message, if this incident was created from one
-                    example: C02AW36C1M5
-                source_message_timestamp:
-                    type: string
-                    description: Timestamp of the source message, if this incident was created from one
-                    example: "1653650280.526509"
-                status:
-                    type: string
-                    description: Current status of the incident
-                    example: triage
-                    enum:
-                        - triage
-                        - investigating
-                        - fixing
-                        - monitoring
-                        - closed
-                        - declined
-                summary:
-                    type: string
-                    description: Detailed description of the incident
-                    example: Our database is really really sad, and we don't know why yet.
-                visibility:
-                    type: string
-                    description: Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-                    example: public
-                    enum:
-                        - public
-                        - private
-            example:
-                custom_field_entries:
-                    - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      values:
-                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          value_link: https://google.com/
-                          value_numeric: "123.456"
-                          value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          value_text: This is my text field, I hope you like it
-                          value_timestamp: ""
-                idempotency_key: alert-uuid
-                incident_role_assignments:
-                    - assignee:
-                        email: bob@example.com
-                        id: 01G0J1EXE7AXZ2C93K61WBPYEH
-                        slack_user_id: USER123
-                      incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-                incident_type_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-                mode: real
-                name: Our database is sad
-                severity_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-                slack_team_id: T02A1FSLE8J
-                source_message_channel_id: C02AW36C1M5
-                source_message_timestamp: "1653650280.526509"
-                status: triage
-                summary: Our database is really really sad, and we don't know why yet.
-                visibility: public
-            required:
-                - idempotency_key
-                - visibility
-        CreateRequestBody11:
-            type: object
-            properties:
-                custom_field_entries:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/CustomFieldEntryPayloadV1'
-                    description: Set the incident's custom fields to these values
-                    example:
-                        - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          values:
-                            - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              value_link: https://google.com/
-                              value_numeric: "123.456"
-                              value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                              value_text: This is my text field, I hope you like it
-                              value_timestamp: ""
-                id:
-                    type: string
-                    description: Unique identifier for the incident
-                    example: 01FDAG4SAP5TYPT98WGR2N7W91
-                idempotency_key:
-                    type: string
-                    description: Unique string used to de-duplicate incident create requests
-                    example: alert-uuid
-                incident_role_assignments:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/IncidentRoleAssignmentPayloadV2'
-                    description: Assign incident roles to these people
-                    example:
-                        - assignee:
-                            email: bob@example.com
-                            id: 01G0J1EXE7AXZ2C93K61WBPYEH
-                            slack_user_id: USER123
-                          incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-                incident_status_id:
-                    type: string
-                    description: Incident status to assign to the incident
-                    example: 01G0J1EXE7AXZ2C93K61WBPYEH
-                incident_timestamp_values:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/IncidentTimestampValuePayloadV2'
-                    description: Assign the incident's timestamps to these values
-                    example:
-                        - incident_timestamp_id: 01FCNDV6P870EA6S7TK1DSYD5H
-                          value: "2021-08-17T13:28:57.801578Z"
-                incident_type_id:
-                    type: string
-                    description: Incident type to create this incident as
-                    example: 01FH5TZRWMNAFB0DZ23FD1TV96
-                mode:
-                    type: string
-                    description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
-                    example: standard
-                    enum:
-                        - standard
-                        - retrospective
-                        - test
-                        - tutorial
-                name:
-                    type: string
-                    description: Explanation of the incident
-                    example: Our database is sad
-                retrospective_incident_options:
-                    $ref: '#/components/schemas/RetrospectiveIncidentOptionsV2'
-                severity_id:
-                    type: string
-                    description: Severity to create incident as
-                    example: 01FH5TZRWMNAFB0DZ23FD1TV96
-                slack_channel_name_override:
-                    type: string
-                    description: Name of the Slack channel to create for this incident
-                    example: inc-123-database-down
-                slack_team_id:
-                    type: string
-                    description: Slack Team to create the incident in
-                    example: T02A1FSLE8J
-                summary:
-                    type: string
-                    description: Detailed description of the incident
-                    example: Our database is really really sad, and we don't know why yet.
-                visibility:
-                    type: string
-                    description: Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-                    example: public
-                    enum:
-                        - public
-                        - private
-            example:
-                custom_field_entries:
-                    - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                      values:
-                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          value_link: https://google.com/
-                          value_numeric: "123.456"
-                          value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
-                          value_text: This is my text field, I hope you like it
-                          value_timestamp: ""
-                id: 01FDAG4SAP5TYPT98WGR2N7W91
-                idempotency_key: alert-uuid
-                incident_role_assignments:
-                    - assignee:
-                        email: bob@example.com
-                        id: 01G0J1EXE7AXZ2C93K61WBPYEH
-                        slack_user_id: USER123
-                      incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-                incident_status_id: 01G0J1EXE7AXZ2C93K61WBPYEH
-                incident_timestamp_values:
-                    - incident_timestamp_id: 01FCNDV6P870EA6S7TK1DSYD5H
-                      value: "2021-08-17T13:28:57.801578Z"
-                incident_type_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-                mode: standard
-                name: Our database is sad
-                retrospective_incident_options:
-                    postmortem_document_url: https://docs.google.com/my_doc_id
-                    slack_channel_id: abc123
-                severity_id: 01FH5TZRWMNAFB0DZ23FD1TV96
-                slack_channel_name_override: inc-123-database-down
-                slack_team_id: T02A1FSLE8J
-                summary: Our database is really really sad, and we don't know why yet.
-                visibility: public
-            required:
-                - idempotency_key
-                - visibility
-        CreateRequestBody12:
+        CreateRequestBody9:
             type: object
             properties:
                 schedule:
@@ -14989,7 +16473,7 @@ components:
                     timezone: America/Los_Angeles
             required:
                 - schedule
-        CreateRequestBody13:
+        CreateRequestBody10:
             type: object
             properties:
                 description:
@@ -15386,7 +16870,7 @@ components:
                     updated_at: "2021-08-17T13:28:57.801578Z"
             required:
                 - catalog_type
-        CreateWorkflowRequestBody:
+        CreateWorkflowPayload:
             type: object
             properties:
                 annotations:
@@ -15504,7 +16988,8 @@ components:
                     type: array
                     items:
                         type: string
-                        example: test
+                        description: Incident mode that workflows can run on
+                        example: standard
                         enum:
                             - standard
                             - test
@@ -15689,6 +17174,39 @@ components:
             required:
                 - custom_field_id
                 - values
+        CustomFieldEntryPayloadV2:
+            type: object
+            properties:
+                custom_field_id:
+                    type: string
+                    description: ID of the custom field this entry is linked against
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                values:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CustomFieldValuePayloadV2'
+                    description: List of values to associate with this entry. Use an empty array to unset the value of the custom field.
+                    example:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_link: https://google.com/
+                          value_numeric: "123.456"
+                          value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_text: This is my text field, I hope you like it
+                          value_timestamp: ""
+            example:
+                custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                values:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      value_link: https://google.com/
+                      value_numeric: "123.456"
+                      value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      value_text: This is my text field, I hope you like it
+                      value_timestamp: ""
+            required:
+                - custom_field_id
+                - values
         CustomFieldEntryV1:
             type: object
             properties:
@@ -15745,7 +17263,170 @@ components:
             required:
                 - custom_field
                 - values
+        CustomFieldEntryV2:
+            type: object
+            properties:
+                custom_field:
+                    $ref: '#/components/schemas/CustomFieldTypeInfoV2'
+                values:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CustomFieldValueV2'
+                    description: List of custom field values set on this entry
+                    example:
+                        - value_catalog_entry:
+                            aliases:
+                                - lawrence@incident.io
+                                - lawrence
+                            external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: Primary On-call
+                          value_link: https://google.com/
+                          value_numeric: "123.456"
+                          value_option:
+                            custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            sort_key: 10
+                            value: Product
+                          value_text: This is my text field, I hope you like it
+            example:
+                custom_field:
+                    description: Which team is impacted by this issue
+                    field_type: single_select
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: Affected Team
+                    options:
+                        - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          sort_key: 10
+                          value: Product
+                values:
+                    - value_catalog_entry:
+                        aliases:
+                            - lawrence@incident.io
+                            - lawrence
+                        external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Primary On-call
+                      value_link: https://google.com/
+                      value_numeric: "123.456"
+                      value_option:
+                        custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        sort_key: 10
+                        value: Product
+                      value_text: This is my text field, I hope you like it
+            required:
+                - custom_field
+                - values
+        CustomFieldOptionDefinitionsV1:
+            type: object
+            properties:
+                archived_at:
+                    type: string
+                    description: When this option was archived
+                    example: "2021-08-17T14:28:57.801578Z"
+                    format: date-time
+                custom_field_id:
+                    type: string
+                    description: ID of the custom field this option belongs to
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                id:
+                    type: string
+                    description: Unique identifier for the custom field option
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                sort_key:
+                    type: integer
+                    description: Sort key used to order the custom field options correctly
+                    default: 1000
+                    example: 10
+                    format: int64
+                value:
+                    type: string
+                    description: Human readable name for the custom field option
+                    example: Product
+            example:
+                archived_at: "2021-08-17T14:28:57.801578Z"
+                custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                sort_key: 10
+                value: Product
+        CustomFieldOptionDefinitionsV2:
+            type: object
+            properties:
+                archived_at:
+                    type: string
+                    description: When this option was archived
+                    example: "2021-08-17T14:28:57.801578Z"
+                    format: date-time
+                custom_field_id:
+                    type: string
+                    description: ID of the custom field this option belongs to
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                id:
+                    type: string
+                    description: Unique identifier for the custom field option
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                sort_key:
+                    type: integer
+                    description: Sort key used to order the custom field options correctly
+                    default: 1000
+                    example: 10
+                    format: int64
+                value:
+                    type: string
+                    description: Human readable name for the custom field option
+                    example: Product
+            example:
+                archived_at: "2021-08-17T14:28:57.801578Z"
+                custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                sort_key: 10
+                value: Product
+        CustomFieldOptionPayloadV1:
+            type: object
+            example: {}
+            required:
+                - custom_field_id
+                - value
+        CustomFieldOptionPayloadV2:
+            type: object
+            example: {}
+            required:
+                - custom_field_id
+                - value
         CustomFieldOptionV1:
+            type: object
+            properties:
+                custom_field_id:
+                    type: string
+                    description: ID of the custom field this option belongs to
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                id:
+                    type: string
+                    description: Unique identifier for the custom field option
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                sort_key:
+                    type: integer
+                    description: Sort key used to order the custom field options correctly
+                    default: 1000
+                    example: 10
+                    format: int64
+                value:
+                    type: string
+                    description: Human readable name for the custom field option
+                    example: Product
+            example:
+                custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                sort_key: 10
+                value: Product
+            required:
+                - id
+                - custom_field_id
+                - value
+                - sort_key
+        CustomFieldOptionV2:
             type: object
             properties:
                 custom_field_id:
@@ -15806,6 +17487,67 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/CustomFieldOptionV1'
+                    description: What options are available for this custom field, if this field has options
+                    example:
+                        - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          sort_key: 10
+                          value: Product
+            example:
+                description: Which team is impacted by this issue
+                field_type: single_select
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Affected Team
+                options:
+                    - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      sort_key: 10
+                      value: Product
+            required:
+                - id
+                - organisation_id
+                - name
+                - description
+                - dynamic_options
+                - rank
+                - field_type
+                - cannot_be_unset
+                - options
+                - is_usable
+                - condition_groups
+                - field_mode
+                - created_at
+                - updated_at
+        CustomFieldTypeInfoV2:
+            type: object
+            properties:
+                description:
+                    type: string
+                    description: Description of the custom field
+                    example: Which team is impacted by this issue
+                field_type:
+                    type: string
+                    description: Type of custom field
+                    example: single_select
+                    enum:
+                        - single_select
+                        - multi_select
+                        - text
+                        - link
+                        - numeric
+                id:
+                    type: string
+                    description: Unique identifier for the custom field
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                name:
+                    type: string
+                    description: Human readable name for the custom field
+                    example: Affected Team
+                    maxLength: 50
+                options:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CustomFieldOptionV2'
                     description: What options are available for this custom field, if this field has options
                     example:
                         - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -16005,7 +17747,168 @@ components:
                 - cannot_be_unset
                 - created_at
                 - updated_at
+        CustomFieldValueDefinitionsV1:
+            type: object
+            properties:
+                created_at:
+                    type: string
+                    description: When the value was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                custom_field_id:
+                    type: string
+                    description: ID of the custom field this option belongs to
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                id:
+                    type: string
+                    description: Unique identifier for the custom field value
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                incident_id:
+                    type: string
+                    description: ID of the incident this value is defined on
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                updated_at:
+                    type: string
+                    description: When the value was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                value_catalog_entry_id:
+                    type: string
+                    description: ID of the catalog entry.
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_link:
+                    type: string
+                    description: If the custom field type is 'link', this will contain the value assigned.
+                    example: https://google.com/
+                value_numeric:
+                    type: string
+                    description: If the custom field type is 'numeric', this will contain the value assigned.
+                    example: "123.456"
+                value_option_id:
+                    type: string
+                    description: ID of the custom field option
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_option_value:
+                    type: string
+                    description: The value of a new option that should be created, if the field supports dynamic options. If this conflicts with an existing option label, you must use its ID instead.
+                    example: New option
+                value_text:
+                    type: string
+                    description: If the custom field type is 'text', this will contain the value assigned.
+                    example: This is my text field, I hope you like it
+            example:
+                created_at: "2021-08-17T13:28:57.801578Z"
+                custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                incident_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                updated_at: "2021-08-17T13:28:57.801578Z"
+                value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_link: https://google.com/
+                value_numeric: "123.456"
+                value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_option_value: New option
+                value_text: This is my text field, I hope you like it
+        CustomFieldValueDefinitionsV2:
+            type: object
+            properties:
+                created_at:
+                    type: string
+                    description: When the value was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                custom_field_id:
+                    type: string
+                    description: ID of the custom field this option belongs to
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                id:
+                    type: string
+                    description: Unique identifier for the custom field value
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                incident_id:
+                    type: string
+                    description: ID of the incident this value is defined on
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                updated_at:
+                    type: string
+                    description: When the value was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                value_catalog_entry_id:
+                    type: string
+                    description: ID of the catalog entry.
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_link:
+                    type: string
+                    description: If the custom field type is 'link', this will contain the value assigned.
+                    example: https://google.com/
+                value_numeric:
+                    type: string
+                    description: If the custom field type is 'numeric', this will contain the value assigned.
+                    example: "123.456"
+                value_option_id:
+                    type: string
+                    description: ID of the custom field option
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_option_value:
+                    type: string
+                    description: The value of a new option that should be created, if the field supports dynamic options. If this conflicts with an existing option label, you must use its ID instead.
+                    example: New option
+                value_text:
+                    type: string
+                    description: If the custom field type is 'text', this will contain the value assigned.
+                    example: This is my text field, I hope you like it
+            example:
+                created_at: "2021-08-17T13:28:57.801578Z"
+                custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                incident_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                updated_at: "2021-08-17T13:28:57.801578Z"
+                value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_link: https://google.com/
+                value_numeric: "123.456"
+                value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_option_value: New option
+                value_text: This is my text field, I hope you like it
         CustomFieldValuePayloadV1:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Unique identifier for the custom field value
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_catalog_entry_id:
+                    type: string
+                    description: ID of the catalog entry. You can also use an ExternalID or an Alias of the catalog entry.
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_link:
+                    type: string
+                    description: If the custom field type is 'link', this will contain the value assigned.
+                    example: https://google.com/
+                value_numeric:
+                    type: string
+                    description: If the custom field type is 'numeric', this will contain the value assigned.
+                    example: "123.456"
+                value_option_id:
+                    type: string
+                    description: ID of the custom field option
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_text:
+                    type: string
+                    description: If the custom field type is 'text', this will contain the value assigned.
+                    example: This is my text field, I hope you like it
+                value_timestamp:
+                    type: string
+                    description: 'Deprecated: please use incident timestamp values instead'
+                    example: ""
+            example:
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_link: https://google.com/
+                value_numeric: "123.456"
+                value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                value_text: This is my text field, I hope you like it
+                value_timestamp: ""
+        CustomFieldValuePayloadV2:
             type: object
             properties:
                 id:
@@ -16059,6 +17962,41 @@ components:
                     example: "123.456"
                 value_option:
                     $ref: '#/components/schemas/CustomFieldOptionV1'
+                value_text:
+                    type: string
+                    description: If the custom field type is 'text', this will contain the value assigned.
+                    example: This is my text field, I hope you like it
+            example:
+                value_catalog_entry:
+                    aliases:
+                        - lawrence@incident.io
+                        - lawrence
+                    external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: Primary On-call
+                value_link: https://google.com/
+                value_numeric: "123.456"
+                value_option:
+                    custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    sort_key: 10
+                    value: Product
+                value_text: This is my text field, I hope you like it
+        CustomFieldValueV2:
+            type: object
+            properties:
+                value_catalog_entry:
+                    $ref: '#/components/schemas/EmbeddedCatalogEntryV2'
+                value_link:
+                    type: string
+                    description: If the custom field type is 'link', this will contain the value assigned.
+                    example: https://google.com/
+                value_numeric:
+                    type: string
+                    description: If the custom field type is 'numeric', this will contain the value assigned.
+                    example: "123.456"
+                value_option:
+                    $ref: '#/components/schemas/CustomFieldOptionV2'
                 value_text:
                     type: string
                     description: If the custom field type is 'text', this will contain the value assigned.
@@ -16154,6 +18092,108 @@ components:
                 - id
                 - name
                 - catalog_type_id
+        EmbeddedCatalogEntryV2:
+            type: object
+            properties:
+                aliases:
+                    type: array
+                    items:
+                        type: string
+                        example: abc123
+                    description: Optional aliases that can be used to reference this entry
+                    example:
+                        - lawrence@incident.io
+                        - lawrence
+                external_id:
+                    type: string
+                    description: An optional alternative ID for this entry, which is ensured to be unique for the type
+                    example: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                id:
+                    type: string
+                    description: ID of this catalog entry
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                name:
+                    type: string
+                    description: Name is the human readable name of this entry
+                    example: Primary On-call
+            example:
+                aliases:
+                    - lawrence@incident.io
+                    - lawrence
+                external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Primary On-call
+            required:
+                - id
+                - name
+                - catalog_type_id
+        EmbeddedIncidentRoleV2:
+            type: object
+            properties:
+                created_at:
+                    type: string
+                    description: When the role was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                description:
+                    type: string
+                    description: Describes the purpose of the role
+                    example: The person currently coordinating the incident
+                    minLength: 1
+                id:
+                    type: string
+                    description: Unique identifier for the role
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                instructions:
+                    type: string
+                    description: Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
+                    example: Take point on the incident; Make sure people are clear on responsibilities
+                name:
+                    type: string
+                    description: Human readable name of the incident role
+                    example: Incident Lead
+                    minLength: 1
+                required:
+                    type: boolean
+                    description: This field is deprecated.
+                    example: false
+                role_type:
+                    type: string
+                    description: Type of incident role
+                    example: lead
+                    enum:
+                        - lead
+                        - reporter
+                        - custom
+                shortform:
+                    type: string
+                    description: Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
+                    example: lead
+                updated_at:
+                    type: string
+                    description: When the role was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+            example:
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: The person currently coordinating the incident
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                instructions: Take point on the incident; Make sure people are clear on responsibilities
+                name: Incident Lead
+                required: false
+                role_type: lead
+                shortform: lead
+                updated_at: "2021-08-17T13:28:57.801578Z"
+            required:
+                - name
+                - shortform
+                - description
+                - instructions
+                - condition_groups
+                - id
+                - role_type
+                - created_at
+                - updated_at
         EngineParamBindingPayloadV2:
             type: object
             properties:
@@ -16203,7 +18243,7 @@ components:
                 array_value:
                     type: array
                     items:
-                        $ref: '#/components/schemas/EngineParamBindingValueV3'
+                        $ref: '#/components/schemas/EngineParamBindingValueV4'
                     description: If array_value is set, this helps render the values
                     example:
                         - label: Lawrence Jones
@@ -16211,6 +18251,213 @@ components:
                           reference: incident.severity
                 value:
                     $ref: '#/components/schemas/EngineParamBindingValueV3'
+            example:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        EngineParamBindingV4:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingValueV6'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                value:
+                    $ref: '#/components/schemas/EngineParamBindingValueV5'
+            example:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        EngineParamBindingV5:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingValueV8'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                value:
+                    $ref: '#/components/schemas/EngineParamBindingValueV7'
+            example:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        EngineParamBindingV6:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingValueV10'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                value:
+                    $ref: '#/components/schemas/EngineParamBindingValueV9'
+            example:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        EngineParamBindingV7:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingValueV12'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                value:
+                    $ref: '#/components/schemas/EngineParamBindingValueV11'
+            example:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        EngineParamBindingV8:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingValueV14'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                value:
+                    $ref: '#/components/schemas/EngineParamBindingValueV13'
+            example:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        EngineParamBindingV9:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingValueV16'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                value:
+                    $ref: '#/components/schemas/EngineParamBindingValueV15'
+            example:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        EngineParamBindingV10:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingValueV18'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                value:
+                    $ref: '#/components/schemas/EngineParamBindingValueV17'
+            example:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        EngineParamBindingV11:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingValueV20'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                value:
+                    $ref: '#/components/schemas/EngineParamBindingValueV19'
+            example:
+                array_value:
+                    - label: Lawrence Jones
+                      literal: SEV123
+                      reference: incident.severity
+                value:
+                    label: Lawrence Jones
+                    literal: SEV123
+                    reference: incident.severity
+        EngineParamBindingV12:
+            type: object
+            properties:
+                array_value:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamBindingValueV22'
+                    description: If array_value is set, this helps render the values
+                    example:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                value:
+                    $ref: '#/components/schemas/EngineParamBindingValueV21'
             example:
                 array_value:
                     - label: Lawrence Jones
@@ -16277,6 +18524,463 @@ components:
                 reference: incident.severity
             required:
                 - label
+        EngineParamBindingValueV4:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV5:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV6:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV7:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV8:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV9:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV10:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV11:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV12:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV13:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV14:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV15:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV16:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV17:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV18:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV19:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV20:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV21:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamBindingValueV22:
+            type: object
+            properties:
+                label:
+                    type: string
+                    description: Human readable label to be displayed for user to select
+                    example: Lawrence Jones
+                literal:
+                    type: string
+                    description: If set, this is the literal value of the step parameter
+                    example: SEV123
+                reference:
+                    type: string
+                    description: If set, this is the reference into the trigger scope that is the value of this parameter
+                    example: incident.severity
+            example:
+                label: Lawrence Jones
+                literal: SEV123
+                reference: incident.severity
+            required:
+                - label
+        EngineParamV2:
+            type: object
+            properties:
+                array:
+                    type: boolean
+                    description: Whether this parameter is an array
+                    example: true
+                default_value:
+                    $ref: '#/components/schemas/EngineParamBindingV2'
+                description:
+                    type: string
+                    description: A string describing the param
+                    example: What slack channel should we send the message to?
+                infer_reference:
+                    type: boolean
+                    description: Whether this parameter should be inferred as a reference from the scope
+                    example: true
+                label:
+                    type: string
+                    description: Human readable label for this parameter
+                    example: To date
+                name:
+                    type: string
+                    description: The unique identifier for the parameter
+                    example: severity
+                optional:
+                    type: boolean
+                    description: Whether this parameter is optional
+                    example: true
+                type:
+                    type: string
+                    description: The type of the parameter
+                    example: IncidentSeverity
+            example:
+                array: true
+                default_value:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+                description: What slack channel should we send the message to?
+                infer_reference: true
+                label: To date
+                name: severity
+                optional: true
+                type: IncidentSeverity
+            required:
+                - name
+                - label
+                - type
+                - array
+                - optional
+                - infer_reference
+                - description
         EngineReferenceV2:
             type: object
             properties:
@@ -16308,6 +19012,101 @@ components:
                 - array
                 - node_label
                 - hide_filter
+        ErrorResponse:
+            type: object
+            properties:
+                errors:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ErrorSingle'
+                    description: List of errors that caused this request to fail
+                    example:
+                        - code: trial_expired
+                          message: Default incident call link must be a valid URL
+                          source:
+                            field: default_call_url
+                            pointer: /settings/default_call_url
+                request_id:
+                    type: string
+                    description: Unique identifier of the request
+                    example: FF1D889F-0741-6290-783B-66E606310D86
+                    format: uuid
+                status:
+                    type: integer
+                    description: HTTP status of the response
+                    example: 429
+                    format: int64
+                type:
+                    type: string
+                    description: Machine-readable identifier for the general category of error
+                    example: invalid_request_error
+                    enum:
+                        - invalid_request_error
+                        - authentication_error
+                        - resource_forbidden
+                        - not_found
+                        - not_acceptable
+                        - conflict
+                        - precondition_failed
+                        - payload_too_large
+                        - validation_error
+                        - too_many_requests
+                        - api_error
+                        - rate_limit_reached
+            example:
+                errors:
+                    - code: trial_expired
+                      message: Default incident call link must be a valid URL
+                      source:
+                        field: default_call_url
+                        pointer: /settings/default_call_url
+                request_id: FF1D889F-0741-6290-783B-66E606310D86
+                status: 429
+                type: invalid_request_error
+            required:
+                - type
+                - status
+                - request_id
+                - errors
+        ErrorSingle:
+            type: object
+            properties:
+                code:
+                    type: string
+                    description: Machine-readable identifier for this specific error
+                    example: trial_expired
+                message:
+                    type: string
+                    description: Human readable description of the error
+                    example: Default incident call link must be a valid URL
+                source:
+                    $ref: '#/components/schemas/ErrorSource'
+            example:
+                code: trial_expired
+                message: Default incident call link must be a valid URL
+                source:
+                    field: default_call_url
+                    pointer: /settings/default_call_url
+            required:
+                - code
+                - message
+        ErrorSource:
+            type: object
+            properties:
+                field:
+                    type: string
+                    description: Field name that is the source of the error
+                    example: default_call_url
+                pointer:
+                    type: string
+                    description: JSON pointer to the request field that is the source of the error
+                    example: /settings/default_call_url
+            example:
+                field: default_call_url
+                pointer: /settings/default_call_url
+            required:
+                - field
+                - pointer
         EscalationPathNodeIfElsePayloadV2:
             type: object
             properties:
@@ -16355,7 +19154,7 @@ components:
                             targets:
                                 - id: lawrencejones
                                   schedule_mode: currently_on_call
-                                  type: user
+                                  type: schedule
                                   urgency: high
                             time_to_ack_interval_condition: active
                             time_to_ack_seconds: 1800
@@ -16393,7 +19192,7 @@ components:
                             targets:
                                 - id: lawrencejones
                                   schedule_mode: currently_on_call
-                                  type: user
+                                  type: schedule
                                   urgency: high
                             time_to_ack_interval_condition: active
                             time_to_ack_seconds: 1800
@@ -16437,7 +19236,7 @@ components:
                         targets:
                             - id: lawrencejones
                               schedule_mode: currently_on_call
-                              type: user
+                              type: schedule
                               urgency: high
                         time_to_ack_interval_condition: active
                         time_to_ack_seconds: 1800
@@ -16470,7 +19269,7 @@ components:
                         targets:
                             - id: lawrencejones
                               schedule_mode: currently_on_call
-                              type: user
+                              type: schedule
                               urgency: high
                         time_to_ack_interval_condition: active
                         time_to_ack_seconds: 1800
@@ -16541,7 +19340,7 @@ components:
                             targets:
                                 - id: lawrencejones
                                   schedule_mode: currently_on_call
-                                  type: user
+                                  type: schedule
                                   urgency: high
                             time_to_ack_interval_condition: active
                             time_to_ack_seconds: 1800
@@ -16585,7 +19384,7 @@ components:
                             targets:
                                 - id: lawrencejones
                                   schedule_mode: currently_on_call
-                                  type: user
+                                  type: schedule
                                   urgency: high
                             time_to_ack_interval_condition: active
                             time_to_ack_seconds: 1800
@@ -16641,7 +19440,7 @@ components:
                         targets:
                             - id: lawrencejones
                               schedule_mode: currently_on_call
-                              type: user
+                              type: schedule
                               urgency: high
                         time_to_ack_interval_condition: active
                         time_to_ack_seconds: 1800
@@ -16680,7 +19479,7 @@ components:
                         targets:
                             - id: lawrencejones
                               schedule_mode: currently_on_call
-                              type: user
+                              type: schedule
                               urgency: high
                         time_to_ack_interval_condition: active
                         time_to_ack_seconds: 1800
@@ -16706,7 +19505,7 @@ components:
                     example:
                         - id: lawrencejones
                           schedule_mode: currently_on_call
-                          type: user
+                          type: schedule
                           urgency: high
                 time_to_ack_interval_condition:
                     type: string
@@ -16731,7 +19530,7 @@ components:
                 targets:
                     - id: lawrencejones
                       schedule_mode: currently_on_call
-                      type: user
+                      type: schedule
                       urgency: high
                 time_to_ack_interval_condition: active
                 time_to_ack_seconds: 1800
@@ -16784,7 +19583,7 @@ components:
                     targets:
                         - id: lawrencejones
                           schedule_mode: currently_on_call
-                          type: user
+                          type: schedule
                           urgency: high
                     time_to_ack_interval_condition: active
                     time_to_ack_seconds: 1800
@@ -16866,7 +19665,7 @@ components:
                     targets:
                         - id: lawrencejones
                           schedule_mode: currently_on_call
-                          type: user
+                          type: schedule
                           urgency: high
                     time_to_ack_interval_condition: active
                     time_to_ack_seconds: 1800
@@ -16878,6 +19677,110 @@ components:
             required:
                 - id
                 - type
+        EscalationPathPayloadV2:
+            type: object
+            properties:
+                name:
+                    type: string
+                    description: The name of this escalation path, for the user's reference.
+                    example: Urgent Support
+                path:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EscalationPathNodePayloadV2'
+                    description: The nodes that form the levels and branches of this escalation path.
+                    example:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          if_else:
+                            conditions:
+                                - operation: one_of
+                                  param_bindings:
+                                    - array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject: incident.severity
+                            else_path:
+                                - {}
+                            then_path:
+                                - {}
+                          level:
+                            round_robin_config:
+                                enabled: false
+                                rotate_after_seconds: 120
+                            targets:
+                                - id: lawrencejones
+                                  schedule_mode: currently_on_call
+                                  type: schedule
+                                  urgency: high
+                            time_to_ack_interval_condition: active
+                            time_to_ack_seconds: 1800
+                            time_to_ack_weekday_interval_config_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          repeat:
+                            repeat_times: 3
+                            to_node: 01FCNDV6P870EA6S7TK1DSYDG0
+                          type: if_else
+                working_hours:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/WeekdayIntervalConfigV2'
+                    description: The working hours for this escalation path.
+                    example:
+                        - id: abc123
+                          name: abc123
+                          timezone: abc123
+                          weekday_intervals:
+                            - end_time: "17:00"
+                              start_time: "09:00"
+                              weekday: abc123
+            example:
+                name: Urgent Support
+                path:
+                    - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      if_else:
+                        conditions:
+                            - operation: one_of
+                              param_bindings:
+                                - array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject: incident.severity
+                        else_path:
+                            - {}
+                        then_path:
+                            - {}
+                      level:
+                        round_robin_config:
+                            enabled: false
+                            rotate_after_seconds: 120
+                        targets:
+                            - id: lawrencejones
+                              schedule_mode: currently_on_call
+                              type: schedule
+                              urgency: high
+                        time_to_ack_interval_condition: active
+                        time_to_ack_seconds: 1800
+                        time_to_ack_weekday_interval_config_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      repeat:
+                        repeat_times: 3
+                        to_node: 01FCNDV6P870EA6S7TK1DSYDG0
+                      type: if_else
+                working_hours:
+                    - id: abc123
+                      name: abc123
+                      timezone: abc123
+                      weekday_intervals:
+                        - end_time: "17:00"
+                          start_time: "09:00"
+                          weekday: abc123
+            required:
+                - name
+                - path
         EscalationPathRoundRobinConfigV2:
             type: object
             properties:
@@ -16913,8 +19816,7 @@ components:
                         - ""
                 type:
                     type: string
-                    description: Controls what type of entity this target identifies, such as EscalationPolicy or User
-                    example: user
+                    example: schedule
                     enum:
                         - schedule
                         - user
@@ -16929,7 +19831,7 @@ components:
             example:
                 id: lawrencejones
                 schedule_mode: currently_on_call
-                type: user
+                type: schedule
                 urgency: high
             required:
                 - type
@@ -16981,7 +19883,7 @@ components:
                             targets:
                                 - id: lawrencejones
                                   schedule_mode: currently_on_call
-                                  type: user
+                                  type: schedule
                                   urgency: high
                             time_to_ack_interval_condition: active
                             time_to_ack_seconds: 1800
@@ -17036,7 +19938,7 @@ components:
                         targets:
                             - id: lawrencejones
                               schedule_mode: currently_on_call
-                              type: user
+                              type: schedule
                               urgency: high
                         time_to_ack_interval_condition: active
                         time_to_ack_seconds: 1800
@@ -17165,7 +20067,7 @@ components:
                 condition_groups:
                     type: array
                     items:
-                        $ref: '#/components/schemas/ConditionGroupV3'
+                        $ref: '#/components/schemas/ConditionGroupV4'
                     description: When one of these condition groups are satisfied, this branch will be evaluated
                     example:
                         - conditions:
@@ -17185,7 +20087,64 @@ components:
                                 label: Incident Severity
                                 reference: incident.severity
                 result:
-                    $ref: '#/components/schemas/EngineParamBindingV3'
+                    $ref: '#/components/schemas/EngineParamBindingV6'
+            example:
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+                result:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+            required:
+                - condition_groups
+                - result
+        ExpressionBranchV4:
+            type: object
+            properties:
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupV7'
+                    description: When one of these condition groups are satisfied, this branch will be evaluated
+                    example:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                result:
+                    $ref: '#/components/schemas/EngineParamBindingV11'
             example:
                 condition_groups:
                     - conditions:
@@ -17413,6 +20372,246 @@ components:
             required:
                 - branches
                 - returns
+        ExpressionBranchesOptsV4:
+            type: object
+            properties:
+                branches:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionBranchV4'
+                    description: The branches to apply for this operation
+                    example:
+                        - condition_groups:
+                            - conditions:
+                                - operation:
+                                    label: Lawrence Jones
+                                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                  param_bindings:
+                                    - array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject:
+                                    label: Incident Severity
+                                    reference: incident.severity
+                          result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                returns:
+                    $ref: '#/components/schemas/ReturnsMetaV2'
+            example:
+                branches:
+                    - condition_groups:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                      result:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                returns:
+                    array: true
+                    type: IncidentStatus
+            required:
+                - branches
+                - returns
+        ExpressionDefinitions:
+            type: object
+            properties:
+                else_branch:
+                    $ref: '#/components/schemas/ExpressionElseBranchV2'
+                id:
+                    type: string
+                    description: The ID of the expression
+                    example: 01G0J1EXE7AXZ2C93K61WBPYEH
+                label:
+                    type: string
+                    description: The human readable label of the expression
+                    example: Team Slack channel
+                operations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionOperationV2'
+                    example:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                reference:
+                    type: string
+                    description: A short ID that can be used to reference the expression
+                    example: abc123
+                returns:
+                    $ref: '#/components/schemas/ReturnsMetaV2'
+                root_reference:
+                    type: string
+                    description: The root reference for this expression (i.e. where the expression starts)
+                    example: incident.status
+            example:
+                else_branch:
+                    result:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                label: Team Slack channel
+                operations:
+                    - branches:
+                        branches:
+                            - condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                              result:
+                                array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                      filter:
+                        condition_groups:
+                            - conditions:
+                                - operation:
+                                    label: Lawrence Jones
+                                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                  param_bindings:
+                                    - array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject:
+                                    label: Incident Severity
+                                    reference: incident.severity
+                      navigate:
+                        reference: "1235"
+                        reference_label: Teams
+                      operation_type: navigate
+                      parse:
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                        source: metadata.annotations["github.com/repo"]
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                reference: abc123
+                returns:
+                    array: true
+                    type: IncidentStatus
+                root_reference: incident.status
         ExpressionElseBranchPayloadV2:
             type: object
             properties:
@@ -17450,6 +20649,23 @@ components:
             properties:
                 result:
                     $ref: '#/components/schemas/EngineParamBindingV3'
+            example:
+                result:
+                    array_value:
+                        - label: Lawrence Jones
+                          literal: SEV123
+                          reference: incident.severity
+                    value:
+                        label: Lawrence Jones
+                        literal: SEV123
+                        reference: incident.severity
+            required:
+                - result
+        ExpressionElseBranchV4:
+            type: object
+            properties:
+                result:
+                    $ref: '#/components/schemas/EngineParamBindingV8'
             example:
                 result:
                     array_value:
@@ -17547,6 +20763,51 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/ConditionGroupV3'
+                    description: The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
+                    example:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+            example:
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+            required:
+                - condition_groups
+        ExpressionFilterOptsV4:
+            type: object
+            properties:
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupV6'
                     description: The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
                     example:
                         - conditions:
@@ -17709,7 +20970,7 @@ components:
                         - parse
                         - branches
                 parse:
-                    $ref: '#/components/schemas/ExpressionParseOptsPayloadV2'
+                    $ref: '#/components/schemas/ExpressionParseOptsV2'
                 returns:
                     $ref: '#/components/schemas/ReturnsMetaV2'
             example:
@@ -17801,7 +21062,99 @@ components:
                         - parse
                         - branches
                 parse:
-                    $ref: '#/components/schemas/ExpressionParseOptsPayloadV2'
+                    $ref: '#/components/schemas/ExpressionParseOptsV2'
+                returns:
+                    $ref: '#/components/schemas/ReturnsMetaV2'
+            example:
+                branches:
+                    branches:
+                        - condition_groups:
+                            - conditions:
+                                - operation:
+                                    label: Lawrence Jones
+                                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                  param_bindings:
+                                    - array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject:
+                                    label: Incident Severity
+                                    reference: incident.severity
+                          result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                    returns:
+                        array: true
+                        type: IncidentStatus
+                filter:
+                    condition_groups:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                navigate:
+                    reference: "1235"
+                    reference_label: Teams
+                operation_type: navigate
+                parse:
+                    returns:
+                        array: true
+                        type: IncidentStatus
+                    source: metadata.annotations["github.com/repo"]
+                returns:
+                    array: true
+                    type: IncidentStatus
+            required:
+                - operation_type
+                - returns
+        ExpressionOperationV4:
+            type: object
+            properties:
+                branches:
+                    $ref: '#/components/schemas/ExpressionBranchesOptsV4'
+                filter:
+                    $ref: '#/components/schemas/ExpressionFilterOptsV4'
+                navigate:
+                    $ref: '#/components/schemas/ExpressionNavigateOptsV2'
+                operation_type:
+                    type: string
+                    description: The type of the operation
+                    example: navigate
+                    enum:
+                        - navigate
+                        - filter
+                        - count
+                        - min
+                        - max
+                        - random
+                        - first
+                        - parse
+                        - branches
+                parse:
+                    $ref: '#/components/schemas/ExpressionParseOptsV2'
                 returns:
                     $ref: '#/components/schemas/ReturnsMetaV2'
             example:
@@ -17870,6 +21223,23 @@ components:
                 - operation_type
                 - returns
         ExpressionParseOptsPayloadV2:
+            type: object
+            properties:
+                returns:
+                    $ref: '#/components/schemas/ReturnsMetaV2'
+                source:
+                    type: string
+                    description: Source expression that is evaluated to a result
+                    example: metadata.annotations["github.com/repo"]
+            example:
+                returns:
+                    array: true
+                    type: IncidentStatus
+                source: metadata.annotations["github.com/repo"]
+            required:
+                - source
+                - returns
+        ExpressionParseOptsV2:
             type: object
             properties:
                 returns:
@@ -18354,35 +21724,178 @@ components:
                 - root_reference
                 - operations
                 - id
-        ExternalIssueReferenceV1:
+        ExpressionV4:
             type: object
             properties:
-                issue_name:
+                else_branch:
+                    $ref: '#/components/schemas/ExpressionElseBranchV4'
+                label:
                     type: string
-                    description: Human readable ID for the issue
-                    example: INC-123
-                issue_permalink:
+                    description: The human readable label of the expression
+                    example: Team Slack channel
+                operations:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionOperationV4'
+                    example:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                reference:
                     type: string
-                    description: URL linking directly to the action in the issue tracker
-                    example: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
-                provider:
+                    description: A short ID that can be used to reference the expression
+                    example: abc123
+                returns:
+                    $ref: '#/components/schemas/ReturnsMetaV2'
+                root_reference:
                     type: string
-                    description: ID of the issue tracker provider
-                    example: asana
-                    enum:
-                        - asana
-                        - click_up
-                        - linear
-                        - jira
-                        - jira_server
-                        - github
-                        - gitlab
-                        - shortcut
+                    description: The root reference for this expression (i.e. where the expression starts)
+                    example: incident.status
             example:
-                issue_name: INC-123
-                issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
-                provider: asana
-        ExternalIssueReferenceV2:
+                else_branch:
+                    result:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                label: Team Slack channel
+                operations:
+                    - branches:
+                        branches:
+                            - condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                              result:
+                                array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                      filter:
+                        condition_groups:
+                            - conditions:
+                                - operation:
+                                    label: Lawrence Jones
+                                    value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                  param_bindings:
+                                    - array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                      value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                                  subject:
+                                    label: Incident Severity
+                                    reference: incident.severity
+                      navigate:
+                        reference: "1235"
+                        reference_label: Teams
+                      operation_type: navigate
+                      parse:
+                        returns:
+                            array: true
+                            type: IncidentStatus
+                        source: metadata.annotations["github.com/repo"]
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                reference: abc123
+                returns:
+                    array: true
+                    type: IncidentStatus
+                root_reference: incident.status
+            required:
+                - label
+                - reference
+                - returns
+                - root_reference
+                - operations
+                - id
+        ExternalIssueReferenceV1:
             type: object
             properties:
                 issue_name:
@@ -18416,6 +21929,207 @@ components:
                 - issue_name
                 - issue_permalink
                 - issue_id
+        ExternalIssueReferenceV2:
+            type: object
+            properties:
+                issue_name:
+                    type: string
+                    description: Human readable ID for the issue
+                    example: INC-123
+                issue_permalink:
+                    type: string
+                    description: URL linking directly to the action in the issue tracker
+                    example: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider:
+                    type: string
+                    description: ID of the issue tracker provider
+                    example: asana
+                    enum:
+                        - asana
+                        - click_up
+                        - linear
+                        - jira
+                        - jira_server
+                        - github
+                        - gitlab
+                        - shortcut
+            example:
+                issue_name: INC-123
+                issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider: asana
+        ExternalIssueReferenceV3:
+            type: object
+            properties:
+                issue_name:
+                    type: string
+                    description: Human readable ID for the issue
+                    example: INC-123
+                issue_permalink:
+                    type: string
+                    description: URL linking directly to the action in the issue tracker
+                    example: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider:
+                    type: string
+                    description: ID of the issue tracker provider
+                    example: asana
+                    enum:
+                        - asana
+                        - click_up
+                        - linear
+                        - jira
+                        - jira_server
+                        - github
+                        - gitlab
+                        - shortcut
+            example:
+                issue_name: INC-123
+                issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider: asana
+            required:
+                - provider
+                - provider_instance_id
+                - issue_name
+                - issue_permalink
+                - issue_id
+        ExternalIssueReferenceV4:
+            type: object
+            properties:
+                issue_name:
+                    type: string
+                    description: Human readable ID for the issue
+                    example: INC-123
+                issue_permalink:
+                    type: string
+                    description: URL linking directly to the action in the issue tracker
+                    example: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider:
+                    type: string
+                    description: ID of the issue tracker provider
+                    example: asana
+                    enum:
+                        - asana
+                        - click_up
+                        - linear
+                        - jira
+                        - jira_server
+                        - github
+                        - gitlab
+                        - shortcut
+            example:
+                issue_name: INC-123
+                issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider: asana
+            required:
+                - provider
+                - provider_instance_id
+                - issue_name
+                - issue_permalink
+                - issue_id
+        ExternalIssueReferenceV5:
+            type: object
+            properties:
+                issue_name:
+                    type: string
+                    description: Human readable ID for the issue
+                    example: INC-123
+                issue_permalink:
+                    type: string
+                    description: URL linking directly to the action in the issue tracker
+                    example: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider:
+                    type: string
+                    description: ID of the issue tracker provider
+                    example: asana
+                    enum:
+                        - asana
+                        - click_up
+                        - linear
+                        - jira
+                        - jira_server
+                        - github
+                        - gitlab
+                        - shortcut
+            example:
+                issue_name: INC-123
+                issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider: asana
+            required:
+                - provider
+                - provider_instance_id
+                - issue_name
+                - issue_permalink
+                - issue_id
+        ExternalIssueReferenceV6:
+            type: object
+            properties:
+                issue_name:
+                    type: string
+                    description: Human readable ID for the issue
+                    example: INC-123
+                issue_permalink:
+                    type: string
+                    description: URL linking directly to the action in the issue tracker
+                    example: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider:
+                    type: string
+                    description: ID of the issue tracker provider
+                    example: asana
+                    enum:
+                        - asana
+                        - click_up
+                        - linear
+                        - jira
+                        - jira_server
+                        - github
+                        - gitlab
+                        - shortcut
+            example:
+                issue_name: INC-123
+                issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                provider: asana
+            required:
+                - provider
+                - provider_instance_id
+                - issue_name
+                - issue_permalink
+                - issue_id
+        ExternalResourceDefinitionsV1:
+            type: object
+            properties:
+                external_id:
+                    type: string
+                    description: ID of the resource in the external system
+                    example: "123"
+                permalink:
+                    type: string
+                    description: URL of the resource
+                    example: https://my.pagerduty.com/incidents/ABC
+                resource_type:
+                    type: string
+                    description: 'E.g. PagerDuty: the external system that holds the resource'
+                    example: pager_duty_incident
+                    enum:
+                        - pager_duty_incident
+                        - opsgenie_alert
+                        - datadog_monitor_alert
+                        - github_pull_request
+                        - gitlab_merge_request
+                        - sentry_issue
+                        - jira_issue
+                        - atlassian_statuspage_incident
+                        - zendesk_ticket
+                        - google_calendar_event
+                        - scrubbed
+                        - statuspage_incident
+                title:
+                    type: string
+                    description: Title of resource
+                    example: The database has gone down
+            example:
+                external_id: "123"
+                permalink: https://my.pagerduty.com/incidents/ABC
+                resource_type: pager_duty_incident
+                title: The database has gone down
         ExternalResourceV1:
             type: object
             properties:
@@ -18495,7 +22209,7 @@ components:
             type: object
             properties:
                 assignee:
-                    $ref: '#/components/schemas/UserV1'
+                    $ref: '#/components/schemas/UserV2'
                 completed_at:
                     type: string
                     description: When the follow-up was completed
@@ -18511,7 +22225,7 @@ components:
                     description: Description of the follow-up
                     example: Call the fire brigade
                 external_issue_reference:
-                    $ref: '#/components/schemas/ExternalIssueReferenceV2'
+                    $ref: '#/components/schemas/ExternalIssueReferenceV5'
                 id:
                     type: string
                     description: Unique identifier for the follow-up
@@ -18610,7 +22324,8 @@ components:
                     type: array
                     items:
                         type: string
-                        example: incident_creator
+                        description: API key roles
+                        example: viewer
                         enum:
                             - viewer
                             - incident_creator
@@ -18627,12 +22342,12 @@ components:
                             - on_call_editor
                     description: Which roles have been enabled for this key
                     example:
-                        - incident_creator
+                        - viewer
             example:
                 dashboard_url: https://app.incident.io/my-org
                 name: Alertmanager token
                 roles:
-                    - incident_creator
+                    - viewer
             required:
                 - name
                 - roles
@@ -18665,6 +22380,251 @@ components:
                 - resource
                 - creator
                 - created_at
+        IncidentCreatePayloadV1:
+            type: object
+            properties:
+                custom_field_entries:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CustomFieldEntryPayloadV1'
+                    description: Set the incident's custom fields to these values
+                    example:
+                        - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          values:
+                            - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              value_link: https://google.com/
+                              value_numeric: "123.456"
+                              value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              value_text: This is my text field, I hope you like it
+                              value_timestamp: ""
+                idempotency_key:
+                    type: string
+                    description: Unique string used to de-duplicate incident create requests
+                    example: alert-uuid
+                incident_role_assignments:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/IncidentRoleAssignmentPayloadV1'
+                    description: Assign incident roles to these people
+                    example:
+                        - assignee:
+                            email: bob@example.com
+                            id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                            slack_user_id: USER123
+                          incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+                incident_type_id:
+                    type: string
+                    description: Incident type to create this incident as
+                    example: 01FH5TZRWMNAFB0DZ23FD1TV96
+                mode:
+                    type: string
+                    description: Whether the incident is real or test
+                    example: real
+                    enum:
+                        - real
+                        - test
+                name:
+                    type: string
+                    description: Explanation of the incident
+                    example: Our database is sad
+                severity_id:
+                    type: string
+                    description: Severity to create incident as
+                    example: 01FH5TZRWMNAFB0DZ23FD1TV96
+                slack_team_id:
+                    type: string
+                    description: ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
+                    example: T02A1FSLE8J
+                source_message_channel_id:
+                    type: string
+                    description: Channel ID of the source message, if this incident was created from one
+                    example: C02AW36C1M5
+                source_message_timestamp:
+                    type: string
+                    description: Timestamp of the source message, if this incident was created from one
+                    example: "1653650280.526509"
+                status:
+                    type: string
+                    description: Current status of the incident
+                    example: triage
+                    enum:
+                        - triage
+                        - investigating
+                        - fixing
+                        - monitoring
+                        - closed
+                        - declined
+                summary:
+                    type: string
+                    description: Detailed description of the incident
+                    example: Our database is really really sad, and we don't know why yet.
+                visibility:
+                    type: string
+                    description: Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+                    example: public
+                    enum:
+                        - public
+                        - private
+            example:
+                custom_field_entries:
+                    - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      values:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_link: https://google.com/
+                          value_numeric: "123.456"
+                          value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_text: This is my text field, I hope you like it
+                          value_timestamp: ""
+                idempotency_key: alert-uuid
+                incident_role_assignments:
+                    - assignee:
+                        email: bob@example.com
+                        id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                        slack_user_id: USER123
+                      incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+                incident_type_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+                mode: real
+                name: Our database is sad
+                severity_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+                slack_team_id: T02A1FSLE8J
+                source_message_channel_id: C02AW36C1M5
+                source_message_timestamp: "1653650280.526509"
+                status: triage
+                summary: Our database is really really sad, and we don't know why yet.
+                visibility: public
+            required:
+                - idempotency_key
+                - visibility
+        IncidentCreatePayloadV2:
+            type: object
+            properties:
+                custom_field_entries:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CustomFieldEntryPayloadV2'
+                    description: Set the incident's custom fields to these values
+                    example:
+                        - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          values:
+                            - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              value_link: https://google.com/
+                              value_numeric: "123.456"
+                              value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                              value_text: This is my text field, I hope you like it
+                              value_timestamp: ""
+                id:
+                    type: string
+                    description: Unique identifier for the incident
+                    example: 01FDAG4SAP5TYPT98WGR2N7W91
+                idempotency_key:
+                    type: string
+                    description: Unique string used to de-duplicate incident create requests
+                    example: alert-uuid
+                incident_role_assignments:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/IncidentRoleAssignmentPayloadV2'
+                    description: Assign incident roles to these people
+                    example:
+                        - assignee:
+                            email: bob@example.com
+                            id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                            slack_user_id: USER123
+                          incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+                incident_status_id:
+                    type: string
+                    description: Incident status to assign to the incident
+                    example: 01G0J1EXE7AXZ2C93K61WBPYEH
+                incident_timestamp_values:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/IncidentTimestampValuePayloadV2'
+                    description: Assign the incident's timestamps to these values
+                    example:
+                        - incident_timestamp_id: 01FCNDV6P870EA6S7TK1DSYD5H
+                          value: "2021-08-17T13:28:57.801578Z"
+                incident_type_id:
+                    type: string
+                    description: Incident type to create this incident as
+                    example: 01FH5TZRWMNAFB0DZ23FD1TV96
+                mode:
+                    type: string
+                    description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
+                    example: standard
+                    enum:
+                        - standard
+                        - retrospective
+                        - test
+                        - tutorial
+                name:
+                    type: string
+                    description: Explanation of the incident
+                    example: Our database is sad
+                retrospective_incident_options:
+                    $ref: '#/components/schemas/RetrospectiveIncidentOptionsV2'
+                severity_id:
+                    type: string
+                    description: Severity to create incident as
+                    example: 01FH5TZRWMNAFB0DZ23FD1TV96
+                slack_channel_name_override:
+                    type: string
+                    description: Name of the Slack channel to create for this incident
+                    example: inc-123-database-down
+                slack_team_id:
+                    type: string
+                    description: Slack Team to create the incident in
+                    example: T02A1FSLE8J
+                summary:
+                    type: string
+                    description: Detailed description of the incident
+                    example: Our database is really really sad, and we don't know why yet.
+                visibility:
+                    type: string
+                    description: Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+                    example: public
+                    enum:
+                        - public
+                        - private
+            example:
+                custom_field_entries:
+                    - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                      values:
+                        - id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_catalog_entry_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_link: https://google.com/
+                          value_numeric: "123.456"
+                          value_option_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                          value_text: This is my text field, I hope you like it
+                          value_timestamp: ""
+                id: 01FDAG4SAP5TYPT98WGR2N7W91
+                idempotency_key: alert-uuid
+                incident_role_assignments:
+                    - assignee:
+                        email: bob@example.com
+                        id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                        slack_user_id: USER123
+                      incident_role_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+                incident_status_id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                incident_timestamp_values:
+                    - incident_timestamp_id: 01FCNDV6P870EA6S7TK1DSYD5H
+                      value: "2021-08-17T13:28:57.801578Z"
+                incident_type_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+                mode: standard
+                name: Our database is sad
+                retrospective_incident_options:
+                    postmortem_document_url: https://docs.google.com/my_doc_id
+                    slack_channel_id: abc123
+                severity_id: 01FH5TZRWMNAFB0DZ23FD1TV96
+                slack_channel_name_override: inc-123-database-down
+                slack_team_id: T02A1FSLE8J
+                summary: Our database is really really sad, and we don't know why yet.
+                visibility: public
+            required:
+                - idempotency_key
+                - visibility
         IncidentDurationMetricV2:
             type: object
             properties:
@@ -18717,7 +22677,7 @@ components:
                 custom_field_entries:
                     type: array
                     items:
-                        $ref: '#/components/schemas/CustomFieldEntryPayloadV1'
+                        $ref: '#/components/schemas/CustomFieldEntryPayloadV2'
                     description: Set the incident's custom fields to these values
                     example:
                         - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -18794,6 +22754,172 @@ components:
                 severity_id: 01FH5TZRWMNAFB0DZ23FD1TV96
                 slack_channel_name_override: inc-123-database-down
                 summary: Our database is really really sad, and we don't know why yet.
+        IncidentFilterFieldsV2:
+            type: object
+            properties:
+                created_at:
+                    type: object
+                    description: Filter on incident created at timestamp. The accepted operators are 'gte', 'lte' and 'date_range'.
+                    example:
+                        created_at[gte]:
+                            - "2024-05-01"
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                            example: some_value
+                        example:
+                            - some_value
+                custom_field:
+                    type: object
+                    description: Filter on an incident custom field. Custom field ID should be sent, followed by the operator and values. Accepted operator will depend on the custom field type.
+                    example:
+                        01GBSQF3FHF7FWZQNWGHAVQ804:
+                            one_of:
+                                - 01GBSQF3FHF7FWZQNWGHAVQ804
+                                - 01ET65M7ZARSFZ6TFDFVQDN9AA
+                    additionalProperties:
+                        type: object
+                        example:
+                            abc123:
+                                - value
+                        additionalProperties:
+                            type: array
+                            items:
+                                type: string
+                                example: value
+                            example:
+                                - value
+                incident_role:
+                    type: object
+                    description: Filter on an incident role. Role ID should be sent, followed by the operator and values. The accepted operators are 'one_of', 'is_blank'.
+                    example:
+                        01GBSQF3FHF7FWZQNWGHAVQ804:
+                            one_of:
+                                - 01GBSQF3FHF7FWZQNWGHAVQ804
+                                - 01ET65M7ZARSFZ6TFDFVQDN9AA
+                    additionalProperties:
+                        type: object
+                        example:
+                            abc123:
+                                - value
+                        additionalProperties:
+                            type: array
+                            items:
+                                type: string
+                                example: value
+                            example:
+                                - value
+                incident_type:
+                    type: object
+                    description: Filter on incident type. The accepted operators are 'one_of, or 'not_in'.
+                    example:
+                        one_of:
+                            - 01GBSQF3FHF7FWZQNWGHAVQ804
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                            example: some_value
+                        example:
+                            - some_value
+                mode:
+                    type: object
+                    description: 'Filter on incident mode. The accepted operator is ''one_of''.  If this is not provided, this value defaults to `{"one_of": ["standard", "retrospective"] }`, meaning that test and tutorial incidents are not included.'
+                    example:
+                        one_of:
+                            - retrospective
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                            example: some_value
+                        example:
+                            - some_value
+                severity:
+                    type: object
+                    description: Filter on incident severity. The accepted operators are 'one_of', 'not_in', 'gte', 'lte'.
+                    example:
+                        one_of:
+                            - 01GBSQF3FHF7FWZQNWGHAVQ804
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                            example: some_value
+                        example:
+                            - some_value
+                status:
+                    type: object
+                    description: Filter on incident status. The accepted operators are 'one_of', or 'not_in'.
+                    example:
+                        one_of:
+                            - 01GBSQF3FHF7FWZQNWGHAVQ804
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                            example: some_value
+                        example:
+                            - some_value
+                status_category:
+                    type: object
+                    description: 'Filter on the category of the incidents status. The accepted operators are ''one_of'', or ''not_in''. If this is not provided, this value defaults to `{"one_of": ["triage", "active", "post-incident", "closed"] }`, meaning that canceled, declined and merged incidents are not included.'
+                    example:
+                        one_of:
+                            - active
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                            example: some_value
+                        example:
+                            - some_value
+                updated_at:
+                    type: object
+                    description: Filter on incident updated at timestamp. The accepted operators are 'gte', 'lte' and 'date_range'.
+                    example:
+                        updated_at[gte]:
+                            - "2024-05-01"
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                            example: some_value
+                        example:
+                            - some_value
+            example:
+                created_at:
+                    created_at[gte]:
+                        - "2024-05-01"
+                custom_field:
+                    01GBSQF3FHF7FWZQNWGHAVQ804:
+                        one_of:
+                            - 01GBSQF3FHF7FWZQNWGHAVQ804
+                            - 01ET65M7ZARSFZ6TFDFVQDN9AA
+                incident_role:
+                    01GBSQF3FHF7FWZQNWGHAVQ804:
+                        one_of:
+                            - 01GBSQF3FHF7FWZQNWGHAVQ804
+                            - 01ET65M7ZARSFZ6TFDFVQDN9AA
+                incident_type:
+                    one_of:
+                        - 01GBSQF3FHF7FWZQNWGHAVQ804
+                mode:
+                    one_of:
+                        - retrospective
+                severity:
+                    one_of:
+                        - 01GBSQF3FHF7FWZQNWGHAVQ804
+                status:
+                    one_of:
+                        - 01GBSQF3FHF7FWZQNWGHAVQ804
+                status_category:
+                    one_of:
+                        - active
+                updated_at:
+                    updated_at[gte]:
+                        - "2024-05-01"
         IncidentMembership:
             type: object
             properties:
@@ -18816,7 +22942,7 @@ components:
                     example: "2021-08-17T13:28:57.801578Z"
                     format: date-time
                 user:
-                    $ref: '#/components/schemas/UserV1'
+                    $ref: '#/components/schemas/UserV2'
             example:
                 created_at: "2021-08-17T13:28:57.801578Z"
                 id: 01FCNDV6P870EA6S7TK1DSYD5H
@@ -18856,7 +22982,7 @@ components:
             type: object
             properties:
                 assignee:
-                    $ref: '#/components/schemas/UserReferencePayloadV1'
+                    $ref: '#/components/schemas/UserReferencePayloadV2'
                 incident_role_id:
                     type: string
                     description: Unique ID of an incident role
@@ -18876,6 +23002,32 @@ components:
                     $ref: '#/components/schemas/UserV1'
                 role:
                     $ref: '#/components/schemas/IncidentRoleV1'
+            example:
+                assignee:
+                    email: lisa@incident.io
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    name: Lisa Karlin Curtis
+                    role: viewer
+                    slack_user_id: U02AYNF2XJM
+                role:
+                    created_at: "2021-08-17T13:28:57.801578Z"
+                    description: The person currently coordinating the incident
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    instructions: Take point on the incident; Make sure people are clear on responsibilities
+                    name: Incident Lead
+                    required: false
+                    role_type: lead
+                    shortform: lead
+                    updated_at: "2021-08-17T13:28:57.801578Z"
+            required:
+                - role
+        IncidentRoleAssignmentV2:
+            type: object
+            properties:
+                assignee:
+                    $ref: '#/components/schemas/UserV2'
+                role:
+                    $ref: '#/components/schemas/EmbeddedIncidentRoleV2'
             example:
                 assignee:
                     email: lisa@incident.io
@@ -19024,7 +23176,121 @@ components:
                 - role_type
                 - created_at
                 - updated_at
+        IncidentStatusDefinitionsV1:
+            type: object
+            properties:
+                category:
+                    type: string
+                    description: What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured
+                    example: triage
+                    enum:
+                        - triage
+                        - declined
+                        - merged
+                        - canceled
+                        - live
+                        - learning
+                        - closed
+                        - paused
+                created_at:
+                    type: string
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                description:
+                    type: string
+                    description: Rich text description of the incident status
+                    example: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                id:
+                    type: string
+                    description: Unique ID of this incident status
+                    example: 01FCNDV6P870EA6S7TK1DSYD5H
+                name:
+                    type: string
+                    description: Unique name of this status
+                    example: Closed
+                rank:
+                    type: integer
+                    description: Order of this incident status
+                    example: 4
+                    format: int64
+                updated_at:
+                    type: string
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+            example:
+                category: triage
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                id: 01FCNDV6P870EA6S7TK1DSYD5H
+                name: Closed
+                rank: 4
+                updated_at: "2021-08-17T13:28:57.801578Z"
+            required:
+                - id
+                - name
+                - description
+                - rank
+                - category
+                - created_at
+                - updated_at
         IncidentStatusV1:
+            type: object
+            properties:
+                category:
+                    type: string
+                    description: What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured
+                    example: triage
+                    enum:
+                        - triage
+                        - declined
+                        - merged
+                        - canceled
+                        - live
+                        - learning
+                        - closed
+                        - paused
+                created_at:
+                    type: string
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                description:
+                    type: string
+                    description: Rich text description of the incident status
+                    example: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                id:
+                    type: string
+                    description: Unique ID of this incident status
+                    example: 01FCNDV6P870EA6S7TK1DSYD5H
+                name:
+                    type: string
+                    description: Unique name of this status
+                    example: Closed
+                rank:
+                    type: integer
+                    description: Order of this incident status
+                    example: 4
+                    format: int64
+                updated_at:
+                    type: string
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+            example:
+                category: triage
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                id: 01FCNDV6P870EA6S7TK1DSYD5H
+                name: Closed
+                rank: 4
+                updated_at: "2021-08-17T13:28:57.801578Z"
+            required:
+                - id
+                - name
+                - description
+                - rank
+                - category
+                - created_at
+                - updated_at
+        IncidentStatusV2:
             type: object
             properties:
                 category:
@@ -19247,6 +23513,72 @@ components:
                 - override_auto_archive_slack_channels
                 - auto_archive_slack_channels
                 - auto_archive_slack_channels_delay_days
+        IncidentTypeV2:
+            type: object
+            properties:
+                create_in_triage:
+                    type: string
+                    description: Whether incidents of this must always, or can optionally, be created in triage
+                    example: always
+                    enum:
+                        - always
+                        - optional
+                created_at:
+                    type: string
+                    description: When this resource was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                description:
+                    type: string
+                    description: What is this incident type for?
+                    example: Customer facing production outages
+                id:
+                    type: string
+                    description: Unique identifier for this Incident Type
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                is_default:
+                    type: boolean
+                    description: The default Incident Type is used when no other type is explicitly specified
+                    example: false
+                name:
+                    type: string
+                    description: The name of this Incident Type
+                    example: Production Outage
+                private_incidents_only:
+                    type: boolean
+                    description: Should all incidents created with this Incident Type be private?
+                    example: false
+                updated_at:
+                    type: string
+                    description: When this resource was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+            example:
+                create_in_triage: always
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Customer facing production outages
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                is_default: false
+                name: Production Outage
+                private_incidents_only: false
+                updated_at: "2021-08-17T13:28:57.801578Z"
+            required:
+                - id
+                - name
+                - is_default
+                - description
+                - private_incidents_only
+                - created_at
+                - updated_at
+                - create_in_triage
+                - severity_aliases
+                - rank
+                - override_auto_close_incidents
+                - auto_close_incidents
+                - auto_close_incidents_delay_days
+                - override_auto_archive_slack_channels
+                - auto_archive_slack_channels
+                - auto_archive_slack_channels_delay_days
         IncidentUpdateV2:
             type: object
             properties:
@@ -19272,7 +23604,7 @@ components:
                     description: Message that explains the context behind the update
                     example: We're working on a fix, hoping to ship in the next 30 minutes
                 new_incident_status:
-                    $ref: '#/components/schemas/IncidentStatusV1'
+                    $ref: '#/components/schemas/IncidentStatusV2'
                 new_severity:
                     $ref: '#/components/schemas/SeverityV2'
                 updater:
@@ -19328,7 +23660,7 @@ components:
                     example: "2021-08-17T13:28:57.801578Z"
                     format: date-time
                 creator:
-                    $ref: '#/components/schemas/ActorV2'
+                    $ref: '#/components/schemas/ActorV1'
                 custom_field_entries:
                     type: array
                     items:
@@ -19414,7 +23746,7 @@ components:
                     description: Reference to this incident, as displayed across the product
                     example: INC-123
                 severity:
-                    $ref: '#/components/schemas/SeverityV2'
+                    $ref: '#/components/schemas/SeverityV1'
                 slack_channel_id:
                     type: string
                     description: ID of the Slack channel in the organisation Slack workspace. Note that the channel is sometimes created asynchronously, so may not be present when the incident is just created.
@@ -19589,7 +23921,7 @@ components:
                 custom_field_entries:
                     type: array
                     items:
-                        $ref: '#/components/schemas/CustomFieldEntryV1'
+                        $ref: '#/components/schemas/CustomFieldEntryV2'
                     description: Custom field entries for this incident
                     example:
                         - custom_field:
@@ -19629,7 +23961,7 @@ components:
                             name: Lasted
                           value_seconds: 1
                 external_issue_reference:
-                    $ref: '#/components/schemas/ExternalIssueReferenceV2'
+                    $ref: '#/components/schemas/ExternalIssueReferenceV4'
                 id:
                     type: string
                     description: Unique identifier for the incident
@@ -19637,7 +23969,7 @@ components:
                 incident_role_assignments:
                     type: array
                     items:
-                        $ref: '#/components/schemas/IncidentRoleAssignmentV1'
+                        $ref: '#/components/schemas/IncidentRoleAssignmentV2'
                     description: A list of who is assigned to each role for this incident
                     example:
                         - assignee:
@@ -19657,7 +23989,7 @@ components:
                             shortform: lead
                             updated_at: "2021-08-17T13:28:57.801578Z"
                 incident_status:
-                    $ref: '#/components/schemas/IncidentStatusV1'
+                    $ref: '#/components/schemas/IncidentStatusV2'
                 incident_timestamp_values:
                     type: array
                     items:
@@ -19671,7 +24003,7 @@ components:
                           value:
                             value: "2021-08-17T13:28:57.801578Z"
                 incident_type:
-                    $ref: '#/components/schemas/IncidentTypeV1'
+                    $ref: '#/components/schemas/IncidentTypeV2'
                 mode:
                     type: string
                     description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
@@ -19886,9 +24218,9 @@ components:
                 incident:
                     $ref: '#/components/schemas/IncidentV2'
                 new_status:
-                    $ref: '#/components/schemas/IncidentStatusV1'
+                    $ref: '#/components/schemas/IncidentStatusV2'
                 previous_status:
-                    $ref: '#/components/schemas/IncidentStatusV1'
+                    $ref: '#/components/schemas/IncidentStatusV2'
             example:
                 incident:
                     call_url: https://zoom.us/foo
@@ -21216,7 +25548,7 @@ components:
                 severities:
                     type: array
                     items:
-                        $ref: '#/components/schemas/SeverityV2'
+                        $ref: '#/components/schemas/SeverityV1'
                     example:
                         - created_at: "2021-08-17T13:28:57.801578Z"
                           description: Issues with **low impact**.
@@ -21696,8 +26028,7 @@ components:
                     example: abc123
                 resource_type:
                     type: string
-                    description: The type of the related resource
-                    example: schedule
+                    example: workflow
                     enum:
                         - workflow
                         - schedule
@@ -21710,13 +26041,41 @@ components:
                     incident.io/terraform/version: 3.0.0
                 managed_by: dashboard
                 resource_id: abc123
-                resource_type: schedule
+                resource_type: workflow
                 source_url: https://github.com/my-company/infrastructure
             required:
                 - resource_type
                 - resource_id
                 - managed_by
                 - annotations
+        ManagementMetaDefinitionsV2:
+            type: object
+            properties:
+                annotations:
+                    type: object
+                    description: Annotations that track metadata about this resource
+                    example:
+                        incident.io/terraform/version: 3.0.0
+                    additionalProperties:
+                        type: string
+                        example: abc123
+                managed_by:
+                    type: string
+                    description: How is this resource managed
+                    example: dashboard
+                    enum:
+                        - dashboard
+                        - terraform
+                        - external
+                source_url:
+                    type: string
+                    description: The url of the external repository where this resource is managed (if there is one)
+                    example: https://github.com/my-company/infrastructure
+            example:
+                annotations:
+                    incident.io/terraform/version: 3.0.0
+                managed_by: dashboard
+                source_url: https://github.com/my-company/infrastructure
         ManagementMetaV2:
             type: object
             properties:
@@ -21790,6 +26149,85 @@ components:
                 total_record_count: 238
             required:
                 - page_size
+        PaginationParamDefinitions:
+            type: object
+            properties:
+                after:
+                    type: string
+                    description: An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.
+                    example: 01FDAG4SAP5TYPT98WGR2N7W91
+                page_size:
+                    type: integer
+                    description: Integer number of records to return
+                    default: 25
+                    example: 25
+                    format: int64
+                    maximum: 500
+            example:
+                after: 01FDAG4SAP5TYPT98WGR2N7W91
+                page_size: 25
+        Priority:
+            type: object
+            properties:
+                archived_at:
+                    type: string
+                    description: When this type was archived
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                description:
+                    $ref: '#/components/schemas/TextNode'
+                id:
+                    type: string
+                    description: The ID of this priority
+                    example: 01GW2G3V0S59R238FAHPDS1R66
+                is_default:
+                    type: boolean
+                    description: Whether this is the default priority
+                    example: true
+                name:
+                    type: string
+                    description: The human readable label for this priority
+                    example: P1
+                rank:
+                    type: integer
+                    description: The rank of the priority. Higher values are less urgent
+                    example: 1
+                    format: int64
+                slugs:
+                    type: array
+                    items:
+                        type: string
+                        example: abc123
+                    description: All the slugs that this priority has
+                    example:
+                        - p1
+                        - priority-1
+            example:
+                archived_at: "2021-08-17T13:28:57.801578Z"
+                description:
+                    attrs:
+                        level: 3
+                    content:
+                        - {}
+                    marks:
+                        - attrs:
+                            color: blue
+                          type: em
+                    text: some nice text
+                    type: text
+                id: 01GW2G3V0S59R238FAHPDS1R66
+                is_default: true
+                name: P1
+                rank: 1
+                slugs:
+                    - p1
+                    - priority-1
+            required:
+                - id
+                - rank
+                - name
+                - slugs
+                - is_default
         PrivateIncidentAccessAttemptedV1ResponseBody:
             type: object
             properties:
@@ -21874,7 +26312,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.action_created_v1:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
             example:
                 event_type: private_incident.action_created_v1
                 private_incident.action_created_v1:
@@ -21906,7 +26344,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.action_updated_v1:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
             example:
                 event_type: private_incident.action_updated_v1
                 private_incident.action_updated_v1:
@@ -21938,7 +26376,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.follow_up_created_v1:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
             example:
                 event_type: private_incident.follow_up_created_v1
                 private_incident.follow_up_created_v1:
@@ -21970,7 +26408,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.follow_up_updated_v1:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
             example:
                 event_type: private_incident.follow_up_updated_v1
                 private_incident.follow_up_updated_v1:
@@ -22002,7 +26440,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.incident_created_v2:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
             example:
                 event_type: private_incident.incident_created_v2
                 private_incident.incident_created_v2:
@@ -22034,7 +26472,7 @@ components:
                         - private_incident.membership_granted_v1
                         - private_incident.membership_revoked_v1
                 private_incident.incident_updated_v2:
-                    $ref: '#/components/schemas/GroupingKeyV2'
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
             example:
                 event_type: private_incident.incident_updated_v2
                 private_incident.incident_updated_v2:
@@ -22815,6 +27253,73 @@ components:
             required:
                 - type
                 - array
+        RunscopeRequestAttribute:
+            type: object
+            properties:
+                assertions:
+                    type: object
+                    example:
+                        abc123: abc123
+                    additionalProperties: true
+                method:
+                    type: string
+                    description: HTTP Method of request sent
+                    example: abc123
+                note:
+                    type: string
+                    description: A description or note of this request step
+                    example: abc123
+                response_size_bytes:
+                    type: integer
+                    description: Number of bytes of response
+                    example: 1
+                    format: int64
+                response_status_code:
+                    type: string
+                    description: Status code of the response
+                    example: abc123
+                response_time_ms:
+                    type: integer
+                    description: Time in milliseconds for response
+                    example: 1
+                    format: int64
+                result:
+                    type: string
+                    description: The result of the request
+                    example: abc123
+                scripts:
+                    type: object
+                    example:
+                        abc123: abc123
+                    additionalProperties: true
+                step_type:
+                    type: string
+                    description: The type of step in the request
+                    example: abc123
+                url:
+                    type: string
+                    description: The URL of the request from Runscope
+                    example: abc123
+                variables:
+                    type: object
+                    example:
+                        abc123: abc123
+                    additionalProperties: true
+            example:
+                assertions:
+                    abc123: abc123
+                method: abc123
+                note: abc123
+                response_size_bytes: 1
+                response_status_code: abc123
+                response_time_ms: 1
+                result: abc123
+                scripts:
+                    abc123: abc123
+                step_type: abc123
+                url: abc123
+                variables:
+                    abc123: abc123
         ScheduleConfigCreatePayloadV2:
             type: object
             properties:
@@ -22827,7 +27332,7 @@ components:
                           handover_start_at: "2021-08-17T13:28:57.801578Z"
                           handovers:
                             - interval: 1
-                              interval_type: daily
+                              interval_type: hourly
                           id: 01G0J1EXE7AXZ2C93K61WBPYEH
                           layers:
                             - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22840,14 +27345,14 @@ components:
                           working_interval:
                             - end_time: "17:00"
                               start_time: "09:00"
-                              weekday: tuesday
+                              weekday: monday
             example:
                 rotations:
                     - effective_from: "2021-08-17T13:28:57.801578Z"
                       handover_start_at: "2021-08-17T13:28:57.801578Z"
                       handovers:
                         - interval: 1
-                          interval_type: daily
+                          interval_type: hourly
                       id: 01G0J1EXE7AXZ2C93K61WBPYEH
                       layers:
                         - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22860,7 +27365,7 @@ components:
                       working_interval:
                         - end_time: "17:00"
                           start_time: "09:00"
-                          weekday: tuesday
+                          weekday: monday
         ScheduleConfigUpdatePayloadV2:
             type: object
             properties:
@@ -22873,7 +27378,7 @@ components:
                           handover_start_at: "2021-08-17T13:28:57.801578Z"
                           handovers:
                             - interval: 1
-                              interval_type: daily
+                              interval_type: hourly
                           id: 01G0J1EXE7AXZ2C93K61WBPYEH
                           layers:
                             - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22886,14 +27391,14 @@ components:
                           working_interval:
                             - end_time: "17:00"
                               start_time: "09:00"
-                              weekday: tuesday
+                              weekday: monday
             example:
                 rotations:
                     - effective_from: "2021-08-17T13:28:57.801578Z"
                       handover_start_at: "2021-08-17T13:28:57.801578Z"
                       handovers:
                         - interval: 1
-                          interval_type: daily
+                          interval_type: hourly
                       id: 01G0J1EXE7AXZ2C93K61WBPYEH
                       layers:
                         - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22906,7 +27411,7 @@ components:
                       working_interval:
                         - end_time: "17:00"
                           start_time: "09:00"
-                          weekday: tuesday
+                          weekday: monday
         ScheduleConfigV2:
             type: object
             properties:
@@ -22920,7 +27425,7 @@ components:
                           handover_start_at: "2021-08-17T13:28:57.801578Z"
                           handovers:
                             - interval: 1
-                              interval_type: daily
+                              interval_type: hourly
                           id: 01G0J1EXE7AXZ2C93K61WBPYEH
                           layers:
                             - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22935,14 +27440,14 @@ components:
                           working_interval:
                             - end_time: "17:00"
                               start_time: "09:00"
-                              weekday: tuesday
+                              weekday: monday
             example:
                 rotations:
                     - effective_from: "2021-08-17T13:28:57.801578Z"
                       handover_start_at: "2021-08-17T13:28:57.801578Z"
                       handovers:
                         - interval: 1
-                          interval_type: daily
+                          interval_type: hourly
                       id: 01G0J1EXE7AXZ2C93K61WBPYEH
                       layers:
                         - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -22957,7 +27462,7 @@ components:
                       working_interval:
                         - end_time: "17:00"
                           start_time: "09:00"
-                          weekday: tuesday
+                          weekday: monday
             required:
                 - rotations
                 - version
@@ -22975,7 +27480,7 @@ components:
                 config:
                     $ref: '#/components/schemas/ScheduleConfigCreatePayloadV2'
                 holidays_public_config:
-                    $ref: '#/components/schemas/ScheduleHolidaysPublicConfigV2'
+                    $ref: '#/components/schemas/ScheduleHolidaysPublicConfigPayloadV2'
                 name:
                     type: string
                     description: Name of the schedule
@@ -22993,7 +27498,7 @@ components:
                           handover_start_at: "2021-08-17T13:28:57.801578Z"
                           handovers:
                             - interval: 1
-                              interval_type: daily
+                              interval_type: hourly
                           id: 01G0J1EXE7AXZ2C93K61WBPYEH
                           layers:
                             - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -23006,7 +27511,7 @@ components:
                           working_interval:
                             - end_time: "17:00"
                               start_time: "09:00"
-                              weekday: tuesday
+                              weekday: monday
                 holidays_public_config:
                     country_codes:
                         - abc123
@@ -23138,7 +27643,7 @@ components:
                     example: "2021-08-17T13:28:57.801578Z"
                     format: date-time
                 user:
-                    $ref: '#/components/schemas/UserV1'
+                    $ref: '#/components/schemas/UserV2'
             example:
                 end_at: "2021-08-17T13:28:57.801578Z"
                 entry_id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -23156,6 +27661,22 @@ components:
                 - external_user_id
                 - start_at
                 - end_at
+        ScheduleHolidaysPublicConfigPayloadV2:
+            type: object
+            properties:
+                country_codes:
+                    type: array
+                    items:
+                        type: string
+                        example: abc123
+                    description: ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for
+                    example:
+                        - abc123
+            example:
+                country_codes:
+                    - abc123
+            required:
+                - country_codes
         ScheduleHolidaysPublicConfigV2:
             type: object
             properties:
@@ -23190,6 +27711,20 @@ components:
                 name: Layer 1
             required:
                 - name
+        ScheduleLayerUpdatePayloadV2:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Unique identifier of the layer
+                    example: 01G0J1EXE7AXZ2C93K61WBPYEH
+                name:
+                    type: string
+                    description: Name of the layer
+                    example: Layer 1
+            example:
+                id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                name: Layer 1
         ScheduleLayerV2:
             type: object
             properties:
@@ -23221,7 +27756,7 @@ components:
                         $ref: '#/components/schemas/ScheduleRotationHandoverV2'
                     example:
                         - interval: 1
-                          interval_type: daily
+                          interval_type: hourly
                 id:
                     type: string
                     description: Unique identifier of the rotation
@@ -23240,7 +27775,7 @@ components:
                 users:
                     type: array
                     items:
-                        $ref: '#/components/schemas/UserReferencePayloadV1'
+                        $ref: '#/components/schemas/UserReferencePayloadV2'
                     example:
                         - email: bob@example.com
                           id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -23248,17 +27783,17 @@ components:
                 working_interval:
                     type: array
                     items:
-                        $ref: '#/components/schemas/WeekdayIntervalV2'
+                        $ref: '#/components/schemas/ScheduleRotationWorkingIntervalCreatePayloadV2'
                     example:
                         - end_time: "17:00"
                           start_time: "09:00"
-                          weekday: tuesday
+                          weekday: monday
             example:
                 effective_from: "2021-08-17T13:28:57.801578Z"
                 handover_start_at: "2021-08-17T13:28:57.801578Z"
                 handovers:
                     - interval: 1
-                      interval_type: daily
+                      interval_type: hourly
                 id: 01G0J1EXE7AXZ2C93K61WBPYEH
                 layers:
                     - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -23271,7 +27806,7 @@ components:
                 working_interval:
                     - end_time: "17:00"
                       start_time: "09:00"
-                      weekday: tuesday
+                      weekday: monday
             required:
                 - name
         ScheduleRotationHandoverV2:
@@ -23283,14 +27818,15 @@ components:
                     format: int64
                 interval_type:
                     type: string
-                    example: daily
+                    description: How often a handover occurs
+                    example: hourly
                     enum:
                         - hourly
                         - daily
                         - weekly
             example:
                 interval: 1
-                interval_type: daily
+                interval_type: hourly
         ScheduleRotationUpdatePayloadV2:
             type: object
             properties:
@@ -23308,7 +27844,7 @@ components:
                         $ref: '#/components/schemas/ScheduleRotationHandoverV2'
                     example:
                         - interval: 1
-                          interval_type: daily
+                          interval_type: hourly
                 id:
                     type: string
                     description: Unique identifier of the rotation
@@ -23316,7 +27852,7 @@ components:
                 layers:
                     type: array
                     items:
-                        $ref: '#/components/schemas/ScheduleLayerV2'
+                        $ref: '#/components/schemas/ScheduleLayerUpdatePayloadV2'
                     example:
                         - id: 01G0J1EXE7AXZ2C93K61WBPYEH
                           name: Layer 1
@@ -23327,7 +27863,7 @@ components:
                 users:
                     type: array
                     items:
-                        $ref: '#/components/schemas/UserReferencePayloadV1'
+                        $ref: '#/components/schemas/UserReferencePayloadV2'
                     example:
                         - email: bob@example.com
                           id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -23339,13 +27875,13 @@ components:
                     example:
                         - end_time: "17:00"
                           start_time: "09:00"
-                          weekday: tuesday
+                          weekday: monday
             example:
                 effective_from: "2021-08-17T13:28:57.801578Z"
                 handover_start_at: "2021-08-17T13:28:57.801578Z"
                 handovers:
                     - interval: 1
-                      interval_type: daily
+                      interval_type: hourly
                 id: 01G0J1EXE7AXZ2C93K61WBPYEH
                 layers:
                     - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -23358,7 +27894,7 @@ components:
                 working_interval:
                     - end_time: "17:00"
                       start_time: "09:00"
-                      weekday: tuesday
+                      weekday: monday
         ScheduleRotationV2:
             type: object
             properties:
@@ -23379,7 +27915,7 @@ components:
                     description: Defines the handover intervals for this rota, in order they should apply
                     example:
                         - interval: 1
-                          interval_type: daily
+                          interval_type: hourly
                 id:
                     type: string
                     description: Unique internal ID of the rotation
@@ -23399,7 +27935,7 @@ components:
                 users:
                     type: array
                     items:
-                        $ref: '#/components/schemas/UserV1'
+                        $ref: '#/components/schemas/UserV2'
                     example:
                         - email: lisa@incident.io
                           id: 01FCNDV6P870EA6S7TK1DSYDG0
@@ -23409,17 +27945,17 @@ components:
                 working_interval:
                     type: array
                     items:
-                        $ref: '#/components/schemas/WeekdayIntervalV2'
+                        $ref: '#/components/schemas/ScheduleRotationWorkingIntervalV2'
                     example:
                         - end_time: "17:00"
                           start_time: "09:00"
-                          weekday: tuesday
+                          weekday: monday
             example:
                 effective_from: "2021-08-17T13:28:57.801578Z"
                 handover_start_at: "2021-08-17T13:28:57.801578Z"
                 handovers:
                     - interval: 1
-                      interval_type: daily
+                      interval_type: hourly
                 id: 01G0J1EXE7AXZ2C93K61WBPYEH
                 layers:
                     - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -23434,7 +27970,7 @@ components:
                 working_interval:
                     - end_time: "17:00"
                       start_time: "09:00"
-                      weekday: tuesday
+                      weekday: monday
             required:
                 - id
                 - name
@@ -23443,6 +27979,37 @@ components:
                 - working_intervals
                 - handover_start_at
                 - handovers
+        ScheduleRotationWorkingIntervalCreatePayloadV2:
+            type: object
+            properties:
+                end_time:
+                    type: string
+                    description: End time of the interval, in 24hr format
+                    example: "17:00"
+                start_time:
+                    type: string
+                    description: Start time of the interval, in 24hr format
+                    example: "09:00"
+                weekday:
+                    type: string
+                    description: Weekdays for use with a schedule
+                    example: monday
+                    enum:
+                        - monday
+                        - tuesday
+                        - wednesday
+                        - thursday
+                        - friday
+                        - saturday
+                        - sunday
+            example:
+                end_time: "17:00"
+                start_time: "09:00"
+                weekday: monday
+            required:
+                - weekday
+                - start_time
+                - end_time
         ScheduleRotationWorkingIntervalUpdatePayloadV2:
             type: object
             properties:
@@ -23456,8 +28023,8 @@ components:
                     example: "09:00"
                 weekday:
                     type: string
-                    description: Weekday this interval applies to
-                    example: tuesday
+                    description: Weekdays for use with a schedule
+                    example: monday
                     enum:
                         - monday
                         - tuesday
@@ -23469,7 +28036,38 @@ components:
             example:
                 end_time: "17:00"
                 start_time: "09:00"
-                weekday: tuesday
+                weekday: monday
+        ScheduleRotationWorkingIntervalV2:
+            type: object
+            properties:
+                end_time:
+                    type: string
+                    description: End time of the interval, in 24hr format
+                    example: "17:00"
+                start_time:
+                    type: string
+                    description: Start time of the interval, in 24hr format
+                    example: "09:00"
+                weekday:
+                    type: string
+                    description: Weekdays for use with a schedule
+                    example: monday
+                    enum:
+                        - monday
+                        - tuesday
+                        - wednesday
+                        - thursday
+                        - friday
+                        - saturday
+                        - sunday
+            example:
+                end_time: "17:00"
+                start_time: "09:00"
+                weekday: monday
+            required:
+                - weekday
+                - start_time
+                - end_time
         ScheduleUpdatePayloadV2:
             type: object
             properties:
@@ -23484,7 +28082,7 @@ components:
                 config:
                     $ref: '#/components/schemas/ScheduleConfigUpdatePayloadV2'
                 holidays_public_config:
-                    $ref: '#/components/schemas/ScheduleHolidaysPublicConfigV2'
+                    $ref: '#/components/schemas/ScheduleHolidaysPublicConfigPayloadV2'
                 name:
                     type: string
                     description: Name of the schedule
@@ -23502,7 +28100,7 @@ components:
                           handover_start_at: "2021-08-17T13:28:57.801578Z"
                           handovers:
                             - interval: 1
-                              interval_type: daily
+                              interval_type: hourly
                           id: 01G0J1EXE7AXZ2C93K61WBPYEH
                           layers:
                             - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -23515,7 +28113,7 @@ components:
                           working_interval:
                             - end_time: "17:00"
                               start_time: "09:00"
-                              weekday: tuesday
+                              weekday: monday
                 holidays_public_config:
                     country_codes:
                         - abc123
@@ -23583,7 +28181,7 @@ components:
                           handover_start_at: "2021-08-17T13:28:57.801578Z"
                           handovers:
                             - interval: 1
-                              interval_type: daily
+                              interval_type: hourly
                           id: 01G0J1EXE7AXZ2C93K61WBPYEH
                           layers:
                             - id: 01G0J1EXE7AXZ2C93K61WBPYEH
@@ -23598,7 +28196,7 @@ components:
                           working_interval:
                             - end_time: "17:00"
                               start_time: "09:00"
-                              weekday: tuesday
+                              weekday: monday
                 created_at: "2021-08-17T13:28:57.801578Z"
                 current_shifts:
                     - end_at: "2021-08-17T13:28:57.801578Z"
@@ -23693,6 +28291,127 @@ components:
                 - targets
                 - context
                 - metadata
+        SeverityDefinitionsV1:
+            type: object
+            properties:
+                created_at:
+                    type: string
+                    description: When the action was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                description:
+                    type: string
+                    description: Description of the severity
+                    example: Issues with **low impact**.
+                id:
+                    type: string
+                    description: Unique identifier of the severity
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                name:
+                    type: string
+                    description: Human readable name of the severity
+                    example: Minor
+                    maxLength: 50
+                rank:
+                    type: integer
+                    description: Rank to help sort severities (lower numbers are less severe)
+                    example: 1
+                    format: int64
+                updated_at:
+                    type: string
+                    description: When the action was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+            example:
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Issues with **low impact**.
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Minor
+                rank: 1
+                updated_at: "2021-08-17T13:28:57.801578Z"
+        SeverityDefinitionsV2:
+            type: object
+            properties:
+                created_at:
+                    type: string
+                    description: When the action was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                description:
+                    type: string
+                    description: Description of the severity
+                    example: Issues with **low impact**.
+                id:
+                    type: string
+                    description: Unique identifier of the severity
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                name:
+                    type: string
+                    description: Human readable name of the severity
+                    example: Minor
+                    maxLength: 50
+                rank:
+                    type: integer
+                    description: Rank to help sort severities (lower numbers are less severe)
+                    example: 1
+                    format: int64
+                updated_at:
+                    type: string
+                    description: When the action was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+            example:
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Issues with **low impact**.
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Minor
+                rank: 1
+                updated_at: "2021-08-17T13:28:57.801578Z"
+        SeverityV1:
+            type: object
+            properties:
+                created_at:
+                    type: string
+                    description: When the action was created
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                description:
+                    type: string
+                    description: Description of the severity
+                    example: Issues with **low impact**.
+                id:
+                    type: string
+                    description: Unique identifier of the severity
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                name:
+                    type: string
+                    description: Human readable name of the severity
+                    example: Minor
+                    maxLength: 50
+                rank:
+                    type: integer
+                    description: Rank to help sort severities (lower numbers are less severe)
+                    example: 1
+                    format: int64
+                updated_at:
+                    type: string
+                    description: When the action was last updated
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+            example:
+                created_at: "2021-08-17T13:28:57.801578Z"
+                description: Issues with **low impact**.
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Minor
+                rank: 1
+                updated_at: "2021-08-17T13:28:57.801578Z"
+            required:
+                - id
+                - name
+                - description
+                - rank
+                - created_at
+                - updated_at
         SeverityV2:
             type: object
             properties:
@@ -24322,7 +29041,7 @@ components:
             type: object
             properties:
                 severity:
-                    $ref: '#/components/schemas/SeverityV2'
+                    $ref: '#/components/schemas/SeverityV1'
             example:
                 severity:
                     created_at: "2021-08-17T13:28:57.801578Z"
@@ -24507,6 +29226,69 @@ components:
             required:
                 - workflow
                 - management_meta
+        Step:
+            type: object
+            properties:
+                description:
+                    type: string
+                    description: Human readable description of what this step does
+                    example: Escalates a page to the default escalation policy of the configured PagerDuty service.
+                label:
+                    type: string
+                    description: Human readable identifier for this step
+                    example: PagerDuty Escalate
+                name:
+                    type: string
+                    description: Unique name of the step in the engine
+                    example: pagerduty.escalate
+                params:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineParamV2'
+                    description: Type information for the step parameters
+                    example:
+                        - array: true
+                          default_value:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          description: What slack channel should we send the message to?
+                          infer_reference: true
+                          label: To date
+                          name: severity
+                          optional: true
+                          type: IncidentSeverity
+            example:
+                description: Escalates a page to the default escalation policy of the configured PagerDuty service.
+                label: PagerDuty Escalate
+                name: pagerduty.escalate
+                params:
+                    - array: true
+                      default_value:
+                        array_value:
+                            - label: Lawrence Jones
+                              literal: SEV123
+                              reference: incident.severity
+                        value:
+                            label: Lawrence Jones
+                            literal: SEV123
+                            reference: incident.severity
+                      description: What slack channel should we send the message to?
+                      infer_reference: true
+                      label: To date
+                      name: severity
+                      optional: true
+                      type: IncidentSeverity
+            required:
+                - name
+                - label
+                - description
+                - params
         StepConfig:
             type: object
             properties:
@@ -24529,7 +29311,7 @@ components:
                 param_bindings:
                     type: array
                     items:
-                        $ref: '#/components/schemas/EngineParamBindingV3'
+                        $ref: '#/components/schemas/EngineParamBindingV2'
                     description: Bindings for the step parameters
                     example:
                         - array_value:
@@ -24625,6 +29407,114 @@ components:
                 - label
                 - description
                 - params
+        TextDocument:
+            type: object
+            properties:
+                markdown:
+                    type: string
+                    description: the original Markdown string
+                    example: There's a snake in my boot
+                text_node:
+                    $ref: '#/components/schemas/TextNode'
+            example:
+                markdown: There's a snake in my boot
+                text_node:
+                    attrs:
+                        level: 3
+                    content:
+                        - {}
+                    marks:
+                        - attrs:
+                            color: blue
+                          type: em
+                    text: some nice text
+                    type: text
+            required:
+                - text_node
+                - markdown
+        TextMark:
+            type: object
+            properties:
+                attrs:
+                    type: object
+                    description: type-specific mark attributes
+                    example:
+                        color: blue
+                    additionalProperties: true
+                type:
+                    type: string
+                    description: the type of the node, eg 'text'
+                    example: em
+            example:
+                attrs:
+                    color: blue
+                type: em
+            required:
+                - type
+        TextNode:
+            type: object
+            properties:
+                attrs:
+                    type: object
+                    description: type-specific node attributes
+                    example:
+                        level: 3
+                    additionalProperties: true
+                content:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TextNode'
+                    description: children of this node
+                    example:
+                        - attrs:
+                            level: 3
+                          content:
+                            - {}
+                          marks:
+                            - attrs:
+                                color: blue
+                              type: em
+                          text: some nice text
+                          type: text
+                marks:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TextMark'
+                    description: marks that apply to this node, eg 'bold'
+                    example:
+                        - attrs:
+                            color: blue
+                          type: em
+                text:
+                    type: string
+                    description: if this node doesn't have children, it has text content
+                    example: some nice text
+                type:
+                    type: string
+                    description: the type of the node
+                    example: text
+            example:
+                attrs:
+                    level: 3
+                content:
+                    - attrs:
+                        level: 3
+                      content:
+                        - {}
+                      marks:
+                        - attrs:
+                            color: blue
+                          type: em
+                      text: some nice text
+                      type: text
+                marks:
+                    - attrs:
+                        color: blue
+                      type: em
+                text: some nice text
+                type: text
+            required:
+                - type
         TriggerSlim:
             type: object
             properties:
@@ -24706,7 +29596,7 @@ components:
                     items:
                         type: string
                         example: abc123
-                    description: The alert sources that will match this alert route
+                    description: Legacy field - the alert sources that will match this alert route
                     example:
                         - 02FCNDV6P870EA6S7TK1DSYDG2
                 auto_decline_enabled:
@@ -25012,6 +29902,7 @@ components:
                 - enabled
                 - incident_enabled
                 - incident_condition_groups
+                - alert_sources
                 - alert_source_ids
                 - auto_cancel_escalations
         UpdateRequestBody2:
@@ -25409,7 +30300,278 @@ components:
                 - engine_resource_type
                 - mode
                 - use_name_as_identifier
-        UpdateWorkflowRequestBody:
+        UpdateWorkflowPayload:
+            type: object
+            properties:
+                annotations:
+                    type: object
+                    description: Annotations that track metadata about this resource
+                    example:
+                        incident.io/terraform/version: 3.0.0
+                    additionalProperties:
+                        type: string
+                        example: abc123
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
+                    description: List of conditions to apply to the workflow
+                    example:
+                        - conditions:
+                            - operation: one_of
+                              param_bindings:
+                                - array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject: incident.severity
+                continue_on_step_error:
+                    type: boolean
+                    description: Whether to continue executing the workflow if a step fails
+                    example: true
+                delay:
+                    $ref: '#/components/schemas/WorkflowDelay'
+                expressions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionPayloadV2'
+                    description: The expressions used in the workflow
+                    example:
+                        - else_branch:
+                            result:
+                                array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                          label: Team Slack channel
+                          operations:
+                            - branches:
+                                branches:
+                                    - condition_groups:
+                                        - conditions:
+                                            - operation: one_of
+                                              param_bindings:
+                                                - array_value:
+                                                    - literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject: incident.severity
+                                      result:
+                                        array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                              filter:
+                                condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                              navigate:
+                                reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                              operation_type: navigate
+                              parse:
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                                source: metadata.annotations["github.com/repo"]
+                          reference: abc123
+                          root_reference: incident.status
+                folder:
+                    type: string
+                    description: Folder to display the workflow in
+                    example: My folder 01
+                id:
+                    type: string
+                    description: ID of the workflow to update
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                include_private_incidents:
+                    type: boolean
+                    description: Whether to include private incidents
+                    example: true
+                name:
+                    type: string
+                    description: The human-readable name of the workflow
+                    example: My workflow
+                once_for:
+                    type: array
+                    items:
+                        type: string
+                        example: incident.url
+                    description: Once For strategy to apply to this workflow
+                    example:
+                        - incident.url
+                runs_on_incident_modes:
+                    type: array
+                    items:
+                        type: string
+                        description: Incident mode that workflows can run on
+                        example: standard
+                        enum:
+                            - standard
+                            - test
+                            - retrospective
+                    description: Which modes of incident this should run on (defaults to just standard incidents)
+                    example:
+                        - standard
+                        - retrospective
+                runs_on_incidents:
+                    type: string
+                    description: Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
+                    example: newly_created
+                    enum:
+                        - newly_created
+                        - newly_created_and_active
+                state:
+                    type: string
+                    description: The state of the workflow (e.g. is it draft, or disabled)
+                    example: active
+                    enum:
+                        - active
+                        - disabled
+                        - draft
+                        - error
+                steps:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/StepConfigPayload'
+                    description: List of step to execute as part of the workflow
+                    example:
+                        - for_each: abc123
+                          id: abc123
+                          name: pagerduty.escalate
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+            example:
+                annotations:
+                    incident.io/terraform/version: 3.0.0
+                condition_groups:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+                continue_on_step_error: true
+                delay:
+                    conditions_apply_over_delay: false
+                    for_seconds: 60
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                                  result:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                          navigate:
+                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                      reference: abc123
+                      root_reference: incident.status
+                folder: My folder 01
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                include_private_incidents: true
+                name: My workflow
+                once_for:
+                    - incident.url
+                runs_on_incident_modes:
+                    - standard
+                    - retrospective
+                runs_on_incidents: newly_created
+                state: active
+                steps:
+                    - for_each: abc123
+                      id: abc123
+                      name: pagerduty.escalate
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+            required:
+                - id
+                - name
+                - once_for
+                - condition_groups
+                - steps
+                - expressions
+                - include_private_incidents
+                - runs_on_incident_modes
+                - continue_on_step_error
+                - runs_on_incidents
+        UpdateWorkflowPayload2:
             type: object
             properties:
                 annotations:
@@ -25692,6 +30854,25 @@ components:
                 email: bob@example.com
                 id: 01G0J1EXE7AXZ2C93K61WBPYEH
                 slack_user_id: USER123
+        UserReferencePayloadV2:
+            type: object
+            properties:
+                email:
+                    type: string
+                    description: The user's email address, matching the email on their Slack account
+                    example: bob@example.com
+                id:
+                    type: string
+                    description: The incident.io ID of a user
+                    example: 01G0J1EXE7AXZ2C93K61WBPYEH
+                slack_user_id:
+                    type: string
+                    description: The ID of the user's Slack account.
+                    example: USER123
+            example:
+                email: bob@example.com
+                id: 01G0J1EXE7AXZ2C93K61WBPYEH
+                slack_user_id: USER123
         UserRoleMembershipsUpdatedV1ResponseBody:
             type: object
             properties:
@@ -25756,6 +30937,48 @@ components:
                 - context
                 - metadata
         UserV1:
+            type: object
+            properties:
+                email:
+                    type: string
+                    description: Email address of the user.
+                    example: lisa@incident.io
+                id:
+                    type: string
+                    description: Unique identifier of the user
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                name:
+                    type: string
+                    description: Name of the user
+                    example: Lisa Karlin Curtis
+                role:
+                    type: string
+                    description: 'DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.'
+                    example: viewer
+                    enum:
+                        - viewer
+                        - responder
+                        - administrator
+                        - owner
+                        - unset
+                slack_user_id:
+                    type: string
+                    description: Slack ID of the user
+                    example: U02AYNF2XJM
+            example:
+                email: lisa@incident.io
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                name: Lisa Karlin Curtis
+                role: viewer
+                slack_user_id: U02AYNF2XJM
+            required:
+                - role
+                - id
+                - slack_role
+                - name
+                - deprecated_base_role
+                - organisation_id
+        UserV2:
             type: object
             properties:
                 email:
@@ -25901,7 +31124,7 @@ components:
                 custom_field_entries:
                     type: array
                     items:
-                        $ref: '#/components/schemas/CustomFieldEntryV1'
+                        $ref: '#/components/schemas/CustomFieldEntryV2'
                     description: Custom field entries for this incident
                     example:
                         - custom_field:
@@ -25941,7 +31164,7 @@ components:
                             name: Lasted
                           value_seconds: 1
                 external_issue_reference:
-                    $ref: '#/components/schemas/ExternalIssueReferenceV2'
+                    $ref: '#/components/schemas/ExternalIssueReferenceV6'
                 id:
                     type: string
                     description: Unique identifier for the incident
@@ -25949,7 +31172,7 @@ components:
                 incident_role_assignments:
                     type: array
                     items:
-                        $ref: '#/components/schemas/IncidentRoleAssignmentV1'
+                        $ref: '#/components/schemas/IncidentRoleAssignmentV2'
                     description: A list of who is assigned to each role for this incident
                     example:
                         - assignee:
@@ -25969,7 +31192,7 @@ components:
                             shortform: lead
                             updated_at: "2021-08-17T13:28:57.801578Z"
                 incident_status:
-                    $ref: '#/components/schemas/IncidentStatusV1'
+                    $ref: '#/components/schemas/IncidentStatusV2'
                 incident_timestamp_values:
                     type: array
                     items:
@@ -25983,7 +31206,7 @@ components:
                           value:
                             value: "2021-08-17T13:28:57.801578Z"
                 incident_type:
-                    $ref: '#/components/schemas/IncidentTypeV1'
+                    $ref: '#/components/schemas/IncidentTypeV2'
                 mode:
                     type: string
                     description: Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
@@ -26202,6 +31425,528 @@ components:
                 - created_at
                 - updated_at
                 - reported_at
+        WebhookPayloadDefinitionsV2:
+            type: object
+            properties:
+                event_type:
+                    type: string
+                    description: What type of event is this webhook for?
+                    example: public_incident.incident_created_v2
+                    enum:
+                        - public_incident.incident_created_v2
+                        - private_incident.incident_created_v2
+                        - public_incident.incident_updated_v2
+                        - private_incident.incident_updated_v2
+                        - public_incident.incident_status_updated_v2
+                        - public_incident.follow_up_created_v1
+                        - private_incident.follow_up_created_v1
+                        - public_incident.follow_up_updated_v1
+                        - private_incident.follow_up_updated_v1
+                        - public_incident.action_created_v1
+                        - private_incident.action_created_v1
+                        - public_incident.action_updated_v1
+                        - private_incident.action_updated_v1
+                        - private_incident.membership_granted_v1
+                        - private_incident.membership_revoked_v1
+                private_incident.action_created_v1:
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                private_incident.action_updated_v1:
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                private_incident.follow_up_created_v1:
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                private_incident.follow_up_updated_v1:
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                private_incident.incident_created_v2:
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                private_incident.incident_updated_v2:
+                    $ref: '#/components/schemas/WebhookPrivateResourceV2'
+                private_incident.membership_granted_v1:
+                    $ref: '#/components/schemas/WebhookIncidentUserV2'
+                private_incident.membership_revoked_v1:
+                    $ref: '#/components/schemas/WebhookIncidentUserV2'
+                public_incident.action_created_v1:
+                    $ref: '#/components/schemas/ActionV1'
+                public_incident.action_updated_v1:
+                    $ref: '#/components/schemas/ActionV1'
+                public_incident.follow_up_created_v1:
+                    $ref: '#/components/schemas/ActionV1'
+                public_incident.follow_up_updated_v1:
+                    $ref: '#/components/schemas/ActionV1'
+                public_incident.incident_created_v2:
+                    $ref: '#/components/schemas/WebhookIncidentV2'
+                public_incident.incident_status_updated_v2:
+                    $ref: '#/components/schemas/IncidentWithStatusChangeV2'
+                public_incident.incident_updated_v2:
+                    $ref: '#/components/schemas/WebhookIncidentV2'
+            example:
+                event_type: public_incident.incident_created_v2
+                private_incident.action_created_v1:
+                    id: abc123
+                private_incident.action_updated_v1:
+                    id: abc123
+                private_incident.follow_up_created_v1:
+                    id: abc123
+                private_incident.follow_up_updated_v1:
+                    id: abc123
+                private_incident.incident_created_v2:
+                    id: abc123
+                private_incident.incident_updated_v2:
+                    id: abc123
+                private_incident.membership_granted_v1:
+                    actor_user_id: abc123
+                    incident_id: abc123
+                    user_id: abc123
+                private_incident.membership_revoked_v1:
+                    actor_user_id: abc123
+                    incident_id: abc123
+                    user_id: abc123
+                public_incident.action_created_v1:
+                    assignee:
+                        email: lisa@incident.io
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Lisa Karlin Curtis
+                        role: viewer
+                        slack_user_id: U02AYNF2XJM
+                    completed_at: "2021-08-17T13:28:57.801578Z"
+                    created_at: "2021-08-17T13:28:57.801578Z"
+                    description: Call the fire brigade
+                    external_issue_reference:
+                        issue_name: INC-123
+                        issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                        provider: asana
+                    follow_up: true
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    incident_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    status: outstanding
+                    updated_at: "2021-08-17T13:28:57.801578Z"
+                public_incident.action_updated_v1:
+                    assignee:
+                        email: lisa@incident.io
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Lisa Karlin Curtis
+                        role: viewer
+                        slack_user_id: U02AYNF2XJM
+                    completed_at: "2021-08-17T13:28:57.801578Z"
+                    created_at: "2021-08-17T13:28:57.801578Z"
+                    description: Call the fire brigade
+                    external_issue_reference:
+                        issue_name: INC-123
+                        issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                        provider: asana
+                    follow_up: true
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    incident_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    status: outstanding
+                    updated_at: "2021-08-17T13:28:57.801578Z"
+                public_incident.follow_up_created_v1:
+                    assignee:
+                        email: lisa@incident.io
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Lisa Karlin Curtis
+                        role: viewer
+                        slack_user_id: U02AYNF2XJM
+                    completed_at: "2021-08-17T13:28:57.801578Z"
+                    created_at: "2021-08-17T13:28:57.801578Z"
+                    description: Call the fire brigade
+                    external_issue_reference:
+                        issue_name: INC-123
+                        issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                        provider: asana
+                    follow_up: true
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    incident_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    status: outstanding
+                    updated_at: "2021-08-17T13:28:57.801578Z"
+                public_incident.follow_up_updated_v1:
+                    assignee:
+                        email: lisa@incident.io
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Lisa Karlin Curtis
+                        role: viewer
+                        slack_user_id: U02AYNF2XJM
+                    completed_at: "2021-08-17T13:28:57.801578Z"
+                    created_at: "2021-08-17T13:28:57.801578Z"
+                    description: Call the fire brigade
+                    external_issue_reference:
+                        issue_name: INC-123
+                        issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                        provider: asana
+                    follow_up: true
+                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    incident_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                    status: outstanding
+                    updated_at: "2021-08-17T13:28:57.801578Z"
+                public_incident.incident_created_v2:
+                    call_url: https://zoom.us/foo
+                    created_at: "2021-08-17T13:28:57.801578Z"
+                    creator:
+                        api_key:
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: My test API key
+                        user:
+                            email: lisa@incident.io
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: Lisa Karlin Curtis
+                            role: viewer
+                            slack_user_id: U02AYNF2XJM
+                    custom_field_entries:
+                        - custom_field:
+                            description: Which team is impacted by this issue
+                            field_type: single_select
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: Affected Team
+                            options:
+                                - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                  id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                  sort_key: 10
+                                  value: Product
+                          values:
+                            - value_catalog_entry:
+                                aliases:
+                                    - lawrence@incident.io
+                                    - lawrence
+                                external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                name: Primary On-call
+                              value_link: https://google.com/
+                              value_numeric: "123.456"
+                              value_option:
+                                custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                sort_key: 10
+                                value: Product
+                              value_text: This is my text field, I hope you like it
+                    duration_metrics:
+                        - duration_metric:
+                            id: 01FCNDV6P870EA6S7TK1DSYD5H
+                            name: Lasted
+                          value_seconds: 1
+                    external_issue_reference:
+                        issue_name: INC-123
+                        issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                        provider: asana
+                    id: 01FDAG4SAP5TYPT98WGR2N7W91
+                    incident_role_assignments:
+                        - assignee:
+                            email: lisa@incident.io
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: Lisa Karlin Curtis
+                            role: viewer
+                            slack_user_id: U02AYNF2XJM
+                          role:
+                            created_at: "2021-08-17T13:28:57.801578Z"
+                            description: The person currently coordinating the incident
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            instructions: Take point on the incident; Make sure people are clear on responsibilities
+                            name: Incident Lead
+                            required: false
+                            role_type: lead
+                            shortform: lead
+                            updated_at: "2021-08-17T13:28:57.801578Z"
+                    incident_status:
+                        category: triage
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                        id: 01FCNDV6P870EA6S7TK1DSYD5H
+                        name: Closed
+                        rank: 4
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+                    incident_timestamp_values:
+                        - incident_timestamp:
+                            id: 01FCNDV6P870EA6S7TK1DSYD5H
+                            name: Impact started
+                            rank: 1
+                          value:
+                            value: "2021-08-17T13:28:57.801578Z"
+                    incident_type:
+                        create_in_triage: always
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        description: Customer facing production outages
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        is_default: false
+                        name: Production Outage
+                        private_incidents_only: false
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+                    mode: standard
+                    name: Our database is sad
+                    permalink: https://app.incident.io/incidents/123
+                    postmortem_document_url: https://docs.google.com/my_doc_id
+                    reference: INC-123
+                    related_incidents:
+                        - INC-237
+                    severity:
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        description: Issues with **low impact**.
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Minor
+                        rank: 1
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+                    slack_channel_id: C02AW36C1M5
+                    slack_channel_name: inc-165-green-parrot
+                    slack_team_id: T02A1FSLE8J
+                    summary: Our database is really really sad, and we don't know why yet.
+                    updated_at: "2021-08-17T13:28:57.801578Z"
+                    visibility: public
+                    workload_minutes_late: 40.7
+                    workload_minutes_sleeping: 0
+                    workload_minutes_total: 60.7
+                    workload_minutes_working: 20
+                public_incident.incident_status_updated_v2:
+                    incident:
+                        call_url: https://zoom.us/foo
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        creator:
+                            api_key:
+                                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                name: My test API key
+                            user:
+                                email: lisa@incident.io
+                                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                name: Lisa Karlin Curtis
+                                role: viewer
+                                slack_user_id: U02AYNF2XJM
+                        custom_field_entries:
+                            - custom_field:
+                                description: Which team is impacted by this issue
+                                field_type: single_select
+                                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                name: Affected Team
+                                options:
+                                    - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                      id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                      sort_key: 10
+                                      value: Product
+                              values:
+                                - value_catalog_entry:
+                                    aliases:
+                                        - lawrence@incident.io
+                                        - lawrence
+                                    external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    name: Primary On-call
+                                  value_link: https://google.com/
+                                  value_numeric: "123.456"
+                                  value_option:
+                                    custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                    sort_key: 10
+                                    value: Product
+                                  value_text: This is my text field, I hope you like it
+                        duration_metrics:
+                            - duration_metric:
+                                id: 01FCNDV6P870EA6S7TK1DSYD5H
+                                name: Lasted
+                              value_seconds: 1
+                        external_issue_reference:
+                            issue_name: INC-123
+                            issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                            provider: asana
+                        id: 01FDAG4SAP5TYPT98WGR2N7W91
+                        incident_role_assignments:
+                            - assignee:
+                                email: lisa@incident.io
+                                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                name: Lisa Karlin Curtis
+                                role: viewer
+                                slack_user_id: U02AYNF2XJM
+                              role:
+                                created_at: "2021-08-17T13:28:57.801578Z"
+                                description: The person currently coordinating the incident
+                                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                instructions: Take point on the incident; Make sure people are clear on responsibilities
+                                name: Incident Lead
+                                required: false
+                                role_type: lead
+                                shortform: lead
+                                updated_at: "2021-08-17T13:28:57.801578Z"
+                        incident_status:
+                            category: triage
+                            created_at: "2021-08-17T13:28:57.801578Z"
+                            description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                            id: 01FCNDV6P870EA6S7TK1DSYD5H
+                            name: Closed
+                            rank: 4
+                            updated_at: "2021-08-17T13:28:57.801578Z"
+                        incident_timestamp_values:
+                            - incident_timestamp:
+                                id: 01FCNDV6P870EA6S7TK1DSYD5H
+                                name: Impact started
+                                rank: 1
+                              value:
+                                value: "2021-08-17T13:28:57.801578Z"
+                        incident_type:
+                            create_in_triage: always
+                            created_at: "2021-08-17T13:28:57.801578Z"
+                            description: Customer facing production outages
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            is_default: false
+                            name: Production Outage
+                            private_incidents_only: false
+                            updated_at: "2021-08-17T13:28:57.801578Z"
+                        mode: standard
+                        name: Our database is sad
+                        permalink: https://app.incident.io/incidents/123
+                        postmortem_document_url: https://docs.google.com/my_doc_id
+                        reference: INC-123
+                        severity:
+                            created_at: "2021-08-17T13:28:57.801578Z"
+                            description: Issues with **low impact**.
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: Minor
+                            rank: 1
+                            updated_at: "2021-08-17T13:28:57.801578Z"
+                        slack_channel_id: C02AW36C1M5
+                        slack_channel_name: inc-165-green-parrot
+                        slack_team_id: T02A1FSLE8J
+                        summary: Our database is really really sad, and we don't know why yet.
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+                        visibility: public
+                        workload_minutes_late: 40.7
+                        workload_minutes_sleeping: 0
+                        workload_minutes_total: 60.7
+                        workload_minutes_working: 20
+                    new_status:
+                        category: triage
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                        id: 01FCNDV6P870EA6S7TK1DSYD5H
+                        name: Closed
+                        rank: 4
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+                    previous_status:
+                        category: triage
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                        id: 01FCNDV6P870EA6S7TK1DSYD5H
+                        name: Closed
+                        rank: 4
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+                public_incident.incident_updated_v2:
+                    call_url: https://zoom.us/foo
+                    created_at: "2021-08-17T13:28:57.801578Z"
+                    creator:
+                        api_key:
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: My test API key
+                        user:
+                            email: lisa@incident.io
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: Lisa Karlin Curtis
+                            role: viewer
+                            slack_user_id: U02AYNF2XJM
+                    custom_field_entries:
+                        - custom_field:
+                            description: Which team is impacted by this issue
+                            field_type: single_select
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: Affected Team
+                            options:
+                                - custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                  id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                  sort_key: 10
+                                  value: Product
+                          values:
+                            - value_catalog_entry:
+                                aliases:
+                                    - lawrence@incident.io
+                                    - lawrence
+                                external_id: 761722cd-d1d7-477b-ac7e-90f9e079dc33
+                                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                name: Primary On-call
+                              value_link: https://google.com/
+                              value_numeric: "123.456"
+                              value_option:
+                                custom_field_id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                                sort_key: 10
+                                value: Product
+                              value_text: This is my text field, I hope you like it
+                    duration_metrics:
+                        - duration_metric:
+                            id: 01FCNDV6P870EA6S7TK1DSYD5H
+                            name: Lasted
+                          value_seconds: 1
+                    external_issue_reference:
+                        issue_name: INC-123
+                        issue_permalink: https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up
+                        provider: asana
+                    id: 01FDAG4SAP5TYPT98WGR2N7W91
+                    incident_role_assignments:
+                        - assignee:
+                            email: lisa@incident.io
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            name: Lisa Karlin Curtis
+                            role: viewer
+                            slack_user_id: U02AYNF2XJM
+                          role:
+                            created_at: "2021-08-17T13:28:57.801578Z"
+                            description: The person currently coordinating the incident
+                            id: 01FCNDV6P870EA6S7TK1DSYDG0
+                            instructions: Take point on the incident; Make sure people are clear on responsibilities
+                            name: Incident Lead
+                            required: false
+                            role_type: lead
+                            shortform: lead
+                            updated_at: "2021-08-17T13:28:57.801578Z"
+                    incident_status:
+                        category: triage
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        description: Impact has been **fully mitigated**, and we're ready to learn from this incident.
+                        id: 01FCNDV6P870EA6S7TK1DSYD5H
+                        name: Closed
+                        rank: 4
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+                    incident_timestamp_values:
+                        - incident_timestamp:
+                            id: 01FCNDV6P870EA6S7TK1DSYD5H
+                            name: Impact started
+                            rank: 1
+                          value:
+                            value: "2021-08-17T13:28:57.801578Z"
+                    incident_type:
+                        create_in_triage: always
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        description: Customer facing production outages
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        is_default: false
+                        name: Production Outage
+                        private_incidents_only: false
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+                    mode: standard
+                    name: Our database is sad
+                    permalink: https://app.incident.io/incidents/123
+                    postmortem_document_url: https://docs.google.com/my_doc_id
+                    reference: INC-123
+                    related_incidents:
+                        - INC-237
+                    severity:
+                        created_at: "2021-08-17T13:28:57.801578Z"
+                        description: Issues with **low impact**.
+                        id: 01FCNDV6P870EA6S7TK1DSYDG0
+                        name: Minor
+                        rank: 1
+                        updated_at: "2021-08-17T13:28:57.801578Z"
+                    slack_channel_id: C02AW36C1M5
+                    slack_channel_name: inc-165-green-parrot
+                    slack_team_id: T02A1FSLE8J
+                    summary: Our database is really really sad, and we don't know why yet.
+                    updated_at: "2021-08-17T13:28:57.801578Z"
+                    visibility: public
+                    workload_minutes_late: 40.7
+                    workload_minutes_sleeping: 0
+                    workload_minutes_total: 60.7
+                    workload_minutes_working: 20
+        WebhookPrivateResourceV2:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: The ID of the resource
+                    example: abc123
+            example:
+                id: abc123
+            required:
+                - id
         WeekdayIntervalConfigV2:
             type: object
             properties:
@@ -26251,7 +31996,6 @@ components:
                     example: "09:00"
                 weekday:
                     type: string
-                    description: Weekday this interval applies to
                     example: abc123
             example:
                 end_time: "17:00"
@@ -26267,7 +32011,7 @@ components:
                 condition_groups:
                     type: array
                     items:
-                        $ref: '#/components/schemas/ConditionGroupV3'
+                        $ref: '#/components/schemas/ConditionGroupV5'
                     description: Conditions that apply to the workflow trigger
                     example:
                         - conditions:
@@ -26411,7 +32155,8 @@ components:
                     type: array
                     items:
                         type: string
-                        example: test
+                        description: Incident mode that workflows can run on
+                        example: standard
                         enum:
                             - standard
                             - test
@@ -26610,31 +32355,13 @@ components:
                 - runs_on_incidents
                 - once_for
                 - state
-        WorkflowDelay:
-            type: object
-            properties:
-                conditions_apply_over_delay:
-                    type: boolean
-                    description: If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution
-                    example: false
-                for_seconds:
-                    type: integer
-                    description: Delay in seconds between trigger firing and running the workflow
-                    example: 60
-                    format: int64
-            example:
-                conditions_apply_over_delay: false
-                for_seconds: 60
-            required:
-                - for_seconds
-                - conditions_apply_over_delay
-        WorkflowSlim:
+        WorkflowDefinitions:
             type: object
             properties:
                 condition_groups:
                     type: array
                     items:
-                        $ref: '#/components/schemas/ConditionGroupV3'
+                        $ref: '#/components/schemas/ConditionGroupV2'
                     description: Conditions that apply to the workflow trigger
                     example:
                         - conditions:
@@ -26662,7 +32389,7 @@ components:
                 expressions:
                     type: array
                     items:
-                        $ref: '#/components/schemas/ExpressionV3'
+                        $ref: '#/components/schemas/ExpressionV2'
                     description: Expressions that make variables available in the scope
                     example:
                         - else_branch:
@@ -26778,7 +32505,574 @@ components:
                     type: array
                     items:
                         type: string
-                        example: test
+                        description: Incident mode that workflows can run on
+                        example: standard
+                        enum:
+                            - standard
+                            - test
+                            - retrospective
+                    description: Which modes of incident this should run on (defaults to just standard incidents)
+                    example:
+                        - standard
+                        - retrospective
+                runs_on_incidents:
+                    type: string
+                    description: Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
+                    example: newly_created
+                    enum:
+                        - newly_created
+                        - newly_created_and_active
+                state:
+                    type: string
+                    description: The state of the workflow (e.g. is it draft, or disabled)
+                    example: active
+                    enum:
+                        - active
+                        - disabled
+                        - draft
+                        - error
+                trigger:
+                    $ref: '#/components/schemas/TriggerSlim'
+                version:
+                    type: integer
+                    description: Revision of the workflow, uniquely identifying its version
+                    example: 3
+                    format: int64
+            example:
+                condition_groups:
+                    - conditions:
+                        - operation:
+                            label: Lawrence Jones
+                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                          param_bindings:
+                            - array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                          subject:
+                            label: Incident Severity
+                            reference: incident.severity
+                continue_on_step_error: true
+                delay:
+                    conditions_apply_over_delay: false
+                    for_seconds: 60
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - label: Lawrence Jones
+                                  literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                label: Lawrence Jones
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                                  result:
+                                    array_value:
+                                        - label: Lawrence Jones
+                                          literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        label: Lawrence Jones
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation:
+                                        label: Lawrence Jones
+                                        value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                      param_bindings:
+                                        - array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject:
+                                        label: Incident Severity
+                                        reference: incident.severity
+                          navigate:
+                            reference: "1235"
+                            reference_label: Teams
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                      reference: abc123
+                      returns:
+                        array: true
+                        type: IncidentStatus
+                      root_reference: incident.status
+                folder: My folder 01
+                id: 01FCNDV6P870EA6S7TK1DSYDG0
+                include_private_incidents: true
+                name: My workflow
+                once_for:
+                    - array: false
+                      key: incident.custom_field["01FCNDV6P870EA6S7TK1DSYDG0"]
+                      label: Incident -> Affected Team
+                      type: IncidentSeverity
+                runs_from: "2021-08-17T13:28:57.801578Z"
+                runs_on_incident_modes:
+                    - standard
+                    - retrospective
+                runs_on_incidents: newly_created
+                state: active
+                trigger:
+                    label: Incident Updated
+                    name: incident.updated
+                version: 3
+        WorkflowDelay:
+            type: object
+            properties:
+                conditions_apply_over_delay:
+                    type: boolean
+                    description: If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution
+                    example: false
+                for_seconds:
+                    type: integer
+                    description: Delay in seconds between trigger firing and running the workflow
+                    example: 60
+                    format: int64
+            example:
+                conditions_apply_over_delay: false
+                for_seconds: 60
+            required:
+                - for_seconds
+                - conditions_apply_over_delay
+        WorkflowPayload:
+            type: object
+            properties:
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupPayloadV2'
+                    description: List of conditions to apply to the workflow
+                    example:
+                        - conditions:
+                            - operation: one_of
+                              param_bindings:
+                                - array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject: incident.severity
+                continue_on_step_error:
+                    type: boolean
+                    description: Whether to continue executing the workflow if a step fails
+                    example: true
+                delay:
+                    $ref: '#/components/schemas/WorkflowDelay'
+                expressions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionPayloadV2'
+                    description: The expressions used in the workflow
+                    example:
+                        - else_branch:
+                            result:
+                                array_value:
+                                    - literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    literal: SEV123
+                                    reference: incident.severity
+                          label: Team Slack channel
+                          operations:
+                            - branches:
+                                branches:
+                                    - condition_groups:
+                                        - conditions:
+                                            - operation: one_of
+                                              param_bindings:
+                                                - array_value:
+                                                    - literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject: incident.severity
+                                      result:
+                                        array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                              filter:
+                                condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                              navigate:
+                                reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                              operation_type: navigate
+                              parse:
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                                source: metadata.annotations["github.com/repo"]
+                          reference: abc123
+                          root_reference: incident.status
+                folder:
+                    type: string
+                    description: Folder to display the workflow in
+                    example: My folder 01
+                include_private_incidents:
+                    type: boolean
+                    description: Whether to include private incidents
+                    example: true
+                name:
+                    type: string
+                    description: The human-readable name of the workflow
+                    example: My workflow
+                once_for:
+                    type: array
+                    items:
+                        type: string
+                        example: incident.url
+                    description: Once For strategy to apply to this workflow
+                    example:
+                        - incident.url
+                runs_on_incident_modes:
+                    type: array
+                    items:
+                        type: string
+                        description: Incident mode that workflows can run on
+                        example: standard
+                        enum:
+                            - standard
+                            - test
+                            - retrospective
+                    description: Which modes of incident this should run on (defaults to just standard incidents)
+                    example:
+                        - standard
+                        - retrospective
+                runs_on_incidents:
+                    type: string
+                    description: Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
+                    example: newly_created
+                    enum:
+                        - newly_created
+                        - newly_created_and_active
+                state:
+                    type: string
+                    description: The state of the workflow (e.g. is it draft, or disabled)
+                    example: active
+                    enum:
+                        - active
+                        - disabled
+                        - draft
+                        - error
+                steps:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/StepConfigPayload'
+                    description: List of step to execute as part of the workflow
+                    example:
+                        - for_each: abc123
+                          id: abc123
+                          name: pagerduty.escalate
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+            example:
+                condition_groups:
+                    - conditions:
+                        - operation: one_of
+                          param_bindings:
+                            - array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                              value:
+                                literal: SEV123
+                                reference: incident.severity
+                          subject: incident.severity
+                continue_on_step_error: true
+                delay:
+                    conditions_apply_over_delay: false
+                    for_seconds: 60
+                expressions:
+                    - else_branch:
+                        result:
+                            array_value:
+                                - literal: SEV123
+                                  reference: incident.severity
+                            value:
+                                literal: SEV123
+                                reference: incident.severity
+                      label: Team Slack channel
+                      operations:
+                        - branches:
+                            branches:
+                                - condition_groups:
+                                    - conditions:
+                                        - operation: one_of
+                                          param_bindings:
+                                            - array_value:
+                                                - literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject: incident.severity
+                                  result:
+                                    array_value:
+                                        - literal: SEV123
+                                          reference: incident.severity
+                                    value:
+                                        literal: SEV123
+                                        reference: incident.severity
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                          filter:
+                            condition_groups:
+                                - conditions:
+                                    - operation: one_of
+                                      param_bindings:
+                                        - array_value:
+                                            - literal: SEV123
+                                              reference: incident.severity
+                                          value:
+                                            literal: SEV123
+                                            reference: incident.severity
+                                      subject: incident.severity
+                          navigate:
+                            reference: catalog_attribute["01FCNDV6P870EA6S7TK1DSYD5H"]
+                          operation_type: navigate
+                          parse:
+                            returns:
+                                array: true
+                                type: IncidentStatus
+                            source: metadata.annotations["github.com/repo"]
+                      reference: abc123
+                      root_reference: incident.status
+                folder: My folder 01
+                include_private_incidents: true
+                name: My workflow
+                once_for:
+                    - incident.url
+                runs_on_incident_modes:
+                    - standard
+                    - retrospective
+                runs_on_incidents: newly_created
+                state: active
+                steps:
+                    - for_each: abc123
+                      id: abc123
+                      name: pagerduty.escalate
+                      param_bindings:
+                        - array_value:
+                            - literal: SEV123
+                              reference: incident.severity
+                          value:
+                            literal: SEV123
+                            reference: incident.severity
+        WorkflowSlim:
+            type: object
+            properties:
+                condition_groups:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ConditionGroupV8'
+                    description: Conditions that apply to the workflow trigger
+                    example:
+                        - conditions:
+                            - operation:
+                                label: Lawrence Jones
+                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                              param_bindings:
+                                - array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                  value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                              subject:
+                                label: Incident Severity
+                                reference: incident.severity
+                continue_on_step_error:
+                    type: boolean
+                    description: Whether to continue executing the workflow if a step fails
+                    example: true
+                delay:
+                    $ref: '#/components/schemas/WorkflowDelay'
+                expressions:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExpressionV4'
+                    description: Expressions that make variables available in the scope
+                    example:
+                        - else_branch:
+                            result:
+                                array_value:
+                                    - label: Lawrence Jones
+                                      literal: SEV123
+                                      reference: incident.severity
+                                value:
+                                    label: Lawrence Jones
+                                    literal: SEV123
+                                    reference: incident.severity
+                          label: Team Slack channel
+                          operations:
+                            - branches:
+                                branches:
+                                    - condition_groups:
+                                        - conditions:
+                                            - operation:
+                                                label: Lawrence Jones
+                                                value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                              param_bindings:
+                                                - array_value:
+                                                    - label: Lawrence Jones
+                                                      literal: SEV123
+                                                      reference: incident.severity
+                                                  value:
+                                                    label: Lawrence Jones
+                                                    literal: SEV123
+                                                    reference: incident.severity
+                                              subject:
+                                                label: Incident Severity
+                                                reference: incident.severity
+                                      result:
+                                        array_value:
+                                            - label: Lawrence Jones
+                                              literal: SEV123
+                                              reference: incident.severity
+                                        value:
+                                            label: Lawrence Jones
+                                            literal: SEV123
+                                            reference: incident.severity
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                              filter:
+                                condition_groups:
+                                    - conditions:
+                                        - operation:
+                                            label: Lawrence Jones
+                                            value: 01FCQSP07Z74QMMYPDDGQB9FTG
+                                          param_bindings:
+                                            - array_value:
+                                                - label: Lawrence Jones
+                                                  literal: SEV123
+                                                  reference: incident.severity
+                                              value:
+                                                label: Lawrence Jones
+                                                literal: SEV123
+                                                reference: incident.severity
+                                          subject:
+                                            label: Incident Severity
+                                            reference: incident.severity
+                              navigate:
+                                reference: "1235"
+                                reference_label: Teams
+                              operation_type: navigate
+                              parse:
+                                returns:
+                                    array: true
+                                    type: IncidentStatus
+                                source: metadata.annotations["github.com/repo"]
+                              returns:
+                                array: true
+                                type: IncidentStatus
+                          reference: abc123
+                          returns:
+                            array: true
+                            type: IncidentStatus
+                          root_reference: incident.status
+                folder:
+                    type: string
+                    description: Folder to display the workflow in
+                    example: My folder 01
+                id:
+                    type: string
+                    description: Unique identifier for the workflow
+                    example: 01FCNDV6P870EA6S7TK1DSYDG0
+                include_private_incidents:
+                    type: boolean
+                    description: Whether to include private incidents
+                    example: true
+                name:
+                    type: string
+                    description: The human-readable name of the workflow
+                    example: My workflow
+                once_for:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/EngineReferenceV2'
+                    description: This workflow will run 'once for' a list of references
+                    example:
+                        - array: false
+                          key: incident.custom_field["01FCNDV6P870EA6S7TK1DSYDG0"]
+                          label: Incident -> Affected Team
+                          type: IncidentSeverity
+                runs_from:
+                    type: string
+                    description: The time from which this workflow will run on incidents
+                    example: "2021-08-17T13:28:57.801578Z"
+                    format: date-time
+                runs_on_incident_modes:
+                    type: array
+                    items:
+                        type: string
+                        description: Incident mode that workflows can run on
+                        example: standard
                         enum:
                             - standard
                             - test

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
-	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
 )
 
 // Defines values for ActionV1Status.
@@ -162,40 +161,27 @@ const (
 	CreateManagedResourceRequestBodyResourceTypeWorkflow CreateManagedResourceRequestBodyResourceType = "workflow"
 )
 
-// Defines values for CreateRequestBody10Mode.
+// Defines values for CreateRequestBody2FieldType.
 const (
-	CreateRequestBody10ModeReal CreateRequestBody10Mode = "real"
-	CreateRequestBody10ModeTest CreateRequestBody10Mode = "test"
+	CreateRequestBody2FieldTypeLink         CreateRequestBody2FieldType = "link"
+	CreateRequestBody2FieldTypeMultiSelect  CreateRequestBody2FieldType = "multi_select"
+	CreateRequestBody2FieldTypeNumeric      CreateRequestBody2FieldType = "numeric"
+	CreateRequestBody2FieldTypeSingleSelect CreateRequestBody2FieldType = "single_select"
+	CreateRequestBody2FieldTypeText         CreateRequestBody2FieldType = "text"
 )
 
-// Defines values for CreateRequestBody10Status.
+// Defines values for CreateRequestBody2Required.
 const (
-	CreateRequestBody10StatusClosed        CreateRequestBody10Status = "closed"
-	CreateRequestBody10StatusDeclined      CreateRequestBody10Status = "declined"
-	CreateRequestBody10StatusFixing        CreateRequestBody10Status = "fixing"
-	CreateRequestBody10StatusInvestigating CreateRequestBody10Status = "investigating"
-	CreateRequestBody10StatusMonitoring    CreateRequestBody10Status = "monitoring"
-	CreateRequestBody10StatusTriage        CreateRequestBody10Status = "triage"
+	CreateRequestBody2RequiredAlways        CreateRequestBody2Required = "always"
+	CreateRequestBody2RequiredBeforeClosure CreateRequestBody2Required = "before_closure"
+	CreateRequestBody2RequiredNever         CreateRequestBody2Required = "never"
 )
 
-// Defines values for CreateRequestBody10Visibility.
+// Defines values for CreateRequestBody2RequiredV2.
 const (
-	CreateRequestBody10VisibilityPrivate CreateRequestBody10Visibility = "private"
-	CreateRequestBody10VisibilityPublic  CreateRequestBody10Visibility = "public"
-)
-
-// Defines values for CreateRequestBody11Mode.
-const (
-	CreateRequestBody11ModeRetrospective CreateRequestBody11Mode = "retrospective"
-	CreateRequestBody11ModeStandard      CreateRequestBody11Mode = "standard"
-	CreateRequestBody11ModeTest          CreateRequestBody11Mode = "test"
-	CreateRequestBody11ModeTutorial      CreateRequestBody11Mode = "tutorial"
-)
-
-// Defines values for CreateRequestBody11Visibility.
-const (
-	CreateRequestBody11VisibilityPrivate CreateRequestBody11Visibility = "private"
-	CreateRequestBody11VisibilityPublic  CreateRequestBody11Visibility = "public"
+	CreateRequestBody2RequiredV2Always           CreateRequestBody2RequiredV2 = "always"
+	CreateRequestBody2RequiredV2BeforeResolution CreateRequestBody2RequiredV2 = "before_resolution"
+	CreateRequestBody2RequiredV2Never            CreateRequestBody2RequiredV2 = "never"
 )
 
 // Defines values for CreateRequestBody3FieldType.
@@ -207,50 +193,27 @@ const (
 	CreateRequestBody3FieldTypeText         CreateRequestBody3FieldType = "text"
 )
 
-// Defines values for CreateRequestBody3Required.
+// Defines values for CreateRequestBody4ResourceResourceType.
 const (
-	CreateRequestBody3RequiredAlways        CreateRequestBody3Required = "always"
-	CreateRequestBody3RequiredBeforeClosure CreateRequestBody3Required = "before_closure"
-	CreateRequestBody3RequiredNever         CreateRequestBody3Required = "never"
+	CreateRequestBody4ResourceResourceTypeAtlassianStatuspageIncident CreateRequestBody4ResourceResourceType = "atlassian_statuspage_incident"
+	CreateRequestBody4ResourceResourceTypeDatadogMonitorAlert         CreateRequestBody4ResourceResourceType = "datadog_monitor_alert"
+	CreateRequestBody4ResourceResourceTypeGithubPullRequest           CreateRequestBody4ResourceResourceType = "github_pull_request"
+	CreateRequestBody4ResourceResourceTypeGitlabMergeRequest          CreateRequestBody4ResourceResourceType = "gitlab_merge_request"
+	CreateRequestBody4ResourceResourceTypeGoogleCalendarEvent         CreateRequestBody4ResourceResourceType = "google_calendar_event"
+	CreateRequestBody4ResourceResourceTypeJiraIssue                   CreateRequestBody4ResourceResourceType = "jira_issue"
+	CreateRequestBody4ResourceResourceTypeOpsgenieAlert               CreateRequestBody4ResourceResourceType = "opsgenie_alert"
+	CreateRequestBody4ResourceResourceTypePagerDutyIncident           CreateRequestBody4ResourceResourceType = "pager_duty_incident"
+	CreateRequestBody4ResourceResourceTypeScrubbed                    CreateRequestBody4ResourceResourceType = "scrubbed"
+	CreateRequestBody4ResourceResourceTypeSentryIssue                 CreateRequestBody4ResourceResourceType = "sentry_issue"
+	CreateRequestBody4ResourceResourceTypeStatuspageIncident          CreateRequestBody4ResourceResourceType = "statuspage_incident"
+	CreateRequestBody4ResourceResourceTypeZendeskTicket               CreateRequestBody4ResourceResourceType = "zendesk_ticket"
 )
 
-// Defines values for CreateRequestBody3RequiredV2.
+// Defines values for CreateRequestBody8Category.
 const (
-	CreateRequestBody3RequiredV2Always           CreateRequestBody3RequiredV2 = "always"
-	CreateRequestBody3RequiredV2BeforeResolution CreateRequestBody3RequiredV2 = "before_resolution"
-	CreateRequestBody3RequiredV2Never            CreateRequestBody3RequiredV2 = "never"
-)
-
-// Defines values for CreateRequestBody4FieldType.
-const (
-	CreateRequestBody4FieldTypeLink         CreateRequestBody4FieldType = "link"
-	CreateRequestBody4FieldTypeMultiSelect  CreateRequestBody4FieldType = "multi_select"
-	CreateRequestBody4FieldTypeNumeric      CreateRequestBody4FieldType = "numeric"
-	CreateRequestBody4FieldTypeSingleSelect CreateRequestBody4FieldType = "single_select"
-	CreateRequestBody4FieldTypeText         CreateRequestBody4FieldType = "text"
-)
-
-// Defines values for CreateRequestBody5ResourceResourceType.
-const (
-	CreateRequestBody5ResourceResourceTypeAtlassianStatuspageIncident CreateRequestBody5ResourceResourceType = "atlassian_statuspage_incident"
-	CreateRequestBody5ResourceResourceTypeDatadogMonitorAlert         CreateRequestBody5ResourceResourceType = "datadog_monitor_alert"
-	CreateRequestBody5ResourceResourceTypeGithubPullRequest           CreateRequestBody5ResourceResourceType = "github_pull_request"
-	CreateRequestBody5ResourceResourceTypeGitlabMergeRequest          CreateRequestBody5ResourceResourceType = "gitlab_merge_request"
-	CreateRequestBody5ResourceResourceTypeGoogleCalendarEvent         CreateRequestBody5ResourceResourceType = "google_calendar_event"
-	CreateRequestBody5ResourceResourceTypeJiraIssue                   CreateRequestBody5ResourceResourceType = "jira_issue"
-	CreateRequestBody5ResourceResourceTypeOpsgenieAlert               CreateRequestBody5ResourceResourceType = "opsgenie_alert"
-	CreateRequestBody5ResourceResourceTypePagerDutyIncident           CreateRequestBody5ResourceResourceType = "pager_duty_incident"
-	CreateRequestBody5ResourceResourceTypeScrubbed                    CreateRequestBody5ResourceResourceType = "scrubbed"
-	CreateRequestBody5ResourceResourceTypeSentryIssue                 CreateRequestBody5ResourceResourceType = "sentry_issue"
-	CreateRequestBody5ResourceResourceTypeStatuspageIncident          CreateRequestBody5ResourceResourceType = "statuspage_incident"
-	CreateRequestBody5ResourceResourceTypeZendeskTicket               CreateRequestBody5ResourceResourceType = "zendesk_ticket"
-)
-
-// Defines values for CreateRequestBody9Category.
-const (
-	CreateRequestBody9CategoryClosed   CreateRequestBody9Category = "closed"
-	CreateRequestBody9CategoryLearning CreateRequestBody9Category = "learning"
-	CreateRequestBody9CategoryLive     CreateRequestBody9Category = "live"
+	CreateRequestBody8CategoryClosed   CreateRequestBody8Category = "closed"
+	CreateRequestBody8CategoryLearning CreateRequestBody8Category = "learning"
+	CreateRequestBody8CategoryLive     CreateRequestBody8Category = "live"
 )
 
 // Defines values for CreateTypeRequestBodyCategories.
@@ -306,25 +269,25 @@ const (
 	CreateTypeRequestBodyIconUsers          CreateTypeRequestBodyIcon = "users"
 )
 
-// Defines values for CreateWorkflowRequestBodyRunsOnIncidentModes.
+// Defines values for CreateWorkflowPayloadRunsOnIncidentModes.
 const (
-	CreateWorkflowRequestBodyRunsOnIncidentModesRetrospective CreateWorkflowRequestBodyRunsOnIncidentModes = "retrospective"
-	CreateWorkflowRequestBodyRunsOnIncidentModesStandard      CreateWorkflowRequestBodyRunsOnIncidentModes = "standard"
-	CreateWorkflowRequestBodyRunsOnIncidentModesTest          CreateWorkflowRequestBodyRunsOnIncidentModes = "test"
+	CreateWorkflowPayloadRunsOnIncidentModesRetrospective CreateWorkflowPayloadRunsOnIncidentModes = "retrospective"
+	CreateWorkflowPayloadRunsOnIncidentModesStandard      CreateWorkflowPayloadRunsOnIncidentModes = "standard"
+	CreateWorkflowPayloadRunsOnIncidentModesTest          CreateWorkflowPayloadRunsOnIncidentModes = "test"
 )
 
-// Defines values for CreateWorkflowRequestBodyRunsOnIncidents.
+// Defines values for CreateWorkflowPayloadRunsOnIncidents.
 const (
-	CreateWorkflowRequestBodyRunsOnIncidentsNewlyCreated          CreateWorkflowRequestBodyRunsOnIncidents = "newly_created"
-	CreateWorkflowRequestBodyRunsOnIncidentsNewlyCreatedAndActive CreateWorkflowRequestBodyRunsOnIncidents = "newly_created_and_active"
+	CreateWorkflowPayloadRunsOnIncidentsNewlyCreated          CreateWorkflowPayloadRunsOnIncidents = "newly_created"
+	CreateWorkflowPayloadRunsOnIncidentsNewlyCreatedAndActive CreateWorkflowPayloadRunsOnIncidents = "newly_created_and_active"
 )
 
-// Defines values for CreateWorkflowRequestBodyState.
+// Defines values for CreateWorkflowPayloadState.
 const (
-	CreateWorkflowRequestBodyStateActive   CreateWorkflowRequestBodyState = "active"
-	CreateWorkflowRequestBodyStateDisabled CreateWorkflowRequestBodyState = "disabled"
-	CreateWorkflowRequestBodyStateDraft    CreateWorkflowRequestBodyState = "draft"
-	CreateWorkflowRequestBodyStateError    CreateWorkflowRequestBodyState = "error"
+	CreateWorkflowPayloadStateActive   CreateWorkflowPayloadState = "active"
+	CreateWorkflowPayloadStateDisabled CreateWorkflowPayloadState = "disabled"
+	CreateWorkflowPayloadStateDraft    CreateWorkflowPayloadState = "draft"
+	CreateWorkflowPayloadStateError    CreateWorkflowPayloadState = "error"
 )
 
 // Defines values for CustomFieldTypeInfoV1FieldType.
@@ -334,6 +297,15 @@ const (
 	CustomFieldTypeInfoV1FieldTypeNumeric      CustomFieldTypeInfoV1FieldType = "numeric"
 	CustomFieldTypeInfoV1FieldTypeSingleSelect CustomFieldTypeInfoV1FieldType = "single_select"
 	CustomFieldTypeInfoV1FieldTypeText         CustomFieldTypeInfoV1FieldType = "text"
+)
+
+// Defines values for CustomFieldTypeInfoV2FieldType.
+const (
+	CustomFieldTypeInfoV2FieldTypeLink         CustomFieldTypeInfoV2FieldType = "link"
+	CustomFieldTypeInfoV2FieldTypeMultiSelect  CustomFieldTypeInfoV2FieldType = "multi_select"
+	CustomFieldTypeInfoV2FieldTypeNumeric      CustomFieldTypeInfoV2FieldType = "numeric"
+	CustomFieldTypeInfoV2FieldTypeSingleSelect CustomFieldTypeInfoV2FieldType = "single_select"
+	CustomFieldTypeInfoV2FieldTypeText         CustomFieldTypeInfoV2FieldType = "text"
 )
 
 // Defines values for CustomFieldV1FieldType.
@@ -361,11 +333,18 @@ const (
 
 // Defines values for CustomFieldV2FieldType.
 const (
-	Link         CustomFieldV2FieldType = "link"
-	MultiSelect  CustomFieldV2FieldType = "multi_select"
-	Numeric      CustomFieldV2FieldType = "numeric"
-	SingleSelect CustomFieldV2FieldType = "single_select"
-	Text         CustomFieldV2FieldType = "text"
+	CustomFieldV2FieldTypeLink         CustomFieldV2FieldType = "link"
+	CustomFieldV2FieldTypeMultiSelect  CustomFieldV2FieldType = "multi_select"
+	CustomFieldV2FieldTypeNumeric      CustomFieldV2FieldType = "numeric"
+	CustomFieldV2FieldTypeSingleSelect CustomFieldV2FieldType = "single_select"
+	CustomFieldV2FieldTypeText         CustomFieldV2FieldType = "text"
+)
+
+// Defines values for EmbeddedIncidentRoleV2RoleType.
+const (
+	EmbeddedIncidentRoleV2RoleTypeCustom   EmbeddedIncidentRoleV2RoleType = "custom"
+	EmbeddedIncidentRoleV2RoleTypeLead     EmbeddedIncidentRoleV2RoleType = "lead"
+	EmbeddedIncidentRoleV2RoleTypeReporter EmbeddedIncidentRoleV2RoleType = "reporter"
 )
 
 // Defines values for EscalationPathNodeLevelV2TimeToAckIntervalCondition.
@@ -439,27 +418,28 @@ const (
 
 // Defines values for ExpressionOperationV3OperationType.
 const (
-	Branches ExpressionOperationV3OperationType = "branches"
-	Count    ExpressionOperationV3OperationType = "count"
-	Filter   ExpressionOperationV3OperationType = "filter"
-	First    ExpressionOperationV3OperationType = "first"
-	Max      ExpressionOperationV3OperationType = "max"
-	Min      ExpressionOperationV3OperationType = "min"
-	Navigate ExpressionOperationV3OperationType = "navigate"
-	Parse    ExpressionOperationV3OperationType = "parse"
-	Random   ExpressionOperationV3OperationType = "random"
+	ExpressionOperationV3OperationTypeBranches ExpressionOperationV3OperationType = "branches"
+	ExpressionOperationV3OperationTypeCount    ExpressionOperationV3OperationType = "count"
+	ExpressionOperationV3OperationTypeFilter   ExpressionOperationV3OperationType = "filter"
+	ExpressionOperationV3OperationTypeFirst    ExpressionOperationV3OperationType = "first"
+	ExpressionOperationV3OperationTypeMax      ExpressionOperationV3OperationType = "max"
+	ExpressionOperationV3OperationTypeMin      ExpressionOperationV3OperationType = "min"
+	ExpressionOperationV3OperationTypeNavigate ExpressionOperationV3OperationType = "navigate"
+	ExpressionOperationV3OperationTypeParse    ExpressionOperationV3OperationType = "parse"
+	ExpressionOperationV3OperationTypeRandom   ExpressionOperationV3OperationType = "random"
 )
 
-// Defines values for ExternalIssueReferenceV1Provider.
+// Defines values for ExpressionOperationV4OperationType.
 const (
-	ExternalIssueReferenceV1ProviderAsana      ExternalIssueReferenceV1Provider = "asana"
-	ExternalIssueReferenceV1ProviderClickUp    ExternalIssueReferenceV1Provider = "click_up"
-	ExternalIssueReferenceV1ProviderGithub     ExternalIssueReferenceV1Provider = "github"
-	ExternalIssueReferenceV1ProviderGitlab     ExternalIssueReferenceV1Provider = "gitlab"
-	ExternalIssueReferenceV1ProviderJira       ExternalIssueReferenceV1Provider = "jira"
-	ExternalIssueReferenceV1ProviderJiraServer ExternalIssueReferenceV1Provider = "jira_server"
-	ExternalIssueReferenceV1ProviderLinear     ExternalIssueReferenceV1Provider = "linear"
-	ExternalIssueReferenceV1ProviderShortcut   ExternalIssueReferenceV1Provider = "shortcut"
+	ExpressionOperationV4OperationTypeBranches ExpressionOperationV4OperationType = "branches"
+	ExpressionOperationV4OperationTypeCount    ExpressionOperationV4OperationType = "count"
+	ExpressionOperationV4OperationTypeFilter   ExpressionOperationV4OperationType = "filter"
+	ExpressionOperationV4OperationTypeFirst    ExpressionOperationV4OperationType = "first"
+	ExpressionOperationV4OperationTypeMax      ExpressionOperationV4OperationType = "max"
+	ExpressionOperationV4OperationTypeMin      ExpressionOperationV4OperationType = "min"
+	ExpressionOperationV4OperationTypeNavigate ExpressionOperationV4OperationType = "navigate"
+	ExpressionOperationV4OperationTypeParse    ExpressionOperationV4OperationType = "parse"
+	ExpressionOperationV4OperationTypeRandom   ExpressionOperationV4OperationType = "random"
 )
 
 // Defines values for ExternalIssueReferenceV2Provider.
@@ -472,6 +452,30 @@ const (
 	ExternalIssueReferenceV2ProviderJiraServer ExternalIssueReferenceV2Provider = "jira_server"
 	ExternalIssueReferenceV2ProviderLinear     ExternalIssueReferenceV2Provider = "linear"
 	ExternalIssueReferenceV2ProviderShortcut   ExternalIssueReferenceV2Provider = "shortcut"
+)
+
+// Defines values for ExternalIssueReferenceV4Provider.
+const (
+	ExternalIssueReferenceV4ProviderAsana      ExternalIssueReferenceV4Provider = "asana"
+	ExternalIssueReferenceV4ProviderClickUp    ExternalIssueReferenceV4Provider = "click_up"
+	ExternalIssueReferenceV4ProviderGithub     ExternalIssueReferenceV4Provider = "github"
+	ExternalIssueReferenceV4ProviderGitlab     ExternalIssueReferenceV4Provider = "gitlab"
+	ExternalIssueReferenceV4ProviderJira       ExternalIssueReferenceV4Provider = "jira"
+	ExternalIssueReferenceV4ProviderJiraServer ExternalIssueReferenceV4Provider = "jira_server"
+	ExternalIssueReferenceV4ProviderLinear     ExternalIssueReferenceV4Provider = "linear"
+	ExternalIssueReferenceV4ProviderShortcut   ExternalIssueReferenceV4Provider = "shortcut"
+)
+
+// Defines values for ExternalIssueReferenceV5Provider.
+const (
+	Asana      ExternalIssueReferenceV5Provider = "asana"
+	ClickUp    ExternalIssueReferenceV5Provider = "click_up"
+	Github     ExternalIssueReferenceV5Provider = "github"
+	Gitlab     ExternalIssueReferenceV5Provider = "gitlab"
+	Jira       ExternalIssueReferenceV5Provider = "jira"
+	JiraServer ExternalIssueReferenceV5Provider = "jira_server"
+	Linear     ExternalIssueReferenceV5Provider = "linear"
+	Shortcut   ExternalIssueReferenceV5Provider = "shortcut"
 )
 
 // Defines values for ExternalResourceV1ResourceType.
@@ -515,6 +519,42 @@ const (
 	IdentityV1RolesWorkflowsEditor           IdentityV1Roles = "workflows_editor"
 )
 
+// Defines values for IncidentCreatePayloadV1Mode.
+const (
+	IncidentCreatePayloadV1ModeReal IncidentCreatePayloadV1Mode = "real"
+	IncidentCreatePayloadV1ModeTest IncidentCreatePayloadV1Mode = "test"
+)
+
+// Defines values for IncidentCreatePayloadV1Status.
+const (
+	IncidentCreatePayloadV1StatusClosed        IncidentCreatePayloadV1Status = "closed"
+	IncidentCreatePayloadV1StatusDeclined      IncidentCreatePayloadV1Status = "declined"
+	IncidentCreatePayloadV1StatusFixing        IncidentCreatePayloadV1Status = "fixing"
+	IncidentCreatePayloadV1StatusInvestigating IncidentCreatePayloadV1Status = "investigating"
+	IncidentCreatePayloadV1StatusMonitoring    IncidentCreatePayloadV1Status = "monitoring"
+	IncidentCreatePayloadV1StatusTriage        IncidentCreatePayloadV1Status = "triage"
+)
+
+// Defines values for IncidentCreatePayloadV1Visibility.
+const (
+	IncidentCreatePayloadV1VisibilityPrivate IncidentCreatePayloadV1Visibility = "private"
+	IncidentCreatePayloadV1VisibilityPublic  IncidentCreatePayloadV1Visibility = "public"
+)
+
+// Defines values for IncidentCreatePayloadV2Mode.
+const (
+	IncidentCreatePayloadV2ModeRetrospective IncidentCreatePayloadV2Mode = "retrospective"
+	IncidentCreatePayloadV2ModeStandard      IncidentCreatePayloadV2Mode = "standard"
+	IncidentCreatePayloadV2ModeTest          IncidentCreatePayloadV2Mode = "test"
+	IncidentCreatePayloadV2ModeTutorial      IncidentCreatePayloadV2Mode = "tutorial"
+)
+
+// Defines values for IncidentCreatePayloadV2Visibility.
+const (
+	IncidentCreatePayloadV2VisibilityPrivate IncidentCreatePayloadV2Visibility = "private"
+	IncidentCreatePayloadV2VisibilityPublic  IncidentCreatePayloadV2Visibility = "public"
+)
+
 // Defines values for IncidentRoleV1RoleType.
 const (
 	IncidentRoleV1RoleTypeCustom   IncidentRoleV1RoleType = "custom"
@@ -524,9 +564,9 @@ const (
 
 // Defines values for IncidentRoleV2RoleType.
 const (
-	IncidentRoleV2RoleTypeCustom   IncidentRoleV2RoleType = "custom"
-	IncidentRoleV2RoleTypeLead     IncidentRoleV2RoleType = "lead"
-	IncidentRoleV2RoleTypeReporter IncidentRoleV2RoleType = "reporter"
+	Custom   IncidentRoleV2RoleType = "custom"
+	Lead     IncidentRoleV2RoleType = "lead"
+	Reporter IncidentRoleV2RoleType = "reporter"
 )
 
 // Defines values for IncidentStatusV1Category.
@@ -541,10 +581,28 @@ const (
 	IncidentStatusV1CategoryTriage   IncidentStatusV1Category = "triage"
 )
 
+// Defines values for IncidentStatusV2Category.
+const (
+	IncidentStatusV2CategoryCanceled IncidentStatusV2Category = "canceled"
+	IncidentStatusV2CategoryClosed   IncidentStatusV2Category = "closed"
+	IncidentStatusV2CategoryDeclined IncidentStatusV2Category = "declined"
+	IncidentStatusV2CategoryLearning IncidentStatusV2Category = "learning"
+	IncidentStatusV2CategoryLive     IncidentStatusV2Category = "live"
+	IncidentStatusV2CategoryMerged   IncidentStatusV2Category = "merged"
+	IncidentStatusV2CategoryPaused   IncidentStatusV2Category = "paused"
+	IncidentStatusV2CategoryTriage   IncidentStatusV2Category = "triage"
+)
+
 // Defines values for IncidentTypeV1CreateInTriage.
 const (
 	IncidentTypeV1CreateInTriageAlways   IncidentTypeV1CreateInTriage = "always"
 	IncidentTypeV1CreateInTriageOptional IncidentTypeV1CreateInTriage = "optional"
+)
+
+// Defines values for IncidentTypeV2CreateInTriage.
+const (
+	IncidentTypeV2CreateInTriageAlways   IncidentTypeV2CreateInTriage = "always"
+	IncidentTypeV2CreateInTriageOptional IncidentTypeV2CreateInTriage = "optional"
 )
 
 // Defines values for IncidentV1Mode.
@@ -556,12 +614,12 @@ const (
 
 // Defines values for IncidentV1Status.
 const (
-	IncidentV1StatusClosed        IncidentV1Status = "closed"
-	IncidentV1StatusDeclined      IncidentV1Status = "declined"
-	IncidentV1StatusFixing        IncidentV1Status = "fixing"
-	IncidentV1StatusInvestigating IncidentV1Status = "investigating"
-	IncidentV1StatusMonitoring    IncidentV1Status = "monitoring"
-	IncidentV1StatusTriage        IncidentV1Status = "triage"
+	Closed        IncidentV1Status = "closed"
+	Declined      IncidentV1Status = "declined"
+	Fixing        IncidentV1Status = "fixing"
+	Investigating IncidentV1Status = "investigating"
+	Monitoring    IncidentV1Status = "monitoring"
+	Triage        IncidentV1Status = "triage"
 )
 
 // Defines values for IncidentV1Visibility.
@@ -611,15 +669,37 @@ const (
 	Weekly ScheduleRotationHandoverV2IntervalType = "weekly"
 )
 
+// Defines values for ScheduleRotationWorkingIntervalCreatePayloadV2Weekday.
+const (
+	ScheduleRotationWorkingIntervalCreatePayloadV2WeekdayFriday    ScheduleRotationWorkingIntervalCreatePayloadV2Weekday = "friday"
+	ScheduleRotationWorkingIntervalCreatePayloadV2WeekdayMonday    ScheduleRotationWorkingIntervalCreatePayloadV2Weekday = "monday"
+	ScheduleRotationWorkingIntervalCreatePayloadV2WeekdaySaturday  ScheduleRotationWorkingIntervalCreatePayloadV2Weekday = "saturday"
+	ScheduleRotationWorkingIntervalCreatePayloadV2WeekdaySunday    ScheduleRotationWorkingIntervalCreatePayloadV2Weekday = "sunday"
+	ScheduleRotationWorkingIntervalCreatePayloadV2WeekdayThursday  ScheduleRotationWorkingIntervalCreatePayloadV2Weekday = "thursday"
+	ScheduleRotationWorkingIntervalCreatePayloadV2WeekdayTuesday   ScheduleRotationWorkingIntervalCreatePayloadV2Weekday = "tuesday"
+	ScheduleRotationWorkingIntervalCreatePayloadV2WeekdayWednesday ScheduleRotationWorkingIntervalCreatePayloadV2Weekday = "wednesday"
+)
+
 // Defines values for ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday.
 const (
-	Friday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "friday"
-	Monday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "monday"
-	Saturday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "saturday"
-	Sunday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "sunday"
-	Thursday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "thursday"
-	Tuesday   ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "tuesday"
-	Wednesday ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "wednesday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayFriday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "friday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayMonday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "monday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdaySaturday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "saturday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdaySunday    ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "sunday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayThursday  ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "thursday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayTuesday   ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "tuesday"
+	ScheduleRotationWorkingIntervalUpdatePayloadV2WeekdayWednesday ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday = "wednesday"
+)
+
+// Defines values for ScheduleRotationWorkingIntervalV2Weekday.
+const (
+	Friday    ScheduleRotationWorkingIntervalV2Weekday = "friday"
+	Monday    ScheduleRotationWorkingIntervalV2Weekday = "monday"
+	Saturday  ScheduleRotationWorkingIntervalV2Weekday = "saturday"
+	Sunday    ScheduleRotationWorkingIntervalV2Weekday = "sunday"
+	Thursday  ScheduleRotationWorkingIntervalV2Weekday = "thursday"
+	Tuesday   ScheduleRotationWorkingIntervalV2Weekday = "tuesday"
+	Wednesday ScheduleRotationWorkingIntervalV2Weekday = "wednesday"
 )
 
 // Defines values for UpdateRequestBody3Required.
@@ -631,9 +711,9 @@ const (
 
 // Defines values for UpdateRequestBody3RequiredV2.
 const (
-	Always           UpdateRequestBody3RequiredV2 = "always"
-	BeforeResolution UpdateRequestBody3RequiredV2 = "before_resolution"
-	Never            UpdateRequestBody3RequiredV2 = "never"
+	UpdateRequestBody3RequiredV2Always           UpdateRequestBody3RequiredV2 = "always"
+	UpdateRequestBody3RequiredV2BeforeResolution UpdateRequestBody3RequiredV2 = "before_resolution"
+	UpdateRequestBody3RequiredV2Never            UpdateRequestBody3RequiredV2 = "never"
 )
 
 // Defines values for UpdateTypeRequestBodyCategories.
@@ -689,25 +769,25 @@ const (
 	UpdateTypeRequestBodyIconUsers          UpdateTypeRequestBodyIcon = "users"
 )
 
-// Defines values for UpdateWorkflowRequestBodyRunsOnIncidentModes.
+// Defines values for UpdateWorkflowPayload2RunsOnIncidentModes.
 const (
-	UpdateWorkflowRequestBodyRunsOnIncidentModesRetrospective UpdateWorkflowRequestBodyRunsOnIncidentModes = "retrospective"
-	UpdateWorkflowRequestBodyRunsOnIncidentModesStandard      UpdateWorkflowRequestBodyRunsOnIncidentModes = "standard"
-	UpdateWorkflowRequestBodyRunsOnIncidentModesTest          UpdateWorkflowRequestBodyRunsOnIncidentModes = "test"
+	UpdateWorkflowPayload2RunsOnIncidentModesRetrospective UpdateWorkflowPayload2RunsOnIncidentModes = "retrospective"
+	UpdateWorkflowPayload2RunsOnIncidentModesStandard      UpdateWorkflowPayload2RunsOnIncidentModes = "standard"
+	UpdateWorkflowPayload2RunsOnIncidentModesTest          UpdateWorkflowPayload2RunsOnIncidentModes = "test"
 )
 
-// Defines values for UpdateWorkflowRequestBodyRunsOnIncidents.
+// Defines values for UpdateWorkflowPayload2RunsOnIncidents.
 const (
-	UpdateWorkflowRequestBodyRunsOnIncidentsNewlyCreated          UpdateWorkflowRequestBodyRunsOnIncidents = "newly_created"
-	UpdateWorkflowRequestBodyRunsOnIncidentsNewlyCreatedAndActive UpdateWorkflowRequestBodyRunsOnIncidents = "newly_created_and_active"
+	UpdateWorkflowPayload2RunsOnIncidentsNewlyCreated          UpdateWorkflowPayload2RunsOnIncidents = "newly_created"
+	UpdateWorkflowPayload2RunsOnIncidentsNewlyCreatedAndActive UpdateWorkflowPayload2RunsOnIncidents = "newly_created_and_active"
 )
 
-// Defines values for UpdateWorkflowRequestBodyState.
+// Defines values for UpdateWorkflowPayload2State.
 const (
-	UpdateWorkflowRequestBodyStateActive   UpdateWorkflowRequestBodyState = "active"
-	UpdateWorkflowRequestBodyStateDisabled UpdateWorkflowRequestBodyState = "disabled"
-	UpdateWorkflowRequestBodyStateDraft    UpdateWorkflowRequestBodyState = "draft"
-	UpdateWorkflowRequestBodyStateError    UpdateWorkflowRequestBodyState = "error"
+	UpdateWorkflowPayload2StateActive   UpdateWorkflowPayload2State = "active"
+	UpdateWorkflowPayload2StateDisabled UpdateWorkflowPayload2State = "disabled"
+	UpdateWorkflowPayload2StateDraft    UpdateWorkflowPayload2State = "draft"
+	UpdateWorkflowPayload2StateError    UpdateWorkflowPayload2State = "error"
 )
 
 // Defines values for UserV1Role.
@@ -719,13 +799,22 @@ const (
 	UserV1RoleViewer        UserV1Role = "viewer"
 )
 
+// Defines values for UserV2Role.
+const (
+	UserV2RoleAdministrator UserV2Role = "administrator"
+	UserV2RoleOwner         UserV2Role = "owner"
+	UserV2RoleResponder     UserV2Role = "responder"
+	UserV2RoleUnset         UserV2Role = "unset"
+	UserV2RoleViewer        UserV2Role = "viewer"
+)
+
 // Defines values for UserWithRolesV2Role.
 const (
-	Administrator UserWithRolesV2Role = "administrator"
-	Owner         UserWithRolesV2Role = "owner"
-	Responder     UserWithRolesV2Role = "responder"
-	Unset         UserWithRolesV2Role = "unset"
-	Viewer        UserWithRolesV2Role = "viewer"
+	UserWithRolesV2RoleAdministrator UserWithRolesV2Role = "administrator"
+	UserWithRolesV2RoleOwner         UserWithRolesV2Role = "owner"
+	UserWithRolesV2RoleResponder     UserWithRolesV2Role = "responder"
+	UserWithRolesV2RoleUnset         UserWithRolesV2Role = "unset"
+	UserWithRolesV2RoleViewer        UserWithRolesV2Role = "viewer"
 )
 
 // Defines values for WorkflowRunsOnIncidentModes.
@@ -811,6 +900,15 @@ const (
 	Tutorial      FollowUpsV2ListParamsIncidentMode = "tutorial"
 )
 
+// APIKeyV1 defines model for APIKeyV1.
+type APIKeyV1 struct {
+	// Id Unique identifier for this API key
+	Id string `json:"id"`
+
+	// Name The name of the API key, for the user's reference
+	Name string `json:"name"`
+}
+
 // APIKeyV2 defines model for APIKeyV2.
 type APIKeyV2 struct {
 	// Id Unique identifier for this API key
@@ -832,7 +930,7 @@ type ActionV1 struct {
 
 	// Description Description of the action
 	Description            *string                   `json:"description,omitempty"`
-	ExternalIssueReference *ExternalIssueReferenceV1 `json:"external_issue_reference,omitempty"`
+	ExternalIssueReference *ExternalIssueReferenceV2 `json:"external_issue_reference,omitempty"`
 
 	// FollowUp Whether an action is marked as follow-up
 	FollowUp bool `json:"follow_up"`
@@ -855,7 +953,7 @@ type ActionV1Status string
 
 // ActionV2 defines model for ActionV2.
 type ActionV2 struct {
-	Assignee *UserV1 `json:"assignee,omitempty"`
+	Assignee *UserV2 `json:"assignee,omitempty"`
 
 	// CompletedAt When the action was completed
 	CompletedAt *time.Time `json:"completed_at,omitempty"`
@@ -882,10 +980,16 @@ type ActionV2 struct {
 // ActionV2Status Status of the action
 type ActionV2Status string
 
+// ActorV1 defines model for ActorV1.
+type ActorV1 struct {
+	ApiKey *APIKeyV1 `json:"api_key,omitempty"`
+	User   *UserV1   `json:"user,omitempty"`
+}
+
 // ActorV2 defines model for ActorV2.
 type ActorV2 struct {
 	ApiKey *APIKeyV2 `json:"api_key,omitempty"`
-	User   *UserV1   `json:"user,omitempty"`
+	User   *UserV2   `json:"user,omitempty"`
 }
 
 // AfterPaginationMetaResultV2 defines model for AfterPaginationMetaResultV2.
@@ -972,6 +1076,46 @@ type AlertRouteIncidentTemplateV2CustomFieldPriorities string
 
 // AlertRouteIncidentTemplateV2PrioritySeverity binding to use to resolve the workspace to create an incident in
 type AlertRouteIncidentTemplateV2PrioritySeverity string
+
+// AlertRoutePayloadV2 defines model for AlertRoutePayloadV2.
+type AlertRoutePayloadV2 struct {
+	// AlertSourceIds Legacy field - the alert sources that will match this alert route
+	AlertSourceIds *[]string `json:"alert_source_ids,omitempty"`
+
+	// AutoDeclineEnabled Should triage incidents be declined when alerts are resolved?
+	AutoDeclineEnabled *bool `json:"auto_decline_enabled,omitempty"`
+
+	// ConditionGroups What condition groups must be true for this alert route to fire?
+	ConditionGroups *[]ConditionGroupPayloadV2 `json:"condition_groups,omitempty"`
+
+	// DeferTimeSeconds How long should the escalation defer time be?
+	DeferTimeSeconds *int64 `json:"defer_time_seconds,omitempty"`
+
+	// Enabled Whether this alert route is enabled or not
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// EscalationBindings Which escalation paths should this alert route escalate to?
+	EscalationBindings *[]AlertRouteEscalationBindingPayloadV2 `json:"escalation_bindings,omitempty"`
+
+	// Expressions The expressions used in this template
+	Expressions *[]ExpressionPayloadV2 `json:"expressions,omitempty"`
+
+	// GroupingKeys Which attributes should this alert route use to group alerts?
+	GroupingKeys *[]GroupingKeyV2 `json:"grouping_keys,omitempty"`
+
+	// GroupingWindowSeconds How large should the grouping window be?
+	GroupingWindowSeconds *int64 `json:"grouping_window_seconds,omitempty"`
+
+	// IncidentConditionGroups What condition groups must be true for this alert route to create an incident?
+	IncidentConditionGroups *[]ConditionGroupPayloadV2 `json:"incident_condition_groups,omitempty"`
+
+	// IncidentEnabled Whether this alert route will create incidents or not
+	IncidentEnabled *bool `json:"incident_enabled,omitempty"`
+
+	// Name The name of this alert route config, for the user's reference
+	Name     *string                              `json:"name,omitempty"`
+	Template *AlertRouteIncidentTemplatePayloadV2 `json:"template,omitempty"`
+}
 
 // AlertRouteV2 defines model for AlertRouteV2.
 type AlertRouteV2 struct {
@@ -1235,7 +1379,7 @@ type CatalogTypeV2 struct {
 	RequiredIntegrations *[]string           `json:"required_integrations,omitempty"`
 	Schema               CatalogTypeSchemaV2 `json:"schema"`
 
-	// SemanticType Semantic type of this resource (unused)
+	// SemanticType What type of resource this catalog type should be understodd as
 	SemanticType string `json:"semantic_type"`
 
 	// SourceRepoUrl The url of the external repository where this type is managed
@@ -1275,6 +1419,36 @@ type ConditionGroupV3 struct {
 	Conditions []ConditionV3 `json:"conditions"`
 }
 
+// ConditionGroupV4 defines model for ConditionGroupV4.
+type ConditionGroupV4 struct {
+	// Conditions All conditions in this list must be satisfied for the group to be satisfied
+	Conditions []ConditionV4 `json:"conditions"`
+}
+
+// ConditionGroupV5 defines model for ConditionGroupV5.
+type ConditionGroupV5 struct {
+	// Conditions All conditions in this list must be satisfied for the group to be satisfied
+	Conditions []ConditionV5 `json:"conditions"`
+}
+
+// ConditionGroupV6 defines model for ConditionGroupV6.
+type ConditionGroupV6 struct {
+	// Conditions All conditions in this list must be satisfied for the group to be satisfied
+	Conditions []ConditionV6 `json:"conditions"`
+}
+
+// ConditionGroupV7 defines model for ConditionGroupV7.
+type ConditionGroupV7 struct {
+	// Conditions All conditions in this list must be satisfied for the group to be satisfied
+	Conditions []ConditionV7 `json:"conditions"`
+}
+
+// ConditionGroupV8 defines model for ConditionGroupV8.
+type ConditionGroupV8 struct {
+	// Conditions All conditions in this list must be satisfied for the group to be satisfied
+	Conditions []ConditionV8 `json:"conditions"`
+}
+
 // ConditionOperationV2 defines model for ConditionOperationV2.
 type ConditionOperationV2 struct {
 	// Label Human readable label to be displayed for user to select
@@ -1286,6 +1460,51 @@ type ConditionOperationV2 struct {
 
 // ConditionOperationV3 defines model for ConditionOperationV3.
 type ConditionOperationV3 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Value Unique identifier for this option
+	Value string `json:"value"`
+}
+
+// ConditionOperationV4 defines model for ConditionOperationV4.
+type ConditionOperationV4 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Value Unique identifier for this option
+	Value string `json:"value"`
+}
+
+// ConditionOperationV5 defines model for ConditionOperationV5.
+type ConditionOperationV5 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Value Unique identifier for this option
+	Value string `json:"value"`
+}
+
+// ConditionOperationV6 defines model for ConditionOperationV6.
+type ConditionOperationV6 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Value Unique identifier for this option
+	Value string `json:"value"`
+}
+
+// ConditionOperationV7 defines model for ConditionOperationV7.
+type ConditionOperationV7 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Value Unique identifier for this option
+	Value string `json:"value"`
+}
+
+// ConditionOperationV8 defines model for ConditionOperationV8.
+type ConditionOperationV8 struct {
 	// Label Human readable label to be displayed for user to select
 	Label string `json:"label"`
 
@@ -1323,6 +1542,51 @@ type ConditionSubjectV3 struct {
 	Reference string `json:"reference"`
 }
 
+// ConditionSubjectV4 defines model for ConditionSubjectV4.
+type ConditionSubjectV4 struct {
+	// Label Human readable identifier for the subject
+	Label string `json:"label"`
+
+	// Reference Reference into the scope for the value of the subject
+	Reference string `json:"reference"`
+}
+
+// ConditionSubjectV5 defines model for ConditionSubjectV5.
+type ConditionSubjectV5 struct {
+	// Label Human readable identifier for the subject
+	Label string `json:"label"`
+
+	// Reference Reference into the scope for the value of the subject
+	Reference string `json:"reference"`
+}
+
+// ConditionSubjectV6 defines model for ConditionSubjectV6.
+type ConditionSubjectV6 struct {
+	// Label Human readable identifier for the subject
+	Label string `json:"label"`
+
+	// Reference Reference into the scope for the value of the subject
+	Reference string `json:"reference"`
+}
+
+// ConditionSubjectV7 defines model for ConditionSubjectV7.
+type ConditionSubjectV7 struct {
+	// Label Human readable identifier for the subject
+	Label string `json:"label"`
+
+	// Reference Reference into the scope for the value of the subject
+	Reference string `json:"reference"`
+}
+
+// ConditionSubjectV8 defines model for ConditionSubjectV8.
+type ConditionSubjectV8 struct {
+	// Label Human readable identifier for the subject
+	Label string `json:"label"`
+
+	// Reference Reference into the scope for the value of the subject
+	Reference string `json:"reference"`
+}
+
 // ConditionV2 defines model for ConditionV2.
 type ConditionV2 struct {
 	Operation ConditionOperationV2 `json:"operation"`
@@ -1337,8 +1601,53 @@ type ConditionV3 struct {
 	Operation ConditionOperationV3 `json:"operation"`
 
 	// ParamBindings Bindings for the operation parameters
-	ParamBindings []EngineParamBindingV3 `json:"param_bindings"`
+	ParamBindings []EngineParamBindingV4 `json:"param_bindings"`
 	Subject       ConditionSubjectV3     `json:"subject"`
+}
+
+// ConditionV4 defines model for ConditionV4.
+type ConditionV4 struct {
+	Operation ConditionOperationV4 `json:"operation"`
+
+	// ParamBindings Bindings for the operation parameters
+	ParamBindings []EngineParamBindingV5 `json:"param_bindings"`
+	Subject       ConditionSubjectV4     `json:"subject"`
+}
+
+// ConditionV5 defines model for ConditionV5.
+type ConditionV5 struct {
+	Operation ConditionOperationV5 `json:"operation"`
+
+	// ParamBindings Bindings for the operation parameters
+	ParamBindings []EngineParamBindingV7 `json:"param_bindings"`
+	Subject       ConditionSubjectV5     `json:"subject"`
+}
+
+// ConditionV6 defines model for ConditionV6.
+type ConditionV6 struct {
+	Operation ConditionOperationV6 `json:"operation"`
+
+	// ParamBindings Bindings for the operation parameters
+	ParamBindings []EngineParamBindingV9 `json:"param_bindings"`
+	Subject       ConditionSubjectV6     `json:"subject"`
+}
+
+// ConditionV7 defines model for ConditionV7.
+type ConditionV7 struct {
+	Operation ConditionOperationV7 `json:"operation"`
+
+	// ParamBindings Bindings for the operation parameters
+	ParamBindings []EngineParamBindingV10 `json:"param_bindings"`
+	Subject       ConditionSubjectV7      `json:"subject"`
+}
+
+// ConditionV8 defines model for ConditionV8.
+type ConditionV8 struct {
+	Operation ConditionOperationV8 `json:"operation"`
+
+	// ParamBindings Bindings for the operation parameters
+	ParamBindings []EngineParamBindingV12 `json:"param_bindings"`
+	Subject       ConditionSubjectV8      `json:"subject"`
 }
 
 // CreateEntryRequestBody defines model for CreateEntryRequestBody.
@@ -1411,18 +1720,6 @@ type CreateManagedResourceResponseBody struct {
 	ManagedResource ManagedResourceV2 `json:"managed_resource"`
 }
 
-// CreatePathRequestBody defines model for CreatePathRequestBody.
-type CreatePathRequestBody struct {
-	// Name The name of this escalation path, for the user's reference.
-	Name string `json:"name"`
-
-	// Path The nodes that form the levels and branches of this escalation path.
-	Path []EscalationPathNodePayloadV2 `json:"path"`
-
-	// WorkingHours The working hours for this escalation path.
-	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
-}
-
 // CreatePathResponseBody defines model for CreatePathResponseBody.
 type CreatePathResponseBody struct {
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
@@ -1430,154 +1727,18 @@ type CreatePathResponseBody struct {
 
 // CreateRequestBody defines model for CreateRequestBody.
 type CreateRequestBody struct {
-	// AlertSourceIds The alert sources that will match this alert route
-	AlertSourceIds *[]string `json:"alert_source_ids,omitempty"`
+	// CustomFieldId ID of the custom field this option belongs to
+	CustomFieldId string `json:"custom_field_id"`
 
-	// AutoDeclineEnabled Should triage incidents be declined when alerts are resolved?
-	AutoDeclineEnabled *bool `json:"auto_decline_enabled,omitempty"`
+	// SortKey Sort key used to order the custom field options correctly
+	SortKey *int64 `json:"sort_key,omitempty"`
 
-	// ConditionGroups What condition groups must be true for this alert route to fire?
-	ConditionGroups *[]ConditionGroupPayloadV2 `json:"condition_groups,omitempty"`
-
-	// DeferTimeSeconds How long should the escalation defer time be?
-	DeferTimeSeconds *int64 `json:"defer_time_seconds,omitempty"`
-
-	// Enabled Whether this alert route is enabled or not
-	Enabled *bool `json:"enabled,omitempty"`
-
-	// EscalationBindings Which escalation paths should this alert route escalate to?
-	EscalationBindings *[]AlertRouteEscalationBindingPayloadV2 `json:"escalation_bindings,omitempty"`
-
-	// Expressions The expressions used in this template
-	Expressions *[]ExpressionPayloadV2 `json:"expressions,omitempty"`
-
-	// GroupingKeys Which attributes should this alert route use to group alerts?
-	GroupingKeys *[]GroupingKeyV2 `json:"grouping_keys,omitempty"`
-
-	// GroupingWindowSeconds How large should the grouping window be?
-	GroupingWindowSeconds *int64 `json:"grouping_window_seconds,omitempty"`
-
-	// IncidentConditionGroups What condition groups must be true for this alert route to create an incident?
-	IncidentConditionGroups *[]ConditionGroupPayloadV2 `json:"incident_condition_groups,omitempty"`
-
-	// IncidentEnabled Whether this alert route will create incidents or not
-	IncidentEnabled *bool `json:"incident_enabled,omitempty"`
-
-	// Name The name of this alert route config, for the user's reference
-	Name     *string                              `json:"name,omitempty"`
-	Template *AlertRouteIncidentTemplatePayloadV2 `json:"template,omitempty"`
+	// Value Human readable name for the custom field option
+	Value string `json:"value"`
 }
 
 // CreateRequestBody10 defines model for CreateRequestBody10.
 type CreateRequestBody10 struct {
-	// CustomFieldEntries Set the incident's custom fields to these values
-	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
-
-	// IdempotencyKey Unique string used to de-duplicate incident create requests
-	IdempotencyKey string `json:"idempotency_key"`
-
-	// IncidentRoleAssignments Assign incident roles to these people
-	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV1 `json:"incident_role_assignments,omitempty"`
-
-	// IncidentTypeId Incident type to create this incident as
-	IncidentTypeId *string `json:"incident_type_id,omitempty"`
-
-	// Mode Whether the incident is real or test
-	Mode *CreateRequestBody10Mode `json:"mode,omitempty"`
-
-	// Name Explanation of the incident
-	Name *string `json:"name,omitempty"`
-
-	// SeverityId Severity to create incident as
-	SeverityId *string `json:"severity_id,omitempty"`
-
-	// SlackTeamId ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
-	SlackTeamId *string `json:"slack_team_id,omitempty"`
-
-	// SourceMessageChannelId Channel ID of the source message, if this incident was created from one
-	SourceMessageChannelId *string `json:"source_message_channel_id,omitempty"`
-
-	// SourceMessageTimestamp Timestamp of the source message, if this incident was created from one
-	SourceMessageTimestamp *string `json:"source_message_timestamp,omitempty"`
-
-	// Status Current status of the incident
-	Status *CreateRequestBody10Status `json:"status,omitempty"`
-
-	// Summary Detailed description of the incident
-	Summary *string `json:"summary,omitempty"`
-
-	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-	Visibility CreateRequestBody10Visibility `json:"visibility"`
-}
-
-// CreateRequestBody10Mode Whether the incident is real or test
-type CreateRequestBody10Mode string
-
-// CreateRequestBody10Status Current status of the incident
-type CreateRequestBody10Status string
-
-// CreateRequestBody10Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-type CreateRequestBody10Visibility string
-
-// CreateRequestBody11 defines model for CreateRequestBody11.
-type CreateRequestBody11 struct {
-	// CustomFieldEntries Set the incident's custom fields to these values
-	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
-
-	// Id Unique identifier for the incident
-	Id *string `json:"id,omitempty"`
-
-	// IdempotencyKey Unique string used to de-duplicate incident create requests
-	IdempotencyKey string `json:"idempotency_key"`
-
-	// IncidentRoleAssignments Assign incident roles to these people
-	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV2 `json:"incident_role_assignments,omitempty"`
-
-	// IncidentStatusId Incident status to assign to the incident
-	IncidentStatusId *string `json:"incident_status_id,omitempty"`
-
-	// IncidentTimestampValues Assign the incident's timestamps to these values
-	IncidentTimestampValues *[]IncidentTimestampValuePayloadV2 `json:"incident_timestamp_values,omitempty"`
-
-	// IncidentTypeId Incident type to create this incident as
-	IncidentTypeId *string `json:"incident_type_id,omitempty"`
-
-	// Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
-	Mode *CreateRequestBody11Mode `json:"mode,omitempty"`
-
-	// Name Explanation of the incident
-	Name                         *string                         `json:"name,omitempty"`
-	RetrospectiveIncidentOptions *RetrospectiveIncidentOptionsV2 `json:"retrospective_incident_options,omitempty"`
-
-	// SeverityId Severity to create incident as
-	SeverityId *string `json:"severity_id,omitempty"`
-
-	// SlackChannelNameOverride Name of the Slack channel to create for this incident
-	SlackChannelNameOverride *string `json:"slack_channel_name_override,omitempty"`
-
-	// SlackTeamId Slack Team to create the incident in
-	SlackTeamId *string `json:"slack_team_id,omitempty"`
-
-	// Summary Detailed description of the incident
-	Summary *string `json:"summary,omitempty"`
-
-	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-	Visibility CreateRequestBody11Visibility `json:"visibility"`
-}
-
-// CreateRequestBody11Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
-type CreateRequestBody11Mode string
-
-// CreateRequestBody11Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
-type CreateRequestBody11Visibility string
-
-// CreateRequestBody12 defines model for CreateRequestBody12.
-type CreateRequestBody12 struct {
-	Schedule ScheduleCreatePayloadV2 `json:"schedule"`
-}
-
-// CreateRequestBody13 defines model for CreateRequestBody13.
-type CreateRequestBody13 struct {
 	// Description Description of the severity
 	Description string `json:"description"`
 
@@ -1590,32 +1751,20 @@ type CreateRequestBody13 struct {
 
 // CreateRequestBody2 defines model for CreateRequestBody2.
 type CreateRequestBody2 struct {
-	// CustomFieldId ID of the custom field this option belongs to
-	CustomFieldId string `json:"custom_field_id"`
-
-	// SortKey Sort key used to order the custom field options correctly
-	SortKey *int64 `json:"sort_key,omitempty"`
-
-	// Value Human readable name for the custom field option
-	Value string `json:"value"`
-}
-
-// CreateRequestBody3 defines model for CreateRequestBody3.
-type CreateRequestBody3 struct {
 	// Description Description of the custom field
 	Description string `json:"description"`
 
 	// FieldType Type of custom field
-	FieldType CreateRequestBody3FieldType `json:"field_type"`
+	FieldType CreateRequestBody2FieldType `json:"field_type"`
 
 	// Name Human readable name for the custom field
 	Name string `json:"name"`
 
 	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-	Required *CreateRequestBody3Required `json:"required,omitempty"`
+	Required *CreateRequestBody2Required `json:"required,omitempty"`
 
 	// RequiredV2 When this custom field must be set during the incident lifecycle.
-	RequiredV2 *CreateRequestBody3RequiredV2 `json:"required_v2,omitempty"`
+	RequiredV2 *CreateRequestBody2RequiredV2 `json:"required_v2,omitempty"`
 
 	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
 	ShowBeforeClosure bool `json:"show_before_closure"`
@@ -1630,32 +1779,32 @@ type CreateRequestBody3 struct {
 	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
 }
 
-// CreateRequestBody3FieldType Type of custom field
-type CreateRequestBody3FieldType string
+// CreateRequestBody2FieldType Type of custom field
+type CreateRequestBody2FieldType string
 
-// CreateRequestBody3Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-type CreateRequestBody3Required string
+// CreateRequestBody2Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+type CreateRequestBody2Required string
 
-// CreateRequestBody3RequiredV2 When this custom field must be set during the incident lifecycle.
-type CreateRequestBody3RequiredV2 string
+// CreateRequestBody2RequiredV2 When this custom field must be set during the incident lifecycle.
+type CreateRequestBody2RequiredV2 string
 
-// CreateRequestBody4 defines model for CreateRequestBody4.
-type CreateRequestBody4 struct {
+// CreateRequestBody3 defines model for CreateRequestBody3.
+type CreateRequestBody3 struct {
 	// Description Description of the custom field
 	Description string `json:"description"`
 
 	// FieldType Type of custom field
-	FieldType CreateRequestBody4FieldType `json:"field_type"`
+	FieldType CreateRequestBody3FieldType `json:"field_type"`
 
 	// Name Human readable name for the custom field
 	Name string `json:"name"`
 }
 
-// CreateRequestBody4FieldType Type of custom field
-type CreateRequestBody4FieldType string
+// CreateRequestBody3FieldType Type of custom field
+type CreateRequestBody3FieldType string
 
-// CreateRequestBody5 defines model for CreateRequestBody5.
-type CreateRequestBody5 struct {
+// CreateRequestBody4 defines model for CreateRequestBody4.
+type CreateRequestBody4 struct {
 	// IncidentId ID of the incident to add an attachment to
 	IncidentId string `json:"incident_id"`
 	Resource   struct {
@@ -1663,21 +1812,21 @@ type CreateRequestBody5 struct {
 		ExternalId string `json:"external_id"`
 
 		// ResourceType E.g. PagerDuty: the external system that holds the resource
-		ResourceType CreateRequestBody5ResourceResourceType `json:"resource_type"`
+		ResourceType CreateRequestBody4ResourceResourceType `json:"resource_type"`
 	} `json:"resource"`
 }
 
-// CreateRequestBody5ResourceResourceType E.g. PagerDuty: the external system that holds the resource
-type CreateRequestBody5ResourceResourceType string
+// CreateRequestBody4ResourceResourceType E.g. PagerDuty: the external system that holds the resource
+type CreateRequestBody4ResourceResourceType string
 
-// CreateRequestBody6 defines model for CreateRequestBody6.
-type CreateRequestBody6 struct {
+// CreateRequestBody5 defines model for CreateRequestBody5.
+type CreateRequestBody5 struct {
 	IncidentId string `json:"incident_id"`
 	UserId     string `json:"user_id"`
 }
 
-// CreateRequestBody7 defines model for CreateRequestBody7.
-type CreateRequestBody7 struct {
+// CreateRequestBody6 defines model for CreateRequestBody6.
+type CreateRequestBody6 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -1694,8 +1843,8 @@ type CreateRequestBody7 struct {
 	Shortform string `json:"shortform"`
 }
 
-// CreateRequestBody8 defines model for CreateRequestBody8.
-type CreateRequestBody8 struct {
+// CreateRequestBody7 defines model for CreateRequestBody7.
+type CreateRequestBody7 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -1709,10 +1858,10 @@ type CreateRequestBody8 struct {
 	Shortform string `json:"shortform"`
 }
 
-// CreateRequestBody9 defines model for CreateRequestBody9.
-type CreateRequestBody9 struct {
+// CreateRequestBody8 defines model for CreateRequestBody8.
+type CreateRequestBody8 struct {
 	// Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
-	Category CreateRequestBody9Category `json:"category"`
+	Category CreateRequestBody8Category `json:"category"`
 
 	// Description Rich text description of the incident status
 	Description string `json:"description"`
@@ -1721,8 +1870,13 @@ type CreateRequestBody9 struct {
 	Name string `json:"name"`
 }
 
-// CreateRequestBody9Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
-type CreateRequestBody9Category string
+// CreateRequestBody8Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
+type CreateRequestBody8Category string
+
+// CreateRequestBody9 defines model for CreateRequestBody9.
+type CreateRequestBody9 struct {
+	Schedule ScheduleCreatePayloadV2 `json:"schedule"`
+}
 
 // CreateResponseBody defines model for CreateResponseBody.
 type CreateResponseBody struct {
@@ -1783,8 +1937,8 @@ type CreateTypeResponseBody struct {
 	CatalogType CatalogTypeV2 `json:"catalog_type"`
 }
 
-// CreateWorkflowRequestBody defines model for CreateWorkflowRequestBody.
-type CreateWorkflowRequestBody struct {
+// CreateWorkflowPayload defines model for CreateWorkflowPayload.
+type CreateWorkflowPayload struct {
 	// Annotations Annotations that track metadata about this resource
 	Annotations *map[string]string `json:"annotations,omitempty"`
 
@@ -1811,13 +1965,13 @@ type CreateWorkflowRequestBody struct {
 	OnceFor []string `json:"once_for"`
 
 	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
-	RunsOnIncidentModes []CreateWorkflowRequestBodyRunsOnIncidentModes `json:"runs_on_incident_modes"`
+	RunsOnIncidentModes []CreateWorkflowPayloadRunsOnIncidentModes `json:"runs_on_incident_modes"`
 
 	// RunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-	RunsOnIncidents CreateWorkflowRequestBodyRunsOnIncidents `json:"runs_on_incidents"`
+	RunsOnIncidents CreateWorkflowPayloadRunsOnIncidents `json:"runs_on_incidents"`
 
 	// State The state of the workflow (e.g. is it draft, or disabled)
-	State *CreateWorkflowRequestBodyState `json:"state,omitempty"`
+	State *CreateWorkflowPayloadState `json:"state,omitempty"`
 
 	// Steps List of step to execute as part of the workflow
 	Steps []StepConfigPayload `json:"steps"`
@@ -1826,14 +1980,14 @@ type CreateWorkflowRequestBody struct {
 	Trigger string `json:"trigger"`
 }
 
-// CreateWorkflowRequestBodyRunsOnIncidentModes defines model for CreateWorkflowRequestBody.RunsOnIncidentModes.
-type CreateWorkflowRequestBodyRunsOnIncidentModes string
+// CreateWorkflowPayloadRunsOnIncidentModes Incident mode that workflows can run on
+type CreateWorkflowPayloadRunsOnIncidentModes string
 
-// CreateWorkflowRequestBodyRunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-type CreateWorkflowRequestBodyRunsOnIncidents string
+// CreateWorkflowPayloadRunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
+type CreateWorkflowPayloadRunsOnIncidents string
 
-// CreateWorkflowRequestBodyState The state of the workflow (e.g. is it draft, or disabled)
-type CreateWorkflowRequestBodyState string
+// CreateWorkflowPayloadState The state of the workflow (e.g. is it draft, or disabled)
+type CreateWorkflowPayloadState string
 
 // CustomFieldEntryPayloadV1 defines model for CustomFieldEntryPayloadV1.
 type CustomFieldEntryPayloadV1 struct {
@@ -1844,6 +1998,15 @@ type CustomFieldEntryPayloadV1 struct {
 	Values []CustomFieldValuePayloadV1 `json:"values"`
 }
 
+// CustomFieldEntryPayloadV2 defines model for CustomFieldEntryPayloadV2.
+type CustomFieldEntryPayloadV2 struct {
+	// CustomFieldId ID of the custom field this entry is linked against
+	CustomFieldId string `json:"custom_field_id"`
+
+	// Values List of values to associate with this entry. Use an empty array to unset the value of the custom field.
+	Values []CustomFieldValuePayloadV2 `json:"values"`
+}
+
 // CustomFieldEntryV1 defines model for CustomFieldEntryV1.
 type CustomFieldEntryV1 struct {
 	CustomField CustomFieldTypeInfoV1 `json:"custom_field"`
@@ -1852,8 +2015,31 @@ type CustomFieldEntryV1 struct {
 	Values []CustomFieldValueV1 `json:"values"`
 }
 
+// CustomFieldEntryV2 defines model for CustomFieldEntryV2.
+type CustomFieldEntryV2 struct {
+	CustomField CustomFieldTypeInfoV2 `json:"custom_field"`
+
+	// Values List of custom field values set on this entry
+	Values []CustomFieldValueV2 `json:"values"`
+}
+
 // CustomFieldOptionV1 defines model for CustomFieldOptionV1.
 type CustomFieldOptionV1 struct {
+	// CustomFieldId ID of the custom field this option belongs to
+	CustomFieldId string `json:"custom_field_id"`
+
+	// Id Unique identifier for the custom field option
+	Id string `json:"id"`
+
+	// SortKey Sort key used to order the custom field options correctly
+	SortKey int64 `json:"sort_key"`
+
+	// Value Human readable name for the custom field option
+	Value string `json:"value"`
+}
+
+// CustomFieldOptionV2 defines model for CustomFieldOptionV2.
+type CustomFieldOptionV2 struct {
 	// CustomFieldId ID of the custom field this option belongs to
 	CustomFieldId string `json:"custom_field_id"`
 
@@ -1887,6 +2073,27 @@ type CustomFieldTypeInfoV1 struct {
 
 // CustomFieldTypeInfoV1FieldType Type of custom field
 type CustomFieldTypeInfoV1FieldType string
+
+// CustomFieldTypeInfoV2 defines model for CustomFieldTypeInfoV2.
+type CustomFieldTypeInfoV2 struct {
+	// Description Description of the custom field
+	Description string `json:"description"`
+
+	// FieldType Type of custom field
+	FieldType CustomFieldTypeInfoV2FieldType `json:"field_type"`
+
+	// Id Unique identifier for the custom field
+	Id string `json:"id"`
+
+	// Name Human readable name for the custom field
+	Name string `json:"name"`
+
+	// Options What options are available for this custom field, if this field has options
+	Options []CustomFieldOptionV2 `json:"options"`
+}
+
+// CustomFieldTypeInfoV2FieldType Type of custom field
+type CustomFieldTypeInfoV2FieldType string
 
 // CustomFieldV1 defines model for CustomFieldV1.
 type CustomFieldV1 struct {
@@ -1993,6 +2200,30 @@ type CustomFieldValuePayloadV1 struct {
 	ValueTimestamp *string `json:"value_timestamp,omitempty"`
 }
 
+// CustomFieldValuePayloadV2 defines model for CustomFieldValuePayloadV2.
+type CustomFieldValuePayloadV2 struct {
+	// Id Unique identifier for the custom field value
+	Id *string `json:"id,omitempty"`
+
+	// ValueCatalogEntryId ID of the catalog entry. You can also use an ExternalID or an Alias of the catalog entry.
+	ValueCatalogEntryId *string `json:"value_catalog_entry_id,omitempty"`
+
+	// ValueLink If the custom field type is 'link', this will contain the value assigned.
+	ValueLink *string `json:"value_link,omitempty"`
+
+	// ValueNumeric If the custom field type is 'numeric', this will contain the value assigned.
+	ValueNumeric *string `json:"value_numeric,omitempty"`
+
+	// ValueOptionId ID of the custom field option
+	ValueOptionId *string `json:"value_option_id,omitempty"`
+
+	// ValueText If the custom field type is 'text', this will contain the value assigned.
+	ValueText *string `json:"value_text,omitempty"`
+
+	// ValueTimestamp Deprecated: please use incident timestamp values instead
+	ValueTimestamp *string `json:"value_timestamp,omitempty"`
+}
+
 // CustomFieldValueV1 defines model for CustomFieldValueV1.
 type CustomFieldValueV1 struct {
 	ValueCatalogEntry *EmbeddedCatalogEntryV1 `json:"value_catalog_entry,omitempty"`
@@ -2003,6 +2234,21 @@ type CustomFieldValueV1 struct {
 	// ValueNumeric If the custom field type is 'numeric', this will contain the value assigned.
 	ValueNumeric *string              `json:"value_numeric,omitempty"`
 	ValueOption  *CustomFieldOptionV1 `json:"value_option,omitempty"`
+
+	// ValueText If the custom field type is 'text', this will contain the value assigned.
+	ValueText *string `json:"value_text,omitempty"`
+}
+
+// CustomFieldValueV2 defines model for CustomFieldValueV2.
+type CustomFieldValueV2 struct {
+	ValueCatalogEntry *EmbeddedCatalogEntryV2 `json:"value_catalog_entry,omitempty"`
+
+	// ValueLink If the custom field type is 'link', this will contain the value assigned.
+	ValueLink *string `json:"value_link,omitempty"`
+
+	// ValueNumeric If the custom field type is 'numeric', this will contain the value assigned.
+	ValueNumeric *string              `json:"value_numeric,omitempty"`
+	ValueOption  *CustomFieldOptionV2 `json:"value_option,omitempty"`
 
 	// ValueText If the custom field type is 'text', this will contain the value assigned.
 	ValueText *string `json:"value_text,omitempty"`
@@ -2031,11 +2277,80 @@ type EmbeddedCatalogEntryV1 struct {
 	Name string `json:"name"`
 }
 
+// EmbeddedCatalogEntryV2 defines model for EmbeddedCatalogEntryV2.
+type EmbeddedCatalogEntryV2 struct {
+	// Aliases Optional aliases that can be used to reference this entry
+	Aliases *[]string `json:"aliases,omitempty"`
+
+	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Id ID of this catalog entry
+	Id string `json:"id"`
+
+	// Name Name is the human readable name of this entry
+	Name string `json:"name"`
+}
+
+// EmbeddedIncidentRoleV2 defines model for EmbeddedIncidentRoleV2.
+type EmbeddedIncidentRoleV2 struct {
+	// CreatedAt When the role was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Description Describes the purpose of the role
+	Description string `json:"description"`
+
+	// Id Unique identifier for the role
+	Id string `json:"id"`
+
+	// Instructions Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
+	Instructions string `json:"instructions"`
+
+	// Name Human readable name of the incident role
+	Name string `json:"name"`
+
+	// Required This field is deprecated.
+	Required *bool `json:"required,omitempty"`
+
+	// RoleType Type of incident role
+	RoleType EmbeddedIncidentRoleV2RoleType `json:"role_type"`
+
+	// Shortform Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
+	Shortform string `json:"shortform"`
+
+	// UpdatedAt When the role was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// EmbeddedIncidentRoleV2RoleType Type of incident role
+type EmbeddedIncidentRoleV2RoleType string
+
 // EngineParamBindingPayloadV2 defines model for EngineParamBindingPayloadV2.
 type EngineParamBindingPayloadV2 struct {
 	// ArrayValue If set, this is the array value of the step parameter
 	ArrayValue *[]EngineParamBindingValuePayloadV2 `json:"array_value,omitempty"`
 	Value      *EngineParamBindingValuePayloadV2   `json:"value,omitempty"`
+}
+
+// EngineParamBindingV10 defines model for EngineParamBindingV10.
+type EngineParamBindingV10 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV18 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV17   `json:"value,omitempty"`
+}
+
+// EngineParamBindingV11 defines model for EngineParamBindingV11.
+type EngineParamBindingV11 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV20 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV19   `json:"value,omitempty"`
+}
+
+// EngineParamBindingV12 defines model for EngineParamBindingV12.
+type EngineParamBindingV12 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV22 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV21   `json:"value,omitempty"`
 }
 
 // EngineParamBindingV2 defines model for EngineParamBindingV2.
@@ -2048,12 +2363,174 @@ type EngineParamBindingV2 struct {
 // EngineParamBindingV3 defines model for EngineParamBindingV3.
 type EngineParamBindingV3 struct {
 	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV3 `json:"array_value,omitempty"`
+	ArrayValue *[]EngineParamBindingValueV4 `json:"array_value,omitempty"`
 	Value      *EngineParamBindingValueV3   `json:"value,omitempty"`
+}
+
+// EngineParamBindingV4 defines model for EngineParamBindingV4.
+type EngineParamBindingV4 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV6 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV5   `json:"value,omitempty"`
+}
+
+// EngineParamBindingV5 defines model for EngineParamBindingV5.
+type EngineParamBindingV5 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV8 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV7   `json:"value,omitempty"`
+}
+
+// EngineParamBindingV6 defines model for EngineParamBindingV6.
+type EngineParamBindingV6 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV10 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV9    `json:"value,omitempty"`
+}
+
+// EngineParamBindingV7 defines model for EngineParamBindingV7.
+type EngineParamBindingV7 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV12 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV11   `json:"value,omitempty"`
+}
+
+// EngineParamBindingV8 defines model for EngineParamBindingV8.
+type EngineParamBindingV8 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV14 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV13   `json:"value,omitempty"`
+}
+
+// EngineParamBindingV9 defines model for EngineParamBindingV9.
+type EngineParamBindingV9 struct {
+	// ArrayValue If array_value is set, this helps render the values
+	ArrayValue *[]EngineParamBindingValueV16 `json:"array_value,omitempty"`
+	Value      *EngineParamBindingValueV15   `json:"value,omitempty"`
 }
 
 // EngineParamBindingValuePayloadV2 defines model for EngineParamBindingValuePayloadV2.
 type EngineParamBindingValuePayloadV2 struct {
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV10 defines model for EngineParamBindingValueV10.
+type EngineParamBindingValueV10 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV11 defines model for EngineParamBindingValueV11.
+type EngineParamBindingValueV11 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV12 defines model for EngineParamBindingValueV12.
+type EngineParamBindingValueV12 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV13 defines model for EngineParamBindingValueV13.
+type EngineParamBindingValueV13 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV14 defines model for EngineParamBindingValueV14.
+type EngineParamBindingValueV14 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV15 defines model for EngineParamBindingValueV15.
+type EngineParamBindingValueV15 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV16 defines model for EngineParamBindingValueV16.
+type EngineParamBindingValueV16 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV17 defines model for EngineParamBindingValueV17.
+type EngineParamBindingValueV17 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV18 defines model for EngineParamBindingValueV18.
+type EngineParamBindingValueV18 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV19 defines model for EngineParamBindingValueV19.
+type EngineParamBindingValueV19 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
 	// Literal If set, this is the literal value of the step parameter
 	Literal *string `json:"literal,omitempty"`
 
@@ -2073,8 +2550,116 @@ type EngineParamBindingValueV2 struct {
 	Reference *string `json:"reference,omitempty"`
 }
 
+// EngineParamBindingValueV20 defines model for EngineParamBindingValueV20.
+type EngineParamBindingValueV20 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV21 defines model for EngineParamBindingValueV21.
+type EngineParamBindingValueV21 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV22 defines model for EngineParamBindingValueV22.
+type EngineParamBindingValueV22 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
 // EngineParamBindingValueV3 defines model for EngineParamBindingValueV3.
 type EngineParamBindingValueV3 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV4 defines model for EngineParamBindingValueV4.
+type EngineParamBindingValueV4 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV5 defines model for EngineParamBindingValueV5.
+type EngineParamBindingValueV5 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV6 defines model for EngineParamBindingValueV6.
+type EngineParamBindingValueV6 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV7 defines model for EngineParamBindingValueV7.
+type EngineParamBindingValueV7 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV8 defines model for EngineParamBindingValueV8.
+type EngineParamBindingValueV8 struct {
+	// Label Human readable label to be displayed for user to select
+	Label string `json:"label"`
+
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+
+	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
+	Reference *string `json:"reference,omitempty"`
+}
+
+// EngineParamBindingValueV9 defines model for EngineParamBindingValueV9.
+type EngineParamBindingValueV9 struct {
 	// Label Human readable label to be displayed for user to select
 	Label string `json:"label"`
 
@@ -2183,6 +2768,18 @@ type EscalationPathNodeV2 struct {
 // EscalationPathNodeV2Type The type of this node: level or branch
 type EscalationPathNodeV2Type string
 
+// EscalationPathPayloadV2 defines model for EscalationPathPayloadV2.
+type EscalationPathPayloadV2 struct {
+	// Name The name of this escalation path, for the user's reference.
+	Name string `json:"name"`
+
+	// Path The nodes that form the levels and branches of this escalation path.
+	Path []EscalationPathNodePayloadV2 `json:"path"`
+
+	// WorkingHours The working hours for this escalation path.
+	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
+}
+
 // EscalationPathRoundRobinConfigV2 defines model for EscalationPathRoundRobinConfigV2.
 type EscalationPathRoundRobinConfigV2 struct {
 	// Enabled Whether round robin is enabled for this level
@@ -2199,9 +2796,7 @@ type EscalationPathTargetV2 struct {
 
 	// ScheduleMode Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
 	ScheduleMode *EscalationPathTargetV2ScheduleMode `json:"schedule_mode,omitempty"`
-
-	// Type Controls what type of entity this target identifies, such as EscalationPolicy or User
-	Type EscalationPathTargetV2Type `json:"type"`
+	Type         EscalationPathTargetV2Type          `json:"type"`
 
 	// Urgency The urgency of this escalation path target
 	Urgency EscalationPathTargetV2Urgency `json:"urgency"`
@@ -2210,7 +2805,7 @@ type EscalationPathTargetV2 struct {
 // EscalationPathTargetV2ScheduleMode Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
 type EscalationPathTargetV2ScheduleMode string
 
-// EscalationPathTargetV2Type Controls what type of entity this target identifies, such as EscalationPolicy or User
+// EscalationPathTargetV2Type defines model for EscalationPathTargetV2.Type.
 type EscalationPathTargetV2Type string
 
 // EscalationPathTargetV2Urgency The urgency of this escalation path target
@@ -2248,8 +2843,15 @@ type ExpressionBranchV2 struct {
 // ExpressionBranchV3 defines model for ExpressionBranchV3.
 type ExpressionBranchV3 struct {
 	// ConditionGroups When one of these condition groups are satisfied, this branch will be evaluated
-	ConditionGroups []ConditionGroupV3   `json:"condition_groups"`
-	Result          EngineParamBindingV3 `json:"result"`
+	ConditionGroups []ConditionGroupV4   `json:"condition_groups"`
+	Result          EngineParamBindingV6 `json:"result"`
+}
+
+// ExpressionBranchV4 defines model for ExpressionBranchV4.
+type ExpressionBranchV4 struct {
+	// ConditionGroups When one of these condition groups are satisfied, this branch will be evaluated
+	ConditionGroups []ConditionGroupV7    `json:"condition_groups"`
+	Result          EngineParamBindingV11 `json:"result"`
 }
 
 // ExpressionBranchesOptsPayloadV2 defines model for ExpressionBranchesOptsPayloadV2.
@@ -2273,6 +2875,13 @@ type ExpressionBranchesOptsV3 struct {
 	Returns  ReturnsMetaV2        `json:"returns"`
 }
 
+// ExpressionBranchesOptsV4 defines model for ExpressionBranchesOptsV4.
+type ExpressionBranchesOptsV4 struct {
+	// Branches The branches to apply for this operation
+	Branches []ExpressionBranchV4 `json:"branches"`
+	Returns  ReturnsMetaV2        `json:"returns"`
+}
+
 // ExpressionElseBranchPayloadV2 defines model for ExpressionElseBranchPayloadV2.
 type ExpressionElseBranchPayloadV2 struct {
 	Result EngineParamBindingPayloadV2 `json:"result"`
@@ -2286,6 +2895,11 @@ type ExpressionElseBranchV2 struct {
 // ExpressionElseBranchV3 defines model for ExpressionElseBranchV3.
 type ExpressionElseBranchV3 struct {
 	Result EngineParamBindingV3 `json:"result"`
+}
+
+// ExpressionElseBranchV4 defines model for ExpressionElseBranchV4.
+type ExpressionElseBranchV4 struct {
+	Result EngineParamBindingV8 `json:"result"`
 }
 
 // ExpressionFilterOptsPayloadV2 defines model for ExpressionFilterOptsPayloadV2.
@@ -2304,6 +2918,12 @@ type ExpressionFilterOptsV2 struct {
 type ExpressionFilterOptsV3 struct {
 	// ConditionGroups The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
 	ConditionGroups []ConditionGroupV3 `json:"condition_groups"`
+}
+
+// ExpressionFilterOptsV4 defines model for ExpressionFilterOptsV4.
+type ExpressionFilterOptsV4 struct {
+	// ConditionGroups The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
+	ConditionGroups []ConditionGroupV6 `json:"condition_groups"`
 }
 
 // ExpressionNavigateOptsPayloadV2 defines model for ExpressionNavigateOptsPayloadV2.
@@ -2343,7 +2963,7 @@ type ExpressionOperationV2 struct {
 
 	// OperationType The type of the operation
 	OperationType ExpressionOperationV2OperationType `json:"operation_type"`
-	Parse         *ExpressionParseOptsPayloadV2      `json:"parse,omitempty"`
+	Parse         *ExpressionParseOptsV2             `json:"parse,omitempty"`
 	Returns       ReturnsMetaV2                      `json:"returns"`
 }
 
@@ -2358,15 +2978,38 @@ type ExpressionOperationV3 struct {
 
 	// OperationType The type of the operation
 	OperationType ExpressionOperationV3OperationType `json:"operation_type"`
-	Parse         *ExpressionParseOptsPayloadV2      `json:"parse,omitempty"`
+	Parse         *ExpressionParseOptsV2             `json:"parse,omitempty"`
 	Returns       ReturnsMetaV2                      `json:"returns"`
 }
 
 // ExpressionOperationV3OperationType The type of the operation
 type ExpressionOperationV3OperationType string
 
+// ExpressionOperationV4 defines model for ExpressionOperationV4.
+type ExpressionOperationV4 struct {
+	Branches *ExpressionBranchesOptsV4 `json:"branches,omitempty"`
+	Filter   *ExpressionFilterOptsV4   `json:"filter,omitempty"`
+	Navigate *ExpressionNavigateOptsV2 `json:"navigate,omitempty"`
+
+	// OperationType The type of the operation
+	OperationType ExpressionOperationV4OperationType `json:"operation_type"`
+	Parse         *ExpressionParseOptsV2             `json:"parse,omitempty"`
+	Returns       ReturnsMetaV2                      `json:"returns"`
+}
+
+// ExpressionOperationV4OperationType The type of the operation
+type ExpressionOperationV4OperationType string
+
 // ExpressionParseOptsPayloadV2 defines model for ExpressionParseOptsPayloadV2.
 type ExpressionParseOptsPayloadV2 struct {
+	Returns ReturnsMetaV2 `json:"returns"`
+
+	// Source Source expression that is evaluated to a result
+	Source string `json:"source"`
+}
+
+// ExpressionParseOptsV2 defines model for ExpressionParseOptsV2.
+type ExpressionParseOptsV2 struct {
 	Returns ReturnsMetaV2 `json:"returns"`
 
 	// Source Source expression that is evaluated to a result
@@ -2420,8 +3063,24 @@ type ExpressionV3 struct {
 	RootReference string `json:"root_reference"`
 }
 
-// ExternalIssueReferenceV1 defines model for ExternalIssueReferenceV1.
-type ExternalIssueReferenceV1 struct {
+// ExpressionV4 defines model for ExpressionV4.
+type ExpressionV4 struct {
+	ElseBranch *ExpressionElseBranchV4 `json:"else_branch,omitempty"`
+
+	// Label The human readable label of the expression
+	Label      string                  `json:"label"`
+	Operations []ExpressionOperationV4 `json:"operations"`
+
+	// Reference A short ID that can be used to reference the expression
+	Reference string        `json:"reference"`
+	Returns   ReturnsMetaV2 `json:"returns"`
+
+	// RootReference The root reference for this expression (i.e. where the expression starts)
+	RootReference string `json:"root_reference"`
+}
+
+// ExternalIssueReferenceV2 defines model for ExternalIssueReferenceV2.
+type ExternalIssueReferenceV2 struct {
 	// IssueName Human readable ID for the issue
 	IssueName *string `json:"issue_name,omitempty"`
 
@@ -2429,14 +3088,14 @@ type ExternalIssueReferenceV1 struct {
 	IssuePermalink *string `json:"issue_permalink,omitempty"`
 
 	// Provider ID of the issue tracker provider
-	Provider *ExternalIssueReferenceV1Provider `json:"provider,omitempty"`
+	Provider *ExternalIssueReferenceV2Provider `json:"provider,omitempty"`
 }
 
-// ExternalIssueReferenceV1Provider ID of the issue tracker provider
-type ExternalIssueReferenceV1Provider string
+// ExternalIssueReferenceV2Provider ID of the issue tracker provider
+type ExternalIssueReferenceV2Provider string
 
-// ExternalIssueReferenceV2 defines model for ExternalIssueReferenceV2.
-type ExternalIssueReferenceV2 struct {
+// ExternalIssueReferenceV4 defines model for ExternalIssueReferenceV4.
+type ExternalIssueReferenceV4 struct {
 	// IssueName Human readable ID for the issue
 	IssueName string `json:"issue_name"`
 
@@ -2444,11 +3103,26 @@ type ExternalIssueReferenceV2 struct {
 	IssuePermalink string `json:"issue_permalink"`
 
 	// Provider ID of the issue tracker provider
-	Provider ExternalIssueReferenceV2Provider `json:"provider"`
+	Provider ExternalIssueReferenceV4Provider `json:"provider"`
 }
 
-// ExternalIssueReferenceV2Provider ID of the issue tracker provider
-type ExternalIssueReferenceV2Provider string
+// ExternalIssueReferenceV4Provider ID of the issue tracker provider
+type ExternalIssueReferenceV4Provider string
+
+// ExternalIssueReferenceV5 defines model for ExternalIssueReferenceV5.
+type ExternalIssueReferenceV5 struct {
+	// IssueName Human readable ID for the issue
+	IssueName string `json:"issue_name"`
+
+	// IssuePermalink URL linking directly to the action in the issue tracker
+	IssuePermalink string `json:"issue_permalink"`
+
+	// Provider ID of the issue tracker provider
+	Provider ExternalIssueReferenceV5Provider `json:"provider"`
+}
+
+// ExternalIssueReferenceV5Provider ID of the issue tracker provider
+type ExternalIssueReferenceV5Provider string
 
 // ExternalResourceV1 defines model for ExternalResourceV1.
 type ExternalResourceV1 struct {
@@ -2485,7 +3159,7 @@ type FollowUpPriorityV2 struct {
 
 // FollowUpV2 defines model for FollowUpV2.
 type FollowUpV2 struct {
-	Assignee *UserV1 `json:"assignee,omitempty"`
+	Assignee *UserV2 `json:"assignee,omitempty"`
 
 	// CompletedAt When the follow-up was completed
 	CompletedAt *time.Time `json:"completed_at,omitempty"`
@@ -2495,7 +3169,7 @@ type FollowUpV2 struct {
 
 	// Description Description of the follow-up
 	Description            *string                   `json:"description,omitempty"`
-	ExternalIssueReference *ExternalIssueReferenceV2 `json:"external_issue_reference,omitempty"`
+	ExternalIssueReference *ExternalIssueReferenceV5 `json:"external_issue_reference,omitempty"`
 
 	// Id Unique identifier for the follow-up
 	Id string `json:"id"`
@@ -2540,7 +3214,7 @@ type IdentityV1 struct {
 	Roles []IdentityV1Roles `json:"roles"`
 }
 
-// IdentityV1Roles defines model for IdentityV1.Roles.
+// IdentityV1Roles API key roles
 type IdentityV1Roles string
 
 // IncidentAttachmentV1 defines model for IncidentAttachmentV1.
@@ -2552,6 +3226,109 @@ type IncidentAttachmentV1 struct {
 	IncidentId string             `json:"incident_id"`
 	Resource   ExternalResourceV1 `json:"resource"`
 }
+
+// IncidentCreatePayloadV1 defines model for IncidentCreatePayloadV1.
+type IncidentCreatePayloadV1 struct {
+	// CustomFieldEntries Set the incident's custom fields to these values
+	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
+
+	// IdempotencyKey Unique string used to de-duplicate incident create requests
+	IdempotencyKey string `json:"idempotency_key"`
+
+	// IncidentRoleAssignments Assign incident roles to these people
+	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV1 `json:"incident_role_assignments,omitempty"`
+
+	// IncidentTypeId Incident type to create this incident as
+	IncidentTypeId *string `json:"incident_type_id,omitempty"`
+
+	// Mode Whether the incident is real or test
+	Mode *IncidentCreatePayloadV1Mode `json:"mode,omitempty"`
+
+	// Name Explanation of the incident
+	Name *string `json:"name,omitempty"`
+
+	// SeverityId Severity to create incident as
+	SeverityId *string `json:"severity_id,omitempty"`
+
+	// SlackTeamId ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
+	SlackTeamId *string `json:"slack_team_id,omitempty"`
+
+	// SourceMessageChannelId Channel ID of the source message, if this incident was created from one
+	SourceMessageChannelId *string `json:"source_message_channel_id,omitempty"`
+
+	// SourceMessageTimestamp Timestamp of the source message, if this incident was created from one
+	SourceMessageTimestamp *string `json:"source_message_timestamp,omitempty"`
+
+	// Status Current status of the incident
+	Status *IncidentCreatePayloadV1Status `json:"status,omitempty"`
+
+	// Summary Detailed description of the incident
+	Summary *string `json:"summary,omitempty"`
+
+	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+	Visibility IncidentCreatePayloadV1Visibility `json:"visibility"`
+}
+
+// IncidentCreatePayloadV1Mode Whether the incident is real or test
+type IncidentCreatePayloadV1Mode string
+
+// IncidentCreatePayloadV1Status Current status of the incident
+type IncidentCreatePayloadV1Status string
+
+// IncidentCreatePayloadV1Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+type IncidentCreatePayloadV1Visibility string
+
+// IncidentCreatePayloadV2 defines model for IncidentCreatePayloadV2.
+type IncidentCreatePayloadV2 struct {
+	// CustomFieldEntries Set the incident's custom fields to these values
+	CustomFieldEntries *[]CustomFieldEntryPayloadV2 `json:"custom_field_entries,omitempty"`
+
+	// Id Unique identifier for the incident
+	Id *string `json:"id,omitempty"`
+
+	// IdempotencyKey Unique string used to de-duplicate incident create requests
+	IdempotencyKey string `json:"idempotency_key"`
+
+	// IncidentRoleAssignments Assign incident roles to these people
+	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV2 `json:"incident_role_assignments,omitempty"`
+
+	// IncidentStatusId Incident status to assign to the incident
+	IncidentStatusId *string `json:"incident_status_id,omitempty"`
+
+	// IncidentTimestampValues Assign the incident's timestamps to these values
+	IncidentTimestampValues *[]IncidentTimestampValuePayloadV2 `json:"incident_timestamp_values,omitempty"`
+
+	// IncidentTypeId Incident type to create this incident as
+	IncidentTypeId *string `json:"incident_type_id,omitempty"`
+
+	// Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
+	Mode *IncidentCreatePayloadV2Mode `json:"mode,omitempty"`
+
+	// Name Explanation of the incident
+	Name                         *string                         `json:"name,omitempty"`
+	RetrospectiveIncidentOptions *RetrospectiveIncidentOptionsV2 `json:"retrospective_incident_options,omitempty"`
+
+	// SeverityId Severity to create incident as
+	SeverityId *string `json:"severity_id,omitempty"`
+
+	// SlackChannelNameOverride Name of the Slack channel to create for this incident
+	SlackChannelNameOverride *string `json:"slack_channel_name_override,omitempty"`
+
+	// SlackTeamId Slack Team to create the incident in
+	SlackTeamId *string `json:"slack_team_id,omitempty"`
+
+	// Summary Detailed description of the incident
+	Summary *string `json:"summary,omitempty"`
+
+	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+	Visibility IncidentCreatePayloadV2Visibility `json:"visibility"`
+}
+
+// IncidentCreatePayloadV2Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
+type IncidentCreatePayloadV2Mode string
+
+// IncidentCreatePayloadV2Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/en/articles/5947963-can-we-mark-incidents-as-sensitive-and-restrict-access).
+type IncidentCreatePayloadV2Visibility string
 
 // IncidentDurationMetricV2 defines model for IncidentDurationMetricV2.
 type IncidentDurationMetricV2 struct {
@@ -2576,7 +3353,7 @@ type IncidentEditPayloadV2 struct {
 	CallUrl *string `json:"call_url,omitempty"`
 
 	// CustomFieldEntries Set the incident's custom fields to these values
-	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
+	CustomFieldEntries *[]CustomFieldEntryPayloadV2 `json:"custom_field_entries,omitempty"`
 
 	// IncidentRoleAssignments Assign incident roles to these people
 	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV2 `json:"incident_role_assignments,omitempty"`
@@ -2613,7 +3390,7 @@ type IncidentMembership struct {
 
 	// UpdatedAt When the membership was last updated
 	UpdatedAt time.Time `json:"updated_at"`
-	User      UserV1    `json:"user"`
+	User      UserV2    `json:"user"`
 }
 
 // IncidentRoleAssignmentPayloadV1 defines model for IncidentRoleAssignmentPayloadV1.
@@ -2626,7 +3403,7 @@ type IncidentRoleAssignmentPayloadV1 struct {
 
 // IncidentRoleAssignmentPayloadV2 defines model for IncidentRoleAssignmentPayloadV2.
 type IncidentRoleAssignmentPayloadV2 struct {
-	Assignee *UserReferencePayloadV1 `json:"assignee,omitempty"`
+	Assignee *UserReferencePayloadV2 `json:"assignee,omitempty"`
 
 	// IncidentRoleId Unique ID of an incident role
 	IncidentRoleId string `json:"incident_role_id"`
@@ -2636,6 +3413,12 @@ type IncidentRoleAssignmentPayloadV2 struct {
 type IncidentRoleAssignmentV1 struct {
 	Assignee *UserV1        `json:"assignee,omitempty"`
 	Role     IncidentRoleV1 `json:"role"`
+}
+
+// IncidentRoleAssignmentV2 defines model for IncidentRoleAssignmentV2.
+type IncidentRoleAssignmentV2 struct {
+	Assignee *UserV2                `json:"assignee,omitempty"`
+	Role     EmbeddedIncidentRoleV2 `json:"role"`
 }
 
 // IncidentRoleV1 defines model for IncidentRoleV1.
@@ -2724,6 +3507,29 @@ type IncidentStatusV1 struct {
 // IncidentStatusV1Category What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured
 type IncidentStatusV1Category string
 
+// IncidentStatusV2 defines model for IncidentStatusV2.
+type IncidentStatusV2 struct {
+	// Category What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured
+	Category  IncidentStatusV2Category `json:"category"`
+	CreatedAt time.Time                `json:"created_at"`
+
+	// Description Rich text description of the incident status
+	Description string `json:"description"`
+
+	// Id Unique ID of this incident status
+	Id string `json:"id"`
+
+	// Name Unique name of this status
+	Name string `json:"name"`
+
+	// Rank Order of this incident status
+	Rank      int64     `json:"rank"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// IncidentStatusV2Category What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured
+type IncidentStatusV2Category string
+
 // IncidentTimestampV1 defines model for IncidentTimestampV1.
 type IncidentTimestampV1 struct {
 	// LastOccurredAt When this last occurred, if it did
@@ -2796,6 +3602,36 @@ type IncidentTypeV1 struct {
 // IncidentTypeV1CreateInTriage Whether incidents of this must always, or can optionally, be created in triage
 type IncidentTypeV1CreateInTriage string
 
+// IncidentTypeV2 defines model for IncidentTypeV2.
+type IncidentTypeV2 struct {
+	// CreateInTriage Whether incidents of this must always, or can optionally, be created in triage
+	CreateInTriage IncidentTypeV2CreateInTriage `json:"create_in_triage"`
+
+	// CreatedAt When this resource was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Description What is this incident type for?
+	Description string `json:"description"`
+
+	// Id Unique identifier for this Incident Type
+	Id string `json:"id"`
+
+	// IsDefault The default Incident Type is used when no other type is explicitly specified
+	IsDefault bool `json:"is_default"`
+
+	// Name The name of this Incident Type
+	Name string `json:"name"`
+
+	// PrivateIncidentsOnly Should all incidents created with this Incident Type be private?
+	PrivateIncidentsOnly bool `json:"private_incidents_only"`
+
+	// UpdatedAt When this resource was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// IncidentTypeV2CreateInTriage Whether incidents of this must always, or can optionally, be created in triage
+type IncidentTypeV2CreateInTriage string
+
 // IncidentUpdateV2 defines model for IncidentUpdateV2.
 type IncidentUpdateV2 struct {
 	// CreatedAt When the update was created
@@ -2812,7 +3648,7 @@ type IncidentUpdateV2 struct {
 
 	// Message Message that explains the context behind the update
 	Message           *string          `json:"message,omitempty"`
-	NewIncidentStatus IncidentStatusV1 `json:"new_incident_status"`
+	NewIncidentStatus IncidentStatusV2 `json:"new_incident_status"`
 	NewSeverity       *SeverityV2      `json:"new_severity,omitempty"`
 	Updater           ActorV2          `json:"updater"`
 }
@@ -2824,7 +3660,7 @@ type IncidentV1 struct {
 
 	// CreatedAt When the incident was created
 	CreatedAt time.Time `json:"created_at"`
-	Creator   ActorV2   `json:"creator"`
+	Creator   ActorV1   `json:"creator"`
 
 	// CustomFieldEntries Custom field entries for this incident
 	CustomFieldEntries []CustomFieldEntryV1 `json:"custom_field_entries"`
@@ -2850,7 +3686,7 @@ type IncidentV1 struct {
 
 	// Reference Reference to this incident, as displayed across the product
 	Reference string      `json:"reference"`
-	Severity  *SeverityV2 `json:"severity,omitempty"`
+	Severity  *SeverityV1 `json:"severity,omitempty"`
 
 	// SlackChannelId ID of the Slack channel in the organisation Slack workspace. Note that the channel is sometimes created asynchronously, so may not be present when the incident is just created.
 	SlackChannelId string `json:"slack_channel_id"`
@@ -2896,22 +3732,22 @@ type IncidentV2 struct {
 	Creator   ActorV2   `json:"creator"`
 
 	// CustomFieldEntries Custom field entries for this incident
-	CustomFieldEntries []CustomFieldEntryV1 `json:"custom_field_entries"`
+	CustomFieldEntries []CustomFieldEntryV2 `json:"custom_field_entries"`
 
 	// DurationMetrics Incident duration metrics and their measurements for this incident
 	DurationMetrics        *[]IncidentDurationMetricWithValueV2 `json:"duration_metrics,omitempty"`
-	ExternalIssueReference *ExternalIssueReferenceV2            `json:"external_issue_reference,omitempty"`
+	ExternalIssueReference *ExternalIssueReferenceV4            `json:"external_issue_reference,omitempty"`
 
 	// Id Unique identifier for the incident
 	Id string `json:"id"`
 
 	// IncidentRoleAssignments A list of who is assigned to each role for this incident
-	IncidentRoleAssignments []IncidentRoleAssignmentV1 `json:"incident_role_assignments"`
-	IncidentStatus          IncidentStatusV1           `json:"incident_status"`
+	IncidentRoleAssignments []IncidentRoleAssignmentV2 `json:"incident_role_assignments"`
+	IncidentStatus          IncidentStatusV2           `json:"incident_status"`
 
 	// IncidentTimestampValues Incident lifecycle events and when they occurred
 	IncidentTimestampValues *[]IncidentTimestampWithValueV2 `json:"incident_timestamp_values,omitempty"`
-	IncidentType            *IncidentTypeV1                 `json:"incident_type,omitempty"`
+	IncidentType            *IncidentTypeV2                 `json:"incident_type,omitempty"`
 
 	// Mode Whether the incident is real, a test, a tutorial, or importing as a retrospective incident
 	Mode IncidentV2Mode `json:"mode"`
@@ -3024,7 +3860,7 @@ type ListResponseBody16 struct {
 
 // ListResponseBody17 defines model for ListResponseBody17.
 type ListResponseBody17 struct {
-	Severities []SeverityV2 `json:"severities"`
+	Severities []SeverityV1 `json:"severities"`
 }
 
 // ListResponseBody18 defines model for ListResponseBody18.
@@ -3099,9 +3935,7 @@ type ManagedResourceV2 struct {
 	ManagedBy ManagedResourceV2ManagedBy `json:"managed_by"`
 
 	// ResourceId The ID of the related resource
-	ResourceId string `json:"resource_id"`
-
-	// ResourceType The type of the related resource
+	ResourceId   string                        `json:"resource_id"`
 	ResourceType ManagedResourceV2ResourceType `json:"resource_type"`
 
 	// SourceUrl The url of the external repository where this resource is managed (if there is one)
@@ -3111,7 +3945,7 @@ type ManagedResourceV2 struct {
 // ManagedResourceV2ManagedBy How is this resource managed
 type ManagedResourceV2ManagedBy string
 
-// ManagedResourceV2ResourceType The type of the related resource
+// ManagedResourceV2ResourceType defines model for ManagedResourceV2.ResourceType.
 type ManagedResourceV2ResourceType string
 
 // ManagementMetaV2 defines model for ManagementMetaV2.
@@ -3202,9 +4036,9 @@ type ScheduleConfigV2 struct {
 // ScheduleCreatePayloadV2 defines model for ScheduleCreatePayloadV2.
 type ScheduleCreatePayloadV2 struct {
 	// Annotations Annotations that can track metadata about the schedule
-	Annotations          *map[string]string              `json:"annotations,omitempty"`
-	Config               *ScheduleConfigCreatePayloadV2  `json:"config,omitempty"`
-	HolidaysPublicConfig *ScheduleHolidaysPublicConfigV2 `json:"holidays_public_config,omitempty"`
+	Annotations          *map[string]string                     `json:"annotations,omitempty"`
+	Config               *ScheduleConfigCreatePayloadV2         `json:"config,omitempty"`
+	HolidaysPublicConfig *ScheduleHolidaysPublicConfigPayloadV2 `json:"holidays_public_config,omitempty"`
 
 	// Name Name of the schedule
 	Name *string `json:"name,omitempty"`
@@ -3236,7 +4070,13 @@ type ScheduleEntryV2 struct {
 	// RotationId If present, the rotation this entry applies to on the schedule
 	RotationId *string   `json:"rotation_id,omitempty"`
 	StartAt    time.Time `json:"start_at"`
-	User       *UserV1   `json:"user,omitempty"`
+	User       *UserV2   `json:"user,omitempty"`
+}
+
+// ScheduleHolidaysPublicConfigPayloadV2 defines model for ScheduleHolidaysPublicConfigPayloadV2.
+type ScheduleHolidaysPublicConfigPayloadV2 struct {
+	// CountryCodes ISO 3166-1 alpha-2 country codes for the countries that this schedule is configured to view holidays for
+	CountryCodes []string `json:"country_codes"`
 }
 
 // ScheduleHolidaysPublicConfigV2 defines model for ScheduleHolidaysPublicConfigV2.
@@ -3252,6 +4092,15 @@ type ScheduleLayerCreatePayloadV2 struct {
 
 	// Name Name of the layer
 	Name string `json:"name"`
+}
+
+// ScheduleLayerUpdatePayloadV2 defines model for ScheduleLayerUpdatePayloadV2.
+type ScheduleLayerUpdatePayloadV2 struct {
+	// Id Unique identifier of the layer
+	Id *string `json:"id,omitempty"`
+
+	// Name Name of the layer
+	Name *string `json:"name,omitempty"`
 }
 
 // ScheduleLayerV2 defines model for ScheduleLayerV2.
@@ -3274,18 +4123,20 @@ type ScheduleRotationCreatePayloadV2 struct {
 	Layers *[]ScheduleLayerCreatePayloadV2 `json:"layers,omitempty"`
 
 	// Name Name of the rotation
-	Name            string                    `json:"name"`
-	Users           *[]UserReferencePayloadV1 `json:"users,omitempty"`
-	WorkingInterval *[]WeekdayIntervalV2      `json:"working_interval,omitempty"`
+	Name            string                                            `json:"name"`
+	Users           *[]UserReferencePayloadV2                         `json:"users,omitempty"`
+	WorkingInterval *[]ScheduleRotationWorkingIntervalCreatePayloadV2 `json:"working_interval,omitempty"`
 }
 
 // ScheduleRotationHandoverV2 defines model for ScheduleRotationHandoverV2.
 type ScheduleRotationHandoverV2 struct {
-	Interval     *int64                                  `json:"interval,omitempty"`
+	Interval *int64 `json:"interval,omitempty"`
+
+	// IntervalType How often a handover occurs
 	IntervalType *ScheduleRotationHandoverV2IntervalType `json:"interval_type,omitempty"`
 }
 
-// ScheduleRotationHandoverV2IntervalType defines model for ScheduleRotationHandoverV2.IntervalType.
+// ScheduleRotationHandoverV2IntervalType How often a handover occurs
 type ScheduleRotationHandoverV2IntervalType string
 
 // ScheduleRotationUpdatePayloadV2 defines model for ScheduleRotationUpdatePayloadV2.
@@ -3295,12 +4146,12 @@ type ScheduleRotationUpdatePayloadV2 struct {
 	Handovers       *[]ScheduleRotationHandoverV2 `json:"handovers,omitempty"`
 
 	// Id Unique identifier of the rotation
-	Id     *string            `json:"id,omitempty"`
-	Layers *[]ScheduleLayerV2 `json:"layers,omitempty"`
+	Id     *string                         `json:"id,omitempty"`
+	Layers *[]ScheduleLayerUpdatePayloadV2 `json:"layers,omitempty"`
 
 	// Name Name of the rotation
 	Name            *string                                           `json:"name,omitempty"`
-	Users           *[]UserReferencePayloadV1                         `json:"users,omitempty"`
+	Users           *[]UserReferencePayloadV2                         `json:"users,omitempty"`
 	WorkingInterval *[]ScheduleRotationWorkingIntervalUpdatePayloadV2 `json:"working_interval,omitempty"`
 }
 
@@ -3322,10 +4173,25 @@ type ScheduleRotationV2 struct {
 	Layers []ScheduleLayerV2 `json:"layers"`
 
 	// Name Human readable name synced from external provider
-	Name            string               `json:"name"`
-	Users           *[]UserV1            `json:"users,omitempty"`
-	WorkingInterval *[]WeekdayIntervalV2 `json:"working_interval,omitempty"`
+	Name            string                               `json:"name"`
+	Users           *[]UserV2                            `json:"users,omitempty"`
+	WorkingInterval *[]ScheduleRotationWorkingIntervalV2 `json:"working_interval,omitempty"`
 }
+
+// ScheduleRotationWorkingIntervalCreatePayloadV2 defines model for ScheduleRotationWorkingIntervalCreatePayloadV2.
+type ScheduleRotationWorkingIntervalCreatePayloadV2 struct {
+	// EndTime End time of the interval, in 24hr format
+	EndTime string `json:"end_time"`
+
+	// StartTime Start time of the interval, in 24hr format
+	StartTime string `json:"start_time"`
+
+	// Weekday Weekdays for use with a schedule
+	Weekday ScheduleRotationWorkingIntervalCreatePayloadV2Weekday `json:"weekday"`
+}
+
+// ScheduleRotationWorkingIntervalCreatePayloadV2Weekday Weekdays for use with a schedule
+type ScheduleRotationWorkingIntervalCreatePayloadV2Weekday string
 
 // ScheduleRotationWorkingIntervalUpdatePayloadV2 defines model for ScheduleRotationWorkingIntervalUpdatePayloadV2.
 type ScheduleRotationWorkingIntervalUpdatePayloadV2 struct {
@@ -3335,19 +4201,34 @@ type ScheduleRotationWorkingIntervalUpdatePayloadV2 struct {
 	// StartTime Start time of the interval, in 24hr format
 	StartTime *string `json:"start_time,omitempty"`
 
-	// Weekday Weekday this interval applies to
+	// Weekday Weekdays for use with a schedule
 	Weekday *ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday `json:"weekday,omitempty"`
 }
 
-// ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday Weekday this interval applies to
+// ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday Weekdays for use with a schedule
 type ScheduleRotationWorkingIntervalUpdatePayloadV2Weekday string
+
+// ScheduleRotationWorkingIntervalV2 defines model for ScheduleRotationWorkingIntervalV2.
+type ScheduleRotationWorkingIntervalV2 struct {
+	// EndTime End time of the interval, in 24hr format
+	EndTime string `json:"end_time"`
+
+	// StartTime Start time of the interval, in 24hr format
+	StartTime string `json:"start_time"`
+
+	// Weekday Weekdays for use with a schedule
+	Weekday ScheduleRotationWorkingIntervalV2Weekday `json:"weekday"`
+}
+
+// ScheduleRotationWorkingIntervalV2Weekday Weekdays for use with a schedule
+type ScheduleRotationWorkingIntervalV2Weekday string
 
 // ScheduleUpdatePayloadV2 defines model for ScheduleUpdatePayloadV2.
 type ScheduleUpdatePayloadV2 struct {
 	// Annotations Annotations that can track metadata about the schedule
-	Annotations          *map[string]string              `json:"annotations,omitempty"`
-	Config               *ScheduleConfigUpdatePayloadV2  `json:"config,omitempty"`
-	HolidaysPublicConfig *ScheduleHolidaysPublicConfigV2 `json:"holidays_public_config,omitempty"`
+	Annotations          *map[string]string                     `json:"annotations,omitempty"`
+	Config               *ScheduleConfigUpdatePayloadV2         `json:"config,omitempty"`
+	HolidaysPublicConfig *ScheduleHolidaysPublicConfigPayloadV2 `json:"holidays_public_config,omitempty"`
 
 	// Name Name of the schedule
 	Name *string `json:"name,omitempty"`
@@ -3375,6 +4256,27 @@ type ScheduleV2 struct {
 
 	// Timezone Timezone of the schedule, as interpreted at the point of generating the report
 	Timezone  string    `json:"timezone"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// SeverityV1 defines model for SeverityV1.
+type SeverityV1 struct {
+	// CreatedAt When the action was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Description Description of the severity
+	Description string `json:"description"`
+
+	// Id Unique identifier of the severity
+	Id string `json:"id"`
+
+	// Name Human readable name of the severity
+	Name string `json:"name"`
+
+	// Rank Rank to help sort severities (lower numbers are less severe)
+	Rank int64 `json:"rank"`
+
+	// UpdatedAt When the action was last updated
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
@@ -3437,7 +4339,7 @@ type ShowResponseBody14 struct {
 
 // ShowResponseBody15 defines model for ShowResponseBody15.
 type ShowResponseBody15 struct {
-	Severity SeverityV2 `json:"severity"`
+	Severity SeverityV1 `json:"severity"`
 }
 
 // ShowResponseBody16 defines model for ShowResponseBody16.
@@ -3506,7 +4408,7 @@ type StepConfig struct {
 	Name string `json:"name"`
 
 	// ParamBindings Bindings for the step parameters
-	ParamBindings []EngineParamBindingV3 `json:"param_bindings"`
+	ParamBindings []EngineParamBindingV2 `json:"param_bindings"`
 }
 
 // StepConfigPayload defines model for StepConfigPayload.
@@ -3531,6 +4433,33 @@ type StepConfigSlim struct {
 
 	// Name Unique name of the step in the engine
 	Name string `json:"name"`
+}
+
+// TextMark defines model for TextMark.
+type TextMark struct {
+	// Attrs type-specific mark attributes
+	Attrs *map[string]interface{} `json:"attrs,omitempty"`
+
+	// Type the type of the node, eg 'text'
+	Type string `json:"type"`
+}
+
+// TextNode defines model for TextNode.
+type TextNode struct {
+	// Attrs type-specific node attributes
+	Attrs *map[string]interface{} `json:"attrs,omitempty"`
+
+	// Content children of this node
+	Content *[]TextNode `json:"content,omitempty"`
+
+	// Marks marks that apply to this node, eg 'bold'
+	Marks *[]TextMark `json:"marks,omitempty"`
+
+	// Text if this node doesn't have children, it has text content
+	Text *string `json:"text,omitempty"`
+
+	// Type the type of the node
+	Type string `json:"type"`
 }
 
 // TriggerSlim defines model for TriggerSlim.
@@ -3562,7 +4491,7 @@ type UpdateEntryRequestBody struct {
 
 // UpdateRequestBody defines model for UpdateRequestBody.
 type UpdateRequestBody struct {
-	// AlertSourceIds The alert sources that will match this alert route
+	// AlertSourceIds Legacy field - the alert sources that will match this alert route
 	AlertSourceIds []string `json:"alert_source_ids"`
 
 	// AutoDeclineEnabled Should triage incidents be declined when alerts are resolved?
@@ -3740,8 +4669,8 @@ type UpdateTypeSchemaRequestBody struct {
 	Version    int64                           `json:"version"`
 }
 
-// UpdateWorkflowRequestBody defines model for UpdateWorkflowRequestBody.
-type UpdateWorkflowRequestBody struct {
+// UpdateWorkflowPayload2 defines model for UpdateWorkflowPayload2.
+type UpdateWorkflowPayload2 struct {
 	// Annotations Annotations that track metadata about this resource
 	Annotations *map[string]string `json:"annotations,omitempty"`
 
@@ -3768,29 +4697,41 @@ type UpdateWorkflowRequestBody struct {
 	OnceFor []string `json:"once_for"`
 
 	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
-	RunsOnIncidentModes []UpdateWorkflowRequestBodyRunsOnIncidentModes `json:"runs_on_incident_modes"`
+	RunsOnIncidentModes []UpdateWorkflowPayload2RunsOnIncidentModes `json:"runs_on_incident_modes"`
 
 	// RunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-	RunsOnIncidents UpdateWorkflowRequestBodyRunsOnIncidents `json:"runs_on_incidents"`
+	RunsOnIncidents UpdateWorkflowPayload2RunsOnIncidents `json:"runs_on_incidents"`
 
 	// State The state of the workflow (e.g. is it draft, or disabled)
-	State *UpdateWorkflowRequestBodyState `json:"state,omitempty"`
+	State *UpdateWorkflowPayload2State `json:"state,omitempty"`
 
 	// Steps List of step to execute as part of the workflow
 	Steps []StepConfigPayload `json:"steps"`
 }
 
-// UpdateWorkflowRequestBodyRunsOnIncidentModes defines model for UpdateWorkflowRequestBody.RunsOnIncidentModes.
-type UpdateWorkflowRequestBodyRunsOnIncidentModes string
+// UpdateWorkflowPayload2RunsOnIncidentModes defines model for UpdateWorkflowPayload2.RunsOnIncidentModes.
+type UpdateWorkflowPayload2RunsOnIncidentModes string
 
-// UpdateWorkflowRequestBodyRunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-type UpdateWorkflowRequestBodyRunsOnIncidents string
+// UpdateWorkflowPayload2RunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
+type UpdateWorkflowPayload2RunsOnIncidents string
 
-// UpdateWorkflowRequestBodyState The state of the workflow (e.g. is it draft, or disabled)
-type UpdateWorkflowRequestBodyState string
+// UpdateWorkflowPayload2State The state of the workflow (e.g. is it draft, or disabled)
+type UpdateWorkflowPayload2State string
 
 // UserReferencePayloadV1 defines model for UserReferencePayloadV1.
 type UserReferencePayloadV1 struct {
+	// Email The user's email address, matching the email on their Slack account
+	Email *string `json:"email,omitempty"`
+
+	// Id The incident.io ID of a user
+	Id *string `json:"id,omitempty"`
+
+	// SlackUserId The ID of the user's Slack account.
+	SlackUserId *string `json:"slack_user_id,omitempty"`
+}
+
+// UserReferencePayloadV2 defines model for UserReferencePayloadV2.
+type UserReferencePayloadV2 struct {
 	// Email The user's email address, matching the email on their Slack account
 	Email *string `json:"email,omitempty"`
 
@@ -3821,6 +4762,27 @@ type UserV1 struct {
 
 // UserV1Role DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.
 type UserV1Role string
+
+// UserV2 defines model for UserV2.
+type UserV2 struct {
+	// Email Email address of the user.
+	Email *string `json:"email,omitempty"`
+
+	// Id Unique identifier of the user
+	Id string `json:"id"`
+
+	// Name Name of the user
+	Name string `json:"name"`
+
+	// Role DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.
+	Role UserV2Role `json:"role"`
+
+	// SlackUserId Slack ID of the user
+	SlackUserId *string `json:"slack_user_id,omitempty"`
+}
+
+// UserV2Role DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.
+type UserV2Role string
 
 // UserWithRolesV2 defines model for UserWithRolesV2.
 type UserWithRolesV2 struct {
@@ -3866,15 +4828,13 @@ type WeekdayIntervalV2 struct {
 
 	// StartTime Start time of the interval, in 24hr format
 	StartTime string `json:"start_time"`
-
-	// Weekday Weekday this interval applies to
-	Weekday string `json:"weekday"`
+	Weekday   string `json:"weekday"`
 }
 
 // Workflow defines model for Workflow.
 type Workflow struct {
 	// ConditionGroups Conditions that apply to the workflow trigger
-	ConditionGroups []ConditionGroupV3 `json:"condition_groups"`
+	ConditionGroups []ConditionGroupV5 `json:"condition_groups"`
 
 	// ContinueOnStepError Whether to continue executing the workflow if a step fails
 	ContinueOnStepError bool           `json:"continue_on_step_error"`
@@ -3918,7 +4878,7 @@ type Workflow struct {
 	Version int64 `json:"version"`
 }
 
-// WorkflowRunsOnIncidentModes defines model for Workflow.RunsOnIncidentModes.
+// WorkflowRunsOnIncidentModes Incident mode that workflows can run on
 type WorkflowRunsOnIncidentModes string
 
 // WorkflowRunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
@@ -3939,14 +4899,14 @@ type WorkflowDelay struct {
 // WorkflowSlim defines model for WorkflowSlim.
 type WorkflowSlim struct {
 	// ConditionGroups Conditions that apply to the workflow trigger
-	ConditionGroups []ConditionGroupV3 `json:"condition_groups"`
+	ConditionGroups []ConditionGroupV8 `json:"condition_groups"`
 
 	// ContinueOnStepError Whether to continue executing the workflow if a step fails
 	ContinueOnStepError bool           `json:"continue_on_step_error"`
 	Delay               *WorkflowDelay `json:"delay,omitempty"`
 
 	// Expressions Expressions that make variables available in the scope
-	Expressions []ExpressionV3 `json:"expressions"`
+	Expressions []ExpressionV4 `json:"expressions"`
 
 	// Folder Folder to display the workflow in
 	Folder *string `json:"folder,omitempty"`
@@ -3983,7 +4943,7 @@ type WorkflowSlim struct {
 	Version int64 `json:"version"`
 }
 
-// WorkflowSlimRunsOnIncidentModes defines model for WorkflowSlim.RunsOnIncidentModes.
+// WorkflowSlimRunsOnIncidentModes Incident mode that workflows can run on
 type WorkflowSlimRunsOnIncidentModes string
 
 // WorkflowSlimRunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
@@ -4173,52 +5133,52 @@ type UsersV2ListParams struct {
 }
 
 // CustomFieldOptionsV1CreateJSONRequestBody defines body for CustomFieldOptionsV1Create for application/json ContentType.
-type CustomFieldOptionsV1CreateJSONRequestBody = CreateRequestBody2
+type CustomFieldOptionsV1CreateJSONRequestBody = CreateRequestBody
 
 // CustomFieldOptionsV1UpdateJSONRequestBody defines body for CustomFieldOptionsV1Update for application/json ContentType.
 type CustomFieldOptionsV1UpdateJSONRequestBody = UpdateRequestBody2
 
 // CustomFieldsV1CreateJSONRequestBody defines body for CustomFieldsV1Create for application/json ContentType.
-type CustomFieldsV1CreateJSONRequestBody = CreateRequestBody3
+type CustomFieldsV1CreateJSONRequestBody = CreateRequestBody2
 
 // CustomFieldsV1UpdateJSONRequestBody defines body for CustomFieldsV1Update for application/json ContentType.
 type CustomFieldsV1UpdateJSONRequestBody = UpdateRequestBody3
 
 // IncidentAttachmentsV1CreateJSONRequestBody defines body for IncidentAttachmentsV1Create for application/json ContentType.
-type IncidentAttachmentsV1CreateJSONRequestBody = CreateRequestBody5
+type IncidentAttachmentsV1CreateJSONRequestBody = CreateRequestBody4
 
 // IncidentMembershipsV1CreateJSONRequestBody defines body for IncidentMembershipsV1Create for application/json ContentType.
-type IncidentMembershipsV1CreateJSONRequestBody = CreateRequestBody6
+type IncidentMembershipsV1CreateJSONRequestBody = CreateRequestBody5
 
 // IncidentMembershipsV1RevokeJSONRequestBody defines body for IncidentMembershipsV1Revoke for application/json ContentType.
-type IncidentMembershipsV1RevokeJSONRequestBody = CreateRequestBody6
+type IncidentMembershipsV1RevokeJSONRequestBody = CreateRequestBody5
 
 // IncidentRolesV1CreateJSONRequestBody defines body for IncidentRolesV1Create for application/json ContentType.
-type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody7
+type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody6
 
 // IncidentRolesV1UpdateJSONRequestBody defines body for IncidentRolesV1Update for application/json ContentType.
 type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody5
 
 // IncidentStatusesV1CreateJSONRequestBody defines body for IncidentStatusesV1Create for application/json ContentType.
-type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody9
+type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody8
 
 // IncidentStatusesV1UpdateJSONRequestBody defines body for IncidentStatusesV1Update for application/json ContentType.
 type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody7
 
 // IncidentsV1CreateJSONRequestBody defines body for IncidentsV1Create for application/json ContentType.
-type IncidentsV1CreateJSONRequestBody = CreateRequestBody10
+type IncidentsV1CreateJSONRequestBody = IncidentCreatePayloadV1
 
 // SeveritiesV1CreateJSONRequestBody defines body for SeveritiesV1Create for application/json ContentType.
-type SeveritiesV1CreateJSONRequestBody = CreateRequestBody13
+type SeveritiesV1CreateJSONRequestBody = CreateRequestBody10
 
 // SeveritiesV1UpdateJSONRequestBody defines body for SeveritiesV1Update for application/json ContentType.
-type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody13
+type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody10
 
 // AlertEventsV2CreateHTTPJSONRequestBody defines body for AlertEventsV2CreateHTTP for application/json ContentType.
 type AlertEventsV2CreateHTTPJSONRequestBody = CreateHTTPRequestBody
 
 // AlertRoutesV2CreateJSONRequestBody defines body for AlertRoutesV2Create for application/json ContentType.
-type AlertRoutesV2CreateJSONRequestBody = CreateRequestBody
+type AlertRoutesV2CreateJSONRequestBody = AlertRoutePayloadV2
 
 // AlertRoutesV2UpdateJSONRequestBody defines body for AlertRoutesV2Update for application/json ContentType.
 type AlertRoutesV2UpdateJSONRequestBody = UpdateRequestBody
@@ -4239,25 +5199,25 @@ type CatalogV2UpdateTypeJSONRequestBody = UpdateTypeRequestBody
 type CatalogV2UpdateTypeSchemaJSONRequestBody = UpdateTypeSchemaRequestBody
 
 // CustomFieldsV2CreateJSONRequestBody defines body for CustomFieldsV2Create for application/json ContentType.
-type CustomFieldsV2CreateJSONRequestBody = CreateRequestBody4
+type CustomFieldsV2CreateJSONRequestBody = CreateRequestBody3
 
 // CustomFieldsV2UpdateJSONRequestBody defines body for CustomFieldsV2Update for application/json ContentType.
 type CustomFieldsV2UpdateJSONRequestBody = UpdateRequestBody4
 
 // EscalationsV2CreatePathJSONRequestBody defines body for EscalationsV2CreatePath for application/json ContentType.
-type EscalationsV2CreatePathJSONRequestBody = CreatePathRequestBody
+type EscalationsV2CreatePathJSONRequestBody = EscalationPathPayloadV2
 
 // EscalationsV2UpdatePathJSONRequestBody defines body for EscalationsV2UpdatePath for application/json ContentType.
-type EscalationsV2UpdatePathJSONRequestBody = CreatePathRequestBody
+type EscalationsV2UpdatePathJSONRequestBody = EscalationPathPayloadV2
 
 // IncidentRolesV2CreateJSONRequestBody defines body for IncidentRolesV2Create for application/json ContentType.
-type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody8
+type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody7
 
 // IncidentRolesV2UpdateJSONRequestBody defines body for IncidentRolesV2Update for application/json ContentType.
 type IncidentRolesV2UpdateJSONRequestBody = UpdateRequestBody6
 
 // IncidentsV2CreateJSONRequestBody defines body for IncidentsV2Create for application/json ContentType.
-type IncidentsV2CreateJSONRequestBody = CreateRequestBody11
+type IncidentsV2CreateJSONRequestBody = IncidentCreatePayloadV2
 
 // IncidentsV2EditJSONRequestBody defines body for IncidentsV2Edit for application/json ContentType.
 type IncidentsV2EditJSONRequestBody = EditRequestBody
@@ -4266,16 +5226,16 @@ type IncidentsV2EditJSONRequestBody = EditRequestBody
 type ManagedResourcesV2CreateManagedResourceJSONRequestBody = CreateManagedResourceRequestBody
 
 // SchedulesV2CreateJSONRequestBody defines body for SchedulesV2Create for application/json ContentType.
-type SchedulesV2CreateJSONRequestBody = CreateRequestBody12
+type SchedulesV2CreateJSONRequestBody = CreateRequestBody9
 
 // SchedulesV2UpdateJSONRequestBody defines body for SchedulesV2Update for application/json ContentType.
 type SchedulesV2UpdateJSONRequestBody = UpdateRequestBody8
 
 // WorkflowsV2CreateWorkflowJSONRequestBody defines body for WorkflowsV2CreateWorkflow for application/json ContentType.
-type WorkflowsV2CreateWorkflowJSONRequestBody = CreateWorkflowRequestBody
+type WorkflowsV2CreateWorkflowJSONRequestBody = CreateWorkflowPayload
 
 // WorkflowsV2UpdateWorkflowJSONRequestBody defines body for WorkflowsV2UpdateWorkflow for application/json ContentType.
-type WorkflowsV2UpdateWorkflowJSONRequestBody = UpdateWorkflowRequestBody
+type WorkflowsV2UpdateWorkflowJSONRequestBody = UpdateWorkflowPayload2
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -11538,7 +12498,7 @@ func (r IncidentsV1ShowResponse) StatusCode() int {
 type UtilitiesV1OpenAPIResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *openapi_types.File
+	JSON200      *interface{}
 }
 
 // Status returns HTTPResponse.Status
@@ -11560,7 +12520,7 @@ func (r UtilitiesV1OpenAPIResponse) StatusCode() int {
 type UtilitiesV1OpenAPIV3Response struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *openapi_types.File
+	JSON200      *interface{}
 }
 
 // Status returns HTTPResponse.Status
@@ -14869,7 +15829,7 @@ func ParseUtilitiesV1OpenAPIResponse(rsp *http.Response) (*UtilitiesV1OpenAPIRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest openapi_types.File
+		var dest interface{}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -14895,7 +15855,7 @@ func ParseUtilitiesV1OpenAPIV3Response(rsp *http.Response) (*UtilitiesV1OpenAPIV
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest openapi_types.File
+		var dest interface{}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/engine.go
+++ b/internal/provider/engine.go
@@ -237,11 +237,11 @@ type IncidentEngineExpressionParseOpts struct {
 
 var paramBindingValueAttributes = map[string]schema.Attribute{
 	"literal": schema.StringAttribute{
-		MarkdownDescription: apischema.Docstring("EngineParamBindingValueV2ResponseBody", "literal"),
+		MarkdownDescription: apischema.Docstring("EngineParamBindingValueV2", "literal"),
 		Optional:            true,
 	},
 	"reference": schema.StringAttribute{
-		MarkdownDescription: apischema.Docstring("EngineParamBindingValueV2ResponseBody", "reference"),
+		MarkdownDescription: apischema.Docstring("EngineParamBindingValueV2", "reference"),
 		Optional:            true,
 	},
 }
@@ -262,7 +262,7 @@ var paramBindingAttributes = map[string]schema.Attribute{
 }
 
 var paramBindingsAttribute = schema.ListNestedAttribute{
-	MarkdownDescription: apischema.Docstring("ConditionV2ResponseBody", "param_bindings"),
+	MarkdownDescription: apischema.Docstring("ConditionV2", "param_bindings"),
 	Required:            true,
 	NestedObject: schema.NestedAttributeObject{
 		Attributes: paramBindingAttributes,
@@ -302,11 +302,11 @@ var returnsAttribute = schema.SingleNestedAttribute{
 	Required:            true,
 	Attributes: map[string]schema.Attribute{
 		"array": schema.BoolAttribute{
-			MarkdownDescription: apischema.Docstring("ReturnsMetaV2ResponseBody", "array"),
+			MarkdownDescription: apischema.Docstring("ReturnsMetaV2", "array"),
 			Required:            true,
 		},
 		"type": schema.StringAttribute{
-			MarkdownDescription: apischema.Docstring("ReturnsMetaV2ResponseBody", "type"),
+			MarkdownDescription: apischema.Docstring("ReturnsMetaV2", "type"),
 			Required:            true,
 		},
 	},
@@ -318,15 +318,15 @@ var expressionsAttribute = schema.SetNestedAttribute{
 	NestedObject: schema.NestedAttributeObject{
 		Attributes: map[string]schema.Attribute{
 			"label": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("ExpressionV2ResponseBody", "label"),
+				MarkdownDescription: apischema.Docstring("ExpressionV2", "label"),
 				Required:            true,
 			},
 			"reference": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("ExpressionV2ResponseBody", "reference"),
+				MarkdownDescription: apischema.Docstring("ExpressionV2", "reference"),
 				Required:            true,
 			},
 			"root_reference": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("ExpressionV2ResponseBody", "root_reference"),
+				MarkdownDescription: apischema.Docstring("ExpressionV2", "root_reference"),
 				Required:            true,
 			},
 			"else_branch": schema.SingleNestedAttribute{
@@ -350,7 +350,7 @@ var expressionsAttribute = schema.SetNestedAttribute{
 							Optional:            true,
 							Attributes: map[string]schema.Attribute{
 								"branches": schema.ListNestedAttribute{
-									MarkdownDescription: apischema.Docstring("ExpressionBranchesOptsV2ResponseBody", "branches"),
+									MarkdownDescription: apischema.Docstring("ExpressionBranchesOptsV2", "branches"),
 									Required:            true,
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{

--- a/internal/provider/engine.go
+++ b/internal/provider/engine.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
@@ -27,6 +28,106 @@ type IncidentEngineParamBinding struct {
 }
 
 func (IncidentEngineParamBinding) FromClientV2(pb client.EngineParamBindingV2) IncidentEngineParamBinding {
+	var arrayValue []IncidentEngineParamBindingValue
+	if pb.ArrayValue != nil {
+		for _, v := range *pb.ArrayValue {
+			arrayValue = append(arrayValue, IncidentEngineParamBindingValue{
+				Literal:   types.StringPointerValue(v.Literal),
+				Reference: types.StringPointerValue(v.Reference),
+			})
+		}
+	}
+
+	var value *IncidentEngineParamBindingValue
+	if pb.Value != nil {
+		value = &IncidentEngineParamBindingValue{
+			Literal:   types.StringPointerValue(pb.Value.Literal),
+			Reference: types.StringPointerValue(pb.Value.Reference),
+		}
+	}
+
+	return IncidentEngineParamBinding{
+		ArrayValue: arrayValue,
+		Value:      value,
+	}
+}
+
+func (IncidentEngineParamBinding) FromClientV7(pb client.EngineParamBindingV7) IncidentEngineParamBinding {
+	var arrayValue []IncidentEngineParamBindingValue
+	if pb.ArrayValue != nil {
+		for _, v := range *pb.ArrayValue {
+			arrayValue = append(arrayValue, IncidentEngineParamBindingValue{
+				Literal:   types.StringPointerValue(v.Literal),
+				Reference: types.StringPointerValue(v.Reference),
+			})
+		}
+	}
+
+	var value *IncidentEngineParamBindingValue
+	if pb.Value != nil {
+		value = &IncidentEngineParamBindingValue{
+			Literal:   types.StringPointerValue(pb.Value.Literal),
+			Reference: types.StringPointerValue(pb.Value.Reference),
+		}
+	}
+
+	return IncidentEngineParamBinding{
+		ArrayValue: arrayValue,
+		Value:      value,
+	}
+}
+
+func (IncidentEngineParamBinding) FromClientV6(pb client.EngineParamBindingV6) IncidentEngineParamBinding {
+	var arrayValue []IncidentEngineParamBindingValue
+	if pb.ArrayValue != nil {
+		for _, v := range *pb.ArrayValue {
+			arrayValue = append(arrayValue, IncidentEngineParamBindingValue{
+				Literal:   types.StringPointerValue(v.Literal),
+				Reference: types.StringPointerValue(v.Reference),
+			})
+		}
+	}
+
+	var value *IncidentEngineParamBindingValue
+	if pb.Value != nil {
+		value = &IncidentEngineParamBindingValue{
+			Literal:   types.StringPointerValue(pb.Value.Literal),
+			Reference: types.StringPointerValue(pb.Value.Reference),
+		}
+	}
+
+	return IncidentEngineParamBinding{
+		ArrayValue: arrayValue,
+		Value:      value,
+	}
+}
+
+func (IncidentEngineParamBinding) FromClientV5(pb client.EngineParamBindingV5) IncidentEngineParamBinding {
+	var arrayValue []IncidentEngineParamBindingValue
+	if pb.ArrayValue != nil {
+		for _, v := range *pb.ArrayValue {
+			arrayValue = append(arrayValue, IncidentEngineParamBindingValue{
+				Literal:   types.StringPointerValue(v.Literal),
+				Reference: types.StringPointerValue(v.Reference),
+			})
+		}
+	}
+
+	var value *IncidentEngineParamBindingValue
+	if pb.Value != nil {
+		value = &IncidentEngineParamBindingValue{
+			Literal:   types.StringPointerValue(pb.Value.Literal),
+			Reference: types.StringPointerValue(pb.Value.Reference),
+		}
+	}
+
+	return IncidentEngineParamBinding{
+		ArrayValue: arrayValue,
+		Value:      value,
+	}
+}
+
+func (IncidentEngineParamBinding) FromClientV4(pb client.EngineParamBindingV4) IncidentEngineParamBinding {
 	var arrayValue []IncidentEngineParamBindingValue
 	if pb.ArrayValue != nil {
 		for _, v := range *pb.ArrayValue {

--- a/internal/provider/incident_catalog_entries_resource.go
+++ b/internal/provider/incident_catalog_entries_resource.go
@@ -16,11 +16,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/incident-io/terraform-provider-incident/internal/apischema"
-	"github.com/incident-io/terraform-provider-incident/internal/client"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/incident-io/terraform-provider-incident/internal/apischema"
+	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
 
 var (
@@ -88,7 +89,7 @@ changes to one entry to an update to that same entry when the upstream changes.
 		`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "catalog_type_id"),
+				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "catalog_type_id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -100,14 +101,14 @@ changes to one entry to an update to that same entry when the upstream changes.
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "id"),
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "id"),
 							Computed:            true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),
 							},
 						},
 						"name": schema.StringAttribute{
-							MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "name"),
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "name"),
 							Required:            true,
 						},
 						"aliases": schema.ListAttribute{
@@ -115,12 +116,12 @@ changes to one entry to an update to that same entry when the upstream changes.
 							PlanModifiers: []planmodifier.List{
 								listplanmodifier.UseStateForUnknown(),
 							},
-							MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "aliases"),
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "aliases"),
 							Optional:            true,
 							Computed:            true,
 						},
 						"rank": schema.Int64Attribute{
-							MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "rank"),
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "rank"),
 							Optional:            true,
 							Computed:            true,
 							Default:             int64default.StaticInt64(0),

--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -95,20 +95,20 @@ If you're working with a large number of entries (>100) or want to be authoritat
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"catalog_type_id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "catalog_type_id"),
+				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "catalog_type_id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 				Required: true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "name"),
+				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "name"),
 				Required:            true,
 			},
 			"aliases": schema.ListAttribute{
@@ -116,12 +116,12 @@ If you're working with a large number of entries (>100) or want to be authoritat
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.UseStateForUnknown(),
 				},
-				MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "aliases"),
+				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "aliases"),
 				Optional:            true,
 				Computed:            true,
 			},
 			"rank": schema.Int64Attribute{
-				MarkdownDescription: apischema.Docstring("CatalogEntryV2ResponseBody", "rank"),
+				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "rank"),
 				Optional:            true,
 				Computed:            true,
 			},

--- a/internal/provider/incident_catalog_type_attribute_resource.go
+++ b/internal/provider/incident_catalog_type_attribute_resource.go
@@ -14,10 +14,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/incident-io/terraform-provider-incident/internal/apischema"
-	"github.com/incident-io/terraform-provider-incident/internal/client"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
+
+	"github.com/incident-io/terraform-provider-incident/internal/apischema"
+	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
 
 var (
@@ -110,7 +111,7 @@ func (r *IncidentCatalogTypeAttributeResource) Schema(ctx context.Context, req r
 			},
 			"catalog_type_id": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/incident_catalog_type_data_source.go
+++ b/internal/provider/incident_catalog_type_data_source.go
@@ -7,9 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
-	"github.com/samber/lo"
 )
 
 var (
@@ -30,21 +31,21 @@ func (i *IncidentCatalogTypeDataSource) Schema(ctx context.Context, req datasour
 		MarkdownDescription: "This data source provides information about a catalog type.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "id"),
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogV2CreateTypeRequestBody", "name"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "name"),
 				Optional:            true,
 				Computed:            true,
 			},
 			"type_name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogV2CreateTypeRequestBody", "type_name"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "type_name"),
 				Optional:            true,
 				Computed:            true,
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2ResponseBody", "description"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "description"),
 				Computed:            true,
 			},
 			"categories": schema.ListAttribute{

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -12,9 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
-	"github.com/samber/lo"
 )
 
 var (
@@ -47,7 +48,7 @@ func (r *IncidentCatalogTypeResource) Metadata(ctx context.Context, req resource
 func (r IncidentCatalogTypeResource) CategoryDescription() string {
 	// Make a category description where we list all the possible values of categories
 	categories := []string{}
-	for _, category := range apischema.Property("CatalogTypeV2ResponseBody", "categories").Value.Items.Value.Enum {
+	for _, category := range apischema.Property("CatalogTypeV2", "categories").Value.Items.Value.Enum {
 		categoryAsString, _ := category.(string)
 		categories = append(categories, "`"+categoryAsString+"`")
 	}
@@ -61,25 +62,25 @@ func (r *IncidentCatalogTypeResource) Schema(ctx context.Context, req resource.S
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogV2CreateTypeRequestBody", "name"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "name"),
 				Required:            true,
 			},
 			"type_name": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true, // If not provided, we'll use the generated ID
-				MarkdownDescription: apischema.Docstring("CatalogV2CreateTypeRequestBody", "type_name"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "type_name"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogV2CreateTypeRequestBody", "description"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "description"),
 				Required:            true,
 			},
 			"categories": schema.ListAttribute{

--- a/internal/provider/incident_custom_field_data_source.go
+++ b/internal/provider/incident_custom_field_data_source.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
-	"github.com/samber/lo"
 )
 
 var (
@@ -33,15 +34,15 @@ func (i *IncidentCustomFieldDataSource) Schema(ctx context.Context, req datasour
 				Computed:            true,
 			},
 			"field_type": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldsV2CreateRequestBody", "field_type"),
+				MarkdownDescription: apischema.Docstring("CustomFieldV2", "field_type"),
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldsV2CreateRequestBody", "name"),
+				MarkdownDescription: apischema.Docstring("CustomFieldV2", "name"),
 				Required:            true,
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldsV2CreateRequestBody", "name"),
+				MarkdownDescription: apischema.Docstring("CustomFieldV2", "description"),
 				Computed:            true,
 			},
 		},

--- a/internal/provider/incident_custom_field_option_data_source.go
+++ b/internal/provider/incident_custom_field_option_data_source.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
-	"github.com/samber/lo"
 )
 
 var (
@@ -29,19 +30,19 @@ func (i *IncidentCustomFieldOptionDataSource) Schema(ctx context.Context, req da
 		MarkdownDescription: "This data source provides information about a custom field option.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1", "id"),
 				Computed:            true,
 			},
 			"custom_field_id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1ResponseBody", "custom_field_id"),
+				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1", "custom_field_id"),
 				Required:            true,
 			},
 			"value": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1ResponseBody", "value"),
+				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1", "value"),
 				Required:            true,
 			},
 			"sort_key": schema.Int64Attribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1ResponseBody", "sort_key"),
+				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1", "sort_key"),
 				Optional:            true,
 			},
 		},

--- a/internal/provider/incident_custom_field_option_resource.go
+++ b/internal/provider/incident_custom_field_option_resource.go
@@ -47,25 +47,25 @@ func (r *IncidentCustomFieldOptionResource) Schema(ctx context.Context, req reso
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"custom_field_id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldOptionsV1CreateRequestBody", "custom_field_id"),
+				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1", "custom_field_id"),
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"sort_key": schema.Int64Attribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldOptionsV1CreateRequestBody", "sort_key"),
+				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1", "sort_key"),
 				Optional:            true,
 				Computed:            true,
 			},
 			"value": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CustomFieldOptionsV1CreateRequestBody", "value"),
+				MarkdownDescription: apischema.Docstring("CustomFieldOptionV1", "value"),
 				Required:            true,
 			},
 		},

--- a/internal/provider/incident_custom_field_resource.go
+++ b/internal/provider/incident_custom_field_resource.go
@@ -98,7 +98,7 @@ func (r *IncidentCustomFieldResource) Create(ctx context.Context, req resource.C
 	result, err := r.client.CustomFieldsV2CreateWithResponse(ctx, client.CustomFieldsV2CreateJSONRequestBody{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
-		FieldType:   client.CreateRequestBody4FieldType(data.FieldType.ValueString()),
+		FieldType:   client.CreateRequestBody3FieldType(data.FieldType.ValueString()),
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))

--- a/internal/provider/incident_custom_field_resource.go
+++ b/internal/provider/incident_custom_field_resource.go
@@ -46,7 +46,7 @@ func (r *IncidentCustomFieldResource) Schema(ctx context.Context, req resource.S
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: apischema.Docstring("CustomFieldV2ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("CustomFieldV2", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -3,8 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -89,22 +90,22 @@ func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resourc
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: apischema.Docstring("EscalationPathV2ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("EscalationPathV2", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("EscalationPathV2ResponseBody", "name"),
+				MarkdownDescription: apischema.Docstring("EscalationPathV2", "name"),
 				Required:            true,
 			},
 			"path": schema.ListNestedAttribute{
-				MarkdownDescription: apischema.Docstring("EscalationPathV2ResponseBody", "path"),
+				MarkdownDescription: apischema.Docstring("EscalationPathV2", "path"),
 				Required:            true,
 				NestedObject:        r.getPathSchema(3),
 			},
 			"working_hours": schema.ListNestedAttribute{
-				MarkdownDescription: apischema.Docstring("EscalationPathV2ResponseBody", "working_hours"),
+				MarkdownDescription: apischema.Docstring("EscalationPathV2", "working_hours"),
 				Optional:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: IncidentWeekdayIntervalConfig{}.Attributes(),
@@ -120,7 +121,7 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 	result := schema.NestedAttributeObject{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("EscalationPathNodeV2ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("EscalationPathNodeV2", "id"),
 				Computed:            true,
 				Optional:            true,
 				PlanModifiers: []planmodifier.String{
@@ -128,32 +129,32 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 				},
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("EscalationPathNodeV2ResponseBody", "type"),
+				MarkdownDescription: apischema.Docstring("EscalationPathNodeV2", "type"),
 				Required:            true,
 			},
 			"level": schema.SingleNestedAttribute{
-				MarkdownDescription: apischema.Docstring("EscalationPathNodeV2ResponseBody", "level"),
+				MarkdownDescription: apischema.Docstring("EscalationPathNodeV2", "level"),
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"targets": schema.ListNestedAttribute{
-						MarkdownDescription: apischema.Docstring("EscalationPathNodeLevelV2ResponseBody", "targets"),
+						MarkdownDescription: apischema.Docstring("EscalationPathNodeLevelV2", "targets"),
 						Required:            true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"id": schema.StringAttribute{
-									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2ResponseBody", "id"),
+									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "id"),
 									Required:            true,
 								},
 								"type": schema.StringAttribute{
-									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2ResponseBody", "type"),
+									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "type"),
 									Required:            true,
 								},
 								"urgency": schema.StringAttribute{
-									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2ResponseBody", "urgency"),
+									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "urgency"),
 									Required:            true,
 								},
 								"schedule_mode": schema.StringAttribute{
-									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2ResponseBody", "schedule_mode"),
+									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "schedule_mode"),
 									Optional:            true,
 									Computed:            true,
 								},
@@ -172,31 +173,31 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 						},
 					},
 					"time_to_ack_seconds": schema.Int64Attribute{
-						MarkdownDescription: apischema.Docstring("EscalationPathNodeLevelV2ResponseBody", "time_to_ack_seconds"),
+						MarkdownDescription: apischema.Docstring("EscalationPathNodeLevelV2", "time_to_ack_seconds"),
 						Optional:            true,
 					},
 					"time_to_ack_interval_condition": schema.StringAttribute{
 						MarkdownDescription: apischema.Docstring(
-							"EscalationPathNodeLevelV2ResponseBody", "time_to_ack_interval_condition"),
+							"EscalationPathNodeLevelV2", "time_to_ack_interval_condition"),
 						Optional: true,
 					},
 					"time_to_ack_weekday_interval_config_id": schema.StringAttribute{
 						MarkdownDescription: apischema.Docstring(
-							"EscalationPathNodeLevelV2ResponseBody", "time_to_ack_weekday_interval_config_id"),
+							"EscalationPathNodeLevelV2", "time_to_ack_weekday_interval_config_id"),
 						Optional: true,
 					},
 				},
 			},
 			"repeat": schema.SingleNestedAttribute{
-				MarkdownDescription: apischema.Docstring("EscalationPathNodeV2ResponseBody", "repeat"),
+				MarkdownDescription: apischema.Docstring("EscalationPathNodeV2", "repeat"),
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"repeat_times": schema.Int64Attribute{
-						MarkdownDescription: apischema.Docstring("EscalationPathNodeRepeatV2ResponseBody", "repeat_times"),
+						MarkdownDescription: apischema.Docstring("EscalationPathNodeRepeatV2", "repeat_times"),
 						Required:            true,
 					},
 					"to_node": schema.StringAttribute{
-						MarkdownDescription: apischema.Docstring("EscalationPathNodeRepeatV2ResponseBody", "to_node"),
+						MarkdownDescription: apischema.Docstring("EscalationPathNodeRepeatV2", "to_node"),
 						Required:            true,
 					},
 				},
@@ -206,12 +207,12 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 
 	if depth > 0 {
 		result.Attributes["if_else"] = schema.SingleNestedAttribute{
-			MarkdownDescription: apischema.Docstring("EscalationPathNodeV2ResponseBody", "if_else"),
+			MarkdownDescription: apischema.Docstring("EscalationPathNodeV2", "if_else"),
 			Optional:            true,
 			Attributes: map[string]schema.Attribute{
 				"conditions": conditionsAttribute,
 				"else_path": schema.ListNestedAttribute{
-					MarkdownDescription: apischema.Docstring("EscalationPathNodeIfElseV2ResponseBody", "else_path"),
+					MarkdownDescription: apischema.Docstring("EscalationPathNodeIfElseV2", "else_path"),
 					Optional:            true,
 					NestedObject:        r.getPathSchema(depth - 1),
 				},

--- a/internal/provider/incident_role_resource.go
+++ b/internal/provider/incident_role_resource.go
@@ -47,25 +47,25 @@ func (r *IncidentRoleResource) Schema(ctx context.Context, req resource.SchemaRe
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: apischema.Docstring("IncidentRoleV2ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("IncidentRoleV2", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("IncidentRolesV2CreateRequestBody", "name"),
+				MarkdownDescription: apischema.Docstring("IncidentRoleV2", "name"),
 				Required:            true,
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("IncidentRolesV2CreateRequestBody", "description"),
+				MarkdownDescription: apischema.Docstring("IncidentRoleV2", "description"),
 				Required:            true,
 			},
 			"instructions": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("IncidentRolesV2CreateRequestBody", "instructions"),
+				MarkdownDescription: apischema.Docstring("IncidentRoleV2", "instructions"),
 				Required:            true,
 			},
 			"shortform": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("IncidentRolesV2CreateRequestBody", "shortform"),
+				MarkdownDescription: apischema.Docstring("IncidentRoleV2", "shortform"),
 				Required:            true,
 			},
 		},

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -434,9 +434,9 @@ func buildScheduleUpdatePayload(data *IncidentScheduleResourceModel, resp *resou
 }
 
 // buildUsersArray converts a list of user IDs to a list of user references.
-func buildUsersArray(users []types.String) []client.UserReferencePayloadV1 {
-	return lo.Map(users, func(user types.String, _ int) client.UserReferencePayloadV1 {
-		return client.UserReferencePayloadV1{
+func buildUsersArray(users []types.String) []client.UserReferencePayloadV2 {
+	return lo.Map(users, func(user types.String, _ int) client.UserReferencePayloadV2 {
+		return client.UserReferencePayloadV2{
 			Id: user.ValueStringPointer(),
 		}
 	})
@@ -511,10 +511,10 @@ func (r *IncidentScheduleResource) buildModel(schedule client.ScheduleV2) *Incid
 				ID:   types.StringValue(rotation.ID),
 				Name: types.StringValue(rotation.Name),
 				Versions: lo.Map(rotationsGroupedByID[rotation.ID], func(rotation client.ScheduleRotationV2, idx int) RotationVersion {
-					var workingIntervals []WorkingInterval
+					var workingIntervals []IncidentWeekdayInterval
 					if rotation.WorkingInterval != nil {
-						workingIntervals = lo.Map(*rotation.WorkingInterval, func(interval client.WeekdayIntervalV2, _ int) WorkingInterval {
-							return WorkingInterval{
+						workingIntervals = lo.Map(*rotation.WorkingInterval, func(interval client.WeekdayIntervalV2, _ int) IncidentWeekdayInterval {
+							return IncidentWeekdayInterval{
 								Start: types.StringValue(interval.StartTime),
 								End:   types.StringValue(interval.EndTime),
 								Day:   types.StringValue(interval.Weekday),
@@ -539,7 +539,7 @@ func (r *IncidentScheduleResource) buildModel(schedule client.ScheduleV2) *Incid
 
 					users := []types.String{}
 					if rotation.Users != nil {
-						users = lo.Map(lo.FromPtr(rotation.Users), func(user client.UserV1, _ int) types.String {
+						users = lo.Map(lo.FromPtr(rotation.Users), func(user client.UserV2, _ int) types.String {
 							return types.StringValue(user.Id)
 						})
 					}
@@ -569,7 +569,7 @@ func (r *IncidentScheduleResource) buildModel(schedule client.ScheduleV2) *Incid
 	}
 }
 
-func buildScheduleHolidaysPublicConfig(data *IncidentScheduleResourceModel) *client.ScheduleHolidaysPublicConfigV2 {
+func buildScheduleHolidaysPublicConfig(data *IncidentScheduleResourceModel) *client.ScheduleHolidaysPublicConfigPayloadV2 {
 	if data.HolidaysPublicConfig == nil {
 		return nil
 	}
@@ -577,7 +577,7 @@ func buildScheduleHolidaysPublicConfig(data *IncidentScheduleResourceModel) *cli
 	for _, countryCode := range data.HolidaysPublicConfig.CountryCodes {
 		countryCodes = append(countryCodes, countryCode.ValueString())
 	}
-	return &client.ScheduleHolidaysPublicConfigV2{
+	return &client.ScheduleHolidaysPublicConfigPayloadV2{
 		CountryCodes: countryCodes,
 	}
 }

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -90,11 +90,11 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				MarkdownDescription: apischema.Docstring("ScheduleV2ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("ScheduleV2", "id"),
 			},
 			"name": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: apischema.Docstring("ScheduleV2ResponseBody", "name"),
+				MarkdownDescription: apischema.Docstring("ScheduleV2", "name"),
 			},
 			"timezone": schema.StringAttribute{
 				Required: true,
@@ -104,7 +104,7 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 					"country_codes": schema.ListAttribute{
 						Required:            true,
 						ElementType:         types.StringType,
-						MarkdownDescription: apischema.Docstring("ScheduleHolidaysPublicConfigV2ResponseBody", "country_codes"),
+						MarkdownDescription: apischema.Docstring("ScheduleHolidaysPublicConfigV2", "country_codes"),
 					},
 				},
 				Optional: true,
@@ -114,11 +114,11 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
 							Required:            true,
-							MarkdownDescription: apischema.Docstring("ScheduleRotationV2ResponseBody", "id"),
+							MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "id"),
 						},
 						"name": schema.StringAttribute{
 							Required:            true,
-							MarkdownDescription: apischema.Docstring("ScheduleRotationV2ResponseBody", "name"),
+							MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "name"),
 						},
 						"versions": schema.ListNestedAttribute{
 							Required: true,
@@ -127,19 +127,19 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 									"users": schema.ListAttribute{
 										Required:            true,
 										ElementType:         types.StringType,
-										MarkdownDescription: apischema.Docstring("UserReferencePayloadV1RequestBody", "id"),
+										MarkdownDescription: apischema.Docstring("UserReferencePayloadV1", "id"),
 									},
 									"effective_from": schema.StringAttribute{
 										Optional:            true,
-										MarkdownDescription: apischema.Docstring("ScheduleRotationV2ResponseBody", "effective_from"),
+										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "effective_from"),
 									},
 									"handover_start_at": schema.StringAttribute{
 										Required:            true,
-										MarkdownDescription: apischema.Docstring("ScheduleRotationV2ResponseBody", "handover_start_at"),
+										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "handover_start_at"),
 									},
 									"working_intervals": schema.ListNestedAttribute{
 										Optional:            true,
-										MarkdownDescription: apischema.Docstring("ScheduleRotationV2ResponseBody", "working_interval"),
+										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "working_interval"),
 										NestedObject: schema.NestedAttributeObject{
 											Attributes: map[string]schema.Attribute{
 												"start": schema.StringAttribute{
@@ -156,7 +156,7 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 									},
 									"layers": schema.ListNestedAttribute{
 										Required:            true,
-										MarkdownDescription: apischema.Docstring("ScheduleRotationV2ResponseBody", "layers"),
+										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "layers"),
 										NestedObject: schema.NestedAttributeObject{
 											Attributes: map[string]schema.Attribute{
 												"id": schema.StringAttribute{
@@ -170,7 +170,7 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 									},
 									"handovers": schema.ListNestedAttribute{
 										Optional:            true,
-										MarkdownDescription: apischema.Docstring("ScheduleRotationV2ResponseBody", "handovers"),
+										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "handovers"),
 										NestedObject: schema.NestedAttributeObject{
 											Attributes: map[string]schema.Attribute{
 												"interval": schema.Int64Attribute{

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -58,7 +58,7 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 										Name: lo.ToPtr("Primary Layer One"),
 									},
 								},
-								WorkingInterval: &[]client.WeekdayIntervalV2{
+								WorkingInterval: &[]client.ScheduleRotationWorkingIntervalV2{
 									{
 										StartTime: "09:00",
 										EndTime:   "17:00",
@@ -122,7 +122,7 @@ func incidentScheduleDefault() client.ScheduleV2 {
 						},
 					},
 					Name:            "Rota",
-					Users:           new([]client.UserV1),
+					Users:           new([]client.UserV2),
 					WorkingInterval: nil,
 				},
 			},
@@ -226,7 +226,7 @@ func generateLayersArray(layers []client.ScheduleLayerV2) string {
 	return result
 }
 
-func generateUsersArray(users *[]client.UserV1) string {
+func generateUsersArray(users *[]client.UserV2) string {
 	var result string
 	if users == nil {
 		return "[]"
@@ -257,14 +257,14 @@ func generateCountryCodesArray(codes []string) string {
 	return result
 }
 
-func generateWorkingIntervalsArray(workingIntervals *[]client.WeekdayIntervalV2) string {
+func generateWorkingIntervalsArray(workingIntervals *[]client.ScheduleRotationWorkingIntervalV2) string {
 	var result string
 	result += "[\n"
 	for _, workingInterval := range *workingIntervals {
 		result += "  {\n"
 		result += "    start_time = " + quote(workingInterval.StartTime) + "\n"
 		result += "    end_time   = " + quote(workingInterval.EndTime) + "\n"
-		result += "    weekday    = " + quote(workingInterval.Weekday) + "\n"
+		result += "    weekday    = " + quote(string(workingInterval.Weekday)) + "\n"
 		result += "  },\n"
 	}
 	result += "]\n"

--- a/internal/provider/incident_severity_resource.go
+++ b/internal/provider/incident_severity_resource.go
@@ -47,21 +47,21 @@ func (r *IncidentSeverityResource) Schema(ctx context.Context, req resource.Sche
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: apischema.Docstring("SeverityV1ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("SeverityV1", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("SeveritiesV1CreateRequestBody", "name"),
+				MarkdownDescription: apischema.Docstring("SeverityV1", "name"),
 				Required:            true,
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("SeveritiesV1CreateRequestBody", "description"),
+				MarkdownDescription: apischema.Docstring("SeverityV1", "description"),
 				Required:            true,
 			},
 			"rank": schema.Int64Attribute{
-				MarkdownDescription: apischema.Docstring("SeveritiesV1CreateRequestBody", "rank"),
+				MarkdownDescription: apischema.Docstring("SeverityV1", "rank"),
 				Optional:            true,
 				Computed:            true,
 			},

--- a/internal/provider/incident_severity_resource.go
+++ b/internal/provider/incident_severity_resource.go
@@ -189,7 +189,7 @@ func (r *IncidentSeverityResource) ImportState(ctx context.Context, req resource
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *IncidentSeverityResource) buildModel(severity client.SeverityV2) *IncidentSeverityResourceModel {
+func (r *IncidentSeverityResource) buildModel(severity client.SeverityV1) *IncidentSeverityResourceModel {
 	return &IncidentSeverityResourceModel{
 		ID:          types.StringValue(severity.Id),
 		Name:        types.StringValue(severity.Name),

--- a/internal/provider/incident_status_resource.go
+++ b/internal/provider/incident_status_resource.go
@@ -46,7 +46,7 @@ func (r *IncidentStatusResource) Schema(ctx context.Context, req resource.Schema
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: apischema.Docstring("IncidentStatusV1ResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("IncidentStatusV1", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/incident_status_resource.go
+++ b/internal/provider/incident_status_resource.go
@@ -98,7 +98,7 @@ func (r *IncidentStatusResource) Create(ctx context.Context, req resource.Create
 	result, err := r.client.IncidentStatusesV1CreateWithResponse(ctx, client.IncidentStatusesV1CreateJSONRequestBody{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
-		Category:    client.CreateRequestBody9Category(data.Category.ValueString()),
+		Category:    client.CreateRequestBody8Category(data.Category.ValueString()),
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/samber/lo"
 
@@ -169,24 +168,24 @@ func (r *IncidentWorkflowResource) Create(ctx context.Context, req resource.Crea
 		onceFor = append(onceFor, v.ValueString())
 	}
 
-	runsOnIncidentModes := []client.CreateWorkflowRequestBodyRunsOnIncidentModes{}
+	runsOnIncidentModes := []client.CreateWorkflowPayloadRunsOnIncidentModes{}
 	for _, v := range data.RunsOnIncidentModes {
-		runsOnIncidentModes = append(runsOnIncidentModes, client.CreateWorkflowRequestBodyRunsOnIncidentModes(v.ValueString()))
+		runsOnIncidentModes = append(runsOnIncidentModes, client.CreateWorkflowPayloadRunsOnIncidentModes(v.ValueString()))
 	}
 
-	payload := client.CreateWorkflowRequestBody{
+	payload := client.CreateWorkflowPayload{
 		Trigger:                 data.Trigger.ValueString(),
 		Name:                    data.Name.ValueString(),
 		OnceFor:                 onceFor,
 		ConditionGroups:         toPayloadConditionGroups(data.ConditionGroups),
 		Steps:                   toPayloadSteps(data.Steps),
 		Expressions:             toPayloadExpressions(data.Expressions),
-		RunsOnIncidents:         client.CreateWorkflowRequestBodyRunsOnIncidents(data.RunsOnIncidents.ValueString()),
+		RunsOnIncidents:         client.CreateWorkflowPayloadRunsOnIncidents(data.RunsOnIncidents.ValueString()),
 		RunsOnIncidentModes:     runsOnIncidentModes,
 		Folder:                  data.Folder.ValueStringPointer(),
 		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
 		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
-		State:                   lo.ToPtr(client.CreateWorkflowRequestBodyState(data.State.ValueString())),
+		State:                   lo.ToPtr(client.CreateWorkflowPayloadState(data.State.ValueString())),
 		Annotations: &map[string]string{
 			"incident.io/terraform/version": r.terraformVersion,
 		},
@@ -231,9 +230,9 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		onceFor = append(onceFor, v.ValueString())
 	}
 
-	runsOnIncidentModes := []client.UpdateWorkflowRequestBodyRunsOnIncidentModes{}
+	runsOnIncidentModes := []client.UpdateWorkflowPayload2RunsOnIncidentModes{}
 	for _, v := range data.RunsOnIncidentModes {
-		runsOnIncidentModes = append(runsOnIncidentModes, client.UpdateWorkflowRequestBodyRunsOnIncidentModes(v.ValueString()))
+		runsOnIncidentModes = append(runsOnIncidentModes, client.UpdateWorkflowPayload2RunsOnIncidentModes(v.ValueString()))
 	}
 
 	payload := client.WorkflowsV2UpdateWorkflowJSONRequestBody{
@@ -242,12 +241,12 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		Steps:                   toPayloadSteps(data.Steps),
 		Expressions:             toPayloadExpressions(data.Expressions),
 		OnceFor:                 onceFor,
-		RunsOnIncidents:         client.UpdateWorkflowRequestBodyRunsOnIncidents(data.RunsOnIncidents.ValueString()),
+		RunsOnIncidents:         client.UpdateWorkflowPayload2RunsOnIncidents(data.RunsOnIncidents.ValueString()),
 		RunsOnIncidentModes:     runsOnIncidentModes,
 		Folder:                  data.Folder.ValueStringPointer(),
 		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
 		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
-		State:                   lo.ToPtr(client.UpdateWorkflowRequestBodyState(data.State.ValueString())),
+		State:                   lo.ToPtr(client.UpdateWorkflowPayload2State(data.State.ValueString())),
 		Annotations: &map[string]string{
 			"incident.io/terraform/version": r.terraformVersion,
 		},
@@ -329,185 +328,6 @@ func (r *IncidentWorkflowResource) Configure(ctx context.Context, req resource.C
 
 	r.client = client.Client
 	r.terraformVersion = client.TerraformVersion
-}
-
-// buildModel converts from the response type to the terraform model/schema type.
-func (r *IncidentWorkflowResource) buildModel(workflow client.Workflow) *IncidentWorkflowResourceModel {
-	model := &IncidentWorkflowResourceModel{
-		ID:                      types.StringValue(workflow.Id),
-		Name:                    types.StringValue(workflow.Name),
-		Trigger:                 types.StringValue(workflow.Trigger.Name),
-		ConditionGroups:         r.buildConditionGroups(workflow.ConditionGroups),
-		Steps:                   r.buildSteps(workflow.Steps),
-		Expressions:             r.buildExpressions(workflow.Expressions),
-		OnceFor:                 r.buildOnceFor(workflow.OnceFor),
-		RunsOnIncidentModes:     r.buildRunsOnIncidentModes(workflow.RunsOnIncidentModes),
-		IncludePrivateIncidents: types.BoolValue(workflow.IncludePrivateIncidents),
-		ContinueOnStepError:     types.BoolValue(workflow.ContinueOnStepError),
-		RunsOnIncidents:         types.StringValue(string(workflow.RunsOnIncidents)),
-		State:                   types.StringValue(string(workflow.State)),
-	}
-	if workflow.Folder != nil {
-		model.Folder = types.StringValue(*workflow.Folder)
-	}
-	if workflow.Delay != nil {
-		model.Delay = &IncidentWorkflowDelay{
-			ConditionsApplyOverDelay: types.BoolValue(workflow.Delay.ConditionsApplyOverDelay),
-			ForSeconds:               types.Int64Value(workflow.Delay.ForSeconds),
-		}
-	}
-	return model
-}
-
-func (r *IncidentWorkflowResource) buildOnceFor(onceFor []client.EngineReferenceV2) []basetypes.StringValue {
-	out := []basetypes.StringValue{}
-
-	for _, ref := range onceFor {
-		out = append(out, types.StringValue(ref.Key))
-	}
-
-	return out
-}
-
-func (r *IncidentWorkflowResource) buildRunsOnIncidentModes(modes []client.WorkflowRunsOnIncidentModes) []basetypes.StringValue {
-	out := []basetypes.StringValue{}
-
-	for _, mode := range modes {
-		out = append(out, types.StringValue(string(mode)))
-	}
-
-	return out
-}
-
-func (r *IncidentWorkflowResource) buildConditionGroups(groups []client.ConditionGroupV3) IncidentEngineConditionGroups {
-	var out IncidentEngineConditionGroups
-
-	for _, g := range groups {
-		out = append(out, IncidentEngineConditionGroup{
-			Conditions: r.buildConditions(g.Conditions),
-		})
-	}
-
-	return out
-}
-
-func (r *IncidentWorkflowResource) buildConditions(conditions []client.ConditionV3) []IncidentEngineCondition {
-	out := []IncidentEngineCondition{}
-
-	for _, c := range conditions {
-		out = append(out, IncidentEngineCondition{
-			Subject:       types.StringValue(c.Subject.Reference),
-			Operation:     types.StringValue(c.Operation.Value),
-			ParamBindings: r.buildParamBindings(c.ParamBindings),
-		})
-	}
-
-	return out
-}
-
-func (r *IncidentWorkflowResource) buildSteps(steps []client.StepConfig) []IncidentWorkflowStep {
-	out := []IncidentWorkflowStep{}
-
-	for _, s := range steps {
-		out = append(out, IncidentWorkflowStep{
-			ForEach:       types.StringPointerValue(s.ForEach),
-			ID:            types.StringValue(s.Id),
-			Name:          types.StringValue(s.Name),
-			ParamBindings: r.buildParamBindings(s.ParamBindings),
-		})
-	}
-
-	return out
-}
-
-func (r *IncidentWorkflowResource) buildParamBindings(pbs []client.EngineParamBindingV3) []IncidentEngineParamBinding {
-	out := []IncidentEngineParamBinding{}
-
-	for _, pb := range pbs {
-		out = append(out, r.buildParamBinding(pb))
-	}
-
-	return out
-}
-
-func (r *IncidentWorkflowResource) buildParamBinding(pb client.EngineParamBindingV3) IncidentEngineParamBinding {
-	return IncidentEngineParamBinding{}.FromClientV3(pb)
-}
-
-func (r *IncidentWorkflowResource) buildExpressions(expressions []client.ExpressionV3) IncidentEngineExpressions {
-	out := IncidentEngineExpressions{}
-
-	for _, e := range expressions {
-		expression := IncidentEngineExpression{
-			Label:         types.StringValue(e.Label),
-			Operations:    r.buildOperations(e.Operations),
-			Reference:     types.StringValue(e.Reference),
-			RootReference: types.StringValue(e.RootReference),
-		}
-		if e.ElseBranch != nil {
-			expression.ElseBranch = &IncidentEngineElseBranch{
-				Result: r.buildParamBinding(e.ElseBranch.Result),
-			}
-		}
-		out = append(out, expression)
-	}
-
-	return out
-}
-
-func (r *IncidentWorkflowResource) buildOperations(operations []client.ExpressionOperationV3) []IncidentEngineExpressionOperation {
-	out := []IncidentEngineExpressionOperation{}
-
-	for _, o := range operations {
-		operation := IncidentEngineExpressionOperation{
-			OperationType: types.StringValue(string(o.OperationType)),
-		}
-		if o.Branches != nil {
-			operation.Branches = &IncidentEngineExpressionBranchesOpts{
-				Branches: r.buildBranches(o.Branches.Branches),
-				Returns:  r.buildReturns(o.Branches.Returns),
-			}
-		}
-		if o.Filter != nil {
-			operation.Filter = &IncidentEngineExpressionFilterOpts{
-				ConditionGroups: r.buildConditionGroups(o.Filter.ConditionGroups),
-			}
-		}
-		if o.Navigate != nil {
-			operation.Navigate = &IncidentEngineExpressionNavigateOpts{
-				Reference: types.StringValue(o.Navigate.Reference),
-			}
-		}
-		if o.Parse != nil {
-			operation.Parse = &IncidentEngineExpressionParseOpts{
-				Returns: r.buildReturns(o.Parse.Returns),
-				Source:  types.StringValue(o.Parse.Source),
-			}
-		}
-		out = append(out, operation)
-	}
-
-	return out
-}
-
-func (r *IncidentWorkflowResource) buildBranches(branches []client.ExpressionBranchV3) []IncidentEngineBranch {
-	out := []IncidentEngineBranch{}
-
-	for _, b := range branches {
-		out = append(out, IncidentEngineBranch{
-			ConditionGroups: r.buildConditionGroups(b.ConditionGroups),
-			Result:          r.buildParamBinding(b.Result),
-		})
-	}
-
-	return out
-}
-
-func (r *IncidentWorkflowResource) buildReturns(returns client.ReturnsMetaV2) IncidentEngineReturnsMeta {
-	return IncidentEngineReturnsMeta{
-		Array: types.BoolValue(returns.Array),
-		Type:  types.StringValue(returns.Type),
-	}
 }
 
 // toPayloadConditionGroups converts from the terraform model to the http payload type.

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -71,22 +71,22 @@ func (r *IncidentWorkflowResource) Schema(ctx context.Context, req resource.Sche
 We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this [Loom](https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448).`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowResponseBody", "id"),
+				MarkdownDescription: apischema.Docstring("Workflow", "id"),
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowResponseBody", "name"),
+				MarkdownDescription: apischema.Docstring("Workflow", "name"),
 				Required:            true,
 			},
 			"folder": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowResponseBody", "folder"),
+				MarkdownDescription: apischema.Docstring("Workflow", "folder"),
 				Optional:            true,
 			},
 			"trigger": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("TriggerSlimResponseBody", "name"),
+				MarkdownDescription: apischema.Docstring("TriggerSlim", "name"),
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -94,7 +94,7 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 			},
 			"condition_groups": conditionGroupsAttribute,
 			"steps": schema.ListNestedAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowResponseBody", "steps"),
+				MarkdownDescription: apischema.Docstring("Workflow", "steps"),
 				Required:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -113,16 +113,16 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 			},
 			"expressions": expressionsAttribute,
 			"once_for": schema.ListAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowResponseBody", "once_for"),
+				MarkdownDescription: apischema.Docstring("Workflow", "once_for"),
 				Required:            true,
 				ElementType:         types.StringType,
 			},
 			"include_private_incidents": schema.BoolAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowResponseBody", "include_private_incidents"),
+				MarkdownDescription: apischema.Docstring("Workflow", "include_private_incidents"),
 				Required:            true,
 			},
 			"continue_on_step_error": schema.BoolAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowResponseBody", "continue_on_step_error"),
+				MarkdownDescription: apischema.Docstring("Workflow", "continue_on_step_error"),
 				Required:            true,
 			},
 			"delay": schema.SingleNestedAttribute{
@@ -130,17 +130,17 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"conditions_apply_over_delay": schema.BoolAttribute{
-						MarkdownDescription: apischema.Docstring("WorkflowDelayRequestBody", "conditions_apply_over_delay"),
+						MarkdownDescription: apischema.Docstring("WorkflowDelay", "conditions_apply_over_delay"),
 						Required:            true,
 					},
 					"for_seconds": schema.Int64Attribute{
-						MarkdownDescription: apischema.Docstring("WorkflowDelayRequestBody", "for_seconds"),
+						MarkdownDescription: apischema.Docstring("WorkflowDelay", "for_seconds"),
 						Required:            true,
 					},
 				},
 			},
 			"runs_on_incidents": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowResponseBody", "runs_on_incidents"),
+				MarkdownDescription: apischema.Docstring("Workflow", "runs_on_incidents"),
 				Required:            true,
 			},
 			"runs_on_incident_modes": schema.ListAttribute{
@@ -149,7 +149,7 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 				ElementType:         types.StringType,
 			},
 			"state": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("WorkflowResponseBody", "state"),
+				MarkdownDescription: apischema.Docstring("Workflow", "state"),
 				Required:            true,
 			},
 		},

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
@@ -17,19 +18,19 @@ type IncidentWeekdayIntervalConfig struct {
 func (IncidentWeekdayIntervalConfig) Attributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"id": schema.StringAttribute{
-			MarkdownDescription: apischema.Docstring("WeekdayIntervalConfigV2ResponseBody", "id"),
+			MarkdownDescription: apischema.Docstring("WeekdayIntervalConfigV2", "id"),
 			Required:            true,
 		},
 		"name": schema.StringAttribute{
-			MarkdownDescription: apischema.Docstring("WeekdayIntervalConfigV2ResponseBody", "name"),
+			MarkdownDescription: apischema.Docstring("WeekdayIntervalConfigV2", "name"),
 			Required:            true,
 		},
 		"timezone": schema.StringAttribute{
-			MarkdownDescription: apischema.Docstring("WeekdayIntervalConfigV2ResponseBody", "timezone"),
+			MarkdownDescription: apischema.Docstring("WeekdayIntervalConfigV2", "timezone"),
 			Required:            true,
 		},
 		"weekday_intervals": schema.ListNestedAttribute{
-			MarkdownDescription: apischema.Docstring("WeekdayIntervalConfigV2ResponseBody", "weekday_intervals"),
+			MarkdownDescription: apischema.Docstring("WeekdayIntervalConfigV2", "weekday_intervals"),
 			Required:            true,
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: IncidentWeekdayInterval{}.Attributes(),
@@ -79,15 +80,15 @@ type IncidentWeekdayInterval struct {
 func (IncidentWeekdayInterval) Attributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"start_time": schema.StringAttribute{
-			MarkdownDescription: apischema.Docstring("WeekdayIntervalV2ResponseBody", "start_time"),
+			MarkdownDescription: apischema.Docstring("WeekdayIntervalV2", "start_time"),
 			Required:            true,
 		},
 		"end_time": schema.StringAttribute{
-			MarkdownDescription: apischema.Docstring("WeekdayIntervalV2ResponseBody", "end_time"),
+			MarkdownDescription: apischema.Docstring("WeekdayIntervalV2", "end_time"),
 			Required:            true,
 		},
 		"weekday": schema.StringAttribute{
-			MarkdownDescription: apischema.Docstring("WeekdayIntervalV2ResponseBody", "weekday"),
+			MarkdownDescription: apischema.Docstring("WeekdayIntervalV2", "weekday"),
 			Required:            true,
 		},
 	}

--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -1,0 +1,299 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/incident-io/terraform-provider-incident/internal/client"
+)
+
+// buildModel converts from the response type to the terraform model/schema type.
+func (r *IncidentWorkflowResource) buildModel(workflow client.Workflow) *IncidentWorkflowResourceModel {
+	model := &IncidentWorkflowResourceModel{
+		ID:                      types.StringValue(workflow.Id),
+		Name:                    types.StringValue(workflow.Name),
+		Trigger:                 types.StringValue(workflow.Trigger.Name),
+		ConditionGroups:         r.buildConditionGroupsFromV5(workflow.ConditionGroups),
+		Steps:                   r.buildSteps(workflow.Steps),
+		Expressions:             r.buildExpressions(workflow.Expressions),
+		OnceFor:                 r.buildOnceFor(workflow.OnceFor),
+		RunsOnIncidentModes:     r.buildRunsOnIncidentModes(workflow.RunsOnIncidentModes),
+		IncludePrivateIncidents: types.BoolValue(workflow.IncludePrivateIncidents),
+		ContinueOnStepError:     types.BoolValue(workflow.ContinueOnStepError),
+		RunsOnIncidents:         types.StringValue(string(workflow.RunsOnIncidents)),
+		State:                   types.StringValue(string(workflow.State)),
+	}
+	if workflow.Folder != nil {
+		model.Folder = types.StringValue(*workflow.Folder)
+	}
+	if workflow.Delay != nil {
+		model.Delay = &IncidentWorkflowDelay{
+			ConditionsApplyOverDelay: types.BoolValue(workflow.Delay.ConditionsApplyOverDelay),
+			ForSeconds:               types.Int64Value(workflow.Delay.ForSeconds),
+		}
+	}
+	return model
+}
+
+func (r *IncidentWorkflowResource) buildOnceFor(onceFor []client.EngineReferenceV2) []basetypes.StringValue {
+	out := []basetypes.StringValue{}
+
+	for _, ref := range onceFor {
+		out = append(out, types.StringValue(ref.Key))
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildRunsOnIncidentModes(modes []client.WorkflowRunsOnIncidentModes) []basetypes.StringValue {
+	out := []basetypes.StringValue{}
+
+	for _, mode := range modes {
+		out = append(out, types.StringValue(string(mode)))
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildConditionGroupsFromV3(groups []client.ConditionGroupV3) IncidentEngineConditionGroups {
+	var out IncidentEngineConditionGroups
+
+	for _, g := range groups {
+		out = append(out, IncidentEngineConditionGroup{
+			Conditions: r.buildConditionsFromV3(g.Conditions),
+		})
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildConditionGroupsFromV4(groups []client.ConditionGroupV4) IncidentEngineConditionGroups {
+	var out IncidentEngineConditionGroups
+
+	for _, g := range groups {
+		out = append(out, IncidentEngineConditionGroup{
+			Conditions: r.buildConditionsFromV4(g.Conditions),
+		})
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildConditionGroupsFromV5(groups []client.ConditionGroupV5) IncidentEngineConditionGroups {
+	var out IncidentEngineConditionGroups
+
+	for _, g := range groups {
+		out = append(out, IncidentEngineConditionGroup{
+			Conditions: r.buildConditionsFromV5(g.Conditions),
+		})
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildConditionsFromV3(conditions []client.ConditionV3) []IncidentEngineCondition {
+	out := []IncidentEngineCondition{}
+
+	for _, c := range conditions {
+		out = append(out, IncidentEngineCondition{
+			Subject:       types.StringValue(c.Subject.Reference),
+			Operation:     types.StringValue(c.Operation.Value),
+			ParamBindings: r.buildParamBindingsFromV4(c.ParamBindings),
+		})
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildConditionsFromV4(conditions []client.ConditionV4) []IncidentEngineCondition {
+	out := []IncidentEngineCondition{}
+
+	for _, c := range conditions {
+		out = append(out, IncidentEngineCondition{
+			Subject:       types.StringValue(c.Subject.Reference),
+			Operation:     types.StringValue(c.Operation.Value),
+			ParamBindings: r.buildParamBindingsFromV5(c.ParamBindings),
+		})
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildConditionsFromV5(conditions []client.ConditionV5) []IncidentEngineCondition {
+	out := []IncidentEngineCondition{}
+
+	for _, c := range conditions {
+		out = append(out, IncidentEngineCondition{
+			Subject:       types.StringValue(c.Subject.Reference),
+			Operation:     types.StringValue(c.Operation.Value),
+			ParamBindings: r.buildParamBindingsFromV7(c.ParamBindings),
+		})
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildSteps(steps []client.StepConfig) []IncidentWorkflowStep {
+	out := []IncidentWorkflowStep{}
+
+	for _, s := range steps {
+		out = append(out, IncidentWorkflowStep{
+			ForEach:       types.StringPointerValue(s.ForEach),
+			ID:            types.StringValue(s.Id),
+			Name:          types.StringValue(s.Name),
+			ParamBindings: r.buildParamBindingsFromV2(s.ParamBindings),
+		})
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingsFromV2(pbs []client.EngineParamBindingV2) []IncidentEngineParamBinding {
+	out := []IncidentEngineParamBinding{}
+
+	for _, pb := range pbs {
+		out = append(out, r.buildParamBindingFromV2(pb))
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingsFromV3(pbs []client.EngineParamBindingV3) []IncidentEngineParamBinding {
+	out := []IncidentEngineParamBinding{}
+
+	for _, pb := range pbs {
+		out = append(out, r.buildParamBindingFromV3(pb))
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingsFromV4(pbs []client.EngineParamBindingV4) []IncidentEngineParamBinding {
+	out := []IncidentEngineParamBinding{}
+
+	for _, pb := range pbs {
+		out = append(out, r.buildParamBindingFromV4(pb))
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingsFromV5(pbs []client.EngineParamBindingV5) []IncidentEngineParamBinding {
+	out := []IncidentEngineParamBinding{}
+
+	for _, pb := range pbs {
+		out = append(out, r.buildParamBindingFromV5(pb))
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingsFromV7(pbs []client.EngineParamBindingV7) []IncidentEngineParamBinding {
+	out := []IncidentEngineParamBinding{}
+
+	for _, pb := range pbs {
+		out = append(out, r.buildParamBindingFromV7(pb))
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingFromV7(pb client.EngineParamBindingV7) IncidentEngineParamBinding {
+	return IncidentEngineParamBinding{}.FromClientV7(pb)
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingFromV6(pb client.EngineParamBindingV6) IncidentEngineParamBinding {
+	return IncidentEngineParamBinding{}.FromClientV6(pb)
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingFromV5(pb client.EngineParamBindingV5) IncidentEngineParamBinding {
+	return IncidentEngineParamBinding{}.FromClientV5(pb)
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingFromV4(pb client.EngineParamBindingV4) IncidentEngineParamBinding {
+	return IncidentEngineParamBinding{}.FromClientV4(pb)
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingFromV3(pb client.EngineParamBindingV3) IncidentEngineParamBinding {
+	return IncidentEngineParamBinding{}.FromClientV3(pb)
+}
+
+func (r *IncidentWorkflowResource) buildParamBindingFromV2(pb client.EngineParamBindingV2) IncidentEngineParamBinding {
+	return IncidentEngineParamBinding{}.FromClientV2(pb)
+}
+
+func (r *IncidentWorkflowResource) buildExpressions(expressions []client.ExpressionV3) IncidentEngineExpressions {
+	out := IncidentEngineExpressions{}
+
+	for _, e := range expressions {
+		expression := IncidentEngineExpression{
+			Label:         types.StringValue(e.Label),
+			Operations:    r.buildOperations(e.Operations),
+			Reference:     types.StringValue(e.Reference),
+			RootReference: types.StringValue(e.RootReference),
+		}
+		if e.ElseBranch != nil {
+			expression.ElseBranch = &IncidentEngineElseBranch{
+				Result: r.buildParamBindingFromV3(e.ElseBranch.Result),
+			}
+		}
+		out = append(out, expression)
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildOperations(operations []client.ExpressionOperationV3) []IncidentEngineExpressionOperation {
+	out := []IncidentEngineExpressionOperation{}
+
+	for _, o := range operations {
+		operation := IncidentEngineExpressionOperation{
+			OperationType: types.StringValue(string(o.OperationType)),
+		}
+		if o.Branches != nil {
+			operation.Branches = &IncidentEngineExpressionBranchesOpts{
+				Branches: r.buildBranches(o.Branches.Branches),
+				Returns:  r.buildReturns(o.Branches.Returns),
+			}
+		}
+		if o.Filter != nil {
+			operation.Filter = &IncidentEngineExpressionFilterOpts{
+				ConditionGroups: r.buildConditionGroupsFromV3(o.Filter.ConditionGroups),
+			}
+		}
+		if o.Navigate != nil {
+			operation.Navigate = &IncidentEngineExpressionNavigateOpts{
+				Reference: types.StringValue(o.Navigate.Reference),
+			}
+		}
+		if o.Parse != nil {
+			operation.Parse = &IncidentEngineExpressionParseOpts{
+				Returns: r.buildReturns(o.Parse.Returns),
+				Source:  types.StringValue(o.Parse.Source),
+			}
+		}
+		out = append(out, operation)
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildBranches(branches []client.ExpressionBranchV3) []IncidentEngineBranch {
+	out := []IncidentEngineBranch{}
+
+	for _, b := range branches {
+		out = append(out, IncidentEngineBranch{
+			ConditionGroups: r.buildConditionGroupsFromV4(b.ConditionGroups),
+			Result:          r.buildParamBindingFromV6(b.Result),
+		})
+	}
+
+	return out
+}
+
+func (r *IncidentWorkflowResource) buildReturns(returns client.ReturnsMetaV2) IncidentEngineReturnsMeta {
+	return IncidentEngineReturnsMeta{
+		Array: types.BoolValue(returns.Array),
+		Type:  types.StringValue(returns.Type),
+	}
+}


### PR DESCRIPTION
Now using our lastest openAPI specs. This involves adding some more tedious type conversion between similar types (the spec hasn't really changed much, I think we just got lucky previously and only needed a handful of conversion functions) and  renaming some of the prop names in the acceptance tests.