### PR TITLE
Alert source: mark email and secret token as non-changing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Mark the 'email_address' and 'secret_token' fields on incident_alert_source as
+  remaining the same for the lifetime of an alert source, to avoid misleading
+  plans.
+
 ## v4.3.0
 
 - `incident_custom_field` resource now supports catalog-powered custom fields,

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -93,6 +93,10 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 				// which makes setting up new alert sources more difficult than
 				// necessary.
 				MarkdownDescription: apischema.Docstring("AlertSourceV2", "secret_token"),
+				PlanModifiers: []planmodifier.String{
+					// This does not change after creation
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"template": schema.SingleNestedAttribute{
 				Required:            true,
@@ -143,6 +147,10 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: apischema.Docstring("AlertSourceEmailOptionsV2", "email_address"),
+				PlanModifiers: []planmodifier.String{
+					// This does not change after creation
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Once an alert source has been created, these won't change, so we need the 'use state for unknown' plan modifier, to ensure we don't get a diff on these.