### PR TITLE
INC-9408 Correctly manage breaking changes around schedule working intervals

### DIFF
--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -180,9 +180,9 @@ Required:
 
 Required:
 
-- `day` (String)
-- `end` (String)
-- `start` (String)
+- `end_time` (String)
+- `start_time` (String)
+- `weekday` (String)
 
 
 

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
+	"github.com/incident-io/terraform-provider-incident/internal/provider/models"
 )
 
 var (
@@ -31,10 +32,10 @@ type IncidentEscalationPathResource struct {
 }
 
 type IncidentEscalationPathResourceModel struct {
-	ID           types.String                    `tfsdk:"id"`
-	Name         types.String                    `tfsdk:"name"`
-	Path         []IncidentEscalationPathNode    `tfsdk:"path"`
-	WorkingHours []IncidentWeekdayIntervalConfig `tfsdk:"working_hours"`
+	ID           types.String                           `tfsdk:"id"`
+	Name         types.String                           `tfsdk:"name"`
+	Path         []IncidentEscalationPathNode           `tfsdk:"path"`
+	WorkingHours []models.IncidentWeekdayIntervalConfig `tfsdk:"working_hours"`
 }
 
 type IncidentEscalationPathNode struct {
@@ -108,7 +109,7 @@ func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resourc
 				MarkdownDescription: apischema.Docstring("EscalationPathV2", "working_hours"),
 				Optional:            true,
 				NestedObject: schema.NestedAttributeObject{
-					Attributes: IncidentWeekdayIntervalConfig{}.Attributes(),
+					Attributes: models.IncidentWeekdayIntervalConfig{}.Attributes(),
 				},
 			},
 		},
