### PR TITLE
Add support for catalog-backed custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- `incident_custom_field` resource now supports catalog-powered custom fields,
+  including controlling which attribute is used to group options, add helptext,
+  and filter the available options by another field's value.
+- `incident_custom_field` data source exposes extra attributes for
+  catalog-powered custom fields.
+
 ## 4.2.0
 
 - `incident_alert_attribute` resource and data source, for managing your alert attributes

--- a/docs/data-sources/custom_field.md
+++ b/docs/data-sources/custom_field.md
@@ -21,8 +21,22 @@ This data source provides information about a custom field.
 
 ### Read-Only
 
+- `catalog_type_id` (String) For catalog fields, the ID of the associated catalog type
 - `description` (String) Description of the custom field
 - `field_type` (String) Type of custom field
+- `filter_by` (Attributes) (see [below for nested schema](#nestedatt--filter_by))
+- `group_by_catalog_attribute_id` (String) For catalog fields, the ID of the attribute used to group catalog entries (if applicable)
+- `helptext_catalog_attribute_id` (String) Which catalog attribute provides helptext for the options
 - `id` (String) The custom field ID
+
+<a id="nestedatt--filter_by"></a>
+### Nested Schema for `filter_by`
+
+Read-Only:
+
+- `catalog_attribute_id` (String) This must be an attribute of the catalog type of this custom field. It must be an attribute that points to another catalog type (so not a plain string, number, or boolean attribute).
+- `custom_field_id` (String) This must be the ID of a custom field, which must have values of the same type as the attribute you are filtering by.
+
+When this filtering field is set on an incident, the options for this custom field will be filtered to only those with the attribute value that matches the value of the filtering field.
 
 

--- a/docs/resources/custom_field.md
+++ b/docs/resources/custom_field.md
@@ -51,8 +51,25 @@ resource "incident_custom_field" "affected_teams" {
 - `field_type` (String) Type of custom field
 - `name` (String) Human readable name for the custom field
 
+### Optional
+
+- `catalog_type_id` (String) For catalog fields, the ID of the associated catalog type
+- `filter_by` (Attributes) (see [below for nested schema](#nestedatt--filter_by))
+- `group_by_catalog_attribute_id` (String) For catalog fields, the ID of the attribute used to group catalog entries (if applicable)
+- `helptext_catalog_attribute_id` (String) Which catalog attribute provides helptext for the options
+
 ### Read-Only
 
 - `id` (String) Unique identifier for the custom field
+
+<a id="nestedatt--filter_by"></a>
+### Nested Schema for `filter_by`
+
+Required:
+
+- `catalog_attribute_id` (String) This must be an attribute of the catalog type of this custom field. It must be an attribute that points to another catalog type (so not a plain string, number, or boolean attribute).
+- `custom_field_id` (String) This must be the ID of a custom field, which must have values of the same type as the attribute you are filtering by.
+
+When this filtering field is set on an incident, the options for this custom field will be filtered to only those with the attribute value that matches the value of the filtering field.
 
 

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -16363,170 +16363,6 @@
       },
       "CreateRequestBody": {
         "example": {
-          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "sort_key": 10,
-          "value": "Product"
-        },
-        "properties": {
-          "custom_field_id": {
-            "description": "ID of the custom field this option belongs to",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "type": "string"
-          },
-          "sort_key": {
-            "default": 1000,
-            "description": "Sort key used to order the custom field options correctly",
-            "example": 10,
-            "format": "int64",
-            "type": "integer"
-          },
-          "value": {
-            "description": "Human readable name for the custom field option",
-            "example": "Product",
-            "type": "string"
-          }
-        },
-        "required": [
-          "custom_field_id",
-          "value"
-        ],
-        "type": "object"
-      },
-      "CreateRequestBody2": {
-        "example": {
-          "description": "Which team is impacted by this issue",
-          "field_type": "single_select",
-          "name": "Affected Team",
-          "required": "never",
-          "required_v2": "never",
-          "show_before_closure": true,
-          "show_before_creation": true,
-          "show_before_update": true,
-          "show_in_announcement_post": true
-        },
-        "properties": {
-          "description": {
-            "description": "Description of the custom field",
-            "example": "Which team is impacted by this issue",
-            "type": "string"
-          },
-          "field_type": {
-            "description": "Type of custom field",
-            "enum": [
-              "single_select",
-              "multi_select",
-              "text",
-              "link",
-              "numeric"
-            ],
-            "example": "single_select",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human readable name for the custom field",
-            "example": "Affected Team",
-            "maxLength": 50,
-            "type": "string"
-          },
-          "required": {
-            "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
-            "enum": [
-              "never",
-              "before_closure",
-              "always"
-            ],
-            "example": "never",
-            "type": "string"
-          },
-          "required_v2": {
-            "description": "When this custom field must be set during the incident lifecycle.",
-            "enum": [
-              "never",
-              "before_resolution",
-              "always"
-            ],
-            "example": "never",
-            "type": "string"
-          },
-          "show_before_closure": {
-            "description": "Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.",
-            "example": true,
-            "type": "boolean"
-          },
-          "show_before_creation": {
-            "description": "Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.",
-            "example": true,
-            "type": "boolean"
-          },
-          "show_before_update": {
-            "description": "Whether a custom field should be shown in the incident update modal.",
-            "example": true,
-            "type": "boolean"
-          },
-          "show_in_announcement_post": {
-            "description": "Whether a custom field should be shown in the list of fields as part of the announcement post when set.",
-            "example": true,
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "description",
-          "field_type",
-          "show_before_creation",
-          "show_before_closure",
-          "show_before_update",
-          "options",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
-      },
-      "CreateRequestBody3": {
-        "example": {
-          "description": "Which team is impacted by this issue",
-          "field_type": "single_select",
-          "name": "Affected Team"
-        },
-        "properties": {
-          "description": {
-            "description": "Description of the custom field",
-            "example": "Which team is impacted by this issue",
-            "type": "string"
-          },
-          "field_type": {
-            "description": "Type of custom field",
-            "enum": [
-              "single_select",
-              "multi_select",
-              "text",
-              "link",
-              "numeric"
-            ],
-            "example": "single_select",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human readable name for the custom field",
-            "example": "Affected Team",
-            "maxLength": 50,
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "description",
-          "field_type",
-          "cannot_be_unset",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
-      },
-      "CreateRequestBody4": {
-        "example": {
           "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
           "resource": {
             "external_id": "123",
@@ -16590,7 +16426,7 @@
         ],
         "type": "object"
       },
-      "CreateRequestBody5": {
+      "CreateRequestBody2": {
         "example": {
           "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
           "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
@@ -16611,7 +16447,7 @@
         ],
         "type": "object"
       },
-      "CreateRequestBody6": {
+      "CreateRequestBody3": {
         "example": {
           "description": "The person currently coordinating the incident",
           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
@@ -16662,7 +16498,7 @@
         ],
         "type": "object"
       },
-      "CreateRequestBody7": {
+      "CreateRequestBody4": {
         "example": {
           "description": "The person currently coordinating the incident",
           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
@@ -16706,7 +16542,7 @@
         ],
         "type": "object"
       },
-      "CreateRequestBody8": {
+      "CreateRequestBody5": {
         "example": {
           "category": "live",
           "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
@@ -16745,7 +16581,7 @@
         ],
         "type": "object"
       },
-      "CreateRequestBody9": {
+      "CreateRequestBody6": {
         "example": {
           "description": "Issues with **low impact**.",
           "name": "Minor",
@@ -18040,7 +17876,71 @@
         ],
         "type": "object"
       },
+      "CustomFieldFilterByOptionsV2": {
+        "example": {
+          "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+          "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+        },
+        "properties": {
+          "catalog_attribute_id": {
+            "description": "This must be an attribute of the catalog type of this custom field. It must be an attribute that points to another catalog type (so not a plain string, number, or boolean attribute).",
+            "example": "01H2FW182TAH0NHEVBY34SCAK0",
+            "type": "string"
+          },
+          "custom_field_id": {
+            "description": "This must be the ID of a custom field, which must have values of the same type as the attribute you are filtering by.\n\nWhen this filtering field is set on an incident, the options for this custom field will be filtered to only those with the attribute value that matches the value of the filtering field.",
+            "example": "01H2FW182TAH0NHEVBY34SCAK0",
+            "type": "string"
+          }
+        },
+        "required": [
+          "custom_field_id",
+          "catalog_attribute_id"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
       "CustomFieldOptionV1": {
+        "example": {
+          "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "sort_key": 10,
+          "value": "Product"
+        },
+        "properties": {
+          "custom_field_id": {
+            "description": "ID of the custom field this option belongs to",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the custom field option",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "sort_key": {
+            "default": 1000,
+            "description": "Sort key used to order the custom field options correctly",
+            "example": 10,
+            "format": "int64",
+            "type": "integer"
+          },
+          "value": {
+            "description": "Human readable name for the custom field option",
+            "example": "Product",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "custom_field_id",
+          "value",
+          "sort_key"
+        ],
+        "type": "object",
+        "x-public-api-version": "v1"
+      },
+      "CustomFieldOptionV2": {
         "example": {
           "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -18079,21 +17979,15 @@
         ],
         "type": "object"
       },
-      "CustomFieldOptionV2": {
+      "CustomFieldOptionsCreatePayloadV1": {
         "example": {
           "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "sort_key": 10,
           "value": "Product"
         },
         "properties": {
           "custom_field_id": {
             "description": "ID of the custom field this option belongs to",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "type": "string"
-          },
-          "id": {
-            "description": "Unique identifier for the custom field option",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
             "type": "string"
           },
@@ -18111,10 +18005,131 @@
           }
         },
         "required": [
-          "id",
           "custom_field_id",
+          "value"
+        ],
+        "type": "object"
+      },
+      "CustomFieldOptionsCreateResultV1": {
+        "example": {
+          "custom_field_option": {
+            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "sort_key": 10,
+            "value": "Product"
+          }
+        },
+        "properties": {
+          "custom_field_option": {
+            "$ref": "#/components/schemas/CustomFieldOptionV1"
+          }
+        },
+        "required": [
+          "custom_field_option"
+        ],
+        "type": "object"
+      },
+      "CustomFieldOptionsListResultV1": {
+        "example": {
+          "custom_field_options": [
+            {
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "sort_key": 10,
+              "value": "Product"
+            }
+          ],
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          }
+        },
+        "properties": {
+          "custom_field_options": {
+            "example": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldOptionV1"
+            },
+            "type": "array"
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV1"
+          }
+        },
+        "required": [
+          "custom_field_options",
+          "pagination_meta"
+        ],
+        "type": "object"
+      },
+      "CustomFieldOptionsShowResultV1": {
+        "example": {
+          "custom_field_option": {
+            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "sort_key": 10,
+            "value": "Product"
+          }
+        },
+        "properties": {
+          "custom_field_option": {
+            "$ref": "#/components/schemas/CustomFieldOptionV1"
+          }
+        },
+        "required": [
+          "custom_field_option"
+        ],
+        "type": "object"
+      },
+      "CustomFieldOptionsUpdatePayloadV1": {
+        "example": {
+          "sort_key": 10,
+          "value": "Product"
+        },
+        "properties": {
+          "sort_key": {
+            "default": 1000,
+            "description": "Sort key used to order the custom field options correctly",
+            "example": 10,
+            "format": "int64",
+            "type": "integer"
+          },
+          "value": {
+            "description": "Human readable name for the custom field option",
+            "example": "Product",
+            "type": "string"
+          }
+        },
+        "required": [
           "value",
+          "custom_field_id",
           "sort_key"
+        ],
+        "type": "object"
+      },
+      "CustomFieldOptionsUpdateResultV1": {
+        "example": {
+          "custom_field_option": {
+            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "sort_key": 10,
+            "value": "Product"
+          }
+        },
+        "properties": {
+          "custom_field_option": {
+            "$ref": "#/components/schemas/CustomFieldOptionV1"
+          }
+        },
+        "required": [
+          "custom_field_option"
         ],
         "type": "object"
       },
@@ -18412,7 +18427,8 @@
           "created_at",
           "updated_at"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v1"
       },
       "CustomFieldV2": {
         "example": {
@@ -18420,6 +18436,12 @@
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Which team is impacted by this issue",
           "field_type": "single_select",
+          "filter_by": {
+            "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+            "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+          },
+          "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Affected Team",
           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -18453,6 +18475,19 @@
             "example": "single_select",
             "type": "string"
           },
+          "filter_by": {
+            "$ref": "#/components/schemas/CustomFieldFilterByOptionsV2"
+          },
+          "group_by_catalog_attribute_id": {
+            "description": "For catalog fields, the ID of the attribute used to group catalog entries (if applicable)",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "helptext_catalog_attribute_id": {
+            "description": "Which catalog attribute provides helptext for the options",
+            "example": "01H2FW182TAH0NHEVBY34SCAK0",
+            "type": "string"
+          },
           "id": {
             "description": "Unique identifier for the custom field",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -18480,7 +18515,8 @@
           "created_at",
           "updated_at"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "CustomFieldValuePayloadV1": {
         "example": {
@@ -18670,6 +18706,596 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "CustomFieldsCreatePayloadV1": {
+        "example": {
+          "description": "Which team is impacted by this issue",
+          "field_type": "single_select",
+          "name": "Affected Team",
+          "required": "never",
+          "required_v2": "never",
+          "show_before_closure": true,
+          "show_before_creation": true,
+          "show_before_update": true,
+          "show_in_announcement_post": true
+        },
+        "properties": {
+          "description": {
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue",
+            "type": "string"
+          },
+          "field_type": {
+            "description": "Type of custom field",
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ],
+            "example": "single_select",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50,
+            "type": "string"
+          },
+          "required": {
+            "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
+            "enum": [
+              "never",
+              "before_closure",
+              "always"
+            ],
+            "example": "never",
+            "type": "string"
+          },
+          "required_v2": {
+            "description": "When this custom field must be set during the incident lifecycle.",
+            "enum": [
+              "never",
+              "before_resolution",
+              "always"
+            ],
+            "example": "never",
+            "type": "string"
+          },
+          "show_before_closure": {
+            "description": "Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.",
+            "example": true,
+            "type": "boolean"
+          },
+          "show_before_creation": {
+            "description": "Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.",
+            "example": true,
+            "type": "boolean"
+          },
+          "show_before_update": {
+            "description": "Whether a custom field should be shown in the incident update modal.",
+            "example": true,
+            "type": "boolean"
+          },
+          "show_in_announcement_post": {
+            "description": "Whether a custom field should be shown in the list of fields as part of the announcement post when set.",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "field_type",
+          "show_before_creation",
+          "show_before_closure",
+          "show_before_update",
+          "options",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsCreatePayloadV2": {
+        "example": {
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "description": "Which team is impacted by this issue",
+          "field_type": "single_select",
+          "filter_by": {
+            "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+            "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+          },
+          "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+          "name": "Affected Team"
+        },
+        "properties": {
+          "catalog_type_id": {
+            "description": "For catalog fields, the ID of the associated catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "description": {
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue",
+            "type": "string"
+          },
+          "field_type": {
+            "description": "Type of custom field",
+            "enum": [
+              "single_select",
+              "multi_select",
+              "text",
+              "link",
+              "numeric"
+            ],
+            "example": "single_select",
+            "type": "string"
+          },
+          "filter_by": {
+            "$ref": "#/components/schemas/CustomFieldFilterByOptionsV2"
+          },
+          "group_by_catalog_attribute_id": {
+            "description": "For catalog fields, the ID of the attribute used to group catalog entries (if applicable)",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "helptext_catalog_attribute_id": {
+            "description": "Which catalog attribute provides helptext for the options",
+            "example": "01H2FW182TAH0NHEVBY34SCAK0",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "field_type",
+          "cannot_be_unset",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsCreateResultV1": {
+        "example": {
+          "custom_field": {
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "options": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              }
+            ],
+            "required": "never",
+            "required_v2": "never",
+            "show_before_closure": true,
+            "show_before_creation": true,
+            "show_before_update": true,
+            "show_in_announcement_post": true,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldV1"
+          }
+        },
+        "required": [
+          "custom_field"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsCreateResultV2": {
+        "example": {
+          "custom_field": {
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "filter_by": {
+              "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+              "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+            },
+            "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldV2"
+          }
+        },
+        "required": [
+          "custom_field"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsListResultV1": {
+        "example": {
+          "custom_fields": [
+            {
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Which team is impacted by this issue",
+              "field_type": "single_select",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Affected Team",
+              "options": [
+                {
+                  "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "sort_key": 10,
+                  "value": "Product"
+                }
+              ],
+              "required": "never",
+              "required_v2": "never",
+              "show_before_closure": true,
+              "show_before_creation": true,
+              "show_before_update": true,
+              "show_in_announcement_post": true,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "custom_fields": {
+            "example": [
+              {
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Which team is impacted by this issue",
+                "field_type": "single_select",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Affected Team",
+                "options": [
+                  {
+                    "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "sort_key": 10,
+                    "value": "Product"
+                  }
+                ],
+                "required": "never",
+                "required_v2": "never",
+                "show_before_closure": true,
+                "show_before_creation": true,
+                "show_before_update": true,
+                "show_in_announcement_post": true,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "custom_fields"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsListResultV2": {
+        "example": {
+          "custom_fields": [
+            {
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Which team is impacted by this issue",
+              "field_type": "single_select",
+              "filter_by": {
+                "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+                "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+              },
+              "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Affected Team",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "custom_fields": {
+            "example": [
+              {
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Which team is impacted by this issue",
+                "field_type": "single_select",
+                "filter_by": {
+                  "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+                  "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+                },
+                "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Affected Team",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "custom_fields"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsShowResultV1": {
+        "example": {
+          "custom_field": {
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "options": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              }
+            ],
+            "required": "never",
+            "required_v2": "never",
+            "show_before_closure": true,
+            "show_before_creation": true,
+            "show_before_update": true,
+            "show_in_announcement_post": true,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldV1"
+          }
+        },
+        "required": [
+          "custom_field"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsShowResultV2": {
+        "example": {
+          "custom_field": {
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "filter_by": {
+              "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+              "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+            },
+            "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldV2"
+          }
+        },
+        "required": [
+          "custom_field"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsUpdatePayloadV1": {
+        "example": {
+          "description": "Which team is impacted by this issue",
+          "name": "Affected Team",
+          "required": "never",
+          "required_v2": "never",
+          "show_before_closure": true,
+          "show_before_creation": true,
+          "show_before_update": true,
+          "show_in_announcement_post": true
+        },
+        "properties": {
+          "description": {
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50,
+            "type": "string"
+          },
+          "required": {
+            "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
+            "enum": [
+              "never",
+              "before_closure",
+              "always"
+            ],
+            "example": "never",
+            "type": "string"
+          },
+          "required_v2": {
+            "description": "When this custom field must be set during the incident lifecycle.",
+            "enum": [
+              "never",
+              "before_resolution",
+              "always"
+            ],
+            "example": "never",
+            "type": "string"
+          },
+          "show_before_closure": {
+            "description": "Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.",
+            "example": true,
+            "type": "boolean"
+          },
+          "show_before_creation": {
+            "description": "Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.",
+            "example": true,
+            "type": "boolean"
+          },
+          "show_before_update": {
+            "description": "Whether a custom field should be shown in the incident update modal.",
+            "example": true,
+            "type": "boolean"
+          },
+          "show_in_announcement_post": {
+            "description": "Whether a custom field should be shown in the list of fields as part of the announcement post when set.",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "field_type",
+          "show_before_creation",
+          "show_before_closure",
+          "show_before_update",
+          "options",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsUpdatePayloadV2": {
+        "example": {
+          "description": "Which team is impacted by this issue",
+          "filter_by": {
+            "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+            "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+          },
+          "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+          "name": "Affected Team"
+        },
+        "properties": {
+          "description": {
+            "description": "Description of the custom field",
+            "example": "Which team is impacted by this issue",
+            "type": "string"
+          },
+          "filter_by": {
+            "$ref": "#/components/schemas/CustomFieldFilterByOptionsV2"
+          },
+          "group_by_catalog_attribute_id": {
+            "description": "For catalog fields, the ID of the attribute used to group catalog entries (if applicable)",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "helptext_catalog_attribute_id": {
+            "description": "Which catalog attribute provides helptext for the options",
+            "example": "01H2FW182TAH0NHEVBY34SCAK0",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name for the custom field",
+            "example": "Affected Team",
+            "maxLength": 50,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "field_type",
+          "cannot_be_unset",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsUpdateResultV1": {
+        "example": {
+          "custom_field": {
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "options": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "sort_key": 10,
+                "value": "Product"
+              }
+            ],
+            "required": "never",
+            "required_v2": "never",
+            "show_before_closure": true,
+            "show_before_creation": true,
+            "show_before_update": true,
+            "show_in_announcement_post": true,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldV1"
+          }
+        },
+        "required": [
+          "custom_field"
+        ],
+        "type": "object"
+      },
+      "CustomFieldsUpdateResultV2": {
+        "example": {
+          "custom_field": {
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Which team is impacted by this issue",
+            "field_type": "single_select",
+            "filter_by": {
+              "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+              "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+            },
+            "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Affected Team",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "custom_field": {
+            "$ref": "#/components/schemas/CustomFieldV2"
+          }
+        },
+        "required": [
+          "custom_field"
+        ],
         "type": "object"
       },
       "EditRequestBody": {
@@ -27696,45 +28322,271 @@
       },
       "ListResponseBody": {
         "example": {
-          "custom_field_options": [
+          "incident_attachments": [
             {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "sort_key": 10,
-              "value": "Product"
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "resource": {
+                "external_id": "123",
+                "permalink": "https://my.pagerduty.com/incidents/ABC",
+                "resource_type": "pager_duty_incident",
+                "title": "The database has gone down"
+              }
             }
-          ],
-          "pagination_meta": {
-            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "page_size": 25
-          }
+          ]
         },
         "properties": {
-          "custom_field_options": {
+          "incident_attachments": {
             "example": [
               {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "sort_key": 10,
-                "value": "Product"
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "resource": {
+                  "external_id": "123",
+                  "permalink": "https://my.pagerduty.com/incidents/ABC",
+                  "resource_type": "pager_duty_incident",
+                  "title": "The database has gone down"
+                }
               }
             ],
             "items": {
-              "$ref": "#/components/schemas/CustomFieldOptionV1"
+              "$ref": "#/components/schemas/IncidentAttachmentV1"
             },
             "type": "array"
-          },
-          "pagination_meta": {
-            "$ref": "#/components/schemas/PaginationMetaResult"
           }
         },
         "required": [
-          "custom_field_options",
-          "pagination_meta"
+          "incident_attachments"
         ],
         "type": "object"
       },
       "ListResponseBody10": {
+        "example": {
+          "severities": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "severities": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SeverityV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "severities"
+        ],
+        "type": "object"
+      },
+      "ListResponseBody2": {
+        "example": {
+          "incident_roles": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "The person currently coordinating the incident",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+              "name": "Incident Lead",
+              "required": false,
+              "role_type": "lead",
+              "shortform": "lead",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "incident_roles": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "The person currently coordinating the incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "required": false,
+                "role_type": "lead",
+                "shortform": "lead",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_roles"
+        ],
+        "type": "object"
+      },
+      "ListResponseBody3": {
+        "example": {
+          "incident_roles": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "The person currently coordinating the incident",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+              "name": "Incident Lead",
+              "role_type": "lead",
+              "shortform": "lead",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "incident_roles": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "The person currently coordinating the incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "role_type": "lead",
+                "shortform": "lead",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_roles"
+        ],
+        "type": "object"
+      },
+      "ListResponseBody4": {
+        "example": {
+          "incident_statuses": [
+            {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "incident_statuses": {
+            "example": [
+              {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentStatusV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_statuses"
+        ],
+        "type": "object"
+      },
+      "ListResponseBody5": {
+        "example": {
+          "incident_timestamps": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Impact started",
+              "rank": 1
+            }
+          ]
+        },
+        "properties": {
+          "incident_timestamps": {
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Impact started",
+                "rank": 1
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentTimestampV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_timestamps"
+        ],
+        "type": "object"
+      },
+      "ListResponseBody6": {
+        "example": {
+          "incident_types": [
+            {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "incident_types": {
+            "example": [
+              {
+                "create_in_triage": "always",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Customer facing production outages",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_default": false,
+                "name": "Production Outage",
+                "private_incidents_only": false,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentTypeV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_types"
+        ],
+        "type": "object"
+      },
+      "ListResponseBody7": {
         "example": {
           "incident_updates": [
             {
@@ -27835,7 +28687,7 @@
         ],
         "type": "object"
       },
-      "ListResponseBody11": {
+      "ListResponseBody8": {
         "example": {
           "incidents": [
             {
@@ -28095,7 +28947,7 @@
         ],
         "type": "object"
       },
-      "ListResponseBody12": {
+      "ListResponseBody9": {
         "example": {
           "incidents": [
             {
@@ -28418,446 +29270,6 @@
         },
         "required": [
           "incidents"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody13": {
-        "example": {
-          "severities": [
-            {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Issues with **low impact**.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Minor",
-              "rank": 1,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "severities": {
-            "example": [
-              {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Issues with **low impact**.",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Minor",
-                "rank": 1,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/SeverityV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "severities"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody14": {
-        "example": {
-          "pagination_meta": {
-            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "page_size": 25
-          },
-          "users": [
-            {
-              "base_role": {
-                "description": "Elevated permissions for the customer success team.",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Customer Success",
-                "slug": "customer-success"
-              },
-              "custom_roles": [
-                {
-                  "description": "Elevated permissions for the customer success team.",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Customer Success",
-                  "slug": "customer-success"
-                }
-              ],
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            }
-          ]
-        },
-        "properties": {
-          "pagination_meta": {
-            "$ref": "#/components/schemas/PaginationMetaResult"
-          },
-          "users": {
-            "example": [
-              {
-                "base_role": {
-                  "description": "Elevated permissions for the customer success team.",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Customer Success",
-                  "slug": "customer-success"
-                },
-                "custom_roles": [
-                  {
-                    "description": "Elevated permissions for the customer success team.",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "Customer Success",
-                    "slug": "customer-success"
-                  }
-                ],
-                "email": "lisa@incident.io",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Lisa Karlin Curtis",
-                "role": "viewer",
-                "slack_user_id": "U02AYNF2XJM"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/UserWithRolesV2"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "users",
-          "pagination_meta"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody2": {
-        "example": {
-          "custom_fields": [
-            {
-              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Which team is impacted by this issue",
-              "field_type": "single_select",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Affected Team",
-              "options": [
-                {
-                  "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "sort_key": 10,
-                  "value": "Product"
-                }
-              ],
-              "required": "never",
-              "required_v2": "never",
-              "show_before_closure": true,
-              "show_before_creation": true,
-              "show_before_update": true,
-              "show_in_announcement_post": true,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "custom_fields": {
-            "example": [
-              {
-                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Which team is impacted by this issue",
-                "field_type": "single_select",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Affected Team",
-                "options": [
-                  {
-                    "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "sort_key": 10,
-                    "value": "Product"
-                  }
-                ],
-                "required": "never",
-                "required_v2": "never",
-                "show_before_closure": true,
-                "show_before_creation": true,
-                "show_before_update": true,
-                "show_in_announcement_post": true,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "custom_fields"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody3": {
-        "example": {
-          "custom_fields": [
-            {
-              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Which team is impacted by this issue",
-              "field_type": "single_select",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Affected Team",
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "custom_fields": {
-            "example": [
-              {
-                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Which team is impacted by this issue",
-                "field_type": "single_select",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Affected Team",
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldV2"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "custom_fields"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody4": {
-        "example": {
-          "incident_attachments": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "resource": {
-                "external_id": "123",
-                "permalink": "https://my.pagerduty.com/incidents/ABC",
-                "resource_type": "pager_duty_incident",
-                "title": "The database has gone down"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "incident_attachments": {
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "resource": {
-                  "external_id": "123",
-                  "permalink": "https://my.pagerduty.com/incidents/ABC",
-                  "resource_type": "pager_duty_incident",
-                  "title": "The database has gone down"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentAttachmentV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_attachments"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody5": {
-        "example": {
-          "incident_roles": [
-            {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "The person currently coordinating the incident",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-              "name": "Incident Lead",
-              "required": false,
-              "role_type": "lead",
-              "shortform": "lead",
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "incident_roles": {
-            "example": [
-              {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "The person currently coordinating the incident",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                "name": "Incident Lead",
-                "required": false,
-                "role_type": "lead",
-                "shortform": "lead",
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_roles"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody6": {
-        "example": {
-          "incident_roles": [
-            {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "The person currently coordinating the incident",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-              "name": "Incident Lead",
-              "role_type": "lead",
-              "shortform": "lead",
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "incident_roles": {
-            "example": [
-              {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "The person currently coordinating the incident",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                "name": "Incident Lead",
-                "role_type": "lead",
-                "shortform": "lead",
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleV2"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_roles"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody7": {
-        "example": {
-          "incident_statuses": [
-            {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "incident_statuses": {
-            "example": [
-              {
-                "category": "triage",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Closed",
-                "rank": 4,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentStatusV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_statuses"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody8": {
-        "example": {
-          "incident_timestamps": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Impact started",
-              "rank": 1
-            }
-          ]
-        },
-        "properties": {
-          "incident_timestamps": {
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Impact started",
-                "rank": 1
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentTimestampV2"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_timestamps"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody9": {
-        "example": {
-          "incident_types": [
-            {
-              "create_in_triage": "always",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Customer facing production outages",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_default": false,
-              "name": "Production Outage",
-              "private_incidents_only": false,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "incident_types": {
-            "example": [
-              {
-                "create_in_triage": "always",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Customer facing production outages",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "is_default": false,
-                "name": "Production Outage",
-                "private_incidents_only": false,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentTypeV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_types"
         ],
         "type": "object"
       },
@@ -29532,6 +29944,56 @@
           "page_size"
         ],
         "type": "object"
+      },
+      "PaginationMetaResultV1": {
+        "example": {
+          "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "page_size": 25
+        },
+        "properties": {
+          "after": {
+            "description": "If provided, pass this as the 'after' param to load the next page",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "page_size": {
+            "default": 25,
+            "description": "What was the maximum number of results requested",
+            "example": 25,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "page_size"
+        ],
+        "type": "object",
+        "x-public-api-version": "v1"
+      },
+      "PaginationMetaResultV2": {
+        "example": {
+          "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "page_size": 25
+        },
+        "properties": {
+          "after": {
+            "description": "If provided, pass this as the 'after' param to load the next page",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "page_size": {
+            "default": 25,
+            "description": "What was the maximum number of results requested",
+            "example": 25,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "page_size"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "PaginationMetaResultWithTotal": {
         "example": {
@@ -30774,10 +31236,17 @@
         },
         "required": [
           "id",
+          "organisation_id",
           "name",
-          "slug"
+          "slug",
+          "privileges",
+          "is_base_role",
+          "rank",
+          "created_at",
+          "updated_at"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "RetrospectiveIncidentOptionsV2": {
         "example": {
@@ -33287,24 +33756,244 @@
       },
       "ShowResponseBody": {
         "example": {
-          "custom_field_option": {
-            "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "sort_key": 10,
-            "value": "Product"
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "required": false,
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
           }
         },
         "properties": {
-          "custom_field_option": {
-            "$ref": "#/components/schemas/CustomFieldOptionV1"
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV1"
           }
         },
         "required": [
-          "custom_field_option"
+          "incident_role"
         ],
         "type": "object"
       },
-      "ShowResponseBody10": {
+      "ShowResponseBody2": {
+        "example": {
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV2"
+          }
+        },
+        "required": [
+          "incident_role"
+        ],
+        "type": "object"
+      },
+      "ShowResponseBody3": {
+        "example": {
+          "incident_status": {
+            "category": "triage",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Closed",
+            "rank": 4,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_status": {
+            "$ref": "#/components/schemas/IncidentStatusV1"
+          }
+        },
+        "required": [
+          "incident_status"
+        ],
+        "type": "object"
+      },
+      "ShowResponseBody4": {
+        "example": {
+          "incident_timestamp": {
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Impact started",
+            "rank": 1
+          }
+        },
+        "properties": {
+          "incident_timestamp": {
+            "$ref": "#/components/schemas/IncidentTimestampV2"
+          }
+        },
+        "required": [
+          "incident_timestamp"
+        ],
+        "type": "object"
+      },
+      "ShowResponseBody5": {
+        "example": {
+          "incident_type": {
+            "create_in_triage": "always",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Customer facing production outages",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_default": false,
+            "name": "Production Outage",
+            "private_incidents_only": false,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_type": {
+            "$ref": "#/components/schemas/IncidentTypeV1"
+          }
+        },
+        "required": [
+          "incident_type"
+        ],
+        "type": "object"
+      },
+      "ShowResponseBody6": {
+        "example": {
+          "incident": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "real",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "status": "triage",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "timestamps": [
+              {
+                "last_occurred_at": "2021-08-17T13:28:57.801578Z",
+                "name": "last_activity"
+              }
+            ],
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public"
+          }
+        },
+        "properties": {
+          "incident": {
+            "$ref": "#/components/schemas/IncidentV1"
+          }
+        },
+        "required": [
+          "incident"
+        ],
+        "type": "object"
+      },
+      "ShowResponseBody7": {
         "example": {
           "incident": {
             "call_url": "https://zoom.us/foo",
@@ -33466,7 +34155,7 @@
         ],
         "type": "object"
       },
-      "ShowResponseBody11": {
+      "ShowResponseBody8": {
         "example": {
           "severity": {
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -33484,337 +34173,6 @@
         },
         "required": [
           "severity"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody12": {
-        "example": {
-          "user": {
-            "base_role": {
-              "description": "Elevated permissions for the customer success team.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Customer Success",
-              "slug": "customer-success"
-            },
-            "custom_roles": [
-              {
-                "description": "Elevated permissions for the customer success team.",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Customer Success",
-                "slug": "customer-success"
-              }
-            ],
-            "email": "lisa@incident.io",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Lisa Karlin Curtis",
-            "role": "viewer",
-            "slack_user_id": "U02AYNF2XJM"
-          }
-        },
-        "properties": {
-          "user": {
-            "$ref": "#/components/schemas/UserWithRolesV2"
-          }
-        },
-        "required": [
-          "user"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody2": {
-        "example": {
-          "custom_field": {
-            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Which team is impacted by this issue",
-            "field_type": "single_select",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Affected Team",
-            "options": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "sort_key": 10,
-                "value": "Product"
-              }
-            ],
-            "required": "never",
-            "required_v2": "never",
-            "show_before_closure": true,
-            "show_before_creation": true,
-            "show_before_update": true,
-            "show_in_announcement_post": true,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "custom_field": {
-            "$ref": "#/components/schemas/CustomFieldV1"
-          }
-        },
-        "required": [
-          "custom_field"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody3": {
-        "example": {
-          "custom_field": {
-            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Which team is impacted by this issue",
-            "field_type": "single_select",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Affected Team",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "custom_field": {
-            "$ref": "#/components/schemas/CustomFieldV2"
-          }
-        },
-        "required": [
-          "custom_field"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody4": {
-        "example": {
-          "incident_role": {
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "The person currently coordinating the incident",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-            "name": "Incident Lead",
-            "required": false,
-            "role_type": "lead",
-            "shortform": "lead",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "incident_role": {
-            "$ref": "#/components/schemas/IncidentRoleV1"
-          }
-        },
-        "required": [
-          "incident_role"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody5": {
-        "example": {
-          "incident_role": {
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "The person currently coordinating the incident",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-            "name": "Incident Lead",
-            "role_type": "lead",
-            "shortform": "lead",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "incident_role": {
-            "$ref": "#/components/schemas/IncidentRoleV2"
-          }
-        },
-        "required": [
-          "incident_role"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody6": {
-        "example": {
-          "incident_status": {
-            "category": "triage",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "name": "Closed",
-            "rank": 4,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "incident_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
-          }
-        },
-        "required": [
-          "incident_status"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody7": {
-        "example": {
-          "incident_timestamp": {
-            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "name": "Impact started",
-            "rank": 1
-          }
-        },
-        "properties": {
-          "incident_timestamp": {
-            "$ref": "#/components/schemas/IncidentTimestampV2"
-          }
-        },
-        "required": [
-          "incident_timestamp"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody8": {
-        "example": {
-          "incident_type": {
-            "create_in_triage": "always",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Customer facing production outages",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "is_default": false,
-            "name": "Production Outage",
-            "private_incidents_only": false,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "incident_type": {
-            "$ref": "#/components/schemas/IncidentTypeV1"
-          }
-        },
-        "required": [
-          "incident_type"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody9": {
-        "example": {
-          "incident": {
-            "call_url": "https://zoom.us/foo",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "creator": {
-              "api_key": {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "My test API key"
-              },
-              "user": {
-                "email": "lisa@incident.io",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Lisa Karlin Curtis",
-                "role": "viewer",
-                "slack_user_id": "U02AYNF2XJM"
-              }
-            },
-            "custom_field_entries": [
-              {
-                "custom_field": {
-                  "description": "Which team is impacted by this issue",
-                  "field_type": "single_select",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Affected Team",
-                  "options": [
-                    {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    }
-                  ]
-                },
-                "values": [
-                  {
-                    "value_catalog_entry": {
-                      "aliases": [
-                        "lawrence@incident.io",
-                        "lawrence"
-                      ],
-                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "name": "Primary On-call"
-                    },
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option": {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    },
-                    "value_text": "This is my text field, I hope you like it"
-                  }
-                ]
-              }
-            ],
-            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-            "incident_role_assignments": [
-              {
-                "assignee": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                },
-                "role": {
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "The person currently coordinating the incident",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                  "name": "Incident Lead",
-                  "required": false,
-                  "role_type": "lead",
-                  "shortform": "lead",
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_type": {
-              "create_in_triage": "always",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Customer facing production outages",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_default": false,
-              "name": "Production Outage",
-              "private_incidents_only": false,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "mode": "real",
-            "name": "Our database is sad",
-            "permalink": "https://app.incident.io/incidents/123",
-            "postmortem_document_url": "https://docs.google.com/my_doc_id",
-            "reference": "INC-123",
-            "severity": {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Issues with **low impact**.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Minor",
-              "rank": 1,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "slack_channel_id": "C02AW36C1M5",
-            "slack_channel_name": "inc-165-green-parrot",
-            "slack_team_id": "T02A1FSLE8J",
-            "status": "triage",
-            "summary": "Our database is really really sad, and we don't know why yet.",
-            "timestamps": [
-              {
-                "last_occurred_at": "2021-08-17T13:28:57.801578Z",
-                "name": "last_activity"
-              }
-            ],
-            "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public"
-          }
-        },
-        "properties": {
-          "incident": {
-            "$ref": "#/components/schemas/IncidentV1"
-          }
-        },
-        "required": [
-          "incident"
         ],
         "type": "object"
       },
@@ -34965,137 +35323,6 @@
       },
       "UpdateRequestBody2": {
         "example": {
-          "sort_key": 10,
-          "value": "Product"
-        },
-        "properties": {
-          "sort_key": {
-            "default": 1000,
-            "description": "Sort key used to order the custom field options correctly",
-            "example": 10,
-            "format": "int64",
-            "type": "integer"
-          },
-          "value": {
-            "description": "Human readable name for the custom field option",
-            "example": "Product",
-            "type": "string"
-          }
-        },
-        "required": [
-          "value",
-          "custom_field_id",
-          "sort_key"
-        ],
-        "type": "object"
-      },
-      "UpdateRequestBody3": {
-        "example": {
-          "description": "Which team is impacted by this issue",
-          "name": "Affected Team",
-          "required": "never",
-          "required_v2": "never",
-          "show_before_closure": true,
-          "show_before_creation": true,
-          "show_before_update": true,
-          "show_in_announcement_post": true
-        },
-        "properties": {
-          "description": {
-            "description": "Description of the custom field",
-            "example": "Which team is impacted by this issue",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human readable name for the custom field",
-            "example": "Affected Team",
-            "maxLength": 50,
-            "type": "string"
-          },
-          "required": {
-            "description": "When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].",
-            "enum": [
-              "never",
-              "before_closure",
-              "always"
-            ],
-            "example": "never",
-            "type": "string"
-          },
-          "required_v2": {
-            "description": "When this custom field must be set during the incident lifecycle.",
-            "enum": [
-              "never",
-              "before_resolution",
-              "always"
-            ],
-            "example": "never",
-            "type": "string"
-          },
-          "show_before_closure": {
-            "description": "Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.",
-            "example": true,
-            "type": "boolean"
-          },
-          "show_before_creation": {
-            "description": "Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.",
-            "example": true,
-            "type": "boolean"
-          },
-          "show_before_update": {
-            "description": "Whether a custom field should be shown in the incident update modal.",
-            "example": true,
-            "type": "boolean"
-          },
-          "show_in_announcement_post": {
-            "description": "Whether a custom field should be shown in the list of fields as part of the announcement post when set.",
-            "example": true,
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "field_type",
-          "show_before_creation",
-          "show_before_closure",
-          "show_before_update",
-          "options",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
-      },
-      "UpdateRequestBody4": {
-        "example": {
-          "description": "Which team is impacted by this issue",
-          "name": "Affected Team"
-        },
-        "properties": {
-          "description": {
-            "description": "Description of the custom field",
-            "example": "Which team is impacted by this issue",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human readable name for the custom field",
-            "example": "Affected Team",
-            "maxLength": 50,
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "field_type",
-          "cannot_be_unset",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
-      },
-      "UpdateRequestBody5": {
-        "example": {
           "description": "The person currently coordinating the incident",
           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
           "name": "Incident Lead",
@@ -35143,7 +35370,7 @@
         ],
         "type": "object"
       },
-      "UpdateRequestBody6": {
+      "UpdateRequestBody3": {
         "example": {
           "description": "The person currently coordinating the incident",
           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
@@ -35186,7 +35413,7 @@
         ],
         "type": "object"
       },
-      "UpdateRequestBody7": {
+      "UpdateRequestBody4": {
         "example": {
           "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
           "name": "Closed"
@@ -36096,6 +36323,111 @@
           "name",
           "deprecated_base_role",
           "organisation_id"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "UsersListResultV2": {
+        "example": {
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          },
+          "users": [
+            {
+              "base_role": {
+                "description": "Elevated permissions for the customer success team.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Customer Success",
+                "slug": "customer-success"
+              },
+              "custom_roles": [
+                {
+                  "description": "Elevated permissions for the customer success team.",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Customer Success",
+                  "slug": "customer-success"
+                }
+              ],
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          ]
+        },
+        "properties": {
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          },
+          "users": {
+            "example": [
+              {
+                "base_role": {
+                  "description": "Elevated permissions for the customer success team.",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Customer Success",
+                  "slug": "customer-success"
+                },
+                "custom_roles": [
+                  {
+                    "description": "Elevated permissions for the customer success team.",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Customer Success",
+                    "slug": "customer-success"
+                  }
+                ],
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/UserWithRolesV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "users",
+          "pagination_meta"
+        ],
+        "type": "object"
+      },
+      "UsersShowResultV2": {
+        "example": {
+          "user": {
+            "base_role": {
+              "description": "Elevated permissions for the customer success team.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Customer Success",
+              "slug": "customer-success"
+            },
+            "custom_roles": [
+              {
+                "description": "Elevated permissions for the customer success team.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Customer Success",
+                "slug": "customer-success"
+              }
+            ],
+            "email": "lisa@incident.io",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Lisa Karlin Curtis",
+            "role": "viewer",
+            "slack_user_id": "U02AYNF2XJM"
+          }
+        },
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/UserWithRolesV2"
+          }
+        },
+        "required": [
+          "user"
         ],
         "type": "object"
       },
@@ -38028,7 +38360,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody"
+                  "$ref": "#/components/schemas/CustomFieldOptionsListResultV1"
                 }
               }
             },
@@ -38038,7 +38370,8 @@
         "summary": "List Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "post": {
         "description": "Create a custom field option. If the sort key is not supplied, it'll default to 1000, so the option appears near the end of the list.",
@@ -38052,7 +38385,7 @@
                 "value": "Product"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody"
+                "$ref": "#/components/schemas/CustomFieldOptionsCreatePayloadV1"
               }
             }
           },
@@ -38071,7 +38404,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody"
+                  "$ref": "#/components/schemas/CustomFieldOptionsCreateResultV1"
                 }
               }
             },
@@ -38081,7 +38414,8 @@
         "summary": "Create Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/custom_field_options/{id}": {
@@ -38110,7 +38444,8 @@
         "summary": "Delete Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "get": {
         "description": "Get a single custom field option",
@@ -38142,7 +38477,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody"
+                  "$ref": "#/components/schemas/CustomFieldOptionsShowResultV1"
                 }
               }
             },
@@ -38152,7 +38487,8 @@
         "summary": "Show Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "put": {
         "description": "Update a custom field option",
@@ -38179,7 +38515,7 @@
                 "value": "Product"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody2"
+                "$ref": "#/components/schemas/CustomFieldOptionsUpdatePayloadV1"
               }
             }
           },
@@ -38198,7 +38534,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody"
+                  "$ref": "#/components/schemas/CustomFieldOptionsUpdateResultV1"
                 }
               }
             },
@@ -38208,7 +38544,8 @@
         "summary": "Update Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/custom_fields": {
@@ -38248,7 +38585,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody2"
+                  "$ref": "#/components/schemas/CustomFieldsListResultV1"
                 }
               }
             },
@@ -38258,7 +38595,8 @@
         "summary": "List Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "post": {
         "deprecated": true,
@@ -38279,7 +38617,7 @@
                 "show_in_announcement_post": true
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody2"
+                "$ref": "#/components/schemas/CustomFieldsCreatePayloadV1"
               }
             }
           },
@@ -38315,7 +38653,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody2"
+                  "$ref": "#/components/schemas/CustomFieldsCreateResultV1"
                 }
               }
             },
@@ -38325,7 +38663,8 @@
         "summary": "Create Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/custom_fields/{id}": {
@@ -38355,7 +38694,8 @@
         "summary": "Delete Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "get": {
         "deprecated": true,
@@ -38405,7 +38745,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody2"
+                  "$ref": "#/components/schemas/CustomFieldsShowResultV1"
                 }
               }
             },
@@ -38415,7 +38755,8 @@
         "summary": "Show Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "put": {
         "deprecated": true,
@@ -38449,7 +38790,7 @@
                 "show_in_announcement_post": true
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody3"
+                "$ref": "#/components/schemas/CustomFieldsUpdatePayloadV1"
               }
             }
           },
@@ -38485,7 +38826,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody2"
+                  "$ref": "#/components/schemas/CustomFieldsUpdateResultV1"
                 }
               }
             },
@@ -38495,7 +38836,8 @@
         "summary": "Update Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/identity": {
@@ -38611,7 +38953,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody4"
+                  "$ref": "#/components/schemas/ListResponseBody"
                 }
               }
             },
@@ -38637,7 +38979,7 @@
                 }
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody4"
+                "$ref": "#/components/schemas/CreateRequestBody"
               }
             }
           },
@@ -38714,7 +39056,7 @@
                 "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/CreateRequestBody2"
               }
             }
           },
@@ -38765,7 +39107,7 @@
                 "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/CreateRequestBody2"
               }
             }
           },
@@ -38807,7 +39149,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody5"
+                  "$ref": "#/components/schemas/ListResponseBody2"
                 }
               }
             },
@@ -38834,7 +39176,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/CreateRequestBody3"
               }
             }
           },
@@ -38858,7 +39200,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody4"
+                  "$ref": "#/components/schemas/ShowResponseBody"
                 }
               }
             },
@@ -38936,7 +39278,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody4"
+                  "$ref": "#/components/schemas/ShowResponseBody"
                 }
               }
             },
@@ -38977,7 +39319,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody5"
+                "$ref": "#/components/schemas/UpdateRequestBody2"
               }
             }
           },
@@ -39001,7 +39343,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody4"
+                  "$ref": "#/components/schemas/ShowResponseBody"
                 }
               }
             },
@@ -39036,7 +39378,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody7"
+                  "$ref": "#/components/schemas/ListResponseBody4"
                 }
               }
             },
@@ -39060,7 +39402,7 @@
                 "name": "Closed"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody8"
+                "$ref": "#/components/schemas/CreateRequestBody5"
               }
             }
           },
@@ -39082,7 +39424,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody6"
+                  "$ref": "#/components/schemas/ShowResponseBody3"
                 }
               }
             },
@@ -39156,7 +39498,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody6"
+                  "$ref": "#/components/schemas/ShowResponseBody3"
                 }
               }
             },
@@ -39193,7 +39535,7 @@
                 "name": "Closed"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody7"
+                "$ref": "#/components/schemas/UpdateRequestBody4"
               }
             }
           },
@@ -39215,7 +39557,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody6"
+                  "$ref": "#/components/schemas/ShowResponseBody3"
                 }
               }
             },
@@ -39251,7 +39593,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody9"
+                  "$ref": "#/components/schemas/ListResponseBody6"
                 }
               }
             },
@@ -39299,7 +39641,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody8"
+                  "$ref": "#/components/schemas/ShowResponseBody5"
                 }
               }
             },
@@ -39501,7 +39843,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody11"
+                  "$ref": "#/components/schemas/ListResponseBody8"
                 }
               }
             },
@@ -39689,7 +40031,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody9"
+                  "$ref": "#/components/schemas/ShowResponseBody6"
                 }
               }
             },
@@ -39844,7 +40186,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody9"
+                  "$ref": "#/components/schemas/ShowResponseBody6"
                 }
               }
             },
@@ -39927,7 +40269,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody13"
+                  "$ref": "#/components/schemas/ListResponseBody10"
                 }
               }
             },
@@ -39951,7 +40293,7 @@
                 "rank": 1
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody9"
+                "$ref": "#/components/schemas/CreateRequestBody6"
               }
             }
           },
@@ -39972,7 +40314,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody11"
+                  "$ref": "#/components/schemas/ShowResponseBody8"
                 }
               }
             },
@@ -40045,7 +40387,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody11"
+                  "$ref": "#/components/schemas/ShowResponseBody8"
                 }
               }
             },
@@ -40083,7 +40425,7 @@
                 "rank": 1
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody9"
+                "$ref": "#/components/schemas/CreateRequestBody6"
               }
             }
           },
@@ -40104,7 +40446,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody11"
+                  "$ref": "#/components/schemas/ShowResponseBody8"
                 }
               }
             },
@@ -44583,6 +44925,12 @@
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Which team is impacted by this issue",
                       "field_type": "single_select",
+                      "filter_by": {
+                        "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+                        "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+                      },
+                      "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Affected Team",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -44590,7 +44938,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody3"
+                  "$ref": "#/components/schemas/CustomFieldsListResultV2"
                 }
               }
             },
@@ -44600,7 +44948,8 @@
         "summary": "List Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "post": {
         "description": "Create a new custom field",
@@ -44609,12 +44958,19 @@
           "content": {
             "application/json": {
               "example": {
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "description": "Which team is impacted by this issue",
                 "field_type": "single_select",
+                "filter_by": {
+                  "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+                  "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+                },
+                "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
                 "name": "Affected Team"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody3"
+                "$ref": "#/components/schemas/CustomFieldsCreatePayloadV2"
               }
             }
           },
@@ -44630,13 +44986,19 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Which team is impacted by this issue",
                     "field_type": "single_select",
+                    "filter_by": {
+                      "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+                      "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+                    },
+                    "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Affected Team",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody3"
+                  "$ref": "#/components/schemas/CustomFieldsCreateResultV2"
                 }
               }
             },
@@ -44646,7 +45008,8 @@
         "summary": "Create Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/custom_fields/{id}": {
@@ -44675,7 +45038,8 @@
         "summary": "Delete Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "get": {
         "description": "Get a single custom field.",
@@ -44704,13 +45068,19 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Which team is impacted by this issue",
                     "field_type": "single_select",
+                    "filter_by": {
+                      "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+                      "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+                    },
+                    "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Affected Team",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody3"
+                  "$ref": "#/components/schemas/CustomFieldsShowResultV2"
                 }
               }
             },
@@ -44720,7 +45090,8 @@
         "summary": "Show Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "put": {
         "description": "Update the details of a custom field",
@@ -44744,10 +45115,16 @@
             "application/json": {
               "example": {
                 "description": "Which team is impacted by this issue",
+                "filter_by": {
+                  "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+                  "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+                },
+                "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
                 "name": "Affected Team"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody4"
+                "$ref": "#/components/schemas/CustomFieldsUpdatePayloadV2"
               }
             }
           },
@@ -44763,13 +45140,19 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Which team is impacted by this issue",
                     "field_type": "single_select",
+                    "filter_by": {
+                      "catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
+                      "custom_field_id": "01H2FW182TAH0NHEVBY34SCAK0"
+                    },
+                    "group_by_catalog_attribute_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "helptext_catalog_attribute_id": "01H2FW182TAH0NHEVBY34SCAK0",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Affected Team",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody3"
+                  "$ref": "#/components/schemas/CustomFieldsUpdateResultV2"
                 }
               }
             },
@@ -44779,7 +45162,8 @@
         "summary": "Update Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/escalation_paths": {
@@ -45557,7 +45941,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody6"
+                  "$ref": "#/components/schemas/ListResponseBody3"
                 }
               }
             },
@@ -45582,7 +45966,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody7"
+                "$ref": "#/components/schemas/CreateRequestBody4"
               }
             }
           },
@@ -45605,7 +45989,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody5"
+                  "$ref": "#/components/schemas/ShowResponseBody2"
                 }
               }
             },
@@ -45680,7 +46064,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody5"
+                  "$ref": "#/components/schemas/ShowResponseBody2"
                 }
               }
             },
@@ -45719,7 +46103,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody6"
+                "$ref": "#/components/schemas/UpdateRequestBody3"
               }
             }
           },
@@ -45742,7 +46126,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody5"
+                  "$ref": "#/components/schemas/ShowResponseBody2"
                 }
               }
             },
