### PR TITLE
Fix nil slice issue in IncidentEngineConditionGroups

### DIFF
--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -59,7 +59,7 @@ func buildRunsOnIncidentModes(modes []client.WorkflowRunsOnIncidentModes) []base
 }
 
 func buildConditionGroups(groups []client.ConditionGroupV2) IncidentEngineConditionGroups {
-	var out IncidentEngineConditionGroups
+	out := IncidentEngineConditionGroups{}
 
 	for _, g := range groups {
 		out = append(out, IncidentEngineConditionGroup{


### PR DESCRIPTION
Similar to #111, we need to apply the same fix here. I have built and tested the provider locally, and it fixes the problem that was reported, where you get an error similar to this:

```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to
│ incident_workflow.when_a_message_is_posted_in_an_incident_channel_send_message_to_a_channel,
│ provider "provider[\"registry.terraform.io/incident-io/incident\"]" produced an unexpected
│ new value: .condition_groups: was
│ cty.SetValEmpty(cty.Object(map[string]cty.Type{"conditions":cty.Set(cty.Object(map[string]cty.Type{"operation":cty.String,
│ "param_bindings":cty.List(cty.Object(map[string]cty.Type{"array_value":cty.Set(cty.Object(map[string]cty.Type{"literal":cty.String,
│ "reference":cty.String})), "value":cty.Object(map[string]cty.Type{"literal":cty.String,
│ "reference":cty.String})})), "subject":cty.String}))})), but now null.
```