### PR TITLE
Add `external_id` to `resource_catalog_entry`

### DIFF
--- a/docs/resources/catalog_entry.md
+++ b/docs/resources/catalog_entry.md
@@ -22,6 +22,26 @@ If you're working with a large number of entries (>100) or want to be authoritat
 ## Example Usage
 
 ```terraform
+locals {
+  service_tiers = [
+    {
+      name        = "tier_1"
+      description = "Critical customer-facing services"
+      external_id = "service-tier-1"
+    },
+    {
+      name        = "tier_2"
+      description = "Either customers or internal user processes are impacted if this service fails"
+      external_id = "service-tier-2"
+    },
+    {
+      name        = "tier_3"
+      description = "Non-essential services"
+      external_id = "service-tier-3"
+    },
+  ]
+}
+
 resource "incident_catalog_type" "service_tier" {
   name        = "Service Tier"
   description = "Level of importance for each service"
@@ -35,26 +55,15 @@ resource "incident_catalog_type_attribute" "service_tier_description" {
 }
 
 resource "incident_catalog_entry" "service_tier" {
-  for_each = {
-    for name, tier in [
-      {
-        name        = "tier_1"
-        description = "Critical customer-facing services"
-      },
-      {
-        name        = "tier_2"
-        description = "Either customers or internal user processes are impacted if this service fails"
-      },
-      {
-        name        = "tier_3"
-        description = "Non-essential services"
-      },
-    ] : tier.name => tier
+  for_each = { for tier in local.service_tiers :
+    tier.name => tier
   }
 
   catalog_type_id = incident_catalog_type.service_tier.id
 
   name = each.value.name
+
+  external_id = each.value.external_id
 
   attribute_values = [
     {
@@ -77,6 +86,7 @@ resource "incident_catalog_entry" "service_tier" {
 ### Optional
 
 - `aliases` (List of String) Optional aliases that can be used to reference this entry
+- `external_id` (String) An optional alternative ID for this entry, which is ensured to be unique for the type
 - `rank` (Number) When catalog type is ranked, this is used to help order things
 
 ### Read-Only

--- a/examples/resources/incident_catalog_entry/resource.tf
+++ b/examples/resources/incident_catalog_entry/resource.tf
@@ -1,3 +1,23 @@
+locals {
+  service_tiers = [
+    {
+      name        = "tier_1"
+      description = "Critical customer-facing services"
+      external_id = "service-tier-1"
+    },
+    {
+      name        = "tier_2"
+      description = "Either customers or internal user processes are impacted if this service fails"
+      external_id = "service-tier-2"
+    },
+    {
+      name        = "tier_3"
+      description = "Non-essential services"
+      external_id = "service-tier-3"
+    },
+  ]
+}
+
 resource "incident_catalog_type" "service_tier" {
   name        = "Service Tier"
   description = "Level of importance for each service"
@@ -11,26 +31,15 @@ resource "incident_catalog_type_attribute" "service_tier_description" {
 }
 
 resource "incident_catalog_entry" "service_tier" {
-  for_each = {
-    for name, tier in [
-      {
-        name        = "tier_1"
-        description = "Critical customer-facing services"
-      },
-      {
-        name        = "tier_2"
-        description = "Either customers or internal user processes are impacted if this service fails"
-      },
-      {
-        name        = "tier_3"
-        description = "Non-essential services"
-      },
-    ] : tier.name => tier
+  for_each = { for tier in local.service_tiers :
+    tier.name => tier
   }
 
   catalog_type_id = incident_catalog_type.service_tier.id
 
   name = each.value.name
+
+  external_id = each.value.external_id
 
   attribute_values = [
     {

--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -33,6 +33,7 @@ type IncidentCatalogEntryResourceModel struct {
 	ID              types.String                 `tfsdk:"id"`
 	CatalogTypeID   types.String                 `tfsdk:"catalog_type_id"`
 	Name            types.String                 `tfsdk:"name"`
+	ExternalID      types.String                 `tfsdk:"external_id"`
 	Aliases         types.List                   `tfsdk:"aliases"`
 	Rank            types.Int64                  `tfsdk:"rank"`
 	AttributeValues []CatalogEntryAttributeValue `tfsdk:"attribute_values"`
@@ -110,6 +111,10 @@ If you're working with a large number of entries (>100) or want to be authoritat
 			"name": schema.StringAttribute{
 				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "name"),
 				Required:            true,
+			},
+			"external_id": schema.StringAttribute{
+				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "external_id"),
+				Optional:            true,
 			},
 			"aliases": schema.ListAttribute{
 				ElementType: types.StringType,
@@ -189,6 +194,7 @@ func (r *IncidentCatalogEntryResource) Create(ctx context.Context, req resource.
 	result, err := r.client.CatalogV2CreateEntryWithResponse(ctx, client.CreateEntryRequestBody{
 		CatalogTypeId:   data.CatalogTypeID.ValueString(),
 		Name:            data.Name.ValueString(),
+		ExternalId:      data.ExternalID.ValueStringPointer(),
 		Rank:            rank,
 		Aliases:         &aliases,
 		AttributeValues: data.buildAttributeValues(),
@@ -256,6 +262,7 @@ func (r *IncidentCatalogEntryResource) Update(ctx context.Context, req resource.
 	result, err := r.client.CatalogV2UpdateEntryWithResponse(ctx, data.ID.ValueString(), client.UpdateEntryRequestBody{
 		Name:            data.Name.ValueString(),
 		Rank:            rank,
+		ExternalId:      data.ExternalID.ValueStringPointer(),
 		Aliases:         &aliases,
 		AttributeValues: data.buildAttributeValues(),
 	})
@@ -334,6 +341,7 @@ func (r *IncidentCatalogEntryResource) buildModel(entry client.CatalogEntryV2) *
 		ID:              types.StringValue(entry.Id),
 		CatalogTypeID:   types.StringValue(entry.CatalogTypeId),
 		Name:            types.StringValue(entry.Name),
+		ExternalID:      types.StringPointerValue(entry.ExternalId),
 		Aliases:         types.ListValueMust(types.StringType, aliases),
 		Rank:            types.Int64Value(int64(entry.Rank)),
 		AttributeValues: values,


### PR DESCRIPTION
- This will allow users to set an external ID using this resource