@@ -358,10 +359,10 @@ func (r *IncidentEscalationPathResource) ImportState(ctx context.Context, req re
 }
 
 func (r *IncidentEscalationPathResource) buildModel(ep client.EscalationPathV2) *IncidentEscalationPathResourceModel {
-	var workingHours []IncidentWeekdayIntervalConfig
+	var workingHours []models.IncidentWeekdayIntervalConfig
 	if ep.WorkingHours != nil {
-		workingHours = lo.Map(*ep.WorkingHours, func(wh client.WeekdayIntervalConfigV2, _ int) IncidentWeekdayIntervalConfig {
-			return IncidentWeekdayIntervalConfig{}.FromClientV2(wh)
+		workingHours = lo.Map(*ep.WorkingHours, func(wh client.WeekdayIntervalConfigV2, _ int) models.IncidentWeekdayIntervalConfig {
+			return models.IncidentWeekdayIntervalConfig{}.FromClientV2(wh)
 		})
 	}
 

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -180,8 +180,6 @@ func readScheduleResource(ctx context.Context, getMethod func(ctx context.Contex
 		}
 
 		v2Data = v1Data.Upgrade()
-
-		return nil, diags
 	}
 
 	return v2Data, nil

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -99,13 +99,13 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "working_interval"),
 										NestedObject: schema.NestedAttributeObject{
 											Attributes: map[string]schema.Attribute{
-												"start": schema.StringAttribute{
+												"start_time": schema.StringAttribute{
 													Required: true,
 												},
-												"end": schema.StringAttribute{
+												"end_time": schema.StringAttribute{
 													Required: true,
 												},
-												"day": schema.StringAttribute{
+												"weekday": schema.StringAttribute{
 													Required: true,
 												},
 											},

--- a/internal/provider/models/common.go
+++ b/internal/provider/models/common.go
@@ -1,4 +1,4 @@
-package provider
+package models
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/provider/models/schedule_v1_model.go
+++ b/internal/provider/models/schedule_v1_model.go
@@ -1,0 +1,108 @@
+package models
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/samber/lo"
+)
+
+type IncidentScheduleResourceModelV1 struct {
+	ID                   types.String            `tfsdk:"id"`
+	Name                 types.String            `tfsdk:"name"`
+	Timezone             types.String            `tfsdk:"timezone"`
+	Rotations            []RotationV1            `tfsdk:"rotations"`
+	HolidaysPublicConfig *HolidaysPublicConfigV1 `tfsdk:"holidays_public_config"`
+}
+
+type RotationV1 struct {
+	ID       types.String        `tfsdk:"id"`
+	Name     types.String        `tfsdk:"name"`
+	Versions []RotationVersionV1 `tfsdk:"versions"`
+}
+
+type RotationVersionV1 struct {
+	EffectiveFrom    types.String        `tfsdk:"effective_from"`
+	HandoverStartAt  types.String        `tfsdk:"handover_start_at"`
+	Handovers        []HandoverV1        `tfsdk:"handovers"`
+	Users            []types.String      `tfsdk:"users"`
+	WorkingIntervals []WorkingIntervalV1 `tfsdk:"working_intervals"`
+	Layers           []LayerV1           `tfsdk:"layers"`
+}
+
+// Deprecated: this has been replaced by IncidentWeekdayInterval.
+type WorkingIntervalV1 struct {
+	Start types.String `tfsdk:"start"`
+	End   types.String `tfsdk:"end"`
+	Day   types.String `tfsdk:"day"`
+}
+
+type LayerV1 struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+type HandoverV1 struct {
+	Interval     types.Int64  `tfsdk:"interval"`
+	IntervalType types.String `tfsdk:"interval_type"`
+}
+
+type HolidaysPublicConfigV1 struct {
+	CountryCodes []types.String `tfsdk:"country_codes"`
+}
+
+func (m *IncidentScheduleResourceModelV1) Upgrade() *IncidentScheduleResourceModelV2 {
+	return &IncidentScheduleResourceModelV2{
+		ID:                   m.ID,
+		Name:                 m.Name,
+		Timezone:             m.Timezone,
+		Rotations:            lo.Map(m.Rotations, func(r RotationV1, _ int) RotationV2 { return r.Upgrade() }),
+		HolidaysPublicConfig: m.HolidaysPublicConfig.Upgrade(),
+	}
+}
+
+func (m *HolidaysPublicConfigV1) Upgrade() *HolidaysPublicConfigV2 {
+	if m == nil {
+		return nil
+	}
+	return &HolidaysPublicConfigV2{
+		CountryCodes: m.CountryCodes,
+	}
+}
+
+func (m *RotationV1) Upgrade() RotationV2 {
+	return RotationV2{
+		ID:       m.ID,
+		Name:     m.Name,
+		Versions: lo.Map(m.Versions, func(v RotationVersionV1, _ int) RotationVersionV2 { return v.Upgrade() }),
+	}
+}
+
+func (m *RotationVersionV1) Upgrade() RotationVersionV2 {
+	return RotationVersionV2{
+		EffectiveFrom:   m.EffectiveFrom,
+		HandoverStartAt: m.HandoverStartAt,
+		Handovers:       lo.Map(m.Handovers, func(h HandoverV1, _ int) HandoverV2 { return h.Upgrade() }),
+		Users:           m.Users,
+		WorkingIntervals: lo.Map(m.WorkingIntervals, func(w WorkingIntervalV1, _ int) IncidentWeekdayInterval {
+			return IncidentWeekdayInterval{
+				StartTime: w.Start,
+				EndTime:   w.End,
+				Weekday:   w.Day,
+			}
+		}),
+		Layers: lo.Map(m.Layers, func(l LayerV1, _ int) LayerV2 { return l.Upgrade() }),
+	}
+}
+
+func (m *LayerV1) Upgrade() LayerV2 {
+	return LayerV2{
+		ID:   m.ID,
+		Name: m.Name,
+	}
+}
+
+func (m *HandoverV1) Upgrade() HandoverV2 {
+	return HandoverV2{
+		Interval:     m.Interval,
+		IntervalType: m.IntervalType,
+	}
+}

--- a/internal/provider/models/schedule_v2_model.go
+++ b/internal/provider/models/schedule_v2_model.go
@@ -1,0 +1,42 @@
+package models
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type IncidentScheduleResourceModelV2 struct {
+	ID                   types.String            `tfsdk:"id"`
+	Name                 types.String            `tfsdk:"name"`
+	Timezone             types.String            `tfsdk:"timezone"`
+	Rotations            []RotationV2            `tfsdk:"rotations"`
+	HolidaysPublicConfig *HolidaysPublicConfigV2 `tfsdk:"holidays_public_config"`
+}
+
+type RotationV2 struct {
+	ID       types.String        `tfsdk:"id"`
+	Name     types.String        `tfsdk:"name"`
+	Versions []RotationVersionV2 `tfsdk:"versions"`
+}
+
+type RotationVersionV2 struct {
+	EffectiveFrom    types.String              `tfsdk:"effective_from"`
+	HandoverStartAt  types.String              `tfsdk:"handover_start_at"`
+	Handovers        []HandoverV2              `tfsdk:"handovers"`
+	Users            []types.String            `tfsdk:"users"`
+	WorkingIntervals []IncidentWeekdayInterval `tfsdk:"working_intervals"`
+	Layers           []LayerV2                 `tfsdk:"layers"`
+}
+
+type LayerV2 struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+type HandoverV2 struct {
+	Interval     types.Int64  `tfsdk:"interval"`
+	IntervalType types.String `tfsdk:"interval_type"`
+}
+
+type HolidaysPublicConfigV2 struct {
+	CountryCodes []types.String `tfsdk:"country_codes"`
+}


### PR DESCRIPTION
We previously implemented a halfway migration from the old working interval format to the new one. But this didn't take account for cases where Terraform state had persisted the old value, and reading that would fail in the code. 

This adds improved support for us reading state regardless of its version, where we'll read old versions and support upgrading them into newer ones. This is a fairly simple `Upgrade()` method on schedule versions currently, but we can build a bit more of a framework around it in future if we need it lots. 

In doing this, I've decided to make the breaking change around `start`, `end` and `day` for the schema, as we've been deferring that and I think this a good chance to remove confusion and make it all consistent. 