@@ -45773,7 +46157,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody8"
+                  "$ref": "#/components/schemas/ListResponseBody5"
                 }
               }
             },
@@ -45816,7 +46200,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody7"
+                  "$ref": "#/components/schemas/ShowResponseBody4"
                 }
               }
             },
@@ -45924,7 +46308,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody10"
+                  "$ref": "#/components/schemas/ListResponseBody7"
                 }
               }
             },
@@ -46430,7 +46814,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody12"
+                  "$ref": "#/components/schemas/ListResponseBody9"
                 }
               }
             },
@@ -46659,7 +47043,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody10"
+                  "$ref": "#/components/schemas/ShowResponseBody7"
                 }
               }
             },
@@ -46846,7 +47230,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody10"
+                  "$ref": "#/components/schemas/ShowResponseBody7"
                 }
               }
             },
@@ -47086,7 +47470,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody10"
+                  "$ref": "#/components/schemas/ShowResponseBody7"
                 }
               }
             },
@@ -47957,7 +48341,7 @@
     },
     "/v2/users": {
       "get": {
-        "description": "List users for an organisation.",
+        "description": "List users in your account.",
         "operationId": "Users V2#List",
         "parameters": [
           {
@@ -47995,7 +48379,6 @@
               "description": "Integer number of records to return",
               "example": 25,
               "format": "int64",
-              "maximum": 500,
               "type": "integer"
             }
           },
@@ -48046,7 +48429,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody14"
+                  "$ref": "#/components/schemas/UsersListResultV2"
                 }
               }
             },
