### PR TITLE
Mark TF-managed escalation paths as managed

### DIFF
--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -28,7 +28,8 @@ var (
 )
 
 type IncidentEscalationPathResource struct {
-	client *client.ClientWithResponses
+	client           *client.ClientWithResponses
+	terraformVersion string
 }
 
 type IncidentEscalationPathResourceModel struct {
@@ -300,6 +301,7 @@ func (r *IncidentEscalationPathResource) Configure(ctx context.Context, req reso
 	}
 
 	r.client = client.Client
+	r.terraformVersion = client.TerraformVersion
 }
 
 func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -329,6 +331,8 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create escalation path, got error: %s", err))
 		return
 	}
+
+	claimResource(ctx, r.client, result.JSON201.EscalationPath.Id, resp.Diagnostics, client.ManagedResourceV2ResourceTypeEscalationPath, r.terraformVersion)
 
 	tflog.Trace(ctx, fmt.Sprintf("created an escalation path resource with id=%s", result.JSON201.EscalationPath.Id))
 	data = r.buildModel(result.JSON201.EscalationPath)
@@ -391,6 +395,8 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 		return
 	}
 
+	claimResource(ctx, r.client, result.JSON200.EscalationPath.Id, resp.Diagnostics, client.ManagedResourceV2ResourceTypeEscalationPath, r.terraformVersion)
+
 	data = r.buildModel(result.JSON200.EscalationPath)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -410,6 +416,7 @@ func (r *IncidentEscalationPathResource) Delete(ctx context.Context, req resourc
 }
 
 func (r *IncidentEscalationPathResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.ManagedResourceV2ResourceTypeEscalationPath, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -309,7 +309,7 @@ func (r *IncidentScheduleResource) Delete(ctx context.Context, req resource.Dele
 }
 
 func (r *IncidentScheduleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req, resp, client.ManagedResourceV2ResourceTypeSchedule, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.ManagedResourceV2ResourceTypeSchedule, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -314,7 +314,7 @@ func (r *IncidentWorkflowResource) Delete(ctx context.Context, req resource.Dele
 }
 
 func (r *IncidentWorkflowResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req, resp, client.ManagedResourceV2ResourceTypeWorkflow, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.ManagedResourceV2ResourceTypeWorkflow, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/provider/managed_resources.go
+++ b/internal/provider/managed_resources.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
 
 func claimResource(
 	ctx context.Context,
 	apiClient *client.ClientWithResponses,
-	req resource.ImportStateRequest,
-	resp *resource.ImportStateResponse,
+	resourceID string,
+	diagnostics diag.Diagnostics,
 	resourceType client.ManagedResourceV2ResourceType,
 	terraformVersion string,
 ) {
@@ -21,7 +21,7 @@ func claimResource(
 			"incident.io/terraform/version": terraformVersion,
 		},
 		ResourceType: client.CreateManagedResourceRequestBodyResourceType(resourceType),
-		ResourceId:   req.ID,
+		ResourceId:   resourceID,
 	}
 
 	result, err := apiClient.ManagedResourcesV2CreateManagedResourceWithResponse(ctx, payload)
@@ -29,7 +29,7 @@ func claimResource(
 		err = fmt.Errorf(string(result.Body))
 	}
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create managed resource, got error: %s", err))
+		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create managed resource, got error: %s", err))
 		return
 	}
 }


### PR DESCRIPTION
Without this, we don't annotate the escalation path as being managed by Terraform, so it remains dashboard-editable.