### PR TITLE
Make timezone a RequiresReplace field in the schedule resource

### DIFF
--- a/internal/provider/incident_custom_field_resource.go
+++ b/internal/provider/incident_custom_field_resource.go
@@ -104,7 +104,7 @@ func (r *IncidentCustomFieldResource) Create(ctx context.Context, req resource.C
 		err = fmt.Errorf(string(result.Body))
 	}
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create custom field, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create custom field '%s', got error: %s", data.Name.ValueString(), err))
 		return
 	}
 

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -55,6 +55,9 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 			},
 			"timezone": schema.StringAttribute{
 				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"holidays_public_config": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/samber/lo"
@@ -98,6 +99,7 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "handover_start_at"),
 									},
 									"working_intervals": schema.ListNestedAttribute{
+										Validators:          []validator.List{NonEmptyListValidator{}},
 										Optional:            true,
 										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "working_interval"),
 										NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"testing"
@@ -58,13 +59,6 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 										Name: lo.ToPtr("Primary Layer One"),
 									},
 								},
-								WorkingInterval: &[]client.ScheduleRotationWorkingIntervalV2{
-									{
-										StartTime: "09:00",
-										EndTime:   "17:00",
-										Weekday:   "monday",
-									},
-								},
 							},
 						},
 					},
@@ -89,6 +83,221 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 				ResourceName:      "incident_schedule.example",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIncidentScheduleResourceTimezoneUpdate(t *testing.T) {
+
+	var scheduleID *string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Initial creation
+			{
+				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
+					Name:     "timezone-test",
+					Timezone: "Europe/London",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "timezone", "Europe/London",
+					),
+					// Store the current id
+					resource.TestCheckResourceAttrWith("incident_schedule.example", "id", func(id string) (err error) {
+						scheduleID = &id
+						return nil
+					}),
+				),
+			},
+			// Attempt to update timezone - should destroy the existing and recreate
+			{
+				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
+					Name:     "timezone-test",
+					Timezone: "America/New_York",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("incident_schedule.example", "id"), // Ensure resource exists
+					// Check that the updated resource is replaced
+					resource.TestCheckResourceAttrWith("incident_schedule.example", "id", func(id string) (err error) {
+						if *scheduleID == id {
+							return fmt.Errorf("expected new resource to be created as timezone has RequiresReplace")
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIncidentScheduleResourceRotationUpdates(t *testing.T) {
+	var (
+		effectiveFrom   = time.Now().Add(24 * time.Hour).UTC()
+		handoverStartAt = time.Date(2024, 4, 26, 16, 0, 0, 0, time.UTC)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with initial rotation
+			{
+				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
+					Name:     "rotation-test",
+					Timezone: "Europe/London",
+					Config: &client.ScheduleConfigV2{
+						Rotations: []client.ScheduleRotationV2{
+							{
+								Id:              "rota-test",
+								Name:            "Test Rota",
+								HandoverStartAt: handoverStartAt,
+								Handovers: []client.ScheduleRotationHandoverV2{
+									{
+										Interval:     lo.ToPtr(int64(1)),
+										IntervalType: lo.ToPtr(client.Weekly),
+									},
+								},
+								Layers: []client.ScheduleLayerV2{
+									{
+										Id:   lo.ToPtr("layer-1"),
+										Name: lo.ToPtr("Layer One"),
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "rotations.0.name", "Test Rota",
+					),
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "rotations.0.versions.0.layers.0.name", "Layer One",
+					),
+				),
+			},
+			// Add a new version to the rotation
+			{
+				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
+					Name:     "rotation-test",
+					Timezone: "Europe/London",
+					Config: &client.ScheduleConfigV2{
+						Rotations: []client.ScheduleRotationV2{
+							{
+								Id:              "rota-test",
+								Name:            "Test Rota",
+								HandoverStartAt: handoverStartAt,
+								Handovers: []client.ScheduleRotationHandoverV2{
+									{
+										Interval:     lo.ToPtr(int64(1)),
+										IntervalType: lo.ToPtr(client.Daily),
+									},
+								},
+								Layers: []client.ScheduleLayerV2{
+									{
+										Id:   lo.ToPtr("layer-1"),
+										Name: lo.ToPtr("Layer One"),
+									},
+								},
+							},
+							{
+								Id:              "rota-test",
+								Name:            "Test Rota",
+								HandoverStartAt: handoverStartAt,
+								Handovers: []client.ScheduleRotationHandoverV2{
+									{
+										Interval:     lo.ToPtr(int64(1)),
+										IntervalType: lo.ToPtr(client.Daily),
+									},
+								},
+								EffectiveFrom: &effectiveFrom,
+								Layers: []client.ScheduleLayerV2{
+									{
+										Id:   lo.ToPtr("layer-1"),
+										Name: lo.ToPtr("Layer Two"),
+									},
+								},
+								WorkingInterval: &[]client.ScheduleRotationWorkingIntervalV2{
+									{
+										EndTime:   "17:00",
+										StartTime: "09:00",
+										Weekday:   "monday",
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "rotations.0.versions.#", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "rotations.0.versions.1.layers.0.name", "Layer Two",
+					),
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "rotations.0.versions.1.working_intervals.0.weekday", "monday",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIncidentScheduleResourceHolidayConfig(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with holiday config
+			{
+				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
+					Name:     "holiday-test",
+					Timezone: "Europe/London",
+					HolidaysPublicConfig: &client.ScheduleHolidaysPublicConfigV2{
+						CountryCodes: []string{"GB", "FR"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "holidays_public_config.country_codes.#", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "holidays_public_config.country_codes.0", "GB",
+					),
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "holidays_public_config.country_codes.1", "FR",
+					),
+				),
+			},
+			// Update holiday config
+			{
+				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
+					Name:     "holiday-test",
+					Timezone: "Europe/London",
+					HolidaysPublicConfig: &client.ScheduleHolidaysPublicConfigV2{
+						CountryCodes: []string{"GB", "DE"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_schedule.example", "holidays_public_config.country_codes.1", "DE",
+					),
+				),
+			},
+			// Remove holiday config
+			{
+				Config: testAccIncidentScheduleResourceConfig(&client.ScheduleV2{
+					Name:     "holiday-test",
+					Timezone: "Europe/London",
+				}),
+				Check: resource.TestCheckResourceAttr(
+					"incident_schedule.example", "holidays_public_config.#", "0",
+				),
 			},
 		},
 	})
@@ -121,9 +330,8 @@ func incidentScheduleDefault() client.ScheduleV2 {
 							Name: lo.ToPtr("Primary Layer One"),
 						},
 					},
-					Name:            "Rota",
-					Users:           new([]client.UserV2),
-					WorkingInterval: nil,
+					Name:  "Rota",
+					Users: new([]client.UserV2),
 				},
 			},
 		},
@@ -192,7 +400,7 @@ func generateVersionsArray(versions []client.ScheduleRotationV2) string {
 		result += "    layers          = " + generateLayersArray(version.Layers) + "\n"
 		result += "    users           = " + generateUsersArray(version.Users) + "\n"
 		if version.WorkingInterval != nil {
-			result += "    working_interval = " + generateWorkingIntervalsArray(version.WorkingInterval) + "\n"
+			result += "    working_intervals = " + generateWorkingIntervalsArray(version.WorkingInterval) + "\n"
 		}
 		result += "  },\n"
 	}

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -59,6 +59,13 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 										Name: lo.ToPtr("Primary Layer One"),
 									},
 								},
+								WorkingInterval: &[]client.ScheduleRotationWorkingIntervalV2{
+									{
+										StartTime: "09:00",
+										EndTime:   "17:00",
+										Weekday:   "monday",
+									},
+								},
 							},
 						},
 					},

--- a/internal/provider/incident_severity_resource.go
+++ b/internal/provider/incident_severity_resource.go
@@ -106,7 +106,7 @@ func (r *IncidentSeverityResource) Create(ctx context.Context, req resource.Crea
 		err = fmt.Errorf(string(result.Body))
 	}
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create incident severity, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create incident severity '%s', got error: %s", data.Name.ValueString(), err))
 		return
 	}
 

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -1,0 +1,27 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+type NonEmptyListValidator struct{}
+
+func (n NonEmptyListValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	if req.ConfigValue.IsNull() {
+		return
+	} else if len(req.ConfigValue.Elements()) == 0 {
+		resp.Diagnostics.AddError("List cannot be empty", fmt.Sprintf("%s cannot be empty", req.Path.String()))
+		return
+	}
+}
+
+func (n NonEmptyListValidator) Description(ctx context.Context) string {
+	return "List cannot be empty"
+}
+
+func (n NonEmptyListValidator) MarkdownDescription(ctx context.Context) string {
+	return "List cannot be empty"
+}


### PR DESCRIPTION
Grab bag of changes in here that I fixed as I found them:

- **The main event:** Modifying the timezone of a schedule resource will now require replacement instead of planning correctly and failing on apply. 
- Fixed an acceptance test that was breaking because we were missing an s.
- Added a validator for rotation working intervals that will now prevent an empty list being provided. This would previously have planned fine and broken on the apply so the impact on anyone who's currently got this in config should be minimal.
- Improved error messages for custom fields and severities when they failed to apply.
- These changes have been tested by creating resources and simulating a provider upgrade. I have pretty good confidence that these don't break backwards compat
Also fixed a bug with schedule integration tests where we were failing to handle working hours correctly.

<img width="688" alt="Screenshot 2025-02-10 at 10 39 24" src="https://github.com/user-attachments/assets/923e0330-1815-4001-931c-f9c5f287f102" />