@@ -48056,7 +48439,8 @@
         "summary": "List Users V2",
         "tags": [
           "Users V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/users/{id}": {
@@ -48105,7 +48489,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody12"
+                  "$ref": "#/components/schemas/UsersShowResultV2"
                 }
               }
             },
@@ -48115,7 +48499,8 @@
         "summary": "Show Users V2",
         "tags": [
           "Users V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/workflows": {

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -234,60 +234,28 @@ const (
 	CreateManagedResourceRequestBodyResourceTypeWorkflow       CreateManagedResourceRequestBodyResourceType = "workflow"
 )
 
-// Defines values for CreateRequestBody2FieldType.
+// Defines values for CreateRequestBodyResourceResourceType.
 const (
-	CreateRequestBody2FieldTypeLink         CreateRequestBody2FieldType = "link"
-	CreateRequestBody2FieldTypeMultiSelect  CreateRequestBody2FieldType = "multi_select"
-	CreateRequestBody2FieldTypeNumeric      CreateRequestBody2FieldType = "numeric"
-	CreateRequestBody2FieldTypeSingleSelect CreateRequestBody2FieldType = "single_select"
-	CreateRequestBody2FieldTypeText         CreateRequestBody2FieldType = "text"
+	CreateRequestBodyResourceResourceTypeAtlassianStatuspageIncident CreateRequestBodyResourceResourceType = "atlassian_statuspage_incident"
+	CreateRequestBodyResourceResourceTypeDatadogMonitorAlert         CreateRequestBodyResourceResourceType = "datadog_monitor_alert"
+	CreateRequestBodyResourceResourceTypeGithubPullRequest           CreateRequestBodyResourceResourceType = "github_pull_request"
+	CreateRequestBodyResourceResourceTypeGitlabMergeRequest          CreateRequestBodyResourceResourceType = "gitlab_merge_request"
+	CreateRequestBodyResourceResourceTypeGoogleCalendarEvent         CreateRequestBodyResourceResourceType = "google_calendar_event"
+	CreateRequestBodyResourceResourceTypeJiraIssue                   CreateRequestBodyResourceResourceType = "jira_issue"
+	CreateRequestBodyResourceResourceTypeOpsgenieAlert               CreateRequestBodyResourceResourceType = "opsgenie_alert"
+	CreateRequestBodyResourceResourceTypeOutlookCalendarEvent        CreateRequestBodyResourceResourceType = "outlook_calendar_event"
+	CreateRequestBodyResourceResourceTypePagerDutyIncident           CreateRequestBodyResourceResourceType = "pager_duty_incident"
+	CreateRequestBodyResourceResourceTypeScrubbed                    CreateRequestBodyResourceResourceType = "scrubbed"
+	CreateRequestBodyResourceResourceTypeSentryIssue                 CreateRequestBodyResourceResourceType = "sentry_issue"
+	CreateRequestBodyResourceResourceTypeStatuspageIncident          CreateRequestBodyResourceResourceType = "statuspage_incident"
+	CreateRequestBodyResourceResourceTypeZendeskTicket               CreateRequestBodyResourceResourceType = "zendesk_ticket"
 )
 
-// Defines values for CreateRequestBody2Required.
+// Defines values for CreateRequestBody5Category.
 const (
-	CreateRequestBody2RequiredAlways        CreateRequestBody2Required = "always"
-	CreateRequestBody2RequiredBeforeClosure CreateRequestBody2Required = "before_closure"
-	CreateRequestBody2RequiredNever         CreateRequestBody2Required = "never"
-)
-
-// Defines values for CreateRequestBody2RequiredV2.
-const (
-	CreateRequestBody2RequiredV2Always           CreateRequestBody2RequiredV2 = "always"
-	CreateRequestBody2RequiredV2BeforeResolution CreateRequestBody2RequiredV2 = "before_resolution"
-	CreateRequestBody2RequiredV2Never            CreateRequestBody2RequiredV2 = "never"
-)
-
-// Defines values for CreateRequestBody3FieldType.
-const (
-	CreateRequestBody3FieldTypeLink         CreateRequestBody3FieldType = "link"
-	CreateRequestBody3FieldTypeMultiSelect  CreateRequestBody3FieldType = "multi_select"
-	CreateRequestBody3FieldTypeNumeric      CreateRequestBody3FieldType = "numeric"
-	CreateRequestBody3FieldTypeSingleSelect CreateRequestBody3FieldType = "single_select"
-	CreateRequestBody3FieldTypeText         CreateRequestBody3FieldType = "text"
-)
-
-// Defines values for CreateRequestBody4ResourceResourceType.
-const (
-	CreateRequestBody4ResourceResourceTypeAtlassianStatuspageIncident CreateRequestBody4ResourceResourceType = "atlassian_statuspage_incident"
-	CreateRequestBody4ResourceResourceTypeDatadogMonitorAlert         CreateRequestBody4ResourceResourceType = "datadog_monitor_alert"
-	CreateRequestBody4ResourceResourceTypeGithubPullRequest           CreateRequestBody4ResourceResourceType = "github_pull_request"
-	CreateRequestBody4ResourceResourceTypeGitlabMergeRequest          CreateRequestBody4ResourceResourceType = "gitlab_merge_request"
-	CreateRequestBody4ResourceResourceTypeGoogleCalendarEvent         CreateRequestBody4ResourceResourceType = "google_calendar_event"
-	CreateRequestBody4ResourceResourceTypeJiraIssue                   CreateRequestBody4ResourceResourceType = "jira_issue"
-	CreateRequestBody4ResourceResourceTypeOpsgenieAlert               CreateRequestBody4ResourceResourceType = "opsgenie_alert"
-	CreateRequestBody4ResourceResourceTypeOutlookCalendarEvent        CreateRequestBody4ResourceResourceType = "outlook_calendar_event"
-	CreateRequestBody4ResourceResourceTypePagerDutyIncident           CreateRequestBody4ResourceResourceType = "pager_duty_incident"
-	CreateRequestBody4ResourceResourceTypeScrubbed                    CreateRequestBody4ResourceResourceType = "scrubbed"
-	CreateRequestBody4ResourceResourceTypeSentryIssue                 CreateRequestBody4ResourceResourceType = "sentry_issue"
-	CreateRequestBody4ResourceResourceTypeStatuspageIncident          CreateRequestBody4ResourceResourceType = "statuspage_incident"
-	CreateRequestBody4ResourceResourceTypeZendeskTicket               CreateRequestBody4ResourceResourceType = "zendesk_ticket"
-)
-
-// Defines values for CreateRequestBody8Category.
-const (
-	CreateRequestBody8CategoryClosed   CreateRequestBody8Category = "closed"
-	CreateRequestBody8CategoryLearning CreateRequestBody8Category = "learning"
-	CreateRequestBody8CategoryLive     CreateRequestBody8Category = "live"
+	CreateRequestBody5CategoryClosed   CreateRequestBody5Category = "closed"
+	CreateRequestBody5CategoryLearning CreateRequestBody5Category = "learning"
+	CreateRequestBody5CategoryLive     CreateRequestBody5Category = "live"
 )
 
 // Defines values for CreateTypeRequestBodyCategories.
@@ -412,6 +380,52 @@ const (
 	CustomFieldV2FieldTypeNumeric      CustomFieldV2FieldType = "numeric"
 	CustomFieldV2FieldTypeSingleSelect CustomFieldV2FieldType = "single_select"
 	CustomFieldV2FieldTypeText         CustomFieldV2FieldType = "text"
+)
+
+// Defines values for CustomFieldsCreatePayloadV1FieldType.
+const (
+	CustomFieldsCreatePayloadV1FieldTypeLink         CustomFieldsCreatePayloadV1FieldType = "link"
+	CustomFieldsCreatePayloadV1FieldTypeMultiSelect  CustomFieldsCreatePayloadV1FieldType = "multi_select"
+	CustomFieldsCreatePayloadV1FieldTypeNumeric      CustomFieldsCreatePayloadV1FieldType = "numeric"
+	CustomFieldsCreatePayloadV1FieldTypeSingleSelect CustomFieldsCreatePayloadV1FieldType = "single_select"
+	CustomFieldsCreatePayloadV1FieldTypeText         CustomFieldsCreatePayloadV1FieldType = "text"
+)
+
+// Defines values for CustomFieldsCreatePayloadV1Required.
+const (
+	CustomFieldsCreatePayloadV1RequiredAlways        CustomFieldsCreatePayloadV1Required = "always"
+	CustomFieldsCreatePayloadV1RequiredBeforeClosure CustomFieldsCreatePayloadV1Required = "before_closure"
+	CustomFieldsCreatePayloadV1RequiredNever         CustomFieldsCreatePayloadV1Required = "never"
+)
+
+// Defines values for CustomFieldsCreatePayloadV1RequiredV2.
+const (
+	CustomFieldsCreatePayloadV1RequiredV2Always           CustomFieldsCreatePayloadV1RequiredV2 = "always"
+	CustomFieldsCreatePayloadV1RequiredV2BeforeResolution CustomFieldsCreatePayloadV1RequiredV2 = "before_resolution"
+	CustomFieldsCreatePayloadV1RequiredV2Never            CustomFieldsCreatePayloadV1RequiredV2 = "never"
+)
+
+// Defines values for CustomFieldsCreatePayloadV2FieldType.
+const (
+	CustomFieldsCreatePayloadV2FieldTypeLink         CustomFieldsCreatePayloadV2FieldType = "link"
+	CustomFieldsCreatePayloadV2FieldTypeMultiSelect  CustomFieldsCreatePayloadV2FieldType = "multi_select"
+	CustomFieldsCreatePayloadV2FieldTypeNumeric      CustomFieldsCreatePayloadV2FieldType = "numeric"
+	CustomFieldsCreatePayloadV2FieldTypeSingleSelect CustomFieldsCreatePayloadV2FieldType = "single_select"
+	CustomFieldsCreatePayloadV2FieldTypeText         CustomFieldsCreatePayloadV2FieldType = "text"
+)
+
+// Defines values for CustomFieldsUpdatePayloadV1Required.
+const (
+	CustomFieldsUpdatePayloadV1RequiredAlways        CustomFieldsUpdatePayloadV1Required = "always"
+	CustomFieldsUpdatePayloadV1RequiredBeforeClosure CustomFieldsUpdatePayloadV1Required = "before_closure"
+	CustomFieldsUpdatePayloadV1RequiredNever         CustomFieldsUpdatePayloadV1Required = "never"
+)
+
+// Defines values for CustomFieldsUpdatePayloadV1RequiredV2.
+const (
+	CustomFieldsUpdatePayloadV1RequiredV2Always           CustomFieldsUpdatePayloadV1RequiredV2 = "always"
+	CustomFieldsUpdatePayloadV1RequiredV2BeforeResolution CustomFieldsUpdatePayloadV1RequiredV2 = "before_resolution"
+	CustomFieldsUpdatePayloadV1RequiredV2Never            CustomFieldsUpdatePayloadV1RequiredV2 = "never"
 )
 
 // Defines values for EmbeddedIncidentRoleV2RoleType.
@@ -790,20 +804,6 @@ const (
 	ScheduleRotationWorkingIntervalV2WeekdayThursday  ScheduleRotationWorkingIntervalV2Weekday = "thursday"
 	ScheduleRotationWorkingIntervalV2WeekdayTuesday   ScheduleRotationWorkingIntervalV2Weekday = "tuesday"
 	ScheduleRotationWorkingIntervalV2WeekdayWednesday ScheduleRotationWorkingIntervalV2Weekday = "wednesday"
-)
-
-// Defines values for UpdateRequestBody3Required.
-const (
-	UpdateRequestBody3RequiredAlways        UpdateRequestBody3Required = "always"
-	UpdateRequestBody3RequiredBeforeClosure UpdateRequestBody3Required = "before_closure"
-	UpdateRequestBody3RequiredNever         UpdateRequestBody3Required = "never"
-)
-
-// Defines values for UpdateRequestBody3RequiredV2.
-const (
-	UpdateRequestBody3RequiredV2Always           UpdateRequestBody3RequiredV2 = "always"
-	UpdateRequestBody3RequiredV2BeforeResolution UpdateRequestBody3RequiredV2 = "before_resolution"
-	UpdateRequestBody3RequiredV2Never            UpdateRequestBody3RequiredV2 = "never"
 )
 
 // Defines values for UpdateTypeRequestBodyCategories.
@@ -2023,72 +2023,6 @@ type CreatePathResponseBody struct {
 
 // CreateRequestBody defines model for CreateRequestBody.
 type CreateRequestBody struct {
-	// CustomFieldId ID of the custom field this option belongs to
-	CustomFieldId string `json:"custom_field_id"`
-
-	// SortKey Sort key used to order the custom field options correctly
-	SortKey *int64 `json:"sort_key,omitempty"`
-
-	// Value Human readable name for the custom field option
-	Value string `json:"value"`
-}
-
-// CreateRequestBody2 defines model for CreateRequestBody2.
-type CreateRequestBody2 struct {
-	// Description Description of the custom field
-	Description string `json:"description"`
-
-	// FieldType Type of custom field
-	FieldType CreateRequestBody2FieldType `json:"field_type"`
-
-	// Name Human readable name for the custom field
-	Name string `json:"name"`
-
-	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-	Required *CreateRequestBody2Required `json:"required,omitempty"`
-
-	// RequiredV2 When this custom field must be set during the incident lifecycle.
-	RequiredV2 *CreateRequestBody2RequiredV2 `json:"required_v2,omitempty"`
-
-	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
-	ShowBeforeClosure bool `json:"show_before_closure"`
-
-	// ShowBeforeCreation Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.
-	ShowBeforeCreation bool `json:"show_before_creation"`
-
-	// ShowBeforeUpdate Whether a custom field should be shown in the incident update modal.
-	ShowBeforeUpdate bool `json:"show_before_update"`
-
-	// ShowInAnnouncementPost Whether a custom field should be shown in the list of fields as part of the announcement post when set.
-	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
-}
-
-// CreateRequestBody2FieldType Type of custom field
-type CreateRequestBody2FieldType string
-
-// CreateRequestBody2Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-type CreateRequestBody2Required string
-
-// CreateRequestBody2RequiredV2 When this custom field must be set during the incident lifecycle.
-type CreateRequestBody2RequiredV2 string
-
-// CreateRequestBody3 defines model for CreateRequestBody3.
-type CreateRequestBody3 struct {
-	// Description Description of the custom field
-	Description string `json:"description"`
-
-	// FieldType Type of custom field
-	FieldType CreateRequestBody3FieldType `json:"field_type"`
-
-	// Name Human readable name for the custom field
-	Name string `json:"name"`
-}
-
-// CreateRequestBody3FieldType Type of custom field
-type CreateRequestBody3FieldType string
-
-// CreateRequestBody4 defines model for CreateRequestBody4.
-type CreateRequestBody4 struct {
 	// IncidentId ID of the incident to add an attachment to
 	IncidentId string `json:"incident_id"`
 	Resource   struct {
@@ -2096,21 +2030,21 @@ type CreateRequestBody4 struct {
 		ExternalId string `json:"external_id"`
 
 		// ResourceType E.g. PagerDuty: the external system that holds the resource
-		ResourceType CreateRequestBody4ResourceResourceType `json:"resource_type"`
+		ResourceType CreateRequestBodyResourceResourceType `json:"resource_type"`
 	} `json:"resource"`
 }
 
-// CreateRequestBody4ResourceResourceType E.g. PagerDuty: the external system that holds the resource
-type CreateRequestBody4ResourceResourceType string
+// CreateRequestBodyResourceResourceType E.g. PagerDuty: the external system that holds the resource
+type CreateRequestBodyResourceResourceType string
 
-// CreateRequestBody5 defines model for CreateRequestBody5.
-type CreateRequestBody5 struct {
+// CreateRequestBody2 defines model for CreateRequestBody2.
+type CreateRequestBody2 struct {
 	IncidentId string `json:"incident_id"`
 	UserId     string `json:"user_id"`
 }
 
-// CreateRequestBody6 defines model for CreateRequestBody6.
-type CreateRequestBody6 struct {
+// CreateRequestBody3 defines model for CreateRequestBody3.
+type CreateRequestBody3 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -2127,8 +2061,8 @@ type CreateRequestBody6 struct {
 	Shortform string `json:"shortform"`
 }
 
-// CreateRequestBody7 defines model for CreateRequestBody7.
-type CreateRequestBody7 struct {
+// CreateRequestBody4 defines model for CreateRequestBody4.
+type CreateRequestBody4 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -2142,10 +2076,10 @@ type CreateRequestBody7 struct {
 	Shortform string `json:"shortform"`
 }
 
-// CreateRequestBody8 defines model for CreateRequestBody8.
-type CreateRequestBody8 struct {
+// CreateRequestBody5 defines model for CreateRequestBody5.
+type CreateRequestBody5 struct {
 	// Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
-	Category CreateRequestBody8Category `json:"category"`
+	Category CreateRequestBody5Category `json:"category"`
 
 	// Description Rich text description of the incident status
 	Description string `json:"description"`
@@ -2154,11 +2088,11 @@ type CreateRequestBody8 struct {
 	Name string `json:"name"`
 }
 
-// CreateRequestBody8Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
-type CreateRequestBody8Category string
+// CreateRequestBody5Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
+type CreateRequestBody5Category string
 
-// CreateRequestBody9 defines model for CreateRequestBody9.
-type CreateRequestBody9 struct {
+// CreateRequestBody6 defines model for CreateRequestBody6.
+type CreateRequestBody6 struct {
 	// Description Description of the severity
 	Description string `json:"description"`
 
@@ -2317,6 +2251,17 @@ type CustomFieldEntryV2 struct {
 	Values []CustomFieldValueV2 `json:"values"`
 }
 
+// CustomFieldFilterByOptionsV2 defines model for CustomFieldFilterByOptionsV2.
+type CustomFieldFilterByOptionsV2 struct {
+	// CatalogAttributeId This must be an attribute of the catalog type of this custom field. It must be an attribute that points to another catalog type (so not a plain string, number, or boolean attribute).
+	CatalogAttributeId string `json:"catalog_attribute_id"`
+
+	// CustomFieldId This must be the ID of a custom field, which must have values of the same type as the attribute you are filtering by.
+	//
+	// When this filtering field is set on an incident, the options for this custom field will be filtered to only those with the attribute value that matches the value of the filtering field.
+	CustomFieldId string `json:"custom_field_id"`
+}
+
 // CustomFieldOptionV1 defines model for CustomFieldOptionV1.
 type CustomFieldOptionV1 struct {
 	// CustomFieldId ID of the custom field this option belongs to
@@ -2345,6 +2290,48 @@ type CustomFieldOptionV2 struct {
 
 	// Value Human readable name for the custom field option
 	Value string `json:"value"`
+}
+
+// CustomFieldOptionsCreatePayloadV1 defines model for CustomFieldOptionsCreatePayloadV1.
+type CustomFieldOptionsCreatePayloadV1 struct {
+	// CustomFieldId ID of the custom field this option belongs to
+	CustomFieldId string `json:"custom_field_id"`
+
+	// SortKey Sort key used to order the custom field options correctly
+	SortKey *int64 `json:"sort_key,omitempty"`
+
+	// Value Human readable name for the custom field option
+	Value string `json:"value"`
+}
+
+// CustomFieldOptionsCreateResultV1 defines model for CustomFieldOptionsCreateResultV1.
+type CustomFieldOptionsCreateResultV1 struct {
+	CustomFieldOption CustomFieldOptionV1 `json:"custom_field_option"`
+}
+
+// CustomFieldOptionsListResultV1 defines model for CustomFieldOptionsListResultV1.
+type CustomFieldOptionsListResultV1 struct {
+	CustomFieldOptions []CustomFieldOptionV1  `json:"custom_field_options"`
+	PaginationMeta     PaginationMetaResultV1 `json:"pagination_meta"`
+}
+
+// CustomFieldOptionsShowResultV1 defines model for CustomFieldOptionsShowResultV1.
+type CustomFieldOptionsShowResultV1 struct {
+	CustomFieldOption CustomFieldOptionV1 `json:"custom_field_option"`
+}
+
+// CustomFieldOptionsUpdatePayloadV1 defines model for CustomFieldOptionsUpdatePayloadV1.
+type CustomFieldOptionsUpdatePayloadV1 struct {
+	// SortKey Sort key used to order the custom field options correctly
+	SortKey int64 `json:"sort_key"`
+
+	// Value Human readable name for the custom field option
+	Value string `json:"value"`
+}
+
+// CustomFieldOptionsUpdateResultV1 defines model for CustomFieldOptionsUpdateResultV1.
+type CustomFieldOptionsUpdateResultV1 struct {
+	CustomFieldOption CustomFieldOptionV1 `json:"custom_field_option"`
 }
 
 // CustomFieldTypeInfoV1 defines model for CustomFieldTypeInfoV1.
@@ -2455,7 +2442,14 @@ type CustomFieldV2 struct {
 	Description string `json:"description"`
 
 	// FieldType Type of custom field
-	FieldType CustomFieldV2FieldType `json:"field_type"`
+	FieldType CustomFieldV2FieldType        `json:"field_type"`
+	FilterBy  *CustomFieldFilterByOptionsV2 `json:"filter_by,omitempty"`
+
+	// GroupByCatalogAttributeId For catalog fields, the ID of the attribute used to group catalog entries (if applicable)
+	GroupByCatalogAttributeId *string `json:"group_by_catalog_attribute_id,omitempty"`
+
+	// HelptextCatalogAttributeId Which catalog attribute provides helptext for the options
+	HelptextCatalogAttributeId *string `json:"helptext_catalog_attribute_id,omitempty"`
 
 	// Id Unique identifier for the custom field
 	Id string `json:"id"`
@@ -2546,6 +2540,159 @@ type CustomFieldValueV2 struct {
 
 	// ValueText If the custom field type is 'text', this will contain the value assigned.
 	ValueText *string `json:"value_text,omitempty"`
+}
+
+// CustomFieldsCreatePayloadV1 defines model for CustomFieldsCreatePayloadV1.
+type CustomFieldsCreatePayloadV1 struct {
+	// Description Description of the custom field
+	Description string `json:"description"`
+
+	// FieldType Type of custom field
+	FieldType CustomFieldsCreatePayloadV1FieldType `json:"field_type"`
+
+	// Name Human readable name for the custom field
+	Name string `json:"name"`
+
+	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+	Required *CustomFieldsCreatePayloadV1Required `json:"required,omitempty"`
+
+	// RequiredV2 When this custom field must be set during the incident lifecycle.
+	RequiredV2 *CustomFieldsCreatePayloadV1RequiredV2 `json:"required_v2,omitempty"`
+
+	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
+	ShowBeforeClosure bool `json:"show_before_closure"`
+
+	// ShowBeforeCreation Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.
+	ShowBeforeCreation bool `json:"show_before_creation"`
+
+	// ShowBeforeUpdate Whether a custom field should be shown in the incident update modal.
+	ShowBeforeUpdate bool `json:"show_before_update"`
+
+	// ShowInAnnouncementPost Whether a custom field should be shown in the list of fields as part of the announcement post when set.
+	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
+}
+
+// CustomFieldsCreatePayloadV1FieldType Type of custom field
+type CustomFieldsCreatePayloadV1FieldType string
+
+// CustomFieldsCreatePayloadV1Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+type CustomFieldsCreatePayloadV1Required string
+
+// CustomFieldsCreatePayloadV1RequiredV2 When this custom field must be set during the incident lifecycle.
+type CustomFieldsCreatePayloadV1RequiredV2 string
+
+// CustomFieldsCreatePayloadV2 defines model for CustomFieldsCreatePayloadV2.
+type CustomFieldsCreatePayloadV2 struct {
+	// CatalogTypeId For catalog fields, the ID of the associated catalog type
+	CatalogTypeId *string `json:"catalog_type_id,omitempty"`
+
+	// Description Description of the custom field
+	Description string `json:"description"`
+
+	// FieldType Type of custom field
+	FieldType CustomFieldsCreatePayloadV2FieldType `json:"field_type"`
+	FilterBy  *CustomFieldFilterByOptionsV2        `json:"filter_by,omitempty"`
+
+	// GroupByCatalogAttributeId For catalog fields, the ID of the attribute used to group catalog entries (if applicable)
+	GroupByCatalogAttributeId *string `json:"group_by_catalog_attribute_id,omitempty"`
+
+	// HelptextCatalogAttributeId Which catalog attribute provides helptext for the options
+	HelptextCatalogAttributeId *string `json:"helptext_catalog_attribute_id,omitempty"`
+
+	// Name Human readable name for the custom field
+	Name string `json:"name"`
+}
+
+// CustomFieldsCreatePayloadV2FieldType Type of custom field
+type CustomFieldsCreatePayloadV2FieldType string
+
+// CustomFieldsCreateResultV1 defines model for CustomFieldsCreateResultV1.
+type CustomFieldsCreateResultV1 struct {
+	CustomField CustomFieldV1 `json:"custom_field"`
+}
+
+// CustomFieldsCreateResultV2 defines model for CustomFieldsCreateResultV2.
+type CustomFieldsCreateResultV2 struct {
+	CustomField CustomFieldV2 `json:"custom_field"`
+}
+
+// CustomFieldsListResultV1 defines model for CustomFieldsListResultV1.
+type CustomFieldsListResultV1 struct {
+	CustomFields []CustomFieldV1 `json:"custom_fields"`
+}
+
+// CustomFieldsListResultV2 defines model for CustomFieldsListResultV2.
+type CustomFieldsListResultV2 struct {
+	CustomFields []CustomFieldV2 `json:"custom_fields"`
+}
+
+// CustomFieldsShowResultV1 defines model for CustomFieldsShowResultV1.
+type CustomFieldsShowResultV1 struct {
+	CustomField CustomFieldV1 `json:"custom_field"`
+}
+
+// CustomFieldsShowResultV2 defines model for CustomFieldsShowResultV2.
+type CustomFieldsShowResultV2 struct {
+	CustomField CustomFieldV2 `json:"custom_field"`
+}
+
+// CustomFieldsUpdatePayloadV1 defines model for CustomFieldsUpdatePayloadV1.
+type CustomFieldsUpdatePayloadV1 struct {
+	// Description Description of the custom field
+	Description string `json:"description"`
+
+	// Name Human readable name for the custom field
+	Name string `json:"name"`
+
+	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+	Required *CustomFieldsUpdatePayloadV1Required `json:"required,omitempty"`
+
+	// RequiredV2 When this custom field must be set during the incident lifecycle.
+	RequiredV2 *CustomFieldsUpdatePayloadV1RequiredV2 `json:"required_v2,omitempty"`
+
+	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
+	ShowBeforeClosure bool `json:"show_before_closure"`
+
+	// ShowBeforeCreation Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.
+	ShowBeforeCreation bool `json:"show_before_creation"`
+
+	// ShowBeforeUpdate Whether a custom field should be shown in the incident update modal.
+	ShowBeforeUpdate bool `json:"show_before_update"`
+
+	// ShowInAnnouncementPost Whether a custom field should be shown in the list of fields as part of the announcement post when set.
+	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
+}
+
+// CustomFieldsUpdatePayloadV1Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
+type CustomFieldsUpdatePayloadV1Required string
+
+// CustomFieldsUpdatePayloadV1RequiredV2 When this custom field must be set during the incident lifecycle.
+type CustomFieldsUpdatePayloadV1RequiredV2 string
+
+// CustomFieldsUpdatePayloadV2 defines model for CustomFieldsUpdatePayloadV2.
+type CustomFieldsUpdatePayloadV2 struct {
+	// Description Description of the custom field
+	Description string                        `json:"description"`
+	FilterBy    *CustomFieldFilterByOptionsV2 `json:"filter_by,omitempty"`
+
+	// GroupByCatalogAttributeId For catalog fields, the ID of the attribute used to group catalog entries (if applicable)
+	GroupByCatalogAttributeId *string `json:"group_by_catalog_attribute_id,omitempty"`
+
+	// HelptextCatalogAttributeId Which catalog attribute provides helptext for the options
+	HelptextCatalogAttributeId *string `json:"helptext_catalog_attribute_id,omitempty"`
+
+	// Name Human readable name for the custom field
+	Name string `json:"name"`
+}
+
+// CustomFieldsUpdateResultV1 defines model for CustomFieldsUpdateResultV1.
+type CustomFieldsUpdateResultV1 struct {
+	CustomField CustomFieldV1 `json:"custom_field"`
+}
+
+// CustomFieldsUpdateResultV2 defines model for CustomFieldsUpdateResultV2.
+type CustomFieldsUpdateResultV2 struct {
+	CustomField CustomFieldV2 `json:"custom_field"`
 }
 
 // EditRequestBody defines model for EditRequestBody.
@@ -4157,77 +4304,55 @@ type ListResourcesResponseBody struct {
 
 // ListResponseBody defines model for ListResponseBody.
 type ListResponseBody struct {
-	CustomFieldOptions []CustomFieldOptionV1 `json:"custom_field_options"`
-	PaginationMeta     PaginationMetaResult  `json:"pagination_meta"`
+	IncidentAttachments []IncidentAttachmentV1 `json:"incident_attachments"`
 }
 
 // ListResponseBody10 defines model for ListResponseBody10.
 type ListResponseBody10 struct {
-	IncidentUpdates []IncidentUpdateV2    `json:"incident_updates"`
-	PaginationMeta  *PaginationMetaResult `json:"pagination_meta,omitempty"`
-}
-
-// ListResponseBody11 defines model for ListResponseBody11.
-type ListResponseBody11 struct {
-	Incidents      []IncidentV1                   `json:"incidents"`
-	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
-}
-
-// ListResponseBody12 defines model for ListResponseBody12.
-type ListResponseBody12 struct {
-	Incidents      []IncidentV2                   `json:"incidents"`
-	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
-}
-
-// ListResponseBody13 defines model for ListResponseBody13.
-type ListResponseBody13 struct {
 	Severities []SeverityV1 `json:"severities"`
-}
-
-// ListResponseBody14 defines model for ListResponseBody14.
-type ListResponseBody14 struct {
-	PaginationMeta PaginationMetaResult `json:"pagination_meta"`
-	Users          []UserWithRolesV2    `json:"users"`
 }
 
 // ListResponseBody2 defines model for ListResponseBody2.
 type ListResponseBody2 struct {
-	CustomFields []CustomFieldV1 `json:"custom_fields"`
+	IncidentRoles []IncidentRoleV1 `json:"incident_roles"`
 }
 
 // ListResponseBody3 defines model for ListResponseBody3.
 type ListResponseBody3 struct {
-	CustomFields []CustomFieldV2 `json:"custom_fields"`
+	IncidentRoles []IncidentRoleV2 `json:"incident_roles"`
 }
 
 // ListResponseBody4 defines model for ListResponseBody4.
 type ListResponseBody4 struct {
-	IncidentAttachments []IncidentAttachmentV1 `json:"incident_attachments"`
+	IncidentStatuses []IncidentStatusV1 `json:"incident_statuses"`
 }
 
 // ListResponseBody5 defines model for ListResponseBody5.
 type ListResponseBody5 struct {
-	IncidentRoles []IncidentRoleV1 `json:"incident_roles"`
+	IncidentTimestamps []IncidentTimestampV2 `json:"incident_timestamps"`
 }
 
 // ListResponseBody6 defines model for ListResponseBody6.
 type ListResponseBody6 struct {
-	IncidentRoles []IncidentRoleV2 `json:"incident_roles"`
+	IncidentTypes []IncidentTypeV1 `json:"incident_types"`
 }
 
 // ListResponseBody7 defines model for ListResponseBody7.
 type ListResponseBody7 struct {
-	IncidentStatuses []IncidentStatusV1 `json:"incident_statuses"`
+	IncidentUpdates []IncidentUpdateV2    `json:"incident_updates"`
+	PaginationMeta  *PaginationMetaResult `json:"pagination_meta,omitempty"`
 }
 
 // ListResponseBody8 defines model for ListResponseBody8.
 type ListResponseBody8 struct {
-	IncidentTimestamps []IncidentTimestampV2 `json:"incident_timestamps"`
+	Incidents      []IncidentV1                   `json:"incidents"`
+	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
 }
 
 // ListResponseBody9 defines model for ListResponseBody9.
 type ListResponseBody9 struct {
-	IncidentTypes []IncidentTypeV1 `json:"incident_types"`
+	Incidents      []IncidentV2                   `json:"incidents"`
+	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
 }
 
 // ListTypesResponseBody defines model for ListTypesResponseBody.
@@ -4279,6 +4404,24 @@ type ManagementMetaV2ManagedBy string
 
 // PaginationMetaResult defines model for PaginationMetaResult.
 type PaginationMetaResult struct {
+	// After If provided, pass this as the 'after' param to load the next page
+	After *string `json:"after,omitempty"`
+
+	// PageSize What was the maximum number of results requested
+	PageSize int64 `json:"page_size"`
+}
+
+// PaginationMetaResultV1 defines model for PaginationMetaResultV1.
+type PaginationMetaResultV1 struct {
+	// After If provided, pass this as the 'after' param to load the next page
+	After *string `json:"after,omitempty"`
+
+	// PageSize What was the maximum number of results requested
+	PageSize int64 `json:"page_size"`
+}
+
+// PaginationMetaResultV2 defines model for PaginationMetaResultV2.
+type PaginationMetaResultV2 struct {
 	// After If provided, pass this as the 'after' param to load the next page
 	After *string `json:"after,omitempty"`
 
@@ -4728,62 +4871,42 @@ type ShowEntryResponseBody struct {
 
 // ShowResponseBody defines model for ShowResponseBody.
 type ShowResponseBody struct {
-	CustomFieldOption CustomFieldOptionV1 `json:"custom_field_option"`
-}
-
-// ShowResponseBody10 defines model for ShowResponseBody10.
-type ShowResponseBody10 struct {
-	Incident IncidentV2 `json:"incident"`
-}
-
-// ShowResponseBody11 defines model for ShowResponseBody11.
-type ShowResponseBody11 struct {
-	Severity SeverityV1 `json:"severity"`
-}
-
-// ShowResponseBody12 defines model for ShowResponseBody12.
-type ShowResponseBody12 struct {
-	User UserWithRolesV2 `json:"user"`
+	IncidentRole IncidentRoleV1 `json:"incident_role"`
 }
 
 // ShowResponseBody2 defines model for ShowResponseBody2.
 type ShowResponseBody2 struct {
-	CustomField CustomFieldV1 `json:"custom_field"`
+	IncidentRole IncidentRoleV2 `json:"incident_role"`
 }
 
 // ShowResponseBody3 defines model for ShowResponseBody3.
 type ShowResponseBody3 struct {
-	CustomField CustomFieldV2 `json:"custom_field"`
+	IncidentStatus IncidentStatusV1 `json:"incident_status"`
 }
 
 // ShowResponseBody4 defines model for ShowResponseBody4.
 type ShowResponseBody4 struct {
-	IncidentRole IncidentRoleV1 `json:"incident_role"`
+	IncidentTimestamp IncidentTimestampV2 `json:"incident_timestamp"`
 }
 
 // ShowResponseBody5 defines model for ShowResponseBody5.
 type ShowResponseBody5 struct {
-	IncidentRole IncidentRoleV2 `json:"incident_role"`
+	IncidentType IncidentTypeV1 `json:"incident_type"`
 }
 
 // ShowResponseBody6 defines model for ShowResponseBody6.
 type ShowResponseBody6 struct {
-	IncidentStatus IncidentStatusV1 `json:"incident_status"`
+	Incident IncidentV1 `json:"incident"`
 }
 
 // ShowResponseBody7 defines model for ShowResponseBody7.
 type ShowResponseBody7 struct {
-	IncidentTimestamp IncidentTimestampV2 `json:"incident_timestamp"`
+	Incident IncidentV2 `json:"incident"`
 }
 
 // ShowResponseBody8 defines model for ShowResponseBody8.
 type ShowResponseBody8 struct {
-	IncidentType IncidentTypeV1 `json:"incident_type"`
-}
-
-// ShowResponseBody9 defines model for ShowResponseBody9.
-type ShowResponseBody9 struct {
-	Incident IncidentV1 `json:"incident"`
+	Severity SeverityV1 `json:"severity"`
 }
 
 // ShowWorkflowResponseBody defines model for ShowWorkflowResponseBody.
@@ -4903,57 +5026,6 @@ type UpdateRequestBody struct {
 
 // UpdateRequestBody2 defines model for UpdateRequestBody2.
 type UpdateRequestBody2 struct {
-	// SortKey Sort key used to order the custom field options correctly
-	SortKey int64 `json:"sort_key"`
-
-	// Value Human readable name for the custom field option
-	Value string `json:"value"`
-}
-
-// UpdateRequestBody3 defines model for UpdateRequestBody3.
-type UpdateRequestBody3 struct {
-	// Description Description of the custom field
-	Description string `json:"description"`
-
-	// Name Human readable name for the custom field
-	Name string `json:"name"`
-
-	// Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-	Required *UpdateRequestBody3Required `json:"required,omitempty"`
-
-	// RequiredV2 When this custom field must be set during the incident lifecycle.
-	RequiredV2 *UpdateRequestBody3RequiredV2 `json:"required_v2,omitempty"`
-
-	// ShowBeforeClosure Whether a custom field should be shown in the incident resolve modal. If this custom field is required before resolution, but no value has been set for it, the field will be shown in the resolve modal whatever the value of this setting.
-	ShowBeforeClosure bool `json:"show_before_closure"`
-
-	// ShowBeforeCreation Whether a custom field should be shown in the incident creation modal. This must be true if the field is always required.
-	ShowBeforeCreation bool `json:"show_before_creation"`
-
-	// ShowBeforeUpdate Whether a custom field should be shown in the incident update modal.
-	ShowBeforeUpdate bool `json:"show_before_update"`
-
-	// ShowInAnnouncementPost Whether a custom field should be shown in the list of fields as part of the announcement post when set.
-	ShowInAnnouncementPost *bool `json:"show_in_announcement_post,omitempty"`
-}
-
-// UpdateRequestBody3Required When this custom field must be set during the incident lifecycle. [DEPRECATED: please use required_v2 instead].
-type UpdateRequestBody3Required string
-
-// UpdateRequestBody3RequiredV2 When this custom field must be set during the incident lifecycle.
-type UpdateRequestBody3RequiredV2 string
-
-// UpdateRequestBody4 defines model for UpdateRequestBody4.
-type UpdateRequestBody4 struct {
-	// Description Description of the custom field
-	Description string `json:"description"`
-
-	// Name Human readable name for the custom field
-	Name string `json:"name"`
-}
-
-// UpdateRequestBody5 defines model for UpdateRequestBody5.
-type UpdateRequestBody5 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -4970,8 +5042,8 @@ type UpdateRequestBody5 struct {
 	Shortform string `json:"shortform"`
 }
 
-// UpdateRequestBody6 defines model for UpdateRequestBody6.
-type UpdateRequestBody6 struct {
+// UpdateRequestBody3 defines model for UpdateRequestBody3.
+type UpdateRequestBody3 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -4985,8 +5057,8 @@ type UpdateRequestBody6 struct {
 	Shortform string `json:"shortform"`
 }
 
-// UpdateRequestBody7 defines model for UpdateRequestBody7.
-type UpdateRequestBody7 struct {
+// UpdateRequestBody4 defines model for UpdateRequestBody4.
+type UpdateRequestBody4 struct {
 	// Description Rich text description of the incident status
 	Description string `json:"description"`
 
@@ -5177,6 +5249,17 @@ type UserWithRolesV2 struct {
 
 // UserWithRolesV2Role DEPRECATED: Role of the user as of March 9th 2023, this value is no longer updated.
 type UserWithRolesV2Role string
+
+// UsersListResultV2 defines model for UsersListResultV2.
+type UsersListResultV2 struct {
+	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
+	Users          []UserWithRolesV2      `json:"users"`
+}
+
+// UsersShowResultV2 defines model for UsersShowResultV2.
+type UsersShowResultV2 struct {
+	User UserWithRolesV2 `json:"user"`
+}
 
 // UtilitiesIdentityResultV1 defines model for UtilitiesIdentityResultV1.
 type UtilitiesIdentityResultV1 struct {
@@ -5519,46 +5602,46 @@ type UsersV2ListParams struct {
 }
 
 // CustomFieldOptionsV1CreateJSONRequestBody defines body for CustomFieldOptionsV1Create for application/json ContentType.
-type CustomFieldOptionsV1CreateJSONRequestBody = CreateRequestBody
+type CustomFieldOptionsV1CreateJSONRequestBody = CustomFieldOptionsCreatePayloadV1
 
 // CustomFieldOptionsV1UpdateJSONRequestBody defines body for CustomFieldOptionsV1Update for application/json ContentType.
-type CustomFieldOptionsV1UpdateJSONRequestBody = UpdateRequestBody2
+type CustomFieldOptionsV1UpdateJSONRequestBody = CustomFieldOptionsUpdatePayloadV1
 
 // CustomFieldsV1CreateJSONRequestBody defines body for CustomFieldsV1Create for application/json ContentType.
-type CustomFieldsV1CreateJSONRequestBody = CreateRequestBody2
+type CustomFieldsV1CreateJSONRequestBody = CustomFieldsCreatePayloadV1
 
 // CustomFieldsV1UpdateJSONRequestBody defines body for CustomFieldsV1Update for application/json ContentType.
-type CustomFieldsV1UpdateJSONRequestBody = UpdateRequestBody3
+type CustomFieldsV1UpdateJSONRequestBody = CustomFieldsUpdatePayloadV1
 
 // IncidentAttachmentsV1CreateJSONRequestBody defines body for IncidentAttachmentsV1Create for application/json ContentType.
-type IncidentAttachmentsV1CreateJSONRequestBody = CreateRequestBody4
+type IncidentAttachmentsV1CreateJSONRequestBody = CreateRequestBody
 
 // IncidentMembershipsV1CreateJSONRequestBody defines body for IncidentMembershipsV1Create for application/json ContentType.
-type IncidentMembershipsV1CreateJSONRequestBody = CreateRequestBody5
+type IncidentMembershipsV1CreateJSONRequestBody = CreateRequestBody2
 
 // IncidentMembershipsV1RevokeJSONRequestBody defines body for IncidentMembershipsV1Revoke for application/json ContentType.
-type IncidentMembershipsV1RevokeJSONRequestBody = CreateRequestBody5
+type IncidentMembershipsV1RevokeJSONRequestBody = CreateRequestBody2
 
 // IncidentRolesV1CreateJSONRequestBody defines body for IncidentRolesV1Create for application/json ContentType.
-type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody6
+type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody3
 
 // IncidentRolesV1UpdateJSONRequestBody defines body for IncidentRolesV1Update for application/json ContentType.
-type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody5
+type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody2
 
 // IncidentStatusesV1CreateJSONRequestBody defines body for IncidentStatusesV1Create for application/json ContentType.
-type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody8
+type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody5
 
 // IncidentStatusesV1UpdateJSONRequestBody defines body for IncidentStatusesV1Update for application/json ContentType.
-type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody7
+type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody4
 
 // IncidentsV1CreateJSONRequestBody defines body for IncidentsV1Create for application/json ContentType.
 type IncidentsV1CreateJSONRequestBody = IncidentCreatePayloadV1
 
 // SeveritiesV1CreateJSONRequestBody defines body for SeveritiesV1Create for application/json ContentType.
-type SeveritiesV1CreateJSONRequestBody = CreateRequestBody9
+type SeveritiesV1CreateJSONRequestBody = CreateRequestBody6
 
 // SeveritiesV1UpdateJSONRequestBody defines body for SeveritiesV1Update for application/json ContentType.
-type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody9
+type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody6
 
 // AlertAttributesV2CreateJSONRequestBody defines body for AlertAttributesV2Create for application/json ContentType.
 type AlertAttributesV2CreateJSONRequestBody = AlertAttributesCreatePayloadV2
@@ -5597,10 +5680,10 @@ type CatalogV2UpdateTypeJSONRequestBody = UpdateTypeRequestBody
 type CatalogV2UpdateTypeSchemaJSONRequestBody = UpdateTypeSchemaRequestBody
 
 // CustomFieldsV2CreateJSONRequestBody defines body for CustomFieldsV2Create for application/json ContentType.
-type CustomFieldsV2CreateJSONRequestBody = CreateRequestBody3
+type CustomFieldsV2CreateJSONRequestBody = CustomFieldsCreatePayloadV2
 
 // CustomFieldsV2UpdateJSONRequestBody defines body for CustomFieldsV2Update for application/json ContentType.
-type CustomFieldsV2UpdateJSONRequestBody = UpdateRequestBody4
+type CustomFieldsV2UpdateJSONRequestBody = CustomFieldsUpdatePayloadV2
 
 // EscalationsV2CreatePathJSONRequestBody defines body for EscalationsV2CreatePath for application/json ContentType.
 type EscalationsV2CreatePathJSONRequestBody = EscalationPathPayloadV2
@@ -5609,10 +5692,10 @@ type EscalationsV2CreatePathJSONRequestBody = EscalationPathPayloadV2
 type EscalationsV2UpdatePathJSONRequestBody = EscalationPathPayloadV2
 
 // IncidentRolesV2CreateJSONRequestBody defines body for IncidentRolesV2Create for application/json ContentType.
-type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody7
+type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody4
 
 // IncidentRolesV2UpdateJSONRequestBody defines body for IncidentRolesV2Update for application/json ContentType.
-type IncidentRolesV2UpdateJSONRequestBody = UpdateRequestBody6
+type IncidentRolesV2UpdateJSONRequestBody = UpdateRequestBody3
 
 // IncidentsV2CreateJSONRequestBody defines body for IncidentsV2Create for application/json ContentType.
 type IncidentsV2CreateJSONRequestBody = IncidentCreatePayloadV2
@@ -12931,7 +13014,7 @@ func (r ActionsV1ShowResponse) StatusCode() int {
 type CustomFieldOptionsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody
+	JSON200      *CustomFieldOptionsListResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -12953,7 +13036,7 @@ func (r CustomFieldOptionsV1ListResponse) StatusCode() int {
 type CustomFieldOptionsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody
+	JSON201      *CustomFieldOptionsCreateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -12996,7 +13079,7 @@ func (r CustomFieldOptionsV1DeleteResponse) StatusCode() int {
 type CustomFieldOptionsV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody
+	JSON200      *CustomFieldOptionsShowResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -13018,7 +13101,7 @@ func (r CustomFieldOptionsV1ShowResponse) StatusCode() int {
 type CustomFieldOptionsV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody
+	JSON200      *CustomFieldOptionsUpdateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -13040,7 +13123,7 @@ func (r CustomFieldOptionsV1UpdateResponse) StatusCode() int {
 type CustomFieldsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody2
+	JSON200      *CustomFieldsListResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -13062,7 +13145,7 @@ func (r CustomFieldsV1ListResponse) StatusCode() int {
 type CustomFieldsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody2
+	JSON201      *CustomFieldsCreateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -13105,7 +13188,7 @@ func (r CustomFieldsV1DeleteResponse) StatusCode() int {
 type CustomFieldsV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody2
+	JSON200      *CustomFieldsShowResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -13127,7 +13210,7 @@ func (r CustomFieldsV1ShowResponse) StatusCode() int {
 type CustomFieldsV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody2
+	JSON200      *CustomFieldsUpdateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -13171,7 +13254,7 @@ func (r UtilitiesV1IdentityResponse) StatusCode() int {
 type IncidentAttachmentsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody4
+	JSON200      *ListResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -13279,7 +13362,7 @@ func (r IncidentMembershipsV1RevokeResponse) StatusCode() int {
 type IncidentRolesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody5
+	JSON200      *ListResponseBody2
 }
 
 // Status returns HTTPResponse.Status
@@ -13301,7 +13384,7 @@ func (r IncidentRolesV1ListResponse) StatusCode() int {
 type IncidentRolesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody4
+	JSON201      *ShowResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -13344,7 +13427,7 @@ func (r IncidentRolesV1DeleteResponse) StatusCode() int {
 type IncidentRolesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody4
+	JSON200      *ShowResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -13366,7 +13449,7 @@ func (r IncidentRolesV1ShowResponse) StatusCode() int {
 type IncidentRolesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody4
+	JSON200      *ShowResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -13388,7 +13471,7 @@ func (r IncidentRolesV1UpdateResponse) StatusCode() int {
 type IncidentStatusesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody7
+	JSON200      *ListResponseBody4
 }
 
 // Status returns HTTPResponse.Status
@@ -13410,7 +13493,7 @@ func (r IncidentStatusesV1ListResponse) StatusCode() int {
 type IncidentStatusesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody6
+	JSON201      *ShowResponseBody3
 }
 
 // Status returns HTTPResponse.Status
@@ -13453,7 +13536,7 @@ func (r IncidentStatusesV1DeleteResponse) StatusCode() int {
 type IncidentStatusesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody6
+	JSON200      *ShowResponseBody3
 }
 
 // Status returns HTTPResponse.Status
@@ -13475,7 +13558,7 @@ func (r IncidentStatusesV1ShowResponse) StatusCode() int {
 type IncidentStatusesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody6
+	JSON200      *ShowResponseBody3
 }
 
 // Status returns HTTPResponse.Status
@@ -13497,7 +13580,7 @@ func (r IncidentStatusesV1UpdateResponse) StatusCode() int {
 type IncidentTypesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody9
+	JSON200      *ListResponseBody6
 }
 
 // Status returns HTTPResponse.Status
@@ -13519,7 +13602,7 @@ func (r IncidentTypesV1ListResponse) StatusCode() int {
 type IncidentTypesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody8
+	JSON200      *ShowResponseBody5
 }
 
 // Status returns HTTPResponse.Status
@@ -13541,7 +13624,7 @@ func (r IncidentTypesV1ShowResponse) StatusCode() int {
 type IncidentsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody11
+	JSON200      *ListResponseBody8
 }
 
 // Status returns HTTPResponse.Status
@@ -13563,7 +13646,7 @@ func (r IncidentsV1ListResponse) StatusCode() int {
 type IncidentsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody9
+	JSON200      *ShowResponseBody6
 }
 
 // Status returns HTTPResponse.Status
@@ -13585,7 +13668,7 @@ func (r IncidentsV1CreateResponse) StatusCode() int {
 type IncidentsV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody9
+	JSON200      *ShowResponseBody6
 }
 
 // Status returns HTTPResponse.Status
@@ -13651,7 +13734,7 @@ func (r UtilitiesV1OpenAPIV3Response) StatusCode() int {
 type SeveritiesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody13
+	JSON200      *ListResponseBody10
 }
 
 // Status returns HTTPResponse.Status
@@ -13673,7 +13756,7 @@ func (r SeveritiesV1ListResponse) StatusCode() int {
 type SeveritiesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody11
+	JSON201      *ShowResponseBody8
 }
 
 // Status returns HTTPResponse.Status
@@ -13716,7 +13799,7 @@ func (r SeveritiesV1DeleteResponse) StatusCode() int {
 type SeveritiesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody11
+	JSON200      *ShowResponseBody8
 }
 
 // Status returns HTTPResponse.Status
@@ -13738,7 +13821,7 @@ func (r SeveritiesV1ShowResponse) StatusCode() int {
 type SeveritiesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody11
+	JSON200      *ShowResponseBody8
 }
 
 // Status returns HTTPResponse.Status
@@ -14393,7 +14476,7 @@ func (r CatalogV2UpdateTypeSchemaResponse) StatusCode() int {
 type CustomFieldsV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody3
+	JSON200      *CustomFieldsListResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14415,7 +14498,7 @@ func (r CustomFieldsV2ListResponse) StatusCode() int {
 type CustomFieldsV2CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody3
+	JSON201      *CustomFieldsCreateResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14458,7 +14541,7 @@ func (r CustomFieldsV2DeleteResponse) StatusCode() int {
 type CustomFieldsV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody3
+	JSON200      *CustomFieldsShowResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14480,7 +14563,7 @@ func (r CustomFieldsV2ShowResponse) StatusCode() int {
 type CustomFieldsV2UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody3
+	JSON200      *CustomFieldsUpdateResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14633,7 +14716,7 @@ func (r FollowUpsV2ShowResponse) StatusCode() int {
 type IncidentRolesV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody6
+	JSON200      *ListResponseBody3
 }
 
 // Status returns HTTPResponse.Status
@@ -14655,7 +14738,7 @@ func (r IncidentRolesV2ListResponse) StatusCode() int {
 type IncidentRolesV2CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody5
+	JSON201      *ShowResponseBody2
 }
 
 // Status returns HTTPResponse.Status
@@ -14698,7 +14781,7 @@ func (r IncidentRolesV2DeleteResponse) StatusCode() int {
 type IncidentRolesV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody5
+	JSON200      *ShowResponseBody2
 }
 
 // Status returns HTTPResponse.Status
@@ -14720,7 +14803,7 @@ func (r IncidentRolesV2ShowResponse) StatusCode() int {
 type IncidentRolesV2UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody5
+	JSON200      *ShowResponseBody2
 }
 
 // Status returns HTTPResponse.Status
@@ -14742,7 +14825,7 @@ func (r IncidentRolesV2UpdateResponse) StatusCode() int {
 type IncidentTimestampsV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody8
+	JSON200      *ListResponseBody5
 }
 
 // Status returns HTTPResponse.Status
@@ -14764,7 +14847,7 @@ func (r IncidentTimestampsV2ListResponse) StatusCode() int {
 type IncidentTimestampsV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody7
+	JSON200      *ShowResponseBody4
 }
 
 // Status returns HTTPResponse.Status
@@ -14786,7 +14869,7 @@ func (r IncidentTimestampsV2ShowResponse) StatusCode() int {
 type IncidentUpdatesV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody10
+	JSON200      *ListResponseBody7
 }
 
 // Status returns HTTPResponse.Status
@@ -14808,7 +14891,7 @@ func (r IncidentUpdatesV2ListResponse) StatusCode() int {
 type IncidentsV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody12
+	JSON200      *ListResponseBody9
 }
 
 // Status returns HTTPResponse.Status
@@ -14830,7 +14913,7 @@ func (r IncidentsV2ListResponse) StatusCode() int {
 type IncidentsV2CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody10
+	JSON200      *ShowResponseBody7
 }
 
 // Status returns HTTPResponse.Status
@@ -14852,7 +14935,7 @@ func (r IncidentsV2CreateResponse) StatusCode() int {
 type IncidentsV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody10
+	JSON200      *ShowResponseBody7
 }
 
 // Status returns HTTPResponse.Status
@@ -14874,7 +14957,7 @@ func (r IncidentsV2ShowResponse) StatusCode() int {
 type IncidentsV2EditResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody10
+	JSON200      *ShowResponseBody7
 }
 
 // Status returns HTTPResponse.Status
@@ -15071,7 +15154,7 @@ func (r SchedulesV2UpdateResponse) StatusCode() int {
 type UsersV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody14
+	JSON200      *UsersListResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15093,7 +15176,7 @@ func (r UsersV2ListResponse) StatusCode() int {
 type UsersV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody12
+	JSON200      *UsersShowResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -16571,7 +16654,7 @@ func ParseCustomFieldOptionsV1ListResponse(rsp *http.Response) (*CustomFieldOpti
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody
+		var dest CustomFieldOptionsListResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16597,7 +16680,7 @@ func ParseCustomFieldOptionsV1CreateResponse(rsp *http.Response) (*CustomFieldOp
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody
+		var dest CustomFieldOptionsCreateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16639,7 +16722,7 @@ func ParseCustomFieldOptionsV1ShowResponse(rsp *http.Response) (*CustomFieldOpti
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody
+		var dest CustomFieldOptionsShowResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16665,7 +16748,7 @@ func ParseCustomFieldOptionsV1UpdateResponse(rsp *http.Response) (*CustomFieldOp
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody
+		var dest CustomFieldOptionsUpdateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16691,7 +16774,7 @@ func ParseCustomFieldsV1ListResponse(rsp *http.Response) (*CustomFieldsV1ListRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody2
+		var dest CustomFieldsListResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16717,7 +16800,7 @@ func ParseCustomFieldsV1CreateResponse(rsp *http.Response) (*CustomFieldsV1Creat
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody2
+		var dest CustomFieldsCreateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16759,7 +16842,7 @@ func ParseCustomFieldsV1ShowResponse(rsp *http.Response) (*CustomFieldsV1ShowRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody2
+		var dest CustomFieldsShowResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16785,7 +16868,7 @@ func ParseCustomFieldsV1UpdateResponse(rsp *http.Response) (*CustomFieldsV1Updat
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody2
+		var dest CustomFieldsUpdateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16837,7 +16920,7 @@ func ParseIncidentAttachmentsV1ListResponse(rsp *http.Response) (*IncidentAttach
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody4
+		var dest ListResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16947,7 +17030,7 @@ func ParseIncidentRolesV1ListResponse(rsp *http.Response) (*IncidentRolesV1ListR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody5
+		var dest ListResponseBody2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16973,7 +17056,7 @@ func ParseIncidentRolesV1CreateResponse(rsp *http.Response) (*IncidentRolesV1Cre
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody4
+		var dest ShowResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17015,7 +17098,7 @@ func ParseIncidentRolesV1ShowResponse(rsp *http.Response) (*IncidentRolesV1ShowR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody4
+		var dest ShowResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17041,7 +17124,7 @@ func ParseIncidentRolesV1UpdateResponse(rsp *http.Response) (*IncidentRolesV1Upd
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody4
+		var dest ShowResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17067,7 +17150,7 @@ func ParseIncidentStatusesV1ListResponse(rsp *http.Response) (*IncidentStatusesV
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody7
+		var dest ListResponseBody4
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17093,7 +17176,7 @@ func ParseIncidentStatusesV1CreateResponse(rsp *http.Response) (*IncidentStatuse
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody6
+		var dest ShowResponseBody3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17135,7 +17218,7 @@ func ParseIncidentStatusesV1ShowResponse(rsp *http.Response) (*IncidentStatusesV
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody6
+		var dest ShowResponseBody3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17161,7 +17244,7 @@ func ParseIncidentStatusesV1UpdateResponse(rsp *http.Response) (*IncidentStatuse
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody6
+		var dest ShowResponseBody3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17187,7 +17270,7 @@ func ParseIncidentTypesV1ListResponse(rsp *http.Response) (*IncidentTypesV1ListR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody9
+		var dest ListResponseBody6
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17213,7 +17296,7 @@ func ParseIncidentTypesV1ShowResponse(rsp *http.Response) (*IncidentTypesV1ShowR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody8
+		var dest ShowResponseBody5
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17239,7 +17322,7 @@ func ParseIncidentsV1ListResponse(rsp *http.Response) (*IncidentsV1ListResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody11
+		var dest ListResponseBody8
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17265,7 +17348,7 @@ func ParseIncidentsV1CreateResponse(rsp *http.Response) (*IncidentsV1CreateRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody9
+		var dest ShowResponseBody6
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17291,7 +17374,7 @@ func ParseIncidentsV1ShowResponse(rsp *http.Response) (*IncidentsV1ShowResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody9
+		var dest ShowResponseBody6
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17369,7 +17452,7 @@ func ParseSeveritiesV1ListResponse(rsp *http.Response) (*SeveritiesV1ListRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody13
+		var dest ListResponseBody10
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17395,7 +17478,7 @@ func ParseSeveritiesV1CreateResponse(rsp *http.Response) (*SeveritiesV1CreateRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody11
+		var dest ShowResponseBody8
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17437,7 +17520,7 @@ func ParseSeveritiesV1ShowResponse(rsp *http.Response) (*SeveritiesV1ShowRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody11
+		var dest ShowResponseBody8
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17463,7 +17546,7 @@ func ParseSeveritiesV1UpdateResponse(rsp *http.Response) (*SeveritiesV1UpdateRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody11
+		var dest ShowResponseBody8
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18193,7 +18276,7 @@ func ParseCustomFieldsV2ListResponse(rsp *http.Response) (*CustomFieldsV2ListRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody3
+		var dest CustomFieldsListResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18219,7 +18302,7 @@ func ParseCustomFieldsV2CreateResponse(rsp *http.Response) (*CustomFieldsV2Creat
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody3
+		var dest CustomFieldsCreateResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18261,7 +18344,7 @@ func ParseCustomFieldsV2ShowResponse(rsp *http.Response) (*CustomFieldsV2ShowRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody3
+		var dest CustomFieldsShowResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18287,7 +18370,7 @@ func ParseCustomFieldsV2UpdateResponse(rsp *http.Response) (*CustomFieldsV2Updat
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody3
+		var dest CustomFieldsUpdateResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18459,7 +18542,7 @@ func ParseIncidentRolesV2ListResponse(rsp *http.Response) (*IncidentRolesV2ListR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody6
+		var dest ListResponseBody3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18485,7 +18568,7 @@ func ParseIncidentRolesV2CreateResponse(rsp *http.Response) (*IncidentRolesV2Cre
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody5
+		var dest ShowResponseBody2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18527,7 +18610,7 @@ func ParseIncidentRolesV2ShowResponse(rsp *http.Response) (*IncidentRolesV2ShowR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody5
+		var dest ShowResponseBody2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18553,7 +18636,7 @@ func ParseIncidentRolesV2UpdateResponse(rsp *http.Response) (*IncidentRolesV2Upd
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody5
+		var dest ShowResponseBody2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18579,7 +18662,7 @@ func ParseIncidentTimestampsV2ListResponse(rsp *http.Response) (*IncidentTimesta
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody8
+		var dest ListResponseBody5
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18605,7 +18688,7 @@ func ParseIncidentTimestampsV2ShowResponse(rsp *http.Response) (*IncidentTimesta
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody7
+		var dest ShowResponseBody4
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18631,7 +18714,7 @@ func ParseIncidentUpdatesV2ListResponse(rsp *http.Response) (*IncidentUpdatesV2L
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody10
+		var dest ListResponseBody7
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18657,7 +18740,7 @@ func ParseIncidentsV2ListResponse(rsp *http.Response) (*IncidentsV2ListResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody12
+		var dest ListResponseBody9
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18683,7 +18766,7 @@ func ParseIncidentsV2CreateResponse(rsp *http.Response) (*IncidentsV2CreateRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody10
+		var dest ShowResponseBody7
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18709,7 +18792,7 @@ func ParseIncidentsV2ShowResponse(rsp *http.Response) (*IncidentsV2ShowResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody10
+		var dest ShowResponseBody7
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18735,7 +18818,7 @@ func ParseIncidentsV2EditResponse(rsp *http.Response) (*IncidentsV2EditResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody10
+		var dest ShowResponseBody7
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18959,7 +19042,7 @@ func ParseUsersV2ListResponse(rsp *http.Response) (*UsersV2ListResponse, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody14
+		var dest UsersListResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18985,7 +19068,7 @@ func ParseUsersV2ShowResponse(rsp *http.Response) (*UsersV2ShowResponse, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody12
+		var dest UsersShowResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/incident_custom_field_data_source.go
+++ b/internal/provider/incident_custom_field_data_source.go
@@ -45,6 +45,32 @@ func (i *IncidentCustomFieldDataSource) Schema(ctx context.Context, req datasour
 				MarkdownDescription: apischema.Docstring("CustomFieldV2", "description"),
 				Computed:            true,
 			},
+			"catalog_type_id": schema.StringAttribute{
+				MarkdownDescription: apischema.Docstring("CustomFieldV2", "catalog_type_id"),
+				Computed:            true,
+			},
+			"filter_by": schema.SingleNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: apischema.Docstring("CustomFieldV2", "filter_by"),
+				Attributes: map[string]schema.Attribute{
+					"custom_field_id": schema.StringAttribute{
+						MarkdownDescription: apischema.Docstring("CustomFieldFilterByOptionsV2", "custom_field_id"),
+						Computed:            true,
+					},
+					"catalog_attribute_id": schema.StringAttribute{
+						MarkdownDescription: apischema.Docstring("CustomFieldFilterByOptionsV2", "catalog_attribute_id"),
+						Computed:            true,
+					},
+				},
+			},
+			"group_by_catalog_attribute_id": schema.StringAttribute{
+				MarkdownDescription: apischema.Docstring("CustomFieldV2", "group_by_catalog_attribute_id"),
+				Computed:            true,
+			},
+			"helptext_catalog_attribute_id": schema.StringAttribute{
+				MarkdownDescription: apischema.Docstring("CustomFieldV2", "helptext_catalog_attribute_id"),
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/incident_custom_field_data_source_test.go
+++ b/internal/provider/incident_custom_field_data_source_test.go
@@ -65,3 +65,11 @@ func testAccIncidentCustomFieldDataSourceConfig(payload customFieldDataSourceFix
 
 	return buf.String()
 }
+
+func customFieldDefault() client.CustomFieldV2 {
+	return client.CustomFieldV2{
+		Name:        "Affected Teams",
+		Description: "The teams that are affected by this incident",
+		FieldType:   client.CustomFieldV2FieldType("multi_select"),
+	}
+}

--- a/internal/provider/incident_status_resource.go
+++ b/internal/provider/incident_status_resource.go
@@ -98,7 +98,7 @@ func (r *IncidentStatusResource) Create(ctx context.Context, req resource.Create
 	result, err := r.client.IncidentStatusesV1CreateWithResponse(ctx, client.IncidentStatusesV1CreateJSONRequestBody{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
-		Category:    client.CreateRequestBody8Category(data.Category.ValueString()),
+		Category:    client.CreateRequestBody5Category(data.Category.ValueString()),
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))


### PR DESCRIPTION
Specifically:
- catalog_type_id can be added to `incident_custom_field` at creation only
- `group_by_catalog_attribute_id` and `helptext_catalog_attribute_id` can be managed - these must be attributes on the catalog type that powers the field
- `filter_by` can be set, to filter available values by the value in a different custom field, using an attribute on the type of this field which matches the catalog type for the other custom field.