### PR TITLE
Ensure empty condition groups end up as an empty JSON array

### DIFF
--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -340,15 +340,15 @@ func (r *IncidentWorkflowResource) Configure(ctx context.Context, req resource.C
 // toPayloadConditionGroups converts from the terraform model to the http payload type.
 // The payload type is different from the response type, which includes more information such as labels.
 func toPayloadConditionGroups(groups IncidentEngineConditionGroups) []client.ConditionGroupPayloadV2 {
-	var payload []client.ConditionGroupPayloadV2
+	out := []client.ConditionGroupPayloadV2{}
 
 	for _, group := range groups {
-		payload = append(payload, client.ConditionGroupPayloadV2{
+		out = append(out, client.ConditionGroupPayloadV2{
 			Conditions: toPayloadConditions(group.Conditions),
 		})
 	}
 
-	return payload
+	return out
 }
 
 func toPayloadConditions(conditions []IncidentEngineCondition) []client.ConditionPayloadV2 {


### PR DESCRIPTION
The "create workflow" API requires that `condition_groups` are specified: that is, they can't be `null`. I discovered that the code for mapping condition groups starts off with an array instantiated like this:

```
var payload []client.ConditionGroupPayloadV2
```

This is subtle but important, because if you `json.Marshal()` that object, it will come back as `null`, which then means that we return a 422, and tell you that `condition_groups` is required.

We fix this by switching to `out := []client.ConditionGroupPayloadV2{}`, which is the pattern used by the other surrounding methods that do similar transformations.