### PR TITLE
Make alert source template attributes a set, not a list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- The order of attributes set within an alert source's `template` block is now
+  ignored when planning and applying changes.
+
 ## v4.3.1
 
 - Mark the 'email_address' and 'secret_token' fields on incident_alert_source as

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -90,7 +90,7 @@ terraform {
   required_providers {
     incident = {
       source  = "incident-io/incident"
-      version = "3.0.0"
+      version = "~> 4"
     }
   }
 }

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -39,7 +39,7 @@ Alert sources are the systems that send alerts to incident.io, which can then be
 
 Required:
 
-- `attributes` (Attributes List) Attributes to set on alerts coming from this source, with a binding describing how to set them. (see [below for nested schema](#nestedatt--template--attributes))
+- `attributes` (Attributes Set) Attributes to set on alerts coming from this source, with a binding describing how to set them. (see [below for nested schema](#nestedatt--template--attributes))
 - `description` (Attributes) (see [below for nested schema](#nestedatt--template--description))
 - `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--template--expressions))
 - `title` (Attributes) (see [below for nested schema](#nestedatt--template--title))

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -113,7 +113,7 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 						Attributes:          models.ParamBindingValueAttributes(),
 						MarkdownDescription: apischema.Docstring("AlertTemplatePayloadV2", "description"),
 					},
-					"attributes": schema.ListNestedAttribute{
+					"attributes": schema.SetNestedAttribute{
 						Required:            true,
 						MarkdownDescription: apischema.Docstring("AlertTemplatePayloadV2", "attributes"),
 						NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
This means plan/apply doesn't produce a diff when the order in which you declare attributes changes, which doesn't matter!

I have tested this by:
- creating a test project
- importing an existing alert source on v4.3.1 (published)
- `terraform plan`-ing with this updated version

It seems like we don't need to write any schema-updating code here, because set and list are represented in the same way in the state file (as a JSON list), so this only matters at plan / apply time.