### PR TITLE
Support schema-only catalog attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+- Add `schema_only` as an option on `incident_catalog_type_attribute`. When set
+  to `true`, the attribute will be created from Terraform, but values for it will
+  be edited in the incident.io dashboard.
+- Add `managed_attributes` to both `incident_catalog_entry` and `incident_catalog_entries`. This
+  allows you to manage only some attributes of a catalog entry, while leaving others
+  unchanged. When attributes on a type are marked as `schema_only`, this avoids
+  Terraform trying to manage their state, allowing values set in the incident.io
+  dashboard to be preserved, and avoiding unnecessary diffs.
+
 ## v4.3.3
 
 - Fixed a panic when using an `incident_escalation_path` with a `notify_channel`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@
   to `true`, the attribute will be created from Terraform, but values for it must
   be edited in the incident.io dashboard.
 - Add `managed_attributes` to both `incident_catalog_entry` and `incident_catalog_entries`. This
-  allows you to manage only some attributes of a catalog entry, while leaving others
-  unchanged. When attributes on a type are marked as `schema_only`, this avoids
-  Terraform trying to manage their state, allowing values set in the incident.io
-  dashboard to be preserved, and avoiding unnecessary diffs.
+  allows you to manage only some attributes of a catalog entry, while leaving
+  others unchanged. This is most useful when attributes have been set as
+  `schema_only`, since it allows you to avoid Terraform trying to manage their
+  state, allowing values set in the incident.io dashboard to be preserved, and
+  avoiding unnecessary diffs.
 
 ## v4.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## Unreleased
 
+- BREAKING: `incident_catalog_type`'s `source_repo_url` attribute is now
+  required. This prevents the catalog type from being edited manually, and ensures
+  there is a link from the incident.io dashboard to the configuration that defines
+  the catalog type.
 - Add `schema_only` as an option on `incident_catalog_type_attribute`. When set
-  to `true`, the attribute will be created from Terraform, but values for it will
+  to `true`, the attribute will be created from Terraform, but values for it must
   be edited in the incident.io dashboard.
 - Add `managed_attributes` to both `incident_catalog_entry` and `incident_catalog_entries`. This
   allows you to manage only some attributes of a catalog entry, while leaving others

--- a/docs/data-sources/catalog_type.md
+++ b/docs/data-sources/catalog_type.md
@@ -42,7 +42,7 @@ resource "incident_catalog_entries" "services" {
 
 - `categories` (List of String) The categories that this type belongs to, to be shown in the web dashboard. Possible values are: `customer`, `issue-tracker`, `product-feature`, `service`, `on-call`, `team`, `user`.
 - `name` (String) Name is the human readable name of this type
-- `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName "]
+- `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
 
 ### Read-Only
 

--- a/docs/resources/catalog_entries.md
+++ b/docs/resources/catalog_entries.md
@@ -185,6 +185,12 @@ resource "incident_catalog_entries" "services" {
 - `entries` (Attributes Map) Map of external ID to entry in the catalog. (see [below for nested schema](#nestedatt--entries))
 - `id` (String) ID of this catalog type
 
+### Optional
+
+- `managed_attributes` (Set of String) The set of attributes that are managed by this resource. By default, all attributes are managed by this resource.
+
+This can be used to allow other attributes of a catalog entry to be managed elsewhere, for example in another Terraform repository or the incident.io web UI.
+
 <a id="nestedatt--entries"></a>
 ### Nested Schema for `entries`
 

--- a/docs/resources/catalog_entry.md
+++ b/docs/resources/catalog_entry.md
@@ -87,6 +87,9 @@ resource "incident_catalog_entry" "service_tier" {
 
 - `aliases` (List of String) Optional aliases that can be used to reference this entry
 - `external_id` (String) An optional alternative ID for this entry, which is ensured to be unique for the type
+- `managed_attributes` (Set of String) The set of attributes that are managed by this resource. By default, all attributes are managed by this resource.
+
+This can be used to allow other attributes of a catalog entry to be managed elsewhere, for example in another Terraform repository or the incident.io web UI.
 - `rank` (Number) When catalog type is ranked, this is used to help order things
 
 ### Read-Only

--- a/docs/resources/catalog_type.md
+++ b/docs/resources/catalog_type.md
@@ -67,11 +67,11 @@ resource "incident_catalog_type" "service_tier" {
 
 - `description` (String) Human readble description of this type
 - `name` (String) Name is the human readable name of this type
+- `source_repo_url` (String) The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.
 
 ### Optional
 
 - `categories` (List of String) The categories that this type belongs to, to be shown in the web dashboard. Possible values are: `customer`, `issue-tracker`, `product-feature`, `service`, `on-call`, `team`, `user`.
-- `source_repo_url` (String) The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.
 - `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
 
 ### Read-Only

--- a/docs/resources/catalog_type.md
+++ b/docs/resources/catalog_type.md
@@ -33,16 +33,16 @@ catalog entry.
 Each type is made up of a series of attributes, and each attribute has a type. Types
 can even have attributes that refer to other catalog types.
 
-We automatically create catalog types when you connect an integration, such as GitHub 
+We automatically create catalog types when you connect an integration, such as GitHub
 repositories or PagerDuty services and teams. You can use this API to create custom
 types, that are specifically tailored to your organisation.
 
-Examples might be a 'Service' type with an 'Alert channel' which you can point at a 
+Examples might be a 'Service' type with an 'Alert channel' which you can point at a
 Slack channel, or 'Team' which specifies its 'Manager' and 'Technical Lead' as Slack
 users. You can then use these types to create powerful new workflows.
 
 Consider using our official [catalog importer](https://github.com/incident-io/catalog-importer).
-It can be used to sync catalog data from sources like local files or GitHub and push 
+It can be used to sync catalog data from sources like local files or GitHub and push
 them into the incident.io catalog without having to directly interact with our public API.
 
 ## Example Usage
@@ -72,7 +72,7 @@ resource "incident_catalog_type" "service_tier" {
 
 - `categories` (List of String) The categories that this type belongs to, to be shown in the web dashboard. Possible values are: `customer`, `issue-tracker`, `product-feature`, `service`, `on-call`, `team`, `user`.
 - `source_repo_url` (String) The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.
-- `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName "]
+- `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
 
 ### Read-Only
 

--- a/docs/resources/catalog_type_attribute.md
+++ b/docs/resources/catalog_type_attribute.md
@@ -103,6 +103,8 @@ resource "incident_catalog_type_attribute" "service_tier_services" {
 - `path` (List of String) If this is a path attribute, the path that we should use to pull the data
 - `schema_only` (Boolean) If true, Terraform will only manage the schema of the attribute. Values for this attribute can be managed from the incident.io web dashboard.
 
+NOTE: When enabled, you should use the `managed_attributes` argument on either `incident_catalog_entry` or `incident_catalog_entries` to manage the values of other attributes on this type, without Terraform overwriting values set in the dashboard.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/docs/resources/catalog_type_attribute.md
+++ b/docs/resources/catalog_type_attribute.md
@@ -33,16 +33,16 @@ catalog entry.
 Each type is made up of a series of attributes, and each attribute has a type. Types
 can even have attributes that refer to other catalog types.
 
-We automatically create catalog types when you connect an integration, such as GitHub 
+We automatically create catalog types when you connect an integration, such as GitHub
 repositories or PagerDuty services and teams. You can use this API to create custom
 types, that are specifically tailored to your organisation.
 
-Examples might be a 'Service' type with an 'Alert channel' which you can point at a 
+Examples might be a 'Service' type with an 'Alert channel' which you can point at a
 Slack channel, or 'Team' which specifies its 'Manager' and 'Technical Lead' as Slack
 users. You can then use these types to create powerful new workflows.
 
 Consider using our official [catalog importer](https://github.com/incident-io/catalog-importer).
-It can be used to sync catalog data from sources like local files or GitHub and push 
+It can be used to sync catalog data from sources like local files or GitHub and push
 them into the incident.io catalog without having to directly interact with our public API.
 
 ## Example Usage

--- a/docs/resources/catalog_type_attribute.md
+++ b/docs/resources/catalog_type_attribute.md
@@ -101,6 +101,7 @@ resource "incident_catalog_type_attribute" "service_tier_services" {
 - `array` (Boolean) Whether this attribute is an array or scalar.
 - `backlink_attribute` (String) If this is a backlink, the id of the attribute that it's linked from
 - `path` (List of String) If this is a path attribute, the path that we should use to pull the data
+- `schema_only` (Boolean) If true, Terraform will only manage the schema of the attribute. Values for this attribute can be managed from the incident.io web dashboard.
 
 ### Read-Only
 

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -85,11 +85,11 @@ resource "incident_workflow" "autoassign_incident_lead" {
 - `continue_on_step_error` (Boolean) Whether to continue executing the workflow if a step fails
 - `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `include_private_incidents` (Boolean) Whether to include private incidents
-- `name` (String) The human-readable name of the workflow
+- `name` (String) Name provided by the user when creating the workflow
 - `once_for` (List of String) This workflow will run 'once for' a list of references
 - `runs_on_incident_modes` (List of String) Incidents in these modes will be affected by the workflow
-- `runs_on_incidents` (String) Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-- `state` (String) The state of the workflow (e.g. is it draft, or disabled)
+- `runs_on_incidents` (String) Which incidents should the workflow be applied to?
+- `state` (String) What state this workflow is in
 - `steps` (Attributes List) Steps that are executed as part of the workflow (see [below for nested schema](#nestedatt--steps))
 - `trigger` (String) Unique name of the trigger
 
@@ -97,7 +97,7 @@ resource "incident_workflow" "autoassign_incident_lead" {
 
 - `delay` (Attributes) Configuration controlling workflow delay behaviour (see [below for nested schema](#nestedatt--delay))
 - `folder` (String) Folder to display the workflow in
-- `shortform` (String) Shortform used to trigger manual workflows in Slack - e.g. `/inc workflows page-ceo`
+- `shortform` (String) The shortform used to trigger this workflow (only applicable for manual triggers)
 
 ### Read-Only
 

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -759,7 +759,8 @@
           "alert_source_id",
           "condition_groups"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "AlertRouteEscalationBindingPayloadV2": {
         "example": {
@@ -784,7 +785,8 @@
         "required": [
           "binding"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "AlertRouteEscalationBindingV2": {
         "example": {
@@ -811,7 +813,8 @@
         "required": [
           "binding"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "AlertRouteIncidentTemplatePayloadV2": {
         "example": {
@@ -986,7 +989,8 @@
           "custom_field_priorities",
           "priority_severity"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "AlertRouteIncidentTemplateV2": {
         "example": {
@@ -1167,9 +1171,581 @@
           "custom_field_priorities",
           "priority_severity"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
-      "AlertRoutePayloadV2": {
+      "AlertRouteV2": {
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "first-wins"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        },
+        "properties": {
+          "condition_groups": {
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV2"
+            },
+            "type": "array"
+          },
+          "defer_time_seconds": {
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          },
+          "escalation_bindings": {
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingV2"
+            },
+            "type": "array"
+          },
+          "expressions": {
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ExpressionV2"
+            },
+            "type": "array"
+          },
+          "grouping_keys": {
+            "description": "Which attributes should this alert route use to group alerts?",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/GroupingKeyV2"
+            },
+            "type": "array"
+          },
+          "grouping_window_seconds": {
+            "description": "How large should the grouping window be?",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          },
+          "id": {
+            "description": "Unique identifier for this alert route config",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of this alert route config, for the user's reference",
+            "example": "Production incidents",
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplateV2"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "condition_groups",
+          "grouping_keys",
+          "grouping_window_seconds",
+          "defer_time_seconds",
+          "escalation_bindings",
+          "auto_decline_enabled",
+          "enabled",
+          "incident_enabled",
+          "is_private",
+          "incident_condition_groups",
+          "alert_sources",
+          "auto_cancel_escalations"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "AlertRoutesCreatePayloadV2": {
         "example": {
           "alert_sources": [
             {
@@ -1773,317 +2349,27 @@
             "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
           }
         },
+        "required": [
+          "name",
+          "condition_groups",
+          "grouping_keys",
+          "grouping_window_seconds",
+          "defer_time_seconds",
+          "auto_decline_enabled",
+          "escalation_bindings",
+          "enabled",
+          "is_private",
+          "incident_enabled",
+          "incident_condition_groups",
+          "alert_sources",
+          "auto_cancel_escalations"
+        ],
         "type": "object"
       },
-      "AlertRouteV2": {
+      "AlertRoutesCreateResultV2": {
         "example": {
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": {
-                    "label": "Lawrence Jones",
-                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                  },
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": {
-                    "label": "Incident Severity",
-                    "reference": "incident.severity"
-                  }
-                }
-              ]
-            }
-          ],
-          "defer_time_seconds": 1,
-          "escalation_bindings": [
-            {
-              "binding": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            }
-          ],
-          "expressions": [
-            {
-              "else_branch": {
-                "result": {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              },
-              "label": "Team Slack channel",
-              "operations": [
-                {
-                  "branches": {
-                    "branches": [
-                      {
-                        "condition_groups": [
-                          {
-                            "conditions": [
-                              {
-                                "operation": {
-                                  "label": "Lawrence Jones",
-                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                                },
-                                "param_bindings": [
-                                  {
-                                    "array_value": [
-                                      {
-                                        "label": "Lawrence Jones",
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    ],
-                                    "value": {
-                                      "label": "Lawrence Jones",
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ],
-                                "subject": {
-                                  "label": "Incident Severity",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ]
-                          }
-                        ],
-                        "result": {
-                          "array_value": [
-                            {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      }
-                    ],
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
-                  },
-                  "filter": {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": {
-                              "label": "Lawrence Jones",
-                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                            },
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "label": "Lawrence Jones",
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "label": "Lawrence Jones",
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": {
-                              "label": "Incident Severity",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "navigate": {
-                    "reference": "1235",
-                    "reference_label": "Teams"
-                  },
-                  "operation_type": "navigate",
-                  "parse": {
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    },
-                    "source": "metadata.annotations[\"github.com/repo\"]"
-                  },
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  }
-                }
-              ],
-              "reference": "abc123",
-              "returns": {
-                "array": true,
-                "type": "IncidentStatus"
-              },
-              "root_reference": "incident.status"
-            }
-          ],
-          "grouping_keys": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
-            }
-          ],
-          "grouping_window_seconds": 1,
-          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "name": "Production incidents",
-          "template": {
-            "custom_field_priorities": {
-              "abc123": "first-wins"
-            },
-            "custom_fields": {
-              "custom_field_10014": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            },
-            "incident_mode": {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "incident_type": {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "name": {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "priority_severity": "severity-first-wins",
-            "severity": {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "summary": {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "workspace": {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          }
-        },
-        "properties": {
-          "condition_groups": {
-            "description": "What condition groups must be true for this alert route to fire?",
-            "example": [
+          "alert_route": {
+            "condition_groups": [
               {
                 "conditions": [
                   {
@@ -2115,20 +2401,8 @@
                 ]
               }
             ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupV2"
-            },
-            "type": "array"
-          },
-          "defer_time_seconds": {
-            "description": "How long should the escalation defer time be?",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
-          "escalation_bindings": {
-            "description": "Which escalation paths should this alert route escalate to?",
-            "example": [
+            "defer_time_seconds": 1,
+            "escalation_bindings": [
               {
                 "binding": {
                   "array_value": [
@@ -2146,14 +2420,7 @@
                 }
               }
             ],
-            "items": {
-              "$ref": "#/components/schemas/AlertRouteEscalationBindingV2"
-            },
-            "type": "array"
-          },
-          "expressions": {
-            "description": "The expressions used in this template",
-            "example": [
+            "expressions": [
               {
                 "else_branch": {
                   "result": {
@@ -2290,8 +2557,987 @@
                 "root_reference": "incident.status"
               }
             ],
+            "grouping_keys": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ],
+            "grouping_window_seconds": 1,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Production incidents",
+            "template": {
+              "custom_field_priorities": {
+                "abc123": "first-wins"
+              },
+              "custom_fields": {
+                "custom_field_10014": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "incident_mode": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "incident_type": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "name": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "priority_severity": "severity-first-wins",
+              "severity": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "summary": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "workspace": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          }
+        },
+        "properties": {
+          "alert_route": {
+            "$ref": "#/components/schemas/AlertRouteV2"
+          }
+        },
+        "required": [
+          "alert_route"
+        ],
+        "type": "object"
+      },
+      "AlertRoutesShowResultV2": {
+        "example": {
+          "alert_route": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defer_time_seconds": 1,
+            "escalation_bindings": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ],
+            "expressions": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ],
+            "grouping_keys": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ],
+            "grouping_window_seconds": 1,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Production incidents",
+            "template": {
+              "custom_field_priorities": {
+                "abc123": "first-wins"
+              },
+              "custom_fields": {
+                "custom_field_10014": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "incident_mode": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "incident_type": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "name": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "priority_severity": "severity-first-wins",
+              "severity": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "summary": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "workspace": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          }
+        },
+        "properties": {
+          "alert_route": {
+            "$ref": "#/components/schemas/AlertRouteV2"
+          }
+        },
+        "required": [
+          "alert_route"
+        ],
+        "type": "object"
+      },
+      "AlertRoutesUpdatePayloadV2": {
+        "example": {
+          "alert_sources": [
+            {
+              "alert_source_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "condition_groups": [
+                {
+                  "conditions": [
+                    {
+                      "operation": "one_of",
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": "incident.severity"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "auto_decline_enabled": false,
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "defer_time_seconds": 1,
+          "enabled": false,
+          "escalation_bindings": [
+            {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          ],
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "grouping_keys": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+            }
+          ],
+          "grouping_window_seconds": 1,
+          "incident_condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "incident_enabled": false,
+          "name": "Production incidents",
+          "template": {
+            "custom_field_priorities": {
+              "abc123": "abc123"
+            },
+            "custom_fields": {
+              "custom_field_10014": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "incident_mode": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "incident_type": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "name": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "priority_severity": "severity-first-wins",
+            "severity": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "start_in_triage": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "summary": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            },
+            "workspace": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        },
+        "properties": {
+          "alert_sources": {
+            "description": "Which alert sources should this alert route match?",
+            "example": [
+              {
+                "alert_source_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": "one_of",
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": "incident.severity"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
             "items": {
-              "$ref": "#/components/schemas/ExpressionV2"
+              "$ref": "#/components/schemas/AlertRouteAlertSourcePayloadV2"
+            },
+            "type": "array"
+          },
+          "auto_decline_enabled": {
+            "description": "Should triage incidents be declined when alerts are resolved?",
+            "example": false,
+            "type": "boolean"
+          },
+          "condition_groups": {
+            "description": "What condition groups must be true for this alert route to fire?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "type": "array"
+          },
+          "defer_time_seconds": {
+            "description": "How long should the escalation defer time be?",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          },
+          "enabled": {
+            "description": "Whether this alert route is enabled or not",
+            "example": false,
+            "type": "boolean"
+          },
+          "escalation_bindings": {
+            "description": "Which escalation paths should this alert route escalate to?",
+            "example": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
+            },
+            "type": "array"
+          },
+          "expressions": {
+            "description": "The expressions used in this template",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
             },
             "type": "array"
           },
@@ -2313,10 +3559,41 @@
             "format": "int64",
             "type": "integer"
           },
-          "id": {
-            "description": "Unique identifier for this alert route config",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "type": "string"
+          "incident_condition_groups": {
+            "description": "What condition groups must be true for this alert route to create an incident?",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "type": "array"
+          },
+          "incident_enabled": {
+            "description": "Whether this alert route will create incidents or not",
+            "example": false,
+            "type": "boolean"
           },
           "name": {
             "description": "The name of this alert route config, for the user's reference",
@@ -2324,11 +3601,10 @@
             "type": "string"
           },
           "template": {
-            "$ref": "#/components/schemas/AlertRouteIncidentTemplateV2"
+            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
           }
         },
         "required": [
-          "id",
           "name",
           "condition_groups",
           "grouping_keys",
@@ -2342,6 +3618,323 @@
           "incident_condition_groups",
           "alert_sources",
           "auto_cancel_escalations"
+        ],
+        "type": "object"
+      },
+      "AlertRoutesUpdateResultV2": {
+        "example": {
+          "alert_route": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defer_time_seconds": 1,
+            "escalation_bindings": [
+              {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ],
+            "expressions": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ],
+            "grouping_keys": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            ],
+            "grouping_window_seconds": 1,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Production incidents",
+            "template": {
+              "custom_field_priorities": {
+                "abc123": "first-wins"
+              },
+              "custom_fields": {
+                "custom_field_10014": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "incident_mode": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "incident_type": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "name": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "priority_severity": "severity-first-wins",
+              "severity": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "summary": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              },
+              "workspace": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            }
+          }
+        },
+        "properties": {
+          "alert_route": {
+            "$ref": "#/components/schemas/AlertRouteV2"
+          }
+        },
+        "required": [
+          "alert_route"
         ],
         "type": "object"
       },
@@ -13665,6 +15258,704 @@
         ],
         "type": "object"
       },
+      "CatalogCreateEntryPayloadV2": {
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "name": "Primary On-call",
+          "rank": 3
+        },
+        "properties": {
+          "aliases": {
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "attribute_values": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+            },
+            "description": "Values of this entry",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "type": "object"
+          },
+          "catalog_type_id": {
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "external_id": {
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call",
+            "type": "string"
+          },
+          "rank": {
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "catalog_type_id",
+          "name",
+          "attribute_values"
+        ],
+        "type": "object"
+      },
+      "CatalogCreateEntryPayloadV3": {
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "literal": "SEV123"
+                }
+              ],
+              "value": {
+                "literal": "SEV123"
+              }
+            }
+          },
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "name": "Primary On-call",
+          "rank": 3
+        },
+        "properties": {
+          "aliases": {
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "attribute_values": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CatalogEngineParamBindingPayloadV3"
+            },
+            "description": "Values of this entry",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "literal": "SEV123"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123"
+                }
+              }
+            },
+            "type": "object"
+          },
+          "catalog_type_id": {
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "external_id": {
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call",
+            "type": "string"
+          },
+          "rank": {
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "catalog_type_id",
+          "name",
+          "attribute_values"
+        ],
+        "type": "object"
+      },
+      "CatalogCreateEntryResultV2": {
+        "example": {
+          "catalog_entry": {
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "attribute_values": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
+                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "helptext": "abc123",
+                    "image_url": "abc123",
+                    "is_image_slack_icon": false,
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity",
+                    "sort_key": "abc123",
+                    "unavailable": false,
+                    "value": "abc123"
+                  }
+                ],
+                "value": {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "abc123",
+                  "image_url": "abc123",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity",
+                  "sort_key": "abc123",
+                  "unavailable": false,
+                  "value": "abc123"
+                }
+              }
+            },
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Primary On-call",
+            "rank": 3,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryV2"
+          }
+        },
+        "required": [
+          "catalog_entry"
+        ],
+        "type": "object"
+      },
+      "CatalogCreateEntryResultV3": {
+        "example": {
+          "catalog_entry": {
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "attribute_values": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123"
+                }
+              }
+            },
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Primary On-call",
+            "rank": 3,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryV3"
+          }
+        },
+        "required": [
+          "catalog_entry"
+        ],
+        "type": "object"
+      },
+      "CatalogCreateTypePayloadV2": {
+        "example": {
+          "annotations": {
+            "incident.io/catalog-importer/id": "id-of-config"
+          },
+          "categories": [
+            "issue-tracker"
+          ],
+          "color": "yellow",
+          "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "icon": "alert",
+          "name": "Kubernetes Cluster",
+          "ranked": true,
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+          "type_name": "Custom[\"BackstageGroup\"]"
+        },
+        "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that can track metadata about this type",
+            "example": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "type": "object"
+          },
+          "categories": {
+            "description": "What categories is this type considered part of",
+            "example": [
+              "issue-tracker"
+            ],
+            "items": {
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-feature",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ],
+              "example": "issue-tracker",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "color": {
+            "description": "Sets the display color of this type in the dashboard",
+            "enum": [
+              "yellow",
+              "green",
+              "blue",
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
+            ],
+            "example": "yellow",
+            "type": "string"
+          },
+          "description": {
+            "description": "Human readble description of this type",
+            "example": "Represents Kubernetes clusters that we run inside of GKE.",
+            "type": "string"
+          },
+          "icon": {
+            "description": "Sets the display icon of this type in the dashboard",
+            "enum": [
+              "alert",
+              "bolt",
+              "box",
+              "briefcase",
+              "browser",
+              "bulb",
+              "calendar",
+              "clock",
+              "cog",
+              "components",
+              "database",
+              "doc",
+              "email",
+              "escalation-path",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
+              "server",
+              "severity",
+              "status-page",
+              "store",
+              "star",
+              "tag",
+              "user",
+              "users"
+            ],
+            "example": "alert",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this type",
+            "example": "Kubernetes Cluster",
+            "type": "string"
+          },
+          "ranked": {
+            "description": "If this type should be ranked",
+            "example": true,
+            "type": "boolean"
+          },
+          "source_repo_url": {
+            "description": "The url of the external repository where this type is managed",
+            "example": "https://github.com/my-company/incident-io-catalog",
+            "type": "string"
+          },
+          "type_name": {
+            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName\"]",
+            "example": "Custom[\"BackstageGroup\"]",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "type": "object"
+      },
+      "CatalogCreateTypePayloadV3": {
+        "example": {
+          "annotations": {
+            "incident.io/catalog-importer/id": "id-of-config"
+          },
+          "categories": [
+            "issue-tracker"
+          ],
+          "color": "yellow",
+          "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "icon": "alert",
+          "name": "Kubernetes Cluster",
+          "ranked": true,
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+          "type_name": "Custom[\"BackstageGroup\"]"
+        },
+        "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that can track metadata about this type",
+            "example": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "type": "object"
+          },
+          "categories": {
+            "description": "What categories is this type considered part of",
+            "example": [
+              "issue-tracker"
+            ],
+            "items": {
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-feature",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ],
+              "example": "issue-tracker",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "color": {
+            "description": "Sets the display color of this type in the dashboard",
+            "enum": [
+              "yellow",
+              "green",
+              "blue",
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
+            ],
+            "example": "yellow",
+            "type": "string"
+          },
+          "description": {
+            "description": "Human readble description of this type",
+            "example": "Represents Kubernetes clusters that we run inside of GKE.",
+            "type": "string"
+          },
+          "icon": {
+            "description": "Sets the display icon of this type in the dashboard",
+            "enum": [
+              "alert",
+              "bolt",
+              "box",
+              "briefcase",
+              "browser",
+              "bulb",
+              "calendar",
+              "clock",
+              "cog",
+              "components",
+              "database",
+              "doc",
+              "email",
+              "escalation-path",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
+              "server",
+              "severity",
+              "status-page",
+              "store",
+              "star",
+              "tag",
+              "user",
+              "users"
+            ],
+            "example": "alert",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this type",
+            "example": "Kubernetes Cluster",
+            "type": "string"
+          },
+          "ranked": {
+            "description": "If this type should be ranked",
+            "example": true,
+            "type": "boolean"
+          },
+          "source_repo_url": {
+            "description": "The url of the external repository where this type is managed",
+            "example": "https://github.com/my-company/incident-io-catalog",
+            "type": "string"
+          },
+          "type_name": {
+            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName\"]",
+            "example": "Custom[\"BackstageGroup\"]",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "type": "object"
+      },
+      "CatalogCreateTypeResultV2": {
+        "example": {
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV2"
+          }
+        },
+        "required": [
+          "catalog_type"
+        ],
+        "type": "object"
+      },
+      "CatalogCreateTypeResultV3": {
+        "example": {
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "api",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV3"
+          }
+        },
+        "required": [
+          "catalog_type"
+        ],
+        "type": "object"
+      },
+      "CatalogEngineParamBindingPayloadV3": {
+        "example": {
+          "array_value": [
+            {
+              "literal": "SEV123"
+            }
+          ],
+          "value": {
+            "literal": "SEV123"
+          }
+        },
+        "properties": {
+          "array_value": {
+            "description": "If set, this is the array value of the step parameter",
+            "example": [
+              {
+                "literal": "SEV123"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogEngineParamBindingValuePayloadV3"
+            },
+            "type": "array"
+          },
+          "value": {
+            "$ref": "#/components/schemas/CatalogEngineParamBindingValuePayloadV3"
+          }
+        },
+        "type": "object",
+        "x-public-api-version": "v3"
+      },
+      "CatalogEngineParamBindingValuePayloadV3": {
+        "example": {
+          "literal": "SEV123"
+        },
+        "properties": {
+          "literal": {
+            "description": "If set, this is the literal value of the step parameter",
+            "example": "SEV123",
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "x-public-api-version": "v3"
+      },
       "CatalogEntryEngineParamBindingV2": {
         "example": {
           "array_value": [
@@ -13735,7 +16026,42 @@
             "$ref": "#/components/schemas/CatalogEntryEngineParamBindingValueV2"
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogEntryEngineParamBindingV3": {
+        "example": {
+          "array_value": [
+            {
+              "label": "Lawrence Jones",
+              "literal": "SEV123"
+            }
+          ],
+          "value": {
+            "label": "Lawrence Jones",
+            "literal": "SEV123"
+          }
+        },
+        "properties": {
+          "array_value": {
+            "description": "If the attribute is multi-valued, the value will be returned here.",
+            "example": [
+              {
+                "label": "Lawrence Jones",
+                "literal": "SEV123"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogEntryEngineParamBindingValueV3"
+            },
+            "type": "array"
+          },
+          "value": {
+            "$ref": "#/components/schemas/CatalogEntryEngineParamBindingValueV3"
+          }
+        },
+        "type": "object",
+        "x-public-api-version": "v3"
       },
       "CatalogEntryEngineParamBindingValueV2": {
         "example": {
@@ -13809,7 +16135,32 @@
           "label",
           "sort_key"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogEntryEngineParamBindingValueV3": {
+        "example": {
+          "label": "Lawrence Jones",
+          "literal": "SEV123"
+        },
+        "properties": {
+          "label": {
+            "description": "A label for this attribute value. If the attribute refers to another Catalog entry, this will be the name of that entry.",
+            "example": "Lawrence Jones",
+            "type": "string"
+          },
+          "literal": {
+            "description": "The underlying value of the attribute, serialized as a string.\n\nFor String, Text, Number, and Bool typed attributes, this will be empty. For attributes that refer to another catalog entry, this can be the ID, external ID, or one of the aliases of that catalog entry.",
+            "example": "SEV123",
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "sort_key"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
       },
       "CatalogEntryReferenceV2": {
         "example": {
@@ -13846,7 +16197,8 @@
           "catalog_entry_id",
           "catalog_entry_name"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "CatalogEntryV2": {
         "example": {
@@ -14018,6 +16370,737 @@
           "created_at",
           "updated_at"
         ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogEntryV3": {
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "archived_at": "2021-08-17T14:28:57.801578Z",
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123"
+              }
+            }
+          },
+          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Primary On-call",
+          "rank": 3,
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "properties": {
+          "aliases": {
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "archived_at": {
+            "description": "When this entry was archived",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "attribute_values": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CatalogEntryEngineParamBindingV3"
+            },
+            "description": "Values of this entry",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123"
+                }
+              }
+            },
+            "type": "object"
+          },
+          "catalog_type_id": {
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "When this entry was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "external_id": {
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "type": "string"
+          },
+          "id": {
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call",
+            "type": "string"
+          },
+          "rank": {
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32",
+            "type": "integer"
+          },
+          "updated_at": {
+            "description": "When this entry was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "catalog_type_id",
+          "name",
+          "aliases",
+          "rank",
+          "attribute_values",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
+      },
+      "CatalogListEntriesResultV2": {
+        "example": {
+          "catalog_entries": [
+            {
+              "aliases": [
+                "lawrence@incident.io",
+                "lawrence"
+              ],
+              "archived_at": "2021-08-17T14:28:57.801578Z",
+              "attribute_values": {
+                "abc123": {
+                  "array_value": [
+                    {
+                      "catalog_entry": {
+                        "archived_at": "2021-08-17T14:28:57.801578Z",
+                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "catalog_entry_name": "Primary escalation",
+                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                      },
+                      "helptext": "abc123",
+                      "image_url": "abc123",
+                      "is_image_slack_icon": false,
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity",
+                      "sort_key": "abc123",
+                      "unavailable": false,
+                      "value": "abc123"
+                    }
+                  ],
+                  "value": {
+                    "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
+                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "helptext": "abc123",
+                    "image_url": "abc123",
+                    "is_image_slack_icon": false,
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity",
+                    "sort_key": "abc123",
+                    "unavailable": false,
+                    "value": "abc123"
+                  }
+                }
+              },
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Primary On-call",
+              "rank": 3,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ],
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          }
+        },
+        "properties": {
+          "catalog_entries": {
+            "example": [
+              {
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
+                "archived_at": "2021-08-17T14:28:57.801578Z",
+                "attribute_values": {
+                  "abc123": {
+                    "array_value": [
+                      {
+                        "catalog_entry": {
+                          "archived_at": "2021-08-17T14:28:57.801578Z",
+                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "catalog_entry_name": "Primary escalation",
+                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                        },
+                        "helptext": "abc123",
+                        "image_url": "abc123",
+                        "is_image_slack_icon": false,
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity",
+                        "sort_key": "abc123",
+                        "unavailable": false,
+                        "value": "abc123"
+                      }
+                    ],
+                    "value": {
+                      "catalog_entry": {
+                        "archived_at": "2021-08-17T14:28:57.801578Z",
+                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "catalog_entry_name": "Primary escalation",
+                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                      },
+                      "helptext": "abc123",
+                      "image_url": "abc123",
+                      "is_image_slack_icon": false,
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity",
+                      "sort_key": "abc123",
+                      "unavailable": false,
+                      "value": "abc123"
+                    }
+                  }
+                },
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Primary On-call",
+                "rank": 3,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogEntryV2"
+            },
+            "type": "array"
+          },
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV2"
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          }
+        },
+        "required": [
+          "catalog_type",
+          "catalog_entries",
+          "pagination_meta"
+        ],
+        "type": "object"
+      },
+      "CatalogListEntriesResultV3": {
+        "example": {
+          "catalog_entries": [
+            {
+              "aliases": [
+                "lawrence@incident.io",
+                "lawrence"
+              ],
+              "archived_at": "2021-08-17T14:28:57.801578Z",
+              "attribute_values": {
+                "abc123": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123"
+                  }
+                }
+              },
+              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Primary On-call",
+              "rank": 3,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ],
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "api",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          }
+        },
+        "properties": {
+          "catalog_entries": {
+            "example": [
+              {
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
+                "archived_at": "2021-08-17T14:28:57.801578Z",
+                "attribute_values": {
+                  "abc123": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123"
+                    }
+                  }
+                },
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Primary On-call",
+                "rank": 3,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogEntryV3"
+            },
+            "type": "array"
+          },
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV3"
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV3"
+          }
+        },
+        "required": [
+          "catalog_type",
+          "catalog_entries",
+          "pagination_meta"
+        ],
+        "type": "object"
+      },
+      "CatalogListResourcesResultV2": {
+        "example": {
+          "resources": [
+            {
+              "category": "custom",
+              "description": "Boolean true or false value",
+              "label": "GitHub Repository",
+              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+              "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
+            }
+          ]
+        },
+        "properties": {
+          "resources": {
+            "example": [
+              {
+                "category": "custom",
+                "description": "Boolean true or false value",
+                "label": "GitHub Repository",
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+                "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogResourceV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "resources"
+        ],
+        "type": "object"
+      },
+      "CatalogListResourcesResultV3": {
+        "example": {
+          "resources": [
+            {
+              "category": "custom",
+              "description": "Boolean true or false value",
+              "label": "GitHub Repository",
+              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+              "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
+            }
+          ]
+        },
+        "properties": {
+          "resources": {
+            "example": [
+              {
+                "category": "custom",
+                "description": "Boolean true or false value",
+                "label": "GitHub Repository",
+                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+                "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogResourceV3"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "resources"
+        ],
+        "type": "object"
+      },
+      "CatalogListTypesResultV2": {
+        "example": {
+          "catalog_types": [
+            {
+              "annotations": {
+                "incident.io/catalog-importer/id": "id-of-config"
+              },
+              "categories": [
+                "issue-tracker"
+              ],
+              "color": "yellow",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Represents Kubernetes clusters that we run inside of GKE.",
+              "dynamic_resource_parameter": "abc123",
+              "estimated_count": 7,
+              "icon": "alert",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_editable": false,
+              "last_synced_at": "2021-08-17T13:28:57.801578Z",
+              "name": "Kubernetes Cluster",
+              "ranked": true,
+              "registry_type": "PagerDutyService",
+              "required_integrations": [
+                "pager_duty"
+              ],
+              "schema": {
+                "attributes": [
+                  {
+                    "array": false,
+                    "backlink_attribute": "abc123",
+                    "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "mode": "manual",
+                    "name": "tier",
+                    "path": [
+                      {
+                        "attribute_id": "abc123",
+                        "attribute_name": "abc123"
+                      }
+                    ],
+                    "type": "Custom[\"Service\"]"
+                  }
+                ],
+                "version": 1
+              },
+              "semantic_type": "custom",
+              "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+              "type_name": "Custom[\"BackstageGroup\"]",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "catalog_types": {
+            "example": [
+              {
+                "annotations": {
+                  "incident.io/catalog-importer/id": "id-of-config"
+                },
+                "categories": [
+                  "issue-tracker"
+                ],
+                "color": "yellow",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                "dynamic_resource_parameter": "abc123",
+                "estimated_count": 7,
+                "icon": "alert",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_editable": false,
+                "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                "name": "Kubernetes Cluster",
+                "ranked": true,
+                "registry_type": "PagerDutyService",
+                "required_integrations": [
+                  "pager_duty"
+                ],
+                "schema": {
+                  "attributes": [
+                    {
+                      "array": false,
+                      "backlink_attribute": "abc123",
+                      "id": "01GW2G3V0S59R238FAHPDS1R66",
+                      "mode": "manual",
+                      "name": "tier",
+                      "path": [
+                        {
+                          "attribute_id": "abc123",
+                          "attribute_name": "abc123"
+                        }
+                      ],
+                      "type": "Custom[\"Service\"]"
+                    }
+                  ],
+                  "version": 1
+                },
+                "semantic_type": "custom",
+                "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                "type_name": "Custom[\"BackstageGroup\"]",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogTypeV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "catalog_types"
+        ],
+        "type": "object"
+      },
+      "CatalogListTypesResultV3": {
+        "example": {
+          "catalog_types": [
+            {
+              "annotations": {
+                "incident.io/catalog-importer/id": "id-of-config"
+              },
+              "categories": [
+                "issue-tracker"
+              ],
+              "color": "yellow",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Represents Kubernetes clusters that we run inside of GKE.",
+              "dynamic_resource_parameter": "abc123",
+              "estimated_count": 7,
+              "icon": "alert",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_editable": false,
+              "last_synced_at": "2021-08-17T13:28:57.801578Z",
+              "name": "Kubernetes Cluster",
+              "ranked": true,
+              "registry_type": "PagerDutyService",
+              "required_integrations": [
+                "pager_duty"
+              ],
+              "schema": {
+                "attributes": [
+                  {
+                    "array": false,
+                    "backlink_attribute": "abc123",
+                    "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "mode": "api",
+                    "name": "tier",
+                    "path": [
+                      {
+                        "attribute_id": "abc123",
+                        "attribute_name": "abc123"
+                      }
+                    ],
+                    "type": "Custom[\"Service\"]"
+                  }
+                ],
+                "version": 1
+              },
+              "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+              "type_name": "Custom[\"BackstageGroup\"]",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "catalog_types": {
+            "example": [
+              {
+                "annotations": {
+                  "incident.io/catalog-importer/id": "id-of-config"
+                },
+                "categories": [
+                  "issue-tracker"
+                ],
+                "color": "yellow",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                "dynamic_resource_parameter": "abc123",
+                "estimated_count": 7,
+                "icon": "alert",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_editable": false,
+                "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                "name": "Kubernetes Cluster",
+                "ranked": true,
+                "registry_type": "PagerDutyService",
+                "required_integrations": [
+                  "pager_duty"
+                ],
+                "schema": {
+                  "attributes": [
+                    {
+                      "array": false,
+                      "backlink_attribute": "abc123",
+                      "id": "01GW2G3V0S59R238FAHPDS1R66",
+                      "mode": "api",
+                      "name": "tier",
+                      "path": [
+                        {
+                          "attribute_id": "abc123",
+                          "attribute_name": "abc123"
+                        }
+                      ],
+                      "type": "Custom[\"Service\"]"
+                    }
+                  ],
+                  "version": 1
+                },
+                "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                "type_name": "Custom[\"BackstageGroup\"]",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogTypeV3"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "catalog_types"
+        ],
         "type": "object"
       },
       "CatalogResourceV2": {
@@ -14069,6 +17152,383 @@
           "config",
           "is_user_link"
         ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogResourceV3": {
+        "example": {
+          "category": "custom",
+          "description": "Boolean true or false value",
+          "label": "GitHub Repository",
+          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+          "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
+        },
+        "properties": {
+          "category": {
+            "description": "Which category of resource",
+            "enum": [
+              "primitive",
+              "custom",
+              "external"
+            ],
+            "example": "custom",
+            "type": "string"
+          },
+          "description": {
+            "description": "Human readable description for this resource",
+            "example": "Boolean true or false value",
+            "type": "string"
+          },
+          "label": {
+            "description": "Label for this catalog resource type",
+            "example": "GitHub Repository",
+            "type": "string"
+          },
+          "type": {
+            "description": "Catalog type name for this resource",
+            "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+            "type": "string"
+          },
+          "value_docstring": {
+            "description": "Documentation for the literal string value of this resource",
+            "example": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "label",
+          "description",
+          "value_docstring",
+          "category",
+          "config",
+          "is_user_link"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
+      },
+      "CatalogShowEntryResultV2": {
+        "example": {
+          "catalog_entry": {
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "attribute_values": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
+                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "helptext": "abc123",
+                    "image_url": "abc123",
+                    "is_image_slack_icon": false,
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity",
+                    "sort_key": "abc123",
+                    "unavailable": false,
+                    "value": "abc123"
+                  }
+                ],
+                "value": {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "abc123",
+                  "image_url": "abc123",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity",
+                  "sort_key": "abc123",
+                  "unavailable": false,
+                  "value": "abc123"
+                }
+              }
+            },
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Primary On-call",
+            "rank": 3,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryV2"
+          },
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV2"
+          }
+        },
+        "required": [
+          "catalog_type",
+          "catalog_entry"
+        ],
+        "type": "object"
+      },
+      "CatalogShowEntryResultV3": {
+        "example": {
+          "catalog_entry": {
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "attribute_values": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123"
+                }
+              }
+            },
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Primary On-call",
+            "rank": 3,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "api",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryV3"
+          },
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV3"
+          }
+        },
+        "required": [
+          "catalog_type",
+          "catalog_entry"
+        ],
+        "type": "object"
+      },
+      "CatalogShowTypeResultV2": {
+        "example": {
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV2"
+          }
+        },
+        "required": [
+          "catalog_type"
+        ],
+        "type": "object"
+      },
+      "CatalogShowTypeResultV3": {
+        "example": {
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "api",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV3"
+          }
+        },
+        "required": [
+          "catalog_type"
+        ],
         "type": "object"
       },
       "CatalogTypeAttributePathItemPayloadV2": {
@@ -14085,7 +17545,25 @@
         "required": [
           "attribute_id"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogTypeAttributePathItemPayloadV3": {
+        "example": {
+          "attribute_id": "abc123"
+        },
+        "properties": {
+          "attribute_id": {
+            "description": "the ID of the attribute to use",
+            "example": "abc123",
+            "type": "string"
+          }
+        },
+        "required": [
+          "attribute_id"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
       },
       "CatalogTypeAttributePathItemV2": {
         "example": {
@@ -14108,7 +17586,32 @@
           "attribute_id",
           "attribute_name"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogTypeAttributePathItemV3": {
+        "example": {
+          "attribute_id": "abc123",
+          "attribute_name": "abc123"
+        },
+        "properties": {
+          "attribute_id": {
+            "description": "the ID of the attribute to use",
+            "example": "abc123",
+            "type": "string"
+          },
+          "attribute_name": {
+            "description": "the name of the attribute to use",
+            "example": "abc123",
+            "type": "string"
+          }
+        },
+        "required": [
+          "attribute_id",
+          "attribute_name"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
       },
       "CatalogTypeAttributePayloadV2": {
         "example": {
@@ -14152,7 +17655,8 @@
               "path"
             ],
             "example": "",
-            "type": "string"
+            "type": "string",
+            "x-public-api-version": "v2"
           },
           "name": {
             "description": "Unique name of this attribute",
@@ -14182,7 +17686,85 @@
           "type",
           "array"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogTypeAttributePayloadV3": {
+        "example": {
+          "array": false,
+          "backlink_attribute": "abc123",
+          "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "mode": "",
+          "name": "tier",
+          "path": [
+            {
+              "attribute_id": "abc123"
+            }
+          ],
+          "type": "Custom[\"Service\"]"
+        },
+        "properties": {
+          "array": {
+            "description": "Whether this attribute is an array",
+            "example": false,
+            "type": "boolean"
+          },
+          "backlink_attribute": {
+            "description": "The attribute to use (if this is a backlink)",
+            "example": "abc123",
+            "type": "string"
+          },
+          "id": {
+            "description": "The ID of this attribute",
+            "example": "01GW2G3V0S59R238FAHPDS1R66",
+            "type": "string"
+          },
+          "mode": {
+            "description": "Controls how this attribute is modified",
+            "enum": [
+              "",
+              "api",
+              "dashboard",
+              "external",
+              "internal",
+              "dynamic",
+              "backlink",
+              "path"
+            ],
+            "example": "",
+            "type": "string",
+            "x-public-api-version": "v3"
+          },
+          "name": {
+            "description": "Unique name of this attribute",
+            "example": "tier",
+            "type": "string"
+          },
+          "path": {
+            "description": "The path to use (if this is an path)",
+            "example": [
+              {
+                "attribute_id": "abc123"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogTypeAttributePathItemPayloadV3"
+            },
+            "type": "array"
+          },
+          "type": {
+            "description": "Catalog type name for this attribute",
+            "example": "Custom[\"Service\"]",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type",
+          "array"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
       },
       "CatalogTypeAttributeV2": {
         "example": {
@@ -14227,7 +17809,8 @@
               "path"
             ],
             "example": "",
-            "type": "string"
+            "type": "string",
+            "x-public-api-version": "v2"
           },
           "name": {
             "description": "Unique name of this attribute",
@@ -14260,7 +17843,89 @@
           "type",
           "array"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogTypeAttributeV3": {
+        "example": {
+          "array": false,
+          "backlink_attribute": "abc123",
+          "id": "01GW2G3V0S59R238FAHPDS1R66",
+          "mode": "",
+          "name": "tier",
+          "path": [
+            {
+              "attribute_id": "abc123",
+              "attribute_name": "abc123"
+            }
+          ],
+          "type": "Custom[\"Service\"]"
+        },
+        "properties": {
+          "array": {
+            "description": "Whether this attribute is an array",
+            "example": false,
+            "type": "boolean"
+          },
+          "backlink_attribute": {
+            "description": "The attribute to use (if this is a backlink)",
+            "example": "abc123",
+            "type": "string"
+          },
+          "id": {
+            "description": "The ID of this attribute",
+            "example": "01GW2G3V0S59R238FAHPDS1R66",
+            "type": "string"
+          },
+          "mode": {
+            "description": "Controls how this attribute is modified",
+            "enum": [
+              "",
+              "api",
+              "dashboard",
+              "external",
+              "internal",
+              "dynamic",
+              "backlink",
+              "path"
+            ],
+            "example": "",
+            "type": "string",
+            "x-public-api-version": "v3"
+          },
+          "name": {
+            "description": "Unique name of this attribute",
+            "example": "tier",
+            "type": "string"
+          },
+          "path": {
+            "description": "The path to use (if this is a path attribute)",
+            "example": [
+              {
+                "attribute_id": "abc123",
+                "attribute_name": "abc123"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogTypeAttributePathItemV3"
+            },
+            "type": "array"
+          },
+          "type": {
+            "description": "Catalog type name for this attribute",
+            "example": "Custom[\"Service\"]",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "mode",
+          "name",
+          "type",
+          "array"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
       },
       "CatalogTypeSchemaV2": {
         "example": {
@@ -14317,7 +17982,66 @@
           "attributes",
           "version"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogTypeSchemaV3": {
+        "example": {
+          "attributes": [
+            {
+              "array": false,
+              "backlink_attribute": "abc123",
+              "id": "01GW2G3V0S59R238FAHPDS1R66",
+              "mode": "",
+              "name": "tier",
+              "path": [
+                {
+                  "attribute_id": "abc123",
+                  "attribute_name": "abc123"
+                }
+              ],
+              "type": "Custom[\"Service\"]"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "attributes": {
+            "description": "Attributes of this catalog type",
+            "example": [
+              {
+                "array": false,
+                "backlink_attribute": "abc123",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "mode": "",
+                "name": "tier",
+                "path": [
+                  {
+                    "attribute_id": "abc123",
+                    "attribute_name": "abc123"
+                  }
+                ],
+                "type": "Custom[\"Service\"]"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogTypeAttributeV3"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "The version number of this schema",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "attributes",
+          "version"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
       },
       "CatalogTypeV2": {
         "example": {
@@ -14394,7 +18118,8 @@
                 "user"
               ],
               "example": "customer",
-              "type": "string"
+              "type": "string",
+              "x-public-api-version": "v2"
             },
             "type": "array"
           },
@@ -14514,9 +18239,10 @@
             "$ref": "#/components/schemas/CatalogTypeSchemaV2"
           },
           "semantic_type": {
-            "description": "What type of resource this catalog type should be understodd as",
+            "description": "This type has been deprecated, and will always be empty.",
             "example": "abc123",
-            "type": "string"
+            "type": "string",
+            "x-public-api-version": "v2"
           },
           "source_repo_url": {
             "description": "The url of the external repository where this type is managed",
@@ -14524,7 +18250,7 @@
             "type": "string"
           },
           "type_name": {
-            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName \"]",
+            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName\"]",
             "example": "Custom[\"BackstageGroup\"]",
             "type": "string"
           },
@@ -14553,6 +18279,1233 @@
           "engine_resource_type",
           "mode",
           "use_name_as_identifier"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "CatalogTypeV3": {
+        "example": {
+          "annotations": {
+            "incident.io/catalog-importer/id": "id-of-config"
+          },
+          "categories": [
+            "customer"
+          ],
+          "color": "yellow",
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "dynamic_resource_parameter": "abc123",
+          "estimated_count": 7,
+          "icon": "alert",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "is_editable": false,
+          "last_synced_at": "2021-08-17T13:28:57.801578Z",
+          "name": "Kubernetes Cluster",
+          "ranked": true,
+          "registry_type": "PagerDutyService",
+          "required_integrations": [
+            "pager_duty"
+          ],
+          "schema": {
+            "attributes": [
+              {
+                "array": false,
+                "backlink_attribute": "abc123",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "mode": "",
+                "name": "tier",
+                "path": [
+                  {
+                    "attribute_id": "abc123",
+                    "attribute_name": "abc123"
+                  }
+                ],
+                "type": "Custom[\"Service\"]"
+              }
+            ],
+            "version": 1
+          },
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+          "type_name": "Custom[\"BackstageGroup\"]",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that can track metadata about this type",
+            "example": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "type": "object"
+          },
+          "categories": {
+            "description": "What categories is this type considered part of",
+            "example": [
+              "customer"
+            ],
+            "items": {
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-feature",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ],
+              "example": "customer",
+              "type": "string",
+              "x-public-api-version": "v3"
+            },
+            "type": "array"
+          },
+          "color": {
+            "description": "Sets the display color of this type in the dashboard",
+            "enum": [
+              "yellow",
+              "green",
+              "blue",
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
+            ],
+            "example": "yellow",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "When this type was created",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "description": {
+            "description": "Human readble description of this type",
+            "example": "Represents Kubernetes clusters that we run inside of GKE.",
+            "type": "string"
+          },
+          "dynamic_resource_parameter": {
+            "description": "If this is a dynamic catalog type, this will be the unique parameter for identitfying this resource externally.",
+            "example": "abc123",
+            "type": "string"
+          },
+          "estimated_count": {
+            "description": "If populated, gives an estimated count of entries for this type",
+            "example": 7,
+            "format": "int64",
+            "type": "integer"
+          },
+          "icon": {
+            "description": "Sets the display icon of this type in the dashboard",
+            "enum": [
+              "alert",
+              "bolt",
+              "box",
+              "briefcase",
+              "browser",
+              "bulb",
+              "calendar",
+              "clock",
+              "cog",
+              "components",
+              "database",
+              "doc",
+              "email",
+              "escalation-path",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
+              "server",
+              "severity",
+              "status-page",
+              "store",
+              "star",
+              "tag",
+              "user",
+              "users"
+            ],
+            "example": "alert",
+            "type": "string"
+          },
+          "id": {
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "is_editable": {
+            "description": "Catalog types that are synced with external resources can't be edited",
+            "example": false,
+            "type": "boolean"
+          },
+          "last_synced_at": {
+            "description": "When this type was last synced (if it's ever been sync'd)",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this type",
+            "example": "Kubernetes Cluster",
+            "type": "string"
+          },
+          "ranked": {
+            "description": "If this type should be ranked",
+            "example": true,
+            "type": "boolean"
+          },
+          "registry_type": {
+            "description": "The registry resource this type is synced from, if any",
+            "example": "PagerDutyService",
+            "type": "string"
+          },
+          "required_integrations": {
+            "description": "If populated, the integrations required for this type",
+            "example": [
+              "pager_duty"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/CatalogTypeSchemaV3"
+          },
+          "source_repo_url": {
+            "description": "The url of the external repository where this type is managed",
+            "example": "https://github.com/my-company/incident-io-catalog",
+            "type": "string"
+          },
+          "type_name": {
+            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName\"]",
+            "example": "Custom[\"BackstageGroup\"]",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "When this type was last updated",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "type_name",
+          "ranked",
+          "schema",
+          "icon",
+          "categories",
+          "color",
+          "is_editable",
+          "annotations",
+          "created_at",
+          "updated_at",
+          "engine_resource_type",
+          "mode",
+          "use_name_as_identifier"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
+      },
+      "CatalogUpdateEntryPayloadV2": {
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "name": "Primary On-call",
+          "rank": 3
+        },
+        "properties": {
+          "aliases": {
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "attribute_values": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
+            },
+            "description": "Values of this entry",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "type": "object"
+          },
+          "external_id": {
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call",
+            "type": "string"
+          },
+          "rank": {
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "attribute_values"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateEntryPayloadV3": {
+        "example": {
+          "aliases": [
+            "lawrence@incident.io",
+            "lawrence"
+          ],
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "literal": "SEV123"
+                }
+              ],
+              "value": {
+                "literal": "SEV123"
+              }
+            }
+          },
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+          "name": "Primary On-call",
+          "rank": 3,
+          "update_attributes": [
+            "abc123"
+          ]
+        },
+        "properties": {
+          "aliases": {
+            "description": "Optional aliases that can be used to reference this entry",
+            "example": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "attribute_values": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CatalogEngineParamBindingPayloadV3"
+            },
+            "description": "Values of this entry",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "literal": "SEV123"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123"
+                }
+              }
+            },
+            "type": "object"
+          },
+          "external_id": {
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this entry",
+            "example": "Primary On-call",
+            "type": "string"
+          },
+          "rank": {
+            "description": "When catalog type is ranked, this is used to help order things",
+            "example": 3,
+            "format": "int32",
+            "type": "integer"
+          },
+          "update_attributes": {
+            "description": "If provided, only update these attribute_values keys. If not provided, update all attribute values.\nIf you specify an attribute key that's not in your payload, the associated attribute value will be cleared.",
+            "example": [
+              "abc123"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "attribute_values"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateEntryResultV2": {
+        "example": {
+          "catalog_entry": {
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "attribute_values": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
+                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "catalog_entry_name": "Primary escalation",
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                    },
+                    "helptext": "abc123",
+                    "image_url": "abc123",
+                    "is_image_slack_icon": false,
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity",
+                    "sort_key": "abc123",
+                    "unavailable": false,
+                    "value": "abc123"
+                  }
+                ],
+                "value": {
+                  "catalog_entry": {
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "catalog_entry_name": "Primary escalation",
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+                  },
+                  "helptext": "abc123",
+                  "image_url": "abc123",
+                  "is_image_slack_icon": false,
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity",
+                  "sort_key": "abc123",
+                  "unavailable": false,
+                  "value": "abc123"
+                }
+              }
+            },
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Primary On-call",
+            "rank": 3,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryV2"
+          },
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV2"
+          }
+        },
+        "required": [
+          "catalog_type",
+          "catalog_entry"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateEntryResultV3": {
+        "example": {
+          "catalog_entry": {
+            "aliases": [
+              "lawrence@incident.io",
+              "lawrence"
+            ],
+            "archived_at": "2021-08-17T14:28:57.801578Z",
+            "attribute_values": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123"
+                }
+              }
+            },
+            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Primary On-call",
+            "rank": 3,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "api",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_entry": {
+            "$ref": "#/components/schemas/CatalogEntryV3"
+          },
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV3"
+          }
+        },
+        "required": [
+          "catalog_type",
+          "catalog_entry"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateTypePayloadV2": {
+        "example": {
+          "annotations": {
+            "incident.io/catalog-importer/id": "id-of-config"
+          },
+          "categories": [
+            "issue-tracker"
+          ],
+          "color": "yellow",
+          "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "icon": "alert",
+          "name": "Kubernetes Cluster",
+          "ranked": true,
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog"
+        },
+        "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that can track metadata about this type",
+            "example": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "type": "object"
+          },
+          "categories": {
+            "description": "What categories is this type considered part of",
+            "example": [
+              "issue-tracker"
+            ],
+            "items": {
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-feature",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ],
+              "example": "issue-tracker",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "color": {
+            "description": "Sets the display color of this type in the dashboard",
+            "enum": [
+              "yellow",
+              "green",
+              "blue",
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
+            ],
+            "example": "yellow",
+            "type": "string"
+          },
+          "description": {
+            "description": "Human readble description of this type",
+            "example": "Represents Kubernetes clusters that we run inside of GKE.",
+            "type": "string"
+          },
+          "icon": {
+            "description": "Sets the display icon of this type in the dashboard",
+            "enum": [
+              "alert",
+              "bolt",
+              "box",
+              "briefcase",
+              "browser",
+              "bulb",
+              "calendar",
+              "clock",
+              "cog",
+              "components",
+              "database",
+              "doc",
+              "email",
+              "escalation-path",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
+              "server",
+              "severity",
+              "status-page",
+              "store",
+              "star",
+              "tag",
+              "user",
+              "users"
+            ],
+            "example": "alert",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this type",
+            "example": "Kubernetes Cluster",
+            "type": "string"
+          },
+          "ranked": {
+            "description": "If this type should be ranked",
+            "example": true,
+            "type": "boolean"
+          },
+          "source_repo_url": {
+            "description": "The url of the external repository where this type is managed",
+            "example": "https://github.com/my-company/incident-io-catalog",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateTypePayloadV3": {
+        "example": {
+          "annotations": {
+            "incident.io/catalog-importer/id": "id-of-config"
+          },
+          "categories": [
+            "issue-tracker"
+          ],
+          "color": "yellow",
+          "description": "Represents Kubernetes clusters that we run inside of GKE.",
+          "icon": "alert",
+          "name": "Kubernetes Cluster",
+          "ranked": true,
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog"
+        },
+        "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that can track metadata about this type",
+            "example": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "type": "object"
+          },
+          "categories": {
+            "description": "What categories is this type considered part of",
+            "example": [
+              "issue-tracker"
+            ],
+            "items": {
+              "enum": [
+                "customer",
+                "issue-tracker",
+                "product-feature",
+                "service",
+                "on-call",
+                "team",
+                "user"
+              ],
+              "example": "issue-tracker",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "color": {
+            "description": "Sets the display color of this type in the dashboard",
+            "enum": [
+              "yellow",
+              "green",
+              "blue",
+              "violet",
+              "pink",
+              "cyan",
+              "orange"
+            ],
+            "example": "yellow",
+            "type": "string"
+          },
+          "description": {
+            "description": "Human readble description of this type",
+            "example": "Represents Kubernetes clusters that we run inside of GKE.",
+            "type": "string"
+          },
+          "icon": {
+            "description": "Sets the display icon of this type in the dashboard",
+            "enum": [
+              "alert",
+              "bolt",
+              "box",
+              "briefcase",
+              "browser",
+              "bulb",
+              "calendar",
+              "clock",
+              "cog",
+              "components",
+              "database",
+              "doc",
+              "email",
+              "escalation-path",
+              "files",
+              "flag",
+              "folder",
+              "globe",
+              "money",
+              "server",
+              "severity",
+              "status-page",
+              "store",
+              "star",
+              "tag",
+              "user",
+              "users"
+            ],
+            "example": "alert",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name is the human readable name of this type",
+            "example": "Kubernetes Cluster",
+            "type": "string"
+          },
+          "ranked": {
+            "description": "If this type should be ranked",
+            "example": true,
+            "type": "boolean"
+          },
+          "source_repo_url": {
+            "description": "The url of the external repository where this type is managed",
+            "example": "https://github.com/my-company/incident-io-catalog",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateTypeResultV2": {
+        "example": {
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV2"
+          }
+        },
+        "required": [
+          "catalog_type"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateTypeResultV3": {
+        "example": {
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "api",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV3"
+          }
+        },
+        "required": [
+          "catalog_type"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateTypeSchemaPayloadV2": {
+        "example": {
+          "attributes": [
+            {
+              "array": false,
+              "backlink_attribute": "abc123",
+              "id": "01GW2G3V0S59R238FAHPDS1R66",
+              "mode": "manual",
+              "name": "tier",
+              "path": [
+                {
+                  "attribute_id": "abc123"
+                }
+              ],
+              "type": "Custom[\"Service\"]"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "attributes": {
+            "example": [
+              {
+                "array": false,
+                "backlink_attribute": "abc123",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "mode": "manual",
+                "name": "tier",
+                "path": [
+                  {
+                    "attribute_id": "abc123"
+                  }
+                ],
+                "type": "Custom[\"Service\"]"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogTypeAttributePayloadV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "attributes",
+          "version",
+          "name",
+          "description",
+          "type_name",
+          "semantic_type",
+          "ranked",
+          "schema",
+          "icon",
+          "categories",
+          "color",
+          "is_editable",
+          "annotations",
+          "created_at",
+          "updated_at",
+          "engine_resource_type",
+          "mode",
+          "use_name_as_identifier"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateTypeSchemaPayloadV3": {
+        "example": {
+          "attributes": [
+            {
+              "array": false,
+              "backlink_attribute": "abc123",
+              "id": "01GW2G3V0S59R238FAHPDS1R66",
+              "mode": "api",
+              "name": "tier",
+              "path": [
+                {
+                  "attribute_id": "abc123"
+                }
+              ],
+              "type": "Custom[\"Service\"]"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "attributes": {
+            "example": [
+              {
+                "array": false,
+                "backlink_attribute": "abc123",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "mode": "api",
+                "name": "tier",
+                "path": [
+                  {
+                    "attribute_id": "abc123"
+                  }
+                ],
+                "type": "Custom[\"Service\"]"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CatalogTypeAttributePayloadV3"
+            },
+            "type": "array"
+          },
+          "version": {
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "attributes",
+          "version",
+          "name",
+          "description",
+          "type_name",
+          "ranked",
+          "schema",
+          "icon",
+          "categories",
+          "color",
+          "is_editable",
+          "annotations",
+          "created_at",
+          "updated_at",
+          "engine_resource_type",
+          "mode",
+          "use_name_as_identifier"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateTypeSchemaResultV2": {
+        "example": {
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "manual",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "semantic_type": "custom",
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV2"
+          }
+        },
+        "required": [
+          "catalog_type"
+        ],
+        "type": "object"
+      },
+      "CatalogUpdateTypeSchemaResultV3": {
+        "example": {
+          "catalog_type": {
+            "annotations": {
+              "incident.io/catalog-importer/id": "id-of-config"
+            },
+            "categories": [
+              "issue-tracker"
+            ],
+            "color": "yellow",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Represents Kubernetes clusters that we run inside of GKE.",
+            "dynamic_resource_parameter": "abc123",
+            "estimated_count": 7,
+            "icon": "alert",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_editable": false,
+            "last_synced_at": "2021-08-17T13:28:57.801578Z",
+            "name": "Kubernetes Cluster",
+            "ranked": true,
+            "registry_type": "PagerDutyService",
+            "required_integrations": [
+              "pager_duty"
+            ],
+            "schema": {
+              "attributes": [
+                {
+                  "array": false,
+                  "backlink_attribute": "abc123",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "mode": "api",
+                  "name": "tier",
+                  "path": [
+                    {
+                      "attribute_id": "abc123",
+                      "attribute_name": "abc123"
+                    }
+                  ],
+                  "type": "Custom[\"Service\"]"
+                }
+              ],
+              "version": 1
+            },
+            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+            "type_name": "Custom[\"BackstageGroup\"]",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "catalog_type": {
+            "$ref": "#/components/schemas/CatalogTypeV3"
+          }
+        },
+        "required": [
+          "catalog_type"
         ],
         "type": "object"
       },
@@ -14688,444 +19641,6 @@
         "type": "object",
         "x-public-api-version": "v2"
       },
-      "ConditionGroupV3": {
-        "example": {
-          "conditions": [
-            {
-              "operation": {
-                "label": "Lawrence Jones",
-                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-              },
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ],
-              "subject": {
-                "label": "Incident Severity",
-                "reference": "incident.severity"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "conditions": {
-            "description": "All conditions in this list must be satisfied for the group to be satisfied",
-            "example": [
-              {
-                "operation": {
-                  "label": "Lawrence Jones",
-                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                },
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ],
-                "subject": {
-                  "label": "Incident Severity",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionV3"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "conditions"
-        ],
-        "type": "object"
-      },
-      "ConditionGroupV4": {
-        "example": {
-          "conditions": [
-            {
-              "operation": {
-                "label": "Lawrence Jones",
-                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-              },
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ],
-              "subject": {
-                "label": "Incident Severity",
-                "reference": "incident.severity"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "conditions": {
-            "description": "All conditions in this list must be satisfied for the group to be satisfied",
-            "example": [
-              {
-                "operation": {
-                  "label": "Lawrence Jones",
-                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                },
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ],
-                "subject": {
-                  "label": "Incident Severity",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionV4"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "conditions"
-        ],
-        "type": "object"
-      },
-      "ConditionGroupV5": {
-        "example": {
-          "conditions": [
-            {
-              "operation": {
-                "label": "Lawrence Jones",
-                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-              },
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ],
-              "subject": {
-                "label": "Incident Severity",
-                "reference": "incident.severity"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "conditions": {
-            "description": "All conditions in this list must be satisfied for the group to be satisfied",
-            "example": [
-              {
-                "operation": {
-                  "label": "Lawrence Jones",
-                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                },
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ],
-                "subject": {
-                  "label": "Incident Severity",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionV5"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "conditions"
-        ],
-        "type": "object"
-      },
-      "ConditionGroupV6": {
-        "example": {
-          "conditions": [
-            {
-              "operation": {
-                "label": "Lawrence Jones",
-                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-              },
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ],
-              "subject": {
-                "label": "Incident Severity",
-                "reference": "incident.severity"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "conditions": {
-            "description": "All conditions in this list must be satisfied for the group to be satisfied",
-            "example": [
-              {
-                "operation": {
-                  "label": "Lawrence Jones",
-                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                },
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ],
-                "subject": {
-                  "label": "Incident Severity",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionV6"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "conditions"
-        ],
-        "type": "object"
-      },
-      "ConditionGroupV7": {
-        "example": {
-          "conditions": [
-            {
-              "operation": {
-                "label": "Lawrence Jones",
-                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-              },
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ],
-              "subject": {
-                "label": "Incident Severity",
-                "reference": "incident.severity"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "conditions": {
-            "description": "All conditions in this list must be satisfied for the group to be satisfied",
-            "example": [
-              {
-                "operation": {
-                  "label": "Lawrence Jones",
-                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                },
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ],
-                "subject": {
-                  "label": "Incident Severity",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionV7"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "conditions"
-        ],
-        "type": "object"
-      },
-      "ConditionGroupV8": {
-        "example": {
-          "conditions": [
-            {
-              "operation": {
-                "label": "Lawrence Jones",
-                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-              },
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ],
-              "subject": {
-                "label": "Incident Severity",
-                "reference": "incident.severity"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "conditions": {
-            "description": "All conditions in this list must be satisfied for the group to be satisfied",
-            "example": [
-              {
-                "operation": {
-                  "label": "Lawrence Jones",
-                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                },
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ],
-                "subject": {
-                  "label": "Incident Severity",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionV8"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "conditions"
-        ],
-        "type": "object"
-      },
       "ConditionOperationV2": {
         "example": {
           "label": "Lawrence Jones",
@@ -15150,144 +19665,6 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "ConditionOperationV3": {
-        "example": {
-          "label": "Lawrence Jones",
-          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "value": {
-            "description": "Unique identifier for this option",
-            "example": "01FCQSP07Z74QMMYPDDGQB9FTG",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "value"
-        ],
-        "type": "object"
-      },
-      "ConditionOperationV4": {
-        "example": {
-          "label": "Lawrence Jones",
-          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "value": {
-            "description": "Unique identifier for this option",
-            "example": "01FCQSP07Z74QMMYPDDGQB9FTG",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "value"
-        ],
-        "type": "object"
-      },
-      "ConditionOperationV5": {
-        "example": {
-          "label": "Lawrence Jones",
-          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "value": {
-            "description": "Unique identifier for this option",
-            "example": "01FCQSP07Z74QMMYPDDGQB9FTG",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "value"
-        ],
-        "type": "object"
-      },
-      "ConditionOperationV6": {
-        "example": {
-          "label": "Lawrence Jones",
-          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "value": {
-            "description": "Unique identifier for this option",
-            "example": "01FCQSP07Z74QMMYPDDGQB9FTG",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "value"
-        ],
-        "type": "object"
-      },
-      "ConditionOperationV7": {
-        "example": {
-          "label": "Lawrence Jones",
-          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "value": {
-            "description": "Unique identifier for this option",
-            "example": "01FCQSP07Z74QMMYPDDGQB9FTG",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "value"
-        ],
-        "type": "object"
-      },
-      "ConditionOperationV8": {
-        "example": {
-          "label": "Lawrence Jones",
-          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "value": {
-            "description": "Unique identifier for this option",
-            "example": "01FCQSP07Z74QMMYPDDGQB9FTG",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "value"
-        ],
-        "type": "object"
       },
       "ConditionPayloadV2": {
         "example": {
@@ -15374,144 +19751,6 @@
         "type": "object",
         "x-public-api-version": "v2"
       },
-      "ConditionSubjectV3": {
-        "example": {
-          "label": "Incident Severity",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable identifier for the subject",
-            "example": "Incident Severity",
-            "type": "string"
-          },
-          "reference": {
-            "description": "Reference into the scope for the value of the subject",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "reference"
-        ],
-        "type": "object"
-      },
-      "ConditionSubjectV4": {
-        "example": {
-          "label": "Incident Severity",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable identifier for the subject",
-            "example": "Incident Severity",
-            "type": "string"
-          },
-          "reference": {
-            "description": "Reference into the scope for the value of the subject",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "reference"
-        ],
-        "type": "object"
-      },
-      "ConditionSubjectV5": {
-        "example": {
-          "label": "Incident Severity",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable identifier for the subject",
-            "example": "Incident Severity",
-            "type": "string"
-          },
-          "reference": {
-            "description": "Reference into the scope for the value of the subject",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "reference"
-        ],
-        "type": "object"
-      },
-      "ConditionSubjectV6": {
-        "example": {
-          "label": "Incident Severity",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable identifier for the subject",
-            "example": "Incident Severity",
-            "type": "string"
-          },
-          "reference": {
-            "description": "Reference into the scope for the value of the subject",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "reference"
-        ],
-        "type": "object"
-      },
-      "ConditionSubjectV7": {
-        "example": {
-          "label": "Incident Severity",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable identifier for the subject",
-            "example": "Incident Severity",
-            "type": "string"
-          },
-          "reference": {
-            "description": "Reference into the scope for the value of the subject",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "reference"
-        ],
-        "type": "object"
-      },
-      "ConditionSubjectV8": {
-        "example": {
-          "label": "Incident Severity",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable identifier for the subject",
-            "example": "Incident Severity",
-            "type": "string"
-          },
-          "reference": {
-            "description": "Reference into the scope for the value of the subject",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "reference"
-        ],
-        "type": "object"
-      },
       "ConditionV2": {
         "example": {
           "operation": {
@@ -15578,553 +19817,6 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "ConditionV3": {
-        "example": {
-          "operation": {
-            "label": "Lawrence Jones",
-            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-          },
-          "param_bindings": [
-            {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          ],
-          "subject": {
-            "label": "Incident Severity",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "operation": {
-            "$ref": "#/components/schemas/ConditionOperationV3"
-          },
-          "param_bindings": {
-            "description": "Bindings for the operation parameters",
-            "example": [
-              {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV4"
-            },
-            "type": "array"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/ConditionSubjectV3"
-          }
-        },
-        "required": [
-          "subject",
-          "operation",
-          "param_bindings"
-        ],
-        "type": "object"
-      },
-      "ConditionV4": {
-        "example": {
-          "operation": {
-            "label": "Lawrence Jones",
-            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-          },
-          "param_bindings": [
-            {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          ],
-          "subject": {
-            "label": "Incident Severity",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "operation": {
-            "$ref": "#/components/schemas/ConditionOperationV4"
-          },
-          "param_bindings": {
-            "description": "Bindings for the operation parameters",
-            "example": [
-              {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV5"
-            },
-            "type": "array"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/ConditionSubjectV4"
-          }
-        },
-        "required": [
-          "subject",
-          "operation",
-          "param_bindings"
-        ],
-        "type": "object"
-      },
-      "ConditionV5": {
-        "example": {
-          "operation": {
-            "label": "Lawrence Jones",
-            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-          },
-          "param_bindings": [
-            {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          ],
-          "subject": {
-            "label": "Incident Severity",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "operation": {
-            "$ref": "#/components/schemas/ConditionOperationV5"
-          },
-          "param_bindings": {
-            "description": "Bindings for the operation parameters",
-            "example": [
-              {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV7"
-            },
-            "type": "array"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/ConditionSubjectV5"
-          }
-        },
-        "required": [
-          "subject",
-          "operation",
-          "param_bindings",
-          "params"
-        ],
-        "type": "object"
-      },
-      "ConditionV6": {
-        "example": {
-          "operation": {
-            "label": "Lawrence Jones",
-            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-          },
-          "param_bindings": [
-            {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          ],
-          "subject": {
-            "label": "Incident Severity",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "operation": {
-            "$ref": "#/components/schemas/ConditionOperationV6"
-          },
-          "param_bindings": {
-            "description": "Bindings for the operation parameters",
-            "example": [
-              {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV9"
-            },
-            "type": "array"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/ConditionSubjectV6"
-          }
-        },
-        "required": [
-          "subject",
-          "operation",
-          "param_bindings"
-        ],
-        "type": "object"
-      },
-      "ConditionV7": {
-        "example": {
-          "operation": {
-            "label": "Lawrence Jones",
-            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-          },
-          "param_bindings": [
-            {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          ],
-          "subject": {
-            "label": "Incident Severity",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "operation": {
-            "$ref": "#/components/schemas/ConditionOperationV7"
-          },
-          "param_bindings": {
-            "description": "Bindings for the operation parameters",
-            "example": [
-              {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV10"
-            },
-            "type": "array"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/ConditionSubjectV7"
-          }
-        },
-        "required": [
-          "subject",
-          "operation",
-          "param_bindings"
-        ],
-        "type": "object"
-      },
-      "ConditionV8": {
-        "example": {
-          "operation": {
-            "label": "Lawrence Jones",
-            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-          },
-          "param_bindings": [
-            {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          ],
-          "subject": {
-            "label": "Incident Severity",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "operation": {
-            "$ref": "#/components/schemas/ConditionOperationV8"
-          },
-          "param_bindings": {
-            "description": "Bindings for the operation parameters",
-            "example": [
-              {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingV12"
-            },
-            "type": "array"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/ConditionSubjectV8"
-          }
-        },
-        "required": [
-          "subject",
-          "operation",
-          "param_bindings",
-          "params"
-        ],
-        "type": "object"
-      },
-      "CreateEntryRequestBody": {
-        "example": {
-          "aliases": [
-            "lawrence@incident.io",
-            "lawrence"
-          ],
-          "attribute_values": {
-            "abc123": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          },
-          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-          "name": "Primary On-call",
-          "rank": 3
-        },
-        "properties": {
-          "aliases": {
-            "description": "Optional aliases that can be used to reference this entry",
-            "example": [
-              "lawrence@incident.io",
-              "lawrence"
-            ],
-            "items": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "attribute_values": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
-            },
-            "description": "Values of this entry",
-            "example": {
-              "abc123": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            },
-            "type": "object"
-          },
-          "catalog_type_id": {
-            "description": "ID of this catalog type",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "type": "string"
-          },
-          "external_id": {
-            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
-            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name is the human readable name of this entry",
-            "example": "Primary On-call",
-            "type": "string"
-          },
-          "rank": {
-            "description": "When catalog type is ranked, this is used to help order things",
-            "example": 3,
-            "format": "int32",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "catalog_type_id",
-          "name",
-          "attribute_values"
-        ],
-        "type": "object"
-      },
-      "CreateEntryResponseBody": {
-        "example": {
-          "catalog_entry": {
-            "aliases": [
-              "lawrence@incident.io",
-              "lawrence"
-            ],
-            "archived_at": "2021-08-17T14:28:57.801578Z",
-            "attribute_values": {
-              "abc123": {
-                "array_value": [
-                  {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "abc123",
-                    "image_url": "abc123",
-                    "is_image_slack_icon": false,
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "abc123",
-                    "unavailable": false,
-                    "value": "abc123"
-                  }
-                ],
-                "value": {
-                  "catalog_entry": {
-                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "catalog_entry_name": "Primary escalation",
-                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                  },
-                  "helptext": "abc123",
-                  "image_url": "abc123",
-                  "is_image_slack_icon": false,
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity",
-                  "sort_key": "abc123",
-                  "unavailable": false,
-                  "value": "abc123"
-                }
-              }
-            },
-            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Primary On-call",
-            "rank": 3,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "catalog_entry": {
-            "$ref": "#/components/schemas/CatalogEntryV2"
-          }
-        },
-        "required": [
-          "catalog_entry"
-        ],
-        "type": "object"
       },
       "CreateHTTPRequestBody": {
         "example": {
@@ -16400,6 +20092,7 @@
                   "zendesk_ticket",
                   "google_calendar_event",
                   "outlook_calendar_event",
+                  "slack_file",
                   "scrubbed",
                   "statuspage_incident"
                 ],
@@ -16581,355 +20274,7 @@
         ],
         "type": "object"
       },
-      "CreateRequestBody6": {
-        "example": {
-          "description": "Issues with **low impact**.",
-          "name": "Minor",
-          "rank": 1
-        },
-        "properties": {
-          "description": {
-            "description": "Description of the severity",
-            "example": "Issues with **low impact**.",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human readable name of the severity",
-            "example": "Minor",
-            "maxLength": 50,
-            "type": "string"
-          },
-          "rank": {
-            "description": "Rank to help sort severities (lower numbers are less severe)",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "name",
-          "description"
-        ],
-        "type": "object"
-      },
       "CreateResponseBody": {
-        "example": {
-          "alert_route": {
-            "condition_groups": [
-              {
-                "conditions": [
-                  {
-                    "operation": {
-                      "label": "Lawrence Jones",
-                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                    },
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": {
-                      "label": "Incident Severity",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "defer_time_seconds": 1,
-            "escalation_bindings": [
-              {
-                "binding": {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              }
-            ],
-            "expressions": [
-              {
-                "else_branch": {
-                  "result": {
-                    "array_value": [
-                      {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                },
-                "label": "Team Slack channel",
-                "operations": [
-                  {
-                    "branches": {
-                      "branches": [
-                        {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": {
-                                    "label": "Lawrence Jones",
-                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                                  },
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "label": "Lawrence Jones",
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "label": "Lawrence Jones",
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": {
-                                    "label": "Incident Severity",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ]
-                            }
-                          ],
-                          "result": {
-                            "array_value": [
-                              {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        }
-                      ],
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    },
-                    "filter": {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": {
-                                "label": "Lawrence Jones",
-                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                              },
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "label": "Lawrence Jones",
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "label": "Lawrence Jones",
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": {
-                                "label": "Incident Severity",
-                                "reference": "incident.severity"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "navigate": {
-                      "reference": "1235",
-                      "reference_label": "Teams"
-                    },
-                    "operation_type": "navigate",
-                    "parse": {
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      },
-                      "source": "metadata.annotations[\"github.com/repo\"]"
-                    },
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
-                  }
-                ],
-                "reference": "abc123",
-                "returns": {
-                  "array": true,
-                  "type": "IncidentStatus"
-                },
-                "root_reference": "incident.status"
-              }
-            ],
-            "grouping_keys": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              }
-            ],
-            "grouping_window_seconds": 1,
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Production incidents",
-            "template": {
-              "custom_field_priorities": {
-                "abc123": "first-wins"
-              },
-              "custom_fields": {
-                "custom_field_10014": {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              },
-              "incident_mode": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              },
-              "incident_type": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              },
-              "name": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              },
-              "priority_severity": "severity-first-wins",
-              "severity": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              },
-              "summary": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              },
-              "workspace": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            }
-          }
-        },
-        "properties": {
-          "alert_route": {
-            "$ref": "#/components/schemas/AlertRouteV2"
-          }
-        },
-        "required": [
-          "alert_route"
-        ],
-        "type": "object"
-      },
-      "CreateResponseBody2": {
         "example": {
           "incident_attachment": {
             "id": "01FCNDV6P870EA6S7TK1DSYD5H",
@@ -16952,7 +20297,7 @@
         ],
         "type": "object"
       },
-      "CreateResponseBody3": {
+      "CreateResponseBody2": {
         "example": {
           "incident_membership": {
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -16975,654 +20320,6 @@
         },
         "required": [
           "incident_membership"
-        ],
-        "type": "object"
-      },
-      "CreateTypeRequestBody": {
-        "example": {
-          "annotations": {
-            "incident.io/catalog-importer/id": "id-of-config"
-          },
-          "categories": [
-            "issue-tracker"
-          ],
-          "color": "yellow",
-          "description": "Represents Kubernetes clusters that we run inside of GKE.",
-          "icon": "alert",
-          "name": "Kubernetes Cluster",
-          "ranked": true,
-          "source_repo_url": "https://github.com/my-company/incident-io-catalog",
-          "type_name": "Custom[\"BackstageGroup\"]"
-        },
-        "properties": {
-          "annotations": {
-            "additionalProperties": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "description": "Annotations that can track metadata about this type",
-            "example": {
-              "incident.io/catalog-importer/id": "id-of-config"
-            },
-            "type": "object"
-          },
-          "categories": {
-            "description": "What categories is this type considered part of",
-            "example": [
-              "issue-tracker"
-            ],
-            "items": {
-              "enum": [
-                "customer",
-                "issue-tracker",
-                "product-feature",
-                "service",
-                "on-call",
-                "team",
-                "user"
-              ],
-              "example": "issue-tracker",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "color": {
-            "description": "Sets the display color of this type in the dashboard",
-            "enum": [
-              "yellow",
-              "green",
-              "blue",
-              "violet",
-              "pink",
-              "cyan",
-              "orange"
-            ],
-            "example": "yellow",
-            "type": "string"
-          },
-          "description": {
-            "description": "Human readble description of this type",
-            "example": "Represents Kubernetes clusters that we run inside of GKE.",
-            "type": "string"
-          },
-          "icon": {
-            "description": "Sets the display icon of this type in the dashboard",
-            "enum": [
-              "alert",
-              "bolt",
-              "box",
-              "briefcase",
-              "browser",
-              "bulb",
-              "calendar",
-              "clock",
-              "cog",
-              "components",
-              "database",
-              "doc",
-              "email",
-              "escalation-path",
-              "files",
-              "flag",
-              "folder",
-              "globe",
-              "money",
-              "server",
-              "severity",
-              "status-page",
-              "store",
-              "star",
-              "tag",
-              "user",
-              "users"
-            ],
-            "example": "alert",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name is the human readable name of this type",
-            "example": "Kubernetes Cluster",
-            "type": "string"
-          },
-          "ranked": {
-            "description": "If this type should be ranked",
-            "example": true,
-            "type": "boolean"
-          },
-          "source_repo_url": {
-            "description": "The url of the external repository where this type is managed",
-            "example": "https://github.com/my-company/incident-io-catalog",
-            "type": "string"
-          },
-          "type_name": {
-            "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName \"]",
-            "example": "Custom[\"BackstageGroup\"]",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "description"
-        ],
-        "type": "object"
-      },
-      "CreateTypeResponseBody": {
-        "example": {
-          "catalog_type": {
-            "annotations": {
-              "incident.io/catalog-importer/id": "id-of-config"
-            },
-            "categories": [
-              "issue-tracker"
-            ],
-            "color": "yellow",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Represents Kubernetes clusters that we run inside of GKE.",
-            "dynamic_resource_parameter": "abc123",
-            "estimated_count": 7,
-            "icon": "alert",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "is_editable": false,
-            "last_synced_at": "2021-08-17T13:28:57.801578Z",
-            "name": "Kubernetes Cluster",
-            "ranked": true,
-            "registry_type": "PagerDutyService",
-            "required_integrations": [
-              "pager_duty"
-            ],
-            "schema": {
-              "attributes": [
-                {
-                  "array": false,
-                  "backlink_attribute": "abc123",
-                  "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
-                  "name": "tier",
-                  "path": [
-                    {
-                      "attribute_id": "abc123",
-                      "attribute_name": "abc123"
-                    }
-                  ],
-                  "type": "Custom[\"Service\"]"
-                }
-              ],
-              "version": 1
-            },
-            "semantic_type": "custom",
-            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
-            "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "catalog_type": {
-            "$ref": "#/components/schemas/CatalogTypeV2"
-          }
-        },
-        "required": [
-          "catalog_type"
-        ],
-        "type": "object"
-      },
-      "CreateWorkflowPayload": {
-        "example": {
-          "annotations": {
-            "incident.io/terraform/version": "3.0.0"
-          },
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ],
-          "continue_on_step_error": true,
-          "delay": {
-            "conditions_apply_over_delay": false,
-            "for_seconds": 60
-          },
-          "expressions": [
-            {
-              "else_branch": {
-                "result": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              },
-              "label": "Team Slack channel",
-              "operations": [
-                {
-                  "branches": {
-                    "branches": [
-                      {
-                        "condition_groups": [
-                          {
-                            "conditions": [
-                              {
-                                "operation": "one_of",
-                                "param_bindings": [
-                                  {
-                                    "array_value": [
-                                      {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    ],
-                                    "value": {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ],
-                                "subject": "incident.severity"
-                              }
-                            ]
-                          }
-                        ],
-                        "result": {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      }
-                    ],
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
-                  },
-                  "filter": {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": "one_of",
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": "incident.severity"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "navigate": {
-                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                  },
-                  "operation_type": "navigate",
-                  "parse": {
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    },
-                    "source": "metadata.annotations[\"github.com/repo\"]"
-                  }
-                }
-              ],
-              "reference": "abc123",
-              "root_reference": "incident.status"
-            }
-          ],
-          "folder": "My folder 01",
-          "include_private_incidents": true,
-          "name": "My workflow",
-          "once_for": [
-            "incident.url"
-          ],
-          "runs_on_incident_modes": [
-            "standard",
-            "retrospective"
-          ],
-          "runs_on_incidents": "newly_created",
-          "shortform": "abc123",
-          "state": "active",
-          "steps": [
-            {
-              "for_each": "abc123",
-              "id": "abc123",
-              "name": "pagerduty.escalate",
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ]
-            }
-          ],
-          "trigger": "incident.updated"
-        },
-        "properties": {
-          "annotations": {
-            "additionalProperties": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "description": "Annotations that track metadata about this resource",
-            "example": {
-              "incident.io/terraform/version": "3.0.0"
-            },
-            "type": "object"
-          },
-          "condition_groups": {
-            "description": "List of conditions to apply to the workflow",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
-            },
-            "type": "array"
-          },
-          "continue_on_step_error": {
-            "description": "Whether to continue executing the workflow if a step fails",
-            "example": true,
-            "type": "boolean"
-          },
-          "delay": {
-            "$ref": "#/components/schemas/WorkflowDelay"
-          },
-          "expressions": {
-            "description": "The expressions used in the workflow",
-            "example": [
-              {
-                "else_branch": {
-                  "result": {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                },
-                "label": "Team Slack channel",
-                "operations": [
-                  {
-                    "branches": {
-                      "branches": [
-                        {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": "one_of",
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": "incident.severity"
-                                }
-                              ]
-                            }
-                          ],
-                          "result": {
-                            "array_value": [
-                              {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        }
-                      ],
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    },
-                    "filter": {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": "one_of",
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": "incident.severity"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "navigate": {
-                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                    },
-                    "operation_type": "navigate",
-                    "parse": {
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      },
-                      "source": "metadata.annotations[\"github.com/repo\"]"
-                    }
-                  }
-                ],
-                "reference": "abc123",
-                "root_reference": "incident.status"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ExpressionPayloadV2"
-            },
-            "type": "array"
-          },
-          "folder": {
-            "description": "Folder to display the workflow in",
-            "example": "My folder 01",
-            "type": "string"
-          },
-          "include_private_incidents": {
-            "description": "Whether to include private incidents",
-            "example": true,
-            "type": "boolean"
-          },
-          "name": {
-            "description": "The human-readable name of the workflow",
-            "example": "My workflow",
-            "type": "string"
-          },
-          "once_for": {
-            "description": "Once For strategy to apply to this workflow",
-            "example": [
-              "incident.url"
-            ],
-            "items": {
-              "example": "incident.url",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "runs_on_incident_modes": {
-            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
-            "example": [
-              "standard",
-              "retrospective"
-            ],
-            "items": {
-              "description": "Incident mode that workflows can run on",
-              "enum": [
-                "standard",
-                "test",
-                "retrospective"
-              ],
-              "example": "standard",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "runs_on_incidents": {
-            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
-            "enum": [
-              "newly_created",
-              "newly_created_and_active"
-            ],
-            "example": "newly_created",
-            "type": "string"
-          },
-          "shortform": {
-            "description": "Shortform used to trigger manual workflows in Slack - e.g. `/inc workflows page-ceo`",
-            "example": "abc123",
-            "type": "string"
-          },
-          "state": {
-            "description": "The state of the workflow (e.g. is it draft, or disabled)",
-            "enum": [
-              "active",
-              "disabled",
-              "draft",
-              "error"
-            ],
-            "example": "active",
-            "type": "string"
-          },
-          "steps": {
-            "description": "List of step to execute as part of the workflow",
-            "example": [
-              {
-                "for_each": "abc123",
-                "id": "abc123",
-                "name": "pagerduty.escalate",
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/StepConfigPayload"
-            },
-            "type": "array"
-          },
-          "trigger": {
-            "description": "Trigger to set on the workflow",
-            "example": "incident.updated",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "trigger",
-          "once_for",
-          "condition_groups",
-          "steps",
-          "expressions",
-          "include_private_incidents",
-          "runs_on_incident_modes",
-          "continue_on_step_error",
-          "runs_on_incidents"
         ],
         "type": "object"
       },
@@ -19565,114 +22262,6 @@
         "type": "object",
         "x-public-api-version": "v2"
       },
-      "EngineParamBindingV10": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV18"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV17"
-          }
-        },
-        "type": "object"
-      },
-      "EngineParamBindingV11": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV20"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV19"
-          }
-        },
-        "type": "object"
-      },
-      "EngineParamBindingV12": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV22"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV21"
-          }
-        },
-        "type": "object"
-      },
       "EngineParamBindingV2": {
         "example": {
           "array_value": [
@@ -19710,258 +22299,6 @@
         "type": "object",
         "x-public-api-version": "v2"
       },
-      "EngineParamBindingV3": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV4"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV3"
-          }
-        },
-        "type": "object"
-      },
-      "EngineParamBindingV4": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV6"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV5"
-          }
-        },
-        "type": "object"
-      },
-      "EngineParamBindingV5": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV8"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV7"
-          }
-        },
-        "type": "object"
-      },
-      "EngineParamBindingV6": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV10"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV9"
-          }
-        },
-        "type": "object"
-      },
-      "EngineParamBindingV7": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV12"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV11"
-          }
-        },
-        "type": "object"
-      },
-      "EngineParamBindingV8": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV14"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV13"
-          }
-        },
-        "type": "object"
-      },
-      "EngineParamBindingV9": {
-        "example": {
-          "array_value": [
-            {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          ],
-          "value": {
-            "label": "Lawrence Jones",
-            "literal": "SEV123",
-            "reference": "incident.severity"
-          }
-        },
-        "properties": {
-          "array_value": {
-            "description": "If array_value is set, this helps render the values",
-            "example": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingValueV16"
-            },
-            "type": "array"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EngineParamBindingValueV15"
-          }
-        },
-        "type": "object"
-      },
       "EngineParamBindingValuePayloadV2": {
         "example": {
           "literal": "SEV123",
@@ -19981,286 +22318,6 @@
         },
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "EngineParamBindingValueV10": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV11": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV12": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV13": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV14": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV15": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV16": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV17": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV18": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV19": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
       },
       "EngineParamBindingValueV2": {
         "example": {
@@ -20292,286 +22349,6 @@
         "type": "object",
         "x-public-api-version": "v2"
       },
-      "EngineParamBindingValueV20": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV21": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV22": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV3": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV4": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV5": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV6": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV7": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV8": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
-      "EngineParamBindingValueV9": {
-        "example": {
-          "label": "Lawrence Jones",
-          "literal": "SEV123",
-          "reference": "incident.severity"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable label to be displayed for user to select",
-            "example": "Lawrence Jones",
-            "type": "string"
-          },
-          "literal": {
-            "description": "If set, this is the literal value of the step parameter",
-            "example": "SEV123",
-            "type": "string"
-          },
-          "reference": {
-            "description": "If set, this is the reference into the trigger scope that is the value of this parameter",
-            "example": "incident.severity",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label"
-        ],
-        "type": "object"
-      },
       "EngineReferenceV2": {
         "example": {
           "array": false,
@@ -20586,7 +22363,7 @@
             "type": "boolean"
           },
           "key": {
-            "description": "The key of the field this is a reference to",
+            "description": "Unique identifier of field will set",
             "example": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
             "type": "string"
           },
@@ -20604,12 +22381,13 @@
         "required": [
           "key",
           "label",
-          "type",
-          "array",
           "node_label",
-          "hide_filter"
+          "type",
+          "hide_filter",
+          "array"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "EscalationPathNodeIfElsePayloadV2": {
         "example": {
@@ -22376,204 +24154,6 @@
         "type": "object",
         "x-public-api-version": "v2"
       },
-      "ExpressionBranchV3": {
-        "example": {
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": {
-                    "label": "Lawrence Jones",
-                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                  },
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": {
-                    "label": "Incident Severity",
-                    "reference": "incident.severity"
-                  }
-                }
-              ]
-            }
-          ],
-          "result": {
-            "array_value": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "value": {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          }
-        },
-        "properties": {
-          "condition_groups": {
-            "description": "When one of these condition groups are satisfied, this branch will be evaluated",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": {
-                      "label": "Lawrence Jones",
-                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                    },
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": {
-                      "label": "Incident Severity",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupV4"
-            },
-            "type": "array"
-          },
-          "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV6"
-          }
-        },
-        "required": [
-          "condition_groups",
-          "result"
-        ],
-        "type": "object"
-      },
-      "ExpressionBranchV4": {
-        "example": {
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": {
-                    "label": "Lawrence Jones",
-                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                  },
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": {
-                    "label": "Incident Severity",
-                    "reference": "incident.severity"
-                  }
-                }
-              ]
-            }
-          ],
-          "result": {
-            "array_value": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "value": {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          }
-        },
-        "properties": {
-          "condition_groups": {
-            "description": "When one of these condition groups are satisfied, this branch will be evaluated",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": {
-                      "label": "Lawrence Jones",
-                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                    },
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": {
-                      "label": "Incident Severity",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupV7"
-            },
-            "type": "array"
-          },
-          "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV11"
-          }
-        },
-        "required": [
-          "condition_groups",
-          "result"
-        ],
-        "type": "object"
-      },
       "ExpressionBranchesOptsPayloadV2": {
         "example": {
           "branches": [
@@ -22806,256 +24386,6 @@
         "type": "object",
         "x-public-api-version": "v2"
       },
-      "ExpressionBranchesOptsV3": {
-        "example": {
-          "branches": [
-            {
-              "condition_groups": [
-                {
-                  "conditions": [
-                    {
-                      "operation": {
-                        "label": "Lawrence Jones",
-                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                      },
-                      "param_bindings": [
-                        {
-                          "array_value": [
-                            {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      ],
-                      "subject": {
-                        "label": "Incident Severity",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ]
-                }
-              ],
-              "result": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            }
-          ],
-          "returns": {
-            "array": true,
-            "type": "IncidentStatus"
-          }
-        },
-        "properties": {
-          "branches": {
-            "description": "The branches to apply for this operation",
-            "example": [
-              {
-                "condition_groups": [
-                  {
-                    "conditions": [
-                      {
-                        "operation": {
-                          "label": "Lawrence Jones",
-                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                        },
-                        "param_bindings": [
-                          {
-                            "array_value": [
-                              {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ],
-                        "subject": {
-                          "label": "Incident Severity",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "result": {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ExpressionBranchV3"
-            },
-            "type": "array"
-          },
-          "returns": {
-            "$ref": "#/components/schemas/ReturnsMetaV2"
-          }
-        },
-        "required": [
-          "branches",
-          "returns"
-        ],
-        "type": "object"
-      },
-      "ExpressionBranchesOptsV4": {
-        "example": {
-          "branches": [
-            {
-              "condition_groups": [
-                {
-                  "conditions": [
-                    {
-                      "operation": {
-                        "label": "Lawrence Jones",
-                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                      },
-                      "param_bindings": [
-                        {
-                          "array_value": [
-                            {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      ],
-                      "subject": {
-                        "label": "Incident Severity",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ]
-                }
-              ],
-              "result": {
-                "array_value": [
-                  {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            }
-          ],
-          "returns": {
-            "array": true,
-            "type": "IncidentStatus"
-          }
-        },
-        "properties": {
-          "branches": {
-            "description": "The branches to apply for this operation",
-            "example": [
-              {
-                "condition_groups": [
-                  {
-                    "conditions": [
-                      {
-                        "operation": {
-                          "label": "Lawrence Jones",
-                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                        },
-                        "param_bindings": [
-                          {
-                            "array_value": [
-                              {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ],
-                        "subject": {
-                          "label": "Incident Severity",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "result": {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ExpressionBranchV4"
-            },
-            "type": "array"
-          },
-          "returns": {
-            "$ref": "#/components/schemas/ReturnsMetaV2"
-          }
-        },
-        "required": [
-          "branches",
-          "returns"
-        ],
-        "type": "object"
-      },
       "ExpressionElseBranchPayloadV2": {
         "example": {
           "result": {
@@ -23109,60 +24439,6 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "ExpressionElseBranchV3": {
-        "example": {
-          "result": {
-            "array_value": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "value": {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          }
-        },
-        "properties": {
-          "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV3"
-          }
-        },
-        "required": [
-          "result"
-        ],
-        "type": "object"
-      },
-      "ExpressionElseBranchV4": {
-        "example": {
-          "result": {
-            "array_value": [
-              {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            ],
-            "value": {
-              "label": "Lawrence Jones",
-              "literal": "SEV123",
-              "reference": "incident.severity"
-            }
-          }
-        },
-        "properties": {
-          "result": {
-            "$ref": "#/components/schemas/EngineParamBindingV8"
-          }
-        },
-        "required": [
-          "result"
-        ],
-        "type": "object"
       },
       "ExpressionFilterOptsPayloadV2": {
         "example": {
@@ -23311,168 +24587,6 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "ExpressionFilterOptsV3": {
-        "example": {
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": {
-                    "label": "Lawrence Jones",
-                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                  },
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": {
-                    "label": "Incident Severity",
-                    "reference": "incident.severity"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "properties": {
-          "condition_groups": {
-            "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": {
-                      "label": "Lawrence Jones",
-                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                    },
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": {
-                      "label": "Incident Severity",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupV3"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "condition_groups"
-        ],
-        "type": "object"
-      },
-      "ExpressionFilterOptsV4": {
-        "example": {
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": {
-                    "label": "Lawrence Jones",
-                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                  },
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": {
-                    "label": "Incident Severity",
-                    "reference": "incident.severity"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "properties": {
-          "condition_groups": {
-            "description": "The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": {
-                      "label": "Lawrence Jones",
-                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                    },
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": {
-                      "label": "Incident Severity",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupV6"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "condition_groups"
-        ],
-        "type": "object"
       },
       "ExpressionNavigateOptsPayloadV2": {
         "example": {
@@ -23788,304 +24902,6 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "ExpressionOperationV3": {
-        "example": {
-          "branches": {
-            "branches": [
-              {
-                "condition_groups": [
-                  {
-                    "conditions": [
-                      {
-                        "operation": {
-                          "label": "Lawrence Jones",
-                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                        },
-                        "param_bindings": [
-                          {
-                            "array_value": [
-                              {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ],
-                        "subject": {
-                          "label": "Incident Severity",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "result": {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              }
-            ],
-            "returns": {
-              "array": true,
-              "type": "IncidentStatus"
-            }
-          },
-          "filter": {
-            "condition_groups": [
-              {
-                "conditions": [
-                  {
-                    "operation": {
-                      "label": "Lawrence Jones",
-                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                    },
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": {
-                      "label": "Incident Severity",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "navigate": {
-            "reference": "1235",
-            "reference_label": "Teams"
-          },
-          "operation_type": "navigate",
-          "parse": {
-            "returns": {
-              "array": true,
-              "type": "IncidentStatus"
-            },
-            "source": "metadata.annotations[\"github.com/repo\"]"
-          },
-          "returns": {
-            "array": true,
-            "type": "IncidentStatus"
-          }
-        },
-        "properties": {
-          "branches": {
-            "$ref": "#/components/schemas/ExpressionBranchesOptsV3"
-          },
-          "filter": {
-            "$ref": "#/components/schemas/ExpressionFilterOptsV3"
-          },
-          "navigate": {
-            "$ref": "#/components/schemas/ExpressionNavigateOptsV2"
-          },
-          "operation_type": {
-            "description": "The type of the operation",
-            "enum": [
-              "navigate",
-              "filter",
-              "count",
-              "min",
-              "max",
-              "sum",
-              "random",
-              "first",
-              "parse",
-              "branches"
-            ],
-            "example": "navigate",
-            "type": "string"
-          },
-          "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsV2"
-          },
-          "returns": {
-            "$ref": "#/components/schemas/ReturnsMetaV2"
-          }
-        },
-        "required": [
-          "operation_type",
-          "returns"
-        ],
-        "type": "object"
-      },
-      "ExpressionOperationV4": {
-        "example": {
-          "branches": {
-            "branches": [
-              {
-                "condition_groups": [
-                  {
-                    "conditions": [
-                      {
-                        "operation": {
-                          "label": "Lawrence Jones",
-                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                        },
-                        "param_bindings": [
-                          {
-                            "array_value": [
-                              {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ],
-                        "subject": {
-                          "label": "Incident Severity",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "result": {
-                  "array_value": [
-                    {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              }
-            ],
-            "returns": {
-              "array": true,
-              "type": "IncidentStatus"
-            }
-          },
-          "filter": {
-            "condition_groups": [
-              {
-                "conditions": [
-                  {
-                    "operation": {
-                      "label": "Lawrence Jones",
-                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                    },
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": {
-                      "label": "Incident Severity",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "navigate": {
-            "reference": "1235",
-            "reference_label": "Teams"
-          },
-          "operation_type": "navigate",
-          "parse": {
-            "returns": {
-              "array": true,
-              "type": "IncidentStatus"
-            },
-            "source": "metadata.annotations[\"github.com/repo\"]"
-          },
-          "returns": {
-            "array": true,
-            "type": "IncidentStatus"
-          }
-        },
-        "properties": {
-          "branches": {
-            "$ref": "#/components/schemas/ExpressionBranchesOptsV4"
-          },
-          "filter": {
-            "$ref": "#/components/schemas/ExpressionFilterOptsV4"
-          },
-          "navigate": {
-            "$ref": "#/components/schemas/ExpressionNavigateOptsV2"
-          },
-          "operation_type": {
-            "description": "The type of the operation",
-            "enum": [
-              "navigate",
-              "filter",
-              "count",
-              "min",
-              "max",
-              "sum",
-              "random",
-              "first",
-              "parse",
-              "branches"
-            ],
-            "example": "navigate",
-            "type": "string"
-          },
-          "parse": {
-            "$ref": "#/components/schemas/ExpressionParseOptsV2"
-          },
-          "returns": {
-            "$ref": "#/components/schemas/ReturnsMetaV2"
-          }
-        },
-        "required": [
-          "operation_type",
-          "returns"
-        ],
-        "type": "object"
       },
       "ExpressionParseOptsPayloadV2": {
         "example": {
@@ -24652,576 +25468,6 @@
         "type": "object",
         "x-public-api-version": "v2"
       },
-      "ExpressionV3": {
-        "example": {
-          "else_branch": {
-            "result": {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          },
-          "label": "Team Slack channel",
-          "operations": [
-            {
-              "branches": {
-                "branches": [
-                  {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": {
-                              "label": "Lawrence Jones",
-                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                            },
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "label": "Lawrence Jones",
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "label": "Lawrence Jones",
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": {
-                              "label": "Incident Severity",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ]
-                      }
-                    ],
-                    "result": {
-                      "array_value": [
-                        {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  }
-                ],
-                "returns": {
-                  "array": true,
-                  "type": "IncidentStatus"
-                }
-              },
-              "filter": {
-                "condition_groups": [
-                  {
-                    "conditions": [
-                      {
-                        "operation": {
-                          "label": "Lawrence Jones",
-                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                        },
-                        "param_bindings": [
-                          {
-                            "array_value": [
-                              {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ],
-                        "subject": {
-                          "label": "Incident Severity",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              "navigate": {
-                "reference": "1235",
-                "reference_label": "Teams"
-              },
-              "operation_type": "navigate",
-              "parse": {
-                "returns": {
-                  "array": true,
-                  "type": "IncidentStatus"
-                },
-                "source": "metadata.annotations[\"github.com/repo\"]"
-              },
-              "returns": {
-                "array": true,
-                "type": "IncidentStatus"
-              }
-            }
-          ],
-          "reference": "abc123",
-          "returns": {
-            "array": true,
-            "type": "IncidentStatus"
-          },
-          "root_reference": "incident.status"
-        },
-        "properties": {
-          "else_branch": {
-            "$ref": "#/components/schemas/ExpressionElseBranchV3"
-          },
-          "label": {
-            "description": "The human readable label of the expression",
-            "example": "Team Slack channel",
-            "type": "string"
-          },
-          "operations": {
-            "example": [
-              {
-                "branches": {
-                  "branches": [
-                    {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": {
-                                "label": "Lawrence Jones",
-                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                              },
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "label": "Lawrence Jones",
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "label": "Lawrence Jones",
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": {
-                                "label": "Incident Severity",
-                                "reference": "incident.severity"
-                              }
-                            }
-                          ]
-                        }
-                      ],
-                      "result": {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    }
-                  ],
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  }
-                },
-                "filter": {
-                  "condition_groups": [
-                    {
-                      "conditions": [
-                        {
-                          "operation": {
-                            "label": "Lawrence Jones",
-                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                          },
-                          "param_bindings": [
-                            {
-                              "array_value": [
-                                {
-                                  "label": "Lawrence Jones",
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              ],
-                              "value": {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            }
-                          ],
-                          "subject": {
-                            "label": "Incident Severity",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "navigate": {
-                  "reference": "1235",
-                  "reference_label": "Teams"
-                },
-                "operation_type": "navigate",
-                "parse": {
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  },
-                  "source": "metadata.annotations[\"github.com/repo\"]"
-                },
-                "returns": {
-                  "array": true,
-                  "type": "IncidentStatus"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ExpressionOperationV3"
-            },
-            "type": "array"
-          },
-          "reference": {
-            "description": "A short ID that can be used to reference the expression",
-            "example": "abc123",
-            "type": "string"
-          },
-          "returns": {
-            "$ref": "#/components/schemas/ReturnsMetaV2"
-          },
-          "root_reference": {
-            "description": "The root reference for this expression (i.e. where the expression starts)",
-            "example": "incident.status",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "reference",
-          "returns",
-          "root_reference",
-          "operations",
-          "id"
-        ],
-        "type": "object"
-      },
-      "ExpressionV4": {
-        "example": {
-          "else_branch": {
-            "result": {
-              "array_value": [
-                {
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "label": "Lawrence Jones",
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          },
-          "label": "Team Slack channel",
-          "operations": [
-            {
-              "branches": {
-                "branches": [
-                  {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": {
-                              "label": "Lawrence Jones",
-                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                            },
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "label": "Lawrence Jones",
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "label": "Lawrence Jones",
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": {
-                              "label": "Incident Severity",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ]
-                      }
-                    ],
-                    "result": {
-                      "array_value": [
-                        {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  }
-                ],
-                "returns": {
-                  "array": true,
-                  "type": "IncidentStatus"
-                }
-              },
-              "filter": {
-                "condition_groups": [
-                  {
-                    "conditions": [
-                      {
-                        "operation": {
-                          "label": "Lawrence Jones",
-                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                        },
-                        "param_bindings": [
-                          {
-                            "array_value": [
-                              {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ],
-                        "subject": {
-                          "label": "Incident Severity",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              "navigate": {
-                "reference": "1235",
-                "reference_label": "Teams"
-              },
-              "operation_type": "navigate",
-              "parse": {
-                "returns": {
-                  "array": true,
-                  "type": "IncidentStatus"
-                },
-                "source": "metadata.annotations[\"github.com/repo\"]"
-              },
-              "returns": {
-                "array": true,
-                "type": "IncidentStatus"
-              }
-            }
-          ],
-          "reference": "abc123",
-          "returns": {
-            "array": true,
-            "type": "IncidentStatus"
-          },
-          "root_reference": "incident.status"
-        },
-        "properties": {
-          "else_branch": {
-            "$ref": "#/components/schemas/ExpressionElseBranchV4"
-          },
-          "label": {
-            "description": "The human readable label of the expression",
-            "example": "Team Slack channel",
-            "type": "string"
-          },
-          "operations": {
-            "example": [
-              {
-                "branches": {
-                  "branches": [
-                    {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": {
-                                "label": "Lawrence Jones",
-                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                              },
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "label": "Lawrence Jones",
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "label": "Lawrence Jones",
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": {
-                                "label": "Incident Severity",
-                                "reference": "incident.severity"
-                              }
-                            }
-                          ]
-                        }
-                      ],
-                      "result": {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    }
-                  ],
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  }
-                },
-                "filter": {
-                  "condition_groups": [
-                    {
-                      "conditions": [
-                        {
-                          "operation": {
-                            "label": "Lawrence Jones",
-                            "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                          },
-                          "param_bindings": [
-                            {
-                              "array_value": [
-                                {
-                                  "label": "Lawrence Jones",
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              ],
-                              "value": {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            }
-                          ],
-                          "subject": {
-                            "label": "Incident Severity",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "navigate": {
-                  "reference": "1235",
-                  "reference_label": "Teams"
-                },
-                "operation_type": "navigate",
-                "parse": {
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  },
-                  "source": "metadata.annotations[\"github.com/repo\"]"
-                },
-                "returns": {
-                  "array": true,
-                  "type": "IncidentStatus"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ExpressionOperationV4"
-            },
-            "type": "array"
-          },
-          "reference": {
-            "description": "A short ID that can be used to reference the expression",
-            "example": "abc123",
-            "type": "string"
-          },
-          "returns": {
-            "$ref": "#/components/schemas/ReturnsMetaV2"
-          },
-          "root_reference": {
-            "description": "The root reference for this expression (i.e. where the expression starts)",
-            "example": "incident.status",
-            "type": "string"
-          }
-        },
-        "required": [
-          "label",
-          "reference",
-          "returns",
-          "root_reference",
-          "operations",
-          "id"
-        ],
-        "type": "object"
-      },
       "ExternalIssueReferenceV1": {
         "example": {
           "issue_name": "INC-123",
@@ -25419,6 +25665,7 @@
               "zendesk_ticket",
               "google_calendar_event",
               "outlook_calendar_event",
+              "slack_file",
               "scrubbed",
               "statuspage_incident"
             ],
@@ -25712,7 +25959,8 @@
         "required": [
           "id"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "IdentityV1": {
         "example": {
@@ -28100,226 +28348,6 @@
         ],
         "type": "object"
       },
-      "ListEntriesResponseBody": {
-        "example": {
-          "catalog_entries": [
-            {
-              "aliases": [
-                "lawrence@incident.io",
-                "lawrence"
-              ],
-              "archived_at": "2021-08-17T14:28:57.801578Z",
-              "attribute_values": {
-                "abc123": {
-                  "array_value": [
-                    {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "abc123",
-                      "image_url": "abc123",
-                      "is_image_slack_icon": false,
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "abc123",
-                      "unavailable": false,
-                      "value": "abc123"
-                    }
-                  ],
-                  "value": {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "abc123",
-                    "image_url": "abc123",
-                    "is_image_slack_icon": false,
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "abc123",
-                    "unavailable": false,
-                    "value": "abc123"
-                  }
-                }
-              },
-              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Primary On-call",
-              "rank": 3,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ],
-          "catalog_type": {
-            "annotations": {
-              "incident.io/catalog-importer/id": "id-of-config"
-            },
-            "categories": [
-              "issue-tracker"
-            ],
-            "color": "yellow",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Represents Kubernetes clusters that we run inside of GKE.",
-            "dynamic_resource_parameter": "abc123",
-            "estimated_count": 7,
-            "icon": "alert",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "is_editable": false,
-            "last_synced_at": "2021-08-17T13:28:57.801578Z",
-            "name": "Kubernetes Cluster",
-            "ranked": true,
-            "registry_type": "PagerDutyService",
-            "required_integrations": [
-              "pager_duty"
-            ],
-            "schema": {
-              "attributes": [
-                {
-                  "array": false,
-                  "backlink_attribute": "abc123",
-                  "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
-                  "name": "tier",
-                  "path": [
-                    {
-                      "attribute_id": "abc123",
-                      "attribute_name": "abc123"
-                    }
-                  ],
-                  "type": "Custom[\"Service\"]"
-                }
-              ],
-              "version": 1
-            },
-            "semantic_type": "custom",
-            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
-            "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          },
-          "pagination_meta": {
-            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "page_size": 25
-          }
-        },
-        "properties": {
-          "catalog_entries": {
-            "example": [
-              {
-                "aliases": [
-                  "lawrence@incident.io",
-                  "lawrence"
-                ],
-                "archived_at": "2021-08-17T14:28:57.801578Z",
-                "attribute_values": {
-                  "abc123": {
-                    "array_value": [
-                      {
-                        "catalog_entry": {
-                          "archived_at": "2021-08-17T14:28:57.801578Z",
-                          "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "catalog_entry_name": "Primary escalation",
-                          "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                        },
-                        "helptext": "abc123",
-                        "image_url": "abc123",
-                        "is_image_slack_icon": false,
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity",
-                        "sort_key": "abc123",
-                        "unavailable": false,
-                        "value": "abc123"
-                      }
-                    ],
-                    "value": {
-                      "catalog_entry": {
-                        "archived_at": "2021-08-17T14:28:57.801578Z",
-                        "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "catalog_entry_name": "Primary escalation",
-                        "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                      },
-                      "helptext": "abc123",
-                      "image_url": "abc123",
-                      "is_image_slack_icon": false,
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity",
-                      "sort_key": "abc123",
-                      "unavailable": false,
-                      "value": "abc123"
-                    }
-                  }
-                },
-                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Primary On-call",
-                "rank": 3,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/CatalogEntryV2"
-            },
-            "type": "array"
-          },
-          "catalog_type": {
-            "$ref": "#/components/schemas/CatalogTypeV2"
-          },
-          "pagination_meta": {
-            "$ref": "#/components/schemas/PaginationMetaResult"
-          }
-        },
-        "required": [
-          "catalog_type",
-          "catalog_entries",
-          "pagination_meta"
-        ],
-        "type": "object"
-      },
-      "ListResourcesResponseBody": {
-        "example": {
-          "resources": [
-            {
-              "category": "custom",
-              "description": "Boolean true or false value",
-              "label": "GitHub Repository",
-              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
-              "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
-            }
-          ]
-        },
-        "properties": {
-          "resources": {
-            "example": [
-              {
-                "category": "custom",
-                "description": "Boolean true or false value",
-                "label": "GitHub Repository",
-                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
-                "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/CatalogResourceV2"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "resources"
-        ],
-        "type": "object"
-      },
       "ListResponseBody": {
         "example": {
           "incident_attachments": [
@@ -28357,42 +28385,6 @@
         },
         "required": [
           "incident_attachments"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody10": {
-        "example": {
-          "severities": [
-            {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Issues with **low impact**.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Minor",
-              "rank": 1,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "severities": {
-            "example": [
-              {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Issues with **low impact**.",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Minor",
-                "rank": 1,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/SeverityV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "severities"
         ],
         "type": "object"
       },
@@ -29273,552 +29265,6 @@
         ],
         "type": "object"
       },
-      "ListTypesResponseBody": {
-        "example": {
-          "catalog_types": [
-            {
-              "annotations": {
-                "incident.io/catalog-importer/id": "id-of-config"
-              },
-              "categories": [
-                "issue-tracker"
-              ],
-              "color": "yellow",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Represents Kubernetes clusters that we run inside of GKE.",
-              "dynamic_resource_parameter": "abc123",
-              "estimated_count": 7,
-              "icon": "alert",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_editable": false,
-              "last_synced_at": "2021-08-17T13:28:57.801578Z",
-              "name": "Kubernetes Cluster",
-              "ranked": true,
-              "registry_type": "PagerDutyService",
-              "required_integrations": [
-                "pager_duty"
-              ],
-              "schema": {
-                "attributes": [
-                  {
-                    "array": false,
-                    "backlink_attribute": "abc123",
-                    "id": "01GW2G3V0S59R238FAHPDS1R66",
-                    "mode": "manual",
-                    "name": "tier",
-                    "path": [
-                      {
-                        "attribute_id": "abc123",
-                        "attribute_name": "abc123"
-                      }
-                    ],
-                    "type": "Custom[\"Service\"]"
-                  }
-                ],
-                "version": 1
-              },
-              "semantic_type": "custom",
-              "source_repo_url": "https://github.com/my-company/incident-io-catalog",
-              "type_name": "Custom[\"BackstageGroup\"]",
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "catalog_types": {
-            "example": [
-              {
-                "annotations": {
-                  "incident.io/catalog-importer/id": "id-of-config"
-                },
-                "categories": [
-                  "issue-tracker"
-                ],
-                "color": "yellow",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Represents Kubernetes clusters that we run inside of GKE.",
-                "dynamic_resource_parameter": "abc123",
-                "estimated_count": 7,
-                "icon": "alert",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "is_editable": false,
-                "last_synced_at": "2021-08-17T13:28:57.801578Z",
-                "name": "Kubernetes Cluster",
-                "ranked": true,
-                "registry_type": "PagerDutyService",
-                "required_integrations": [
-                  "pager_duty"
-                ],
-                "schema": {
-                  "attributes": [
-                    {
-                      "array": false,
-                      "backlink_attribute": "abc123",
-                      "id": "01GW2G3V0S59R238FAHPDS1R66",
-                      "mode": "manual",
-                      "name": "tier",
-                      "path": [
-                        {
-                          "attribute_id": "abc123",
-                          "attribute_name": "abc123"
-                        }
-                      ],
-                      "type": "Custom[\"Service\"]"
-                    }
-                  ],
-                  "version": 1
-                },
-                "semantic_type": "custom",
-                "source_repo_url": "https://github.com/my-company/incident-io-catalog",
-                "type_name": "Custom[\"BackstageGroup\"]",
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/CatalogTypeV2"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "catalog_types"
-        ],
-        "type": "object"
-      },
-      "ListWorkflowsResponseBody": {
-        "example": {
-          "workflows": [
-            {
-              "condition_groups": [
-                {
-                  "conditions": [
-                    {
-                      "operation": {
-                        "label": "Lawrence Jones",
-                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                      },
-                      "param_bindings": [
-                        {
-                          "array_value": [
-                            {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      ],
-                      "subject": {
-                        "label": "Incident Severity",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ]
-                }
-              ],
-              "continue_on_step_error": true,
-              "delay": {
-                "conditions_apply_over_delay": false,
-                "for_seconds": 60
-              },
-              "expressions": [
-                {
-                  "else_branch": {
-                    "result": {
-                      "array_value": [
-                        {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  },
-                  "label": "Team Slack channel",
-                  "operations": [
-                    {
-                      "branches": {
-                        "branches": [
-                          {
-                            "condition_groups": [
-                              {
-                                "conditions": [
-                                  {
-                                    "operation": {
-                                      "label": "Lawrence Jones",
-                                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                                    },
-                                    "param_bindings": [
-                                      {
-                                        "array_value": [
-                                          {
-                                            "label": "Lawrence Jones",
-                                            "literal": "SEV123",
-                                            "reference": "incident.severity"
-                                          }
-                                        ],
-                                        "value": {
-                                          "label": "Lawrence Jones",
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      }
-                                    ],
-                                    "subject": {
-                                      "label": "Incident Severity",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ]
-                              }
-                            ],
-                            "result": {
-                              "array_value": [
-                                {
-                                  "label": "Lawrence Jones",
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              ],
-                              "value": {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            }
-                          }
-                        ],
-                        "returns": {
-                          "array": true,
-                          "type": "IncidentStatus"
-                        }
-                      },
-                      "filter": {
-                        "condition_groups": [
-                          {
-                            "conditions": [
-                              {
-                                "operation": {
-                                  "label": "Lawrence Jones",
-                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                                },
-                                "param_bindings": [
-                                  {
-                                    "array_value": [
-                                      {
-                                        "label": "Lawrence Jones",
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    ],
-                                    "value": {
-                                      "label": "Lawrence Jones",
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ],
-                                "subject": {
-                                  "label": "Incident Severity",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      "navigate": {
-                        "reference": "1235",
-                        "reference_label": "Teams"
-                      },
-                      "operation_type": "navigate",
-                      "parse": {
-                        "returns": {
-                          "array": true,
-                          "type": "IncidentStatus"
-                        },
-                        "source": "metadata.annotations[\"github.com/repo\"]"
-                      },
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    }
-                  ],
-                  "reference": "abc123",
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
-                  },
-                  "root_reference": "incident.status"
-                }
-              ],
-              "folder": "My folder 01",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "include_private_incidents": true,
-              "name": "My workflow",
-              "once_for": [
-                {
-                  "array": false,
-                  "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
-                  "label": "Incident -\u003e Affected Team",
-                  "type": "IncidentSeverity"
-                }
-              ],
-              "runs_from": "2021-08-17T13:28:57.801578Z",
-              "runs_on_incident_modes": [
-                "standard",
-                "retrospective"
-              ],
-              "runs_on_incidents": "newly_created",
-              "shortform": "abc123",
-              "state": "active",
-              "steps": [
-                {
-                  "label": "PagerDuty Escalate",
-                  "name": "pagerduty.escalate"
-                }
-              ],
-              "trigger": {
-                "label": "Incident Updated",
-                "name": "incident.updated"
-              },
-              "version": 3
-            }
-          ]
-        },
-        "properties": {
-          "workflows": {
-            "example": [
-              {
-                "condition_groups": [
-                  {
-                    "conditions": [
-                      {
-                        "operation": {
-                          "label": "Lawrence Jones",
-                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                        },
-                        "param_bindings": [
-                          {
-                            "array_value": [
-                              {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ],
-                        "subject": {
-                          "label": "Incident Severity",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "continue_on_step_error": true,
-                "delay": {
-                  "conditions_apply_over_delay": false,
-                  "for_seconds": 60
-                },
-                "expressions": [
-                  {
-                    "else_branch": {
-                      "result": {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    },
-                    "label": "Team Slack channel",
-                    "operations": [
-                      {
-                        "branches": {
-                          "branches": [
-                            {
-                              "condition_groups": [
-                                {
-                                  "conditions": [
-                                    {
-                                      "operation": {
-                                        "label": "Lawrence Jones",
-                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                                      },
-                                      "param_bindings": [
-                                        {
-                                          "array_value": [
-                                            {
-                                              "label": "Lawrence Jones",
-                                              "literal": "SEV123",
-                                              "reference": "incident.severity"
-                                            }
-                                          ],
-                                          "value": {
-                                            "label": "Lawrence Jones",
-                                            "literal": "SEV123",
-                                            "reference": "incident.severity"
-                                          }
-                                        }
-                                      ],
-                                      "subject": {
-                                        "label": "Incident Severity",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ]
-                                }
-                              ],
-                              "result": {
-                                "array_value": [
-                                  {
-                                    "label": "Lawrence Jones",
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "label": "Lawrence Jones",
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            }
-                          ],
-                          "returns": {
-                            "array": true,
-                            "type": "IncidentStatus"
-                          }
-                        },
-                        "filter": {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": {
-                                    "label": "Lawrence Jones",
-                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                                  },
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "label": "Lawrence Jones",
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "label": "Lawrence Jones",
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": {
-                                    "label": "Incident Severity",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "navigate": {
-                          "reference": "1235",
-                          "reference_label": "Teams"
-                        },
-                        "operation_type": "navigate",
-                        "parse": {
-                          "returns": {
-                            "array": true,
-                            "type": "IncidentStatus"
-                          },
-                          "source": "metadata.annotations[\"github.com/repo\"]"
-                        },
-                        "returns": {
-                          "array": true,
-                          "type": "IncidentStatus"
-                        }
-                      }
-                    ],
-                    "reference": "abc123",
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    },
-                    "root_reference": "incident.status"
-                  }
-                ],
-                "folder": "My folder 01",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "include_private_incidents": true,
-                "name": "My workflow",
-                "once_for": [
-                  {
-                    "array": false,
-                    "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
-                    "label": "Incident -\u003e Affected Team",
-                    "type": "IncidentSeverity"
-                  }
-                ],
-                "runs_from": "2021-08-17T13:28:57.801578Z",
-                "runs_on_incident_modes": [
-                  "standard",
-                  "retrospective"
-                ],
-                "runs_on_incidents": "newly_created",
-                "shortform": "abc123",
-                "state": "active",
-                "steps": [
-                  {
-                    "label": "PagerDuty Escalate",
-                    "name": "pagerduty.escalate"
-                  }
-                ],
-                "trigger": {
-                  "label": "Incident Updated",
-                  "name": "incident.updated"
-                },
-                "version": 3
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/WorkflowSlim"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "workflows"
-        ],
-        "type": "object"
-      },
       "ManagedResourceV2": {
         "example": {
           "annotations": {
@@ -29919,7 +29365,8 @@
           "annotations",
           "managed_by"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "PaginationMetaResult": {
         "example": {
@@ -29994,6 +29441,31 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
+      },
+      "PaginationMetaResultV3": {
+        "example": {
+          "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "page_size": 25
+        },
+        "properties": {
+          "after": {
+            "description": "If provided, pass this as the 'after' param to load the next page",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "page_size": {
+            "default": 25,
+            "description": "What was the maximum number of results requested",
+            "example": 25,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "page_size"
+        ],
+        "type": "object",
+        "x-public-api-version": "v3"
       },
       "PaginationMetaResultWithTotal": {
         "example": {
@@ -33527,6 +32999,168 @@
         ],
         "type": "object"
       },
+      "SeveritiesCreatePayloadV1": {
+        "example": {
+          "description": "Issues with **low impact**.",
+          "name": "Minor",
+          "rank": 1
+        },
+        "properties": {
+          "description": {
+            "description": "Description of the severity",
+            "example": "Issues with **low impact**.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name of the severity",
+            "example": "Minor",
+            "maxLength": 50,
+            "type": "string"
+          },
+          "rank": {
+            "description": "Rank to help sort severities (lower numbers are less severe)",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "id"
+        ],
+        "type": "object"
+      },
+      "SeveritiesCreateResultV1": {
+        "example": {
+          "severity": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Issues with **low impact**.",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Minor",
+            "rank": 1,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "severity": {
+            "$ref": "#/components/schemas/SeverityV1"
+          }
+        },
+        "required": [
+          "severity"
+        ],
+        "type": "object"
+      },
+      "SeveritiesListResultV1": {
+        "example": {
+          "severities": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "severities": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SeverityV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "severities"
+        ],
+        "type": "object"
+      },
+      "SeveritiesShowResultV1": {
+        "example": {
+          "severity": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Issues with **low impact**.",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Minor",
+            "rank": 1,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "severity": {
+            "$ref": "#/components/schemas/SeverityV1"
+          }
+        },
+        "required": [
+          "severity"
+        ],
+        "type": "object"
+      },
+      "SeveritiesUpdatePayloadV1": {
+        "example": {
+          "description": "Issues with **low impact**.",
+          "name": "Minor",
+          "rank": 1
+        },
+        "properties": {
+          "description": {
+            "description": "Description of the severity",
+            "example": "Issues with **low impact**.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name of the severity",
+            "example": "Minor",
+            "maxLength": 50,
+            "type": "string"
+          },
+          "rank": {
+            "description": "Rank to help sort severities (lower numbers are less severe)",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "type": "object"
+      },
+      "SeveritiesUpdateResultV1": {
+        "example": {
+          "severity": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Issues with **low impact**.",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Minor",
+            "rank": 1,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "severity": {
+            "$ref": "#/components/schemas/SeverityV1"
+          }
+        },
+        "required": [
+          "severity"
+        ],
+        "type": "object"
+      },
       "SeverityV1": {
         "example": {
           "created_at": "2021-08-17T13:28:57.801578Z",
@@ -33573,14 +33207,15 @@
           }
         },
         "required": [
-          "id",
-          "name",
-          "description",
           "rank",
           "created_at",
-          "updated_at"
+          "updated_at",
+          "id",
+          "name",
+          "description"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v1"
       },
       "SeverityV2": {
         "example": {
@@ -33634,123 +33269,6 @@
           "rank",
           "created_at",
           "updated_at"
-        ],
-        "type": "object"
-      },
-      "ShowEntryResponseBody": {
-        "example": {
-          "catalog_entry": {
-            "aliases": [
-              "lawrence@incident.io",
-              "lawrence"
-            ],
-            "archived_at": "2021-08-17T14:28:57.801578Z",
-            "attribute_values": {
-              "abc123": {
-                "array_value": [
-                  {
-                    "catalog_entry": {
-                      "archived_at": "2021-08-17T14:28:57.801578Z",
-                      "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "catalog_entry_name": "Primary escalation",
-                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                    },
-                    "helptext": "abc123",
-                    "image_url": "abc123",
-                    "is_image_slack_icon": false,
-                    "label": "Lawrence Jones",
-                    "literal": "SEV123",
-                    "reference": "incident.severity",
-                    "sort_key": "abc123",
-                    "unavailable": false,
-                    "value": "abc123"
-                  }
-                ],
-                "value": {
-                  "catalog_entry": {
-                    "archived_at": "2021-08-17T14:28:57.801578Z",
-                    "catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "catalog_entry_name": "Primary escalation",
-                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0"
-                  },
-                  "helptext": "abc123",
-                  "image_url": "abc123",
-                  "is_image_slack_icon": false,
-                  "label": "Lawrence Jones",
-                  "literal": "SEV123",
-                  "reference": "incident.severity",
-                  "sort_key": "abc123",
-                  "unavailable": false,
-                  "value": "abc123"
-                }
-              }
-            },
-            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Primary On-call",
-            "rank": 3,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          },
-          "catalog_type": {
-            "annotations": {
-              "incident.io/catalog-importer/id": "id-of-config"
-            },
-            "categories": [
-              "issue-tracker"
-            ],
-            "color": "yellow",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Represents Kubernetes clusters that we run inside of GKE.",
-            "dynamic_resource_parameter": "abc123",
-            "estimated_count": 7,
-            "icon": "alert",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "is_editable": false,
-            "last_synced_at": "2021-08-17T13:28:57.801578Z",
-            "name": "Kubernetes Cluster",
-            "ranked": true,
-            "registry_type": "PagerDutyService",
-            "required_integrations": [
-              "pager_duty"
-            ],
-            "schema": {
-              "attributes": [
-                {
-                  "array": false,
-                  "backlink_attribute": "abc123",
-                  "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
-                  "name": "tier",
-                  "path": [
-                    {
-                      "attribute_id": "abc123",
-                      "attribute_name": "abc123"
-                    }
-                  ],
-                  "type": "Custom[\"Service\"]"
-                }
-              ],
-              "version": 1
-            },
-            "semantic_type": "custom",
-            "source_repo_url": "https://github.com/my-company/incident-io-catalog",
-            "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "catalog_entry": {
-            "$ref": "#/components/schemas/CatalogEntryV2"
-          },
-          "catalog_type": {
-            "$ref": "#/components/schemas/CatalogTypeV2"
-          }
-        },
-        "required": [
-          "catalog_type",
-          "catalog_entry"
         ],
         "type": "object"
       },
@@ -34155,277 +33673,108 @@
         ],
         "type": "object"
       },
-      "ShowResponseBody8": {
+      "StepConfigPayloadV2": {
         "example": {
-          "severity": {
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Issues with **low impact**.",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "name": "Minor",
-            "rank": 1,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
+          "for_each": "abc123",
+          "id": "abc123",
+          "name": "pagerduty.escalate",
+          "param_bindings": [
+            {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          ]
         },
         "properties": {
-          "severity": {
-            "$ref": "#/components/schemas/SeverityV1"
-          }
-        },
-        "required": [
-          "severity"
-        ],
-        "type": "object"
-      },
-      "ShowWorkflowResponseBody": {
-        "example": {
-          "management_meta": {
-            "annotations": {
-              "incident.io/terraform/version": "3.0.0"
-            },
-            "managed_by": "dashboard",
-            "source_url": "https://github.com/my-company/infrastructure"
+          "for_each": {
+            "description": "Reference to an expression that returns resources to run this step over",
+            "example": "abc123",
+            "type": "string"
           },
-          "workflow": {
-            "condition_groups": [
+          "id": {
+            "description": "Unique ID of this step in a workflow",
+            "example": "abc123",
+            "type": "string"
+          },
+          "name": {
+            "description": "Unique name of the step in the engine",
+            "example": "pagerduty.escalate",
+            "type": "string"
+          },
+          "param_bindings": {
+            "description": "List of parameter bindings",
+            "example": [
               {
-                "conditions": [
+                "array_value": [
                   {
-                    "operation": {
-                      "label": "Lawrence Jones",
-                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                    },
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "label": "Lawrence Jones",
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "label": "Lawrence Jones",
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": {
-                      "label": "Incident Severity",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "continue_on_step_error": true,
-            "delay": {
-              "conditions_apply_over_delay": false,
-              "for_seconds": 60
-            },
-            "expressions": [
-              {
-                "else_branch": {
-                  "result": {
-                    "array_value": [
-                      {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                },
-                "label": "Team Slack channel",
-                "operations": [
-                  {
-                    "branches": {
-                      "branches": [
-                        {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": {
-                                    "label": "Lawrence Jones",
-                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                                  },
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "label": "Lawrence Jones",
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "label": "Lawrence Jones",
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": {
-                                    "label": "Incident Severity",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ]
-                            }
-                          ],
-                          "result": {
-                            "array_value": [
-                              {
-                                "label": "Lawrence Jones",
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "label": "Lawrence Jones",
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        }
-                      ],
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    },
-                    "filter": {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": {
-                                "label": "Lawrence Jones",
-                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                              },
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "label": "Lawrence Jones",
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "label": "Lawrence Jones",
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": {
-                                "label": "Incident Severity",
-                                "reference": "incident.severity"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "navigate": {
-                      "reference": "1235",
-                      "reference_label": "Teams"
-                    },
-                    "operation_type": "navigate",
-                    "parse": {
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      },
-                      "source": "metadata.annotations[\"github.com/repo\"]"
-                    },
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
                   }
                 ],
-                "reference": "abc123",
-                "returns": {
-                  "array": true,
-                  "type": "IncidentStatus"
-                },
-                "root_reference": "incident.status"
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
               }
             ],
-            "folder": "My folder 01",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "include_private_incidents": true,
-            "name": "My workflow",
-            "once_for": [
-              {
-                "array": false,
-                "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
-                "label": "Incident -\u003e Affected Team",
-                "type": "IncidentSeverity"
-              }
-            ],
-            "runs_from": "2021-08-17T13:28:57.801578Z",
-            "runs_on_incident_modes": [
-              "standard",
-              "retrospective"
-            ],
-            "runs_on_incidents": "newly_created",
-            "shortform": "abc123",
-            "state": "active",
-            "steps": [
-              {
-                "for_each": "abc123",
-                "id": "abc123",
-                "label": "PagerDuty Escalate",
-                "name": "pagerduty.escalate",
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "label": "Lawrence Jones",
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "label": "Lawrence Jones",
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "trigger": {
-              "label": "Incident Updated",
-              "name": "incident.updated"
+            "items": {
+              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
             },
-            "version": 3
-          }
-        },
-        "properties": {
-          "management_meta": {
-            "$ref": "#/components/schemas/ManagementMetaV2"
-          },
-          "workflow": {
-            "$ref": "#/components/schemas/Workflow"
+            "type": "array"
           }
         },
         "required": [
-          "workflow",
-          "management_meta"
+          "id",
+          "name",
+          "param_bindings",
+          "organisation_is_eligible",
+          "release_channel",
+          "label",
+          "description",
+          "params",
+          "group_label"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
-      "StepConfig": {
+      "StepConfigSlimV2": {
+        "example": {
+          "label": "PagerDuty Escalate",
+          "name": "pagerduty.escalate"
+        },
+        "properties": {
+          "label": {
+            "description": "Human readable identifier for this step",
+            "example": "PagerDuty Escalate",
+            "type": "string"
+          },
+          "name": {
+            "description": "Unique name of the step in the engine",
+            "example": "pagerduty.escalate",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "label",
+          "group_label",
+          "organisation_is_eligible",
+          "release_channel",
+          "description",
+          "params"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "StepConfigV2": {
         "example": {
           "for_each": "abc123",
           "id": "abc123",
@@ -34450,7 +33799,7 @@
         },
         "properties": {
           "for_each": {
-            "description": "Reference to the loop variable to run this step over",
+            "description": "Reference to an expression that returns resources to run this step over",
             "example": "abc123",
             "type": "string"
           },
@@ -34498,105 +33847,16 @@
           "name",
           "label",
           "description",
+          "params",
           "param_bindings",
-          "params"
+          "organisation_is_eligible",
+          "release_channel",
+          "group_label"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
-      "StepConfigPayload": {
-        "example": {
-          "for_each": "abc123",
-          "id": "abc123",
-          "name": "pagerduty.escalate",
-          "param_bindings": [
-            {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          ]
-        },
-        "properties": {
-          "for_each": {
-            "description": "Reference to an expression that returns resources to run this step over",
-            "example": "abc123",
-            "type": "string"
-          },
-          "id": {
-            "description": "Unique ID of this step in a workflow. This must be a valid ULID.",
-            "example": "abc123",
-            "type": "string"
-          },
-          "name": {
-            "description": "Unique name of the step in the engine",
-            "example": "pagerduty.escalate",
-            "type": "string"
-          },
-          "param_bindings": {
-            "description": "List of parameter bindings",
-            "example": [
-              {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "param_bindings",
-          "label",
-          "description",
-          "params"
-        ],
-        "type": "object"
-      },
-      "StepConfigSlim": {
-        "example": {
-          "label": "PagerDuty Escalate",
-          "name": "pagerduty.escalate"
-        },
-        "properties": {
-          "label": {
-            "description": "Human readable identifier for this step",
-            "example": "PagerDuty Escalate",
-            "type": "string"
-          },
-          "name": {
-            "description": "Unique name of the step in the engine",
-            "example": "pagerduty.escalate",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "label",
-          "description",
-          "params"
-        ],
-        "type": "object"
-      },
-      "TriggerSlim": {
+      "TriggerSlimV2": {
         "example": {
           "label": "Incident Updated",
           "name": "incident.updated"
@@ -34615,713 +33875,18 @@
         },
         "required": [
           "name",
-          "label"
+          "icon",
+          "label",
+          "group_label",
+          "when_description",
+          "default_once_for",
+          "default_condition_groups",
+          "scope"
         ],
-        "type": "object"
-      },
-      "UpdateEntryRequestBody": {
-        "example": {
-          "aliases": [
-            "lawrence@incident.io",
-            "lawrence"
-          ],
-          "attribute_values": {
-            "abc123": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          },
-          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-          "name": "Primary On-call",
-          "rank": 3
-        },
-        "properties": {
-          "aliases": {
-            "description": "Optional aliases that can be used to reference this entry",
-            "example": [
-              "lawrence@incident.io",
-              "lawrence"
-            ],
-            "items": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "attribute_values": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/EngineParamBindingPayloadV2"
-            },
-            "description": "Values of this entry",
-            "example": {
-              "abc123": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            },
-            "type": "object"
-          },
-          "external_id": {
-            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
-            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name is the human readable name of this entry",
-            "example": "Primary On-call",
-            "type": "string"
-          },
-          "rank": {
-            "description": "When catalog type is ranked, this is used to help order things",
-            "example": 3,
-            "format": "int32",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "name",
-          "attribute_values"
-        ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "UpdateRequestBody": {
-        "example": {
-          "alert_sources": [
-            {
-              "alert_source_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "condition_groups": [
-                {
-                  "conditions": [
-                    {
-                      "operation": "one_of",
-                      "param_bindings": [
-                        {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      ],
-                      "subject": "incident.severity"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "auto_decline_enabled": false,
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ],
-          "defer_time_seconds": 1,
-          "enabled": false,
-          "escalation_bindings": [
-            {
-              "binding": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            }
-          ],
-          "expressions": [
-            {
-              "else_branch": {
-                "result": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              },
-              "label": "Team Slack channel",
-              "operations": [
-                {
-                  "branches": {
-                    "branches": [
-                      {
-                        "condition_groups": [
-                          {
-                            "conditions": [
-                              {
-                                "operation": "one_of",
-                                "param_bindings": [
-                                  {
-                                    "array_value": [
-                                      {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    ],
-                                    "value": {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ],
-                                "subject": "incident.severity"
-                              }
-                            ]
-                          }
-                        ],
-                        "result": {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      }
-                    ],
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
-                  },
-                  "filter": {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": "one_of",
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": "incident.severity"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "navigate": {
-                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                  },
-                  "operation_type": "navigate",
-                  "parse": {
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    },
-                    "source": "metadata.annotations[\"github.com/repo\"]"
-                  }
-                }
-              ],
-              "reference": "abc123",
-              "root_reference": "incident.status"
-            }
-          ],
-          "grouping_keys": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0"
-            }
-          ],
-          "grouping_window_seconds": 1,
-          "incident_condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ],
-          "incident_enabled": false,
-          "name": "Production incidents",
-          "template": {
-            "custom_field_priorities": {
-              "abc123": "abc123"
-            },
-            "custom_fields": {
-              "custom_field_10014": {
-                "array_value": [
-                  {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                ],
-                "value": {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              }
-            },
-            "incident_mode": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "incident_type": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "name": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "priority_severity": "severity-first-wins",
-            "severity": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "start_in_triage": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "summary": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            },
-            "workspace": {
-              "array_value": [
-                {
-                  "literal": "SEV123",
-                  "reference": "incident.severity"
-                }
-              ],
-              "value": {
-                "literal": "SEV123",
-                "reference": "incident.severity"
-              }
-            }
-          }
-        },
-        "properties": {
-          "alert_sources": {
-            "description": "Which alert sources should this alert route match?",
-            "example": [
-              {
-                "alert_source_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "condition_groups": [
-                  {
-                    "conditions": [
-                      {
-                        "operation": "one_of",
-                        "param_bindings": [
-                          {
-                            "array_value": [
-                              {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        ],
-                        "subject": "incident.severity"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/AlertRouteAlertSourcePayloadV2"
-            },
-            "type": "array"
-          },
-          "auto_decline_enabled": {
-            "description": "Should triage incidents be declined when alerts are resolved?",
-            "example": false,
-            "type": "boolean"
-          },
-          "condition_groups": {
-            "description": "What condition groups must be true for this alert route to fire?",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
-            },
-            "type": "array"
-          },
-          "defer_time_seconds": {
-            "description": "How long should the escalation defer time be?",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
-          "enabled": {
-            "description": "Whether this alert route is enabled or not",
-            "example": false,
-            "type": "boolean"
-          },
-          "escalation_bindings": {
-            "description": "Which escalation paths should this alert route escalate to?",
-            "example": [
-              {
-                "binding": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/AlertRouteEscalationBindingPayloadV2"
-            },
-            "type": "array"
-          },
-          "expressions": {
-            "description": "The expressions used in this template",
-            "example": [
-              {
-                "else_branch": {
-                  "result": {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                },
-                "label": "Team Slack channel",
-                "operations": [
-                  {
-                    "branches": {
-                      "branches": [
-                        {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": "one_of",
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": "incident.severity"
-                                }
-                              ]
-                            }
-                          ],
-                          "result": {
-                            "array_value": [
-                              {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        }
-                      ],
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    },
-                    "filter": {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": "one_of",
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": "incident.severity"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "navigate": {
-                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                    },
-                    "operation_type": "navigate",
-                    "parse": {
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      },
-                      "source": "metadata.annotations[\"github.com/repo\"]"
-                    }
-                  }
-                ],
-                "reference": "abc123",
-                "root_reference": "incident.status"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ExpressionPayloadV2"
-            },
-            "type": "array"
-          },
-          "grouping_keys": {
-            "description": "Which attributes should this alert route use to group alerts?",
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/GroupingKeyV2"
-            },
-            "type": "array"
-          },
-          "grouping_window_seconds": {
-            "description": "How large should the grouping window be?",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          },
-          "incident_condition_groups": {
-            "description": "What condition groups must be true for this alert route to create an incident?",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
-            },
-            "type": "array"
-          },
-          "incident_enabled": {
-            "description": "Whether this alert route will create incidents or not",
-            "example": false,
-            "type": "boolean"
-          },
-          "name": {
-            "description": "The name of this alert route config, for the user's reference",
-            "example": "Production incidents",
-            "type": "string"
-          },
-          "template": {
-            "$ref": "#/components/schemas/AlertRouteIncidentTemplatePayloadV2"
-          }
-        },
-        "required": [
-          "name",
-          "condition_groups",
-          "grouping_keys",
-          "grouping_window_seconds",
-          "defer_time_seconds",
-          "escalation_bindings",
-          "auto_decline_enabled",
-          "enabled",
-          "incident_enabled",
-          "is_private",
-          "incident_condition_groups",
-          "alert_sources",
-          "auto_cancel_escalations"
-        ],
-        "type": "object"
-      },
-      "UpdateRequestBody2": {
         "example": {
           "description": "The person currently coordinating the incident",
           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
@@ -35370,7 +33935,7 @@
         ],
         "type": "object"
       },
-      "UpdateRequestBody3": {
+      "UpdateRequestBody2": {
         "example": {
           "description": "The person currently coordinating the incident",
           "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
@@ -35413,7 +33978,7 @@
         ],
         "type": "object"
       },
-      "UpdateRequestBody4": {
+      "UpdateRequestBody3": {
         "example": {
           "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
           "name": "Closed"
@@ -35437,650 +34002,6 @@
           "category",
           "created_at",
           "updated_at"
-        ],
-        "type": "object"
-      },
-      "UpdateTypeRequestBody": {
-        "example": {
-          "annotations": {
-            "incident.io/catalog-importer/id": "id-of-config"
-          },
-          "categories": [
-            "issue-tracker"
-          ],
-          "color": "yellow",
-          "description": "Represents Kubernetes clusters that we run inside of GKE.",
-          "icon": "alert",
-          "name": "Kubernetes Cluster",
-          "ranked": true,
-          "source_repo_url": "https://github.com/my-company/incident-io-catalog"
-        },
-        "properties": {
-          "annotations": {
-            "additionalProperties": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "description": "Annotations that can track metadata about this type",
-            "example": {
-              "incident.io/catalog-importer/id": "id-of-config"
-            },
-            "type": "object"
-          },
-          "categories": {
-            "description": "What categories is this type considered part of",
-            "example": [
-              "issue-tracker"
-            ],
-            "items": {
-              "enum": [
-                "customer",
-                "issue-tracker",
-                "product-feature",
-                "service",
-                "on-call",
-                "team",
-                "user"
-              ],
-              "example": "issue-tracker",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "color": {
-            "description": "Sets the display color of this type in the dashboard",
-            "enum": [
-              "yellow",
-              "green",
-              "blue",
-              "violet",
-              "pink",
-              "cyan",
-              "orange"
-            ],
-            "example": "yellow",
-            "type": "string"
-          },
-          "description": {
-            "description": "Human readble description of this type",
-            "example": "Represents Kubernetes clusters that we run inside of GKE.",
-            "type": "string"
-          },
-          "icon": {
-            "description": "Sets the display icon of this type in the dashboard",
-            "enum": [
-              "alert",
-              "bolt",
-              "box",
-              "briefcase",
-              "browser",
-              "bulb",
-              "calendar",
-              "clock",
-              "cog",
-              "components",
-              "database",
-              "doc",
-              "email",
-              "escalation-path",
-              "files",
-              "flag",
-              "folder",
-              "globe",
-              "money",
-              "server",
-              "severity",
-              "status-page",
-              "store",
-              "star",
-              "tag",
-              "user",
-              "users"
-            ],
-            "example": "alert",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name is the human readable name of this type",
-            "example": "Kubernetes Cluster",
-            "type": "string"
-          },
-          "ranked": {
-            "description": "If this type should be ranked",
-            "example": true,
-            "type": "boolean"
-          },
-          "source_repo_url": {
-            "description": "The url of the external repository where this type is managed",
-            "example": "https://github.com/my-company/incident-io-catalog",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "description"
-        ],
-        "type": "object"
-      },
-      "UpdateTypeSchemaRequestBody": {
-        "example": {
-          "attributes": [
-            {
-              "array": false,
-              "backlink_attribute": "abc123",
-              "id": "01GW2G3V0S59R238FAHPDS1R66",
-              "mode": "manual",
-              "name": "tier",
-              "path": [
-                {
-                  "attribute_id": "abc123"
-                }
-              ],
-              "type": "Custom[\"Service\"]"
-            }
-          ],
-          "version": 1
-        },
-        "properties": {
-          "attributes": {
-            "example": [
-              {
-                "array": false,
-                "backlink_attribute": "abc123",
-                "id": "01GW2G3V0S59R238FAHPDS1R66",
-                "mode": "manual",
-                "name": "tier",
-                "path": [
-                  {
-                    "attribute_id": "abc123"
-                  }
-                ],
-                "type": "Custom[\"Service\"]"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/CatalogTypeAttributePayloadV2"
-            },
-            "type": "array"
-          },
-          "version": {
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "attributes",
-          "version",
-          "name",
-          "description",
-          "type_name",
-          "semantic_type",
-          "ranked",
-          "schema",
-          "icon",
-          "categories",
-          "color",
-          "is_editable",
-          "annotations",
-          "created_at",
-          "updated_at",
-          "engine_resource_type",
-          "mode",
-          "use_name_as_identifier"
-        ],
-        "type": "object"
-      },
-      "UpdateWorkflowPayload2": {
-        "example": {
-          "annotations": {
-            "incident.io/terraform/version": "3.0.0"
-          },
-          "condition_groups": [
-            {
-              "conditions": [
-                {
-                  "operation": "one_of",
-                  "param_bindings": [
-                    {
-                      "array_value": [
-                        {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      ],
-                      "value": {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    }
-                  ],
-                  "subject": "incident.severity"
-                }
-              ]
-            }
-          ],
-          "continue_on_step_error": true,
-          "delay": {
-            "conditions_apply_over_delay": false,
-            "for_seconds": 60
-          },
-          "expressions": [
-            {
-              "else_branch": {
-                "result": {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              },
-              "label": "Team Slack channel",
-              "operations": [
-                {
-                  "branches": {
-                    "branches": [
-                      {
-                        "condition_groups": [
-                          {
-                            "conditions": [
-                              {
-                                "operation": "one_of",
-                                "param_bindings": [
-                                  {
-                                    "array_value": [
-                                      {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    ],
-                                    "value": {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  }
-                                ],
-                                "subject": "incident.severity"
-                              }
-                            ]
-                          }
-                        ],
-                        "result": {
-                          "array_value": [
-                            {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          ],
-                          "value": {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        }
-                      }
-                    ],
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    }
-                  },
-                  "filter": {
-                    "condition_groups": [
-                      {
-                        "conditions": [
-                          {
-                            "operation": "one_of",
-                            "param_bindings": [
-                              {
-                                "array_value": [
-                                  {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                ],
-                                "value": {
-                                  "literal": "SEV123",
-                                  "reference": "incident.severity"
-                                }
-                              }
-                            ],
-                            "subject": "incident.severity"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "navigate": {
-                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                  },
-                  "operation_type": "navigate",
-                  "parse": {
-                    "returns": {
-                      "array": true,
-                      "type": "IncidentStatus"
-                    },
-                    "source": "metadata.annotations[\"github.com/repo\"]"
-                  }
-                }
-              ],
-              "reference": "abc123",
-              "root_reference": "incident.status"
-            }
-          ],
-          "folder": "My folder 01",
-          "include_private_incidents": true,
-          "name": "My workflow",
-          "once_for": [
-            "incident.url"
-          ],
-          "runs_on_incident_modes": [
-            "standard",
-            "retrospective"
-          ],
-          "runs_on_incidents": "newly_created",
-          "shortform": "abc123",
-          "state": "active",
-          "steps": [
-            {
-              "for_each": "abc123",
-              "id": "abc123",
-              "name": "pagerduty.escalate",
-              "param_bindings": [
-                {
-                  "array_value": [
-                    {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  ],
-                  "value": {
-                    "literal": "SEV123",
-                    "reference": "incident.severity"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "properties": {
-          "annotations": {
-            "additionalProperties": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "description": "Annotations that track metadata about this resource",
-            "example": {
-              "incident.io/terraform/version": "3.0.0"
-            },
-            "type": "object"
-          },
-          "condition_groups": {
-            "description": "List of conditions to apply to the workflow",
-            "example": [
-              {
-                "conditions": [
-                  {
-                    "operation": "one_of",
-                    "param_bindings": [
-                      {
-                        "array_value": [
-                          {
-                            "literal": "SEV123",
-                            "reference": "incident.severity"
-                          }
-                        ],
-                        "value": {
-                          "literal": "SEV123",
-                          "reference": "incident.severity"
-                        }
-                      }
-                    ],
-                    "subject": "incident.severity"
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
-            },
-            "type": "array"
-          },
-          "continue_on_step_error": {
-            "description": "Whether to continue executing the workflow if a step fails",
-            "example": true,
-            "type": "boolean"
-          },
-          "delay": {
-            "$ref": "#/components/schemas/WorkflowDelay"
-          },
-          "expressions": {
-            "description": "The expressions used in the workflow",
-            "example": [
-              {
-                "else_branch": {
-                  "result": {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                },
-                "label": "Team Slack channel",
-                "operations": [
-                  {
-                    "branches": {
-                      "branches": [
-                        {
-                          "condition_groups": [
-                            {
-                              "conditions": [
-                                {
-                                  "operation": "one_of",
-                                  "param_bindings": [
-                                    {
-                                      "array_value": [
-                                        {
-                                          "literal": "SEV123",
-                                          "reference": "incident.severity"
-                                        }
-                                      ],
-                                      "value": {
-                                        "literal": "SEV123",
-                                        "reference": "incident.severity"
-                                      }
-                                    }
-                                  ],
-                                  "subject": "incident.severity"
-                                }
-                              ]
-                            }
-                          ],
-                          "result": {
-                            "array_value": [
-                              {
-                                "literal": "SEV123",
-                                "reference": "incident.severity"
-                              }
-                            ],
-                            "value": {
-                              "literal": "SEV123",
-                              "reference": "incident.severity"
-                            }
-                          }
-                        }
-                      ],
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      }
-                    },
-                    "filter": {
-                      "condition_groups": [
-                        {
-                          "conditions": [
-                            {
-                              "operation": "one_of",
-                              "param_bindings": [
-                                {
-                                  "array_value": [
-                                    {
-                                      "literal": "SEV123",
-                                      "reference": "incident.severity"
-                                    }
-                                  ],
-                                  "value": {
-                                    "literal": "SEV123",
-                                    "reference": "incident.severity"
-                                  }
-                                }
-                              ],
-                              "subject": "incident.severity"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    "navigate": {
-                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
-                    },
-                    "operation_type": "navigate",
-                    "parse": {
-                      "returns": {
-                        "array": true,
-                        "type": "IncidentStatus"
-                      },
-                      "source": "metadata.annotations[\"github.com/repo\"]"
-                    }
-                  }
-                ],
-                "reference": "abc123",
-                "root_reference": "incident.status"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/ExpressionPayloadV2"
-            },
-            "type": "array"
-          },
-          "folder": {
-            "description": "Folder to display the workflow in",
-            "example": "My folder 01",
-            "type": "string"
-          },
-          "include_private_incidents": {
-            "description": "Whether to include private incidents",
-            "example": true,
-            "type": "boolean"
-          },
-          "name": {
-            "description": "The human-readable name of the workflow",
-            "example": "My workflow",
-            "type": "string"
-          },
-          "once_for": {
-            "description": "Once For strategy to apply to this workflow",
-            "example": [
-              "incident.url"
-            ],
-            "items": {
-              "example": "incident.url",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "runs_on_incident_modes": {
-            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
-            "example": [
-              "standard",
-              "retrospective"
-            ],
-            "items": {
-              "enum": [
-                "standard",
-                "test",
-                "retrospective"
-              ],
-              "example": "test",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "runs_on_incidents": {
-            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
-            "enum": [
-              "newly_created",
-              "newly_created_and_active"
-            ],
-            "example": "newly_created",
-            "type": "string"
-          },
-          "shortform": {
-            "description": "Shortform used to trigger manual workflows in Slack - e.g. `/inc workflows page-ceo`",
-            "example": "abc123",
-            "type": "string"
-          },
-          "state": {
-            "description": "The state of the workflow (e.g. is it draft, or disabled)",
-            "enum": [
-              "active",
-              "disabled",
-              "draft",
-              "error"
-            ],
-            "example": "active",
-            "type": "string"
-          },
-          "steps": {
-            "description": "List of step to execute as part of the workflow",
-            "example": [
-              {
-                "for_each": "abc123",
-                "id": "abc123",
-                "name": "pagerduty.escalate",
-                "param_bindings": [
-                  {
-                    "array_value": [
-                      {
-                        "literal": "SEV123",
-                        "reference": "incident.severity"
-                      }
-                    ],
-                    "value": {
-                      "literal": "SEV123",
-                      "reference": "incident.severity"
-                    }
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/StepConfigPayload"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "name",
-          "once_for",
-          "condition_groups",
-          "steps",
-          "expressions",
-          "include_private_incidents",
-          "runs_on_incident_modes",
-          "continue_on_step_error",
-          "runs_on_incidents"
         ],
         "type": "object"
       },
@@ -37019,7 +34940,32 @@
         ],
         "type": "object"
       },
-      "Workflow": {
+      "WorkflowDelayV2": {
+        "example": {
+          "conditions_apply_over_delay": false,
+          "for_seconds": 60
+        },
+        "properties": {
+          "conditions_apply_over_delay": {
+            "description": "If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution",
+            "example": false,
+            "type": "boolean"
+          },
+          "for_seconds": {
+            "description": "Delay in seconds between trigger firing and running the workflow",
+            "example": 60,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "for_seconds",
+          "conditions_apply_over_delay"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "WorkflowSlimV2": {
         "example": {
           "condition_groups": [
             {
@@ -37198,7 +35144,7 @@
           "folder": "My folder 01",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "include_private_incidents": true,
-          "name": "My workflow",
+          "name": "My little workflow",
           "once_for": [
             {
               "array": false,
@@ -37210,10 +35156,540 @@
           "runs_from": "2021-08-17T13:28:57.801578Z",
           "runs_on_incident_modes": [
             "standard",
+            "test",
             "retrospective"
           ],
           "runs_on_incidents": "newly_created",
-          "shortform": "abc123",
+          "shortform": "page-the-ceo",
+          "state": "active",
+          "steps": [
+            {
+              "label": "PagerDuty Escalate",
+              "name": "pagerduty.escalate"
+            }
+          ],
+          "trigger": {
+            "label": "Incident Updated",
+            "name": "incident.updated"
+          },
+          "version": 3
+        },
+        "properties": {
+          "condition_groups": {
+            "description": "Conditions that apply to the workflow trigger",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupV2"
+            },
+            "type": "array"
+          },
+          "continue_on_step_error": {
+            "description": "Whether to continue executing the workflow if a step fails",
+            "example": true,
+            "type": "boolean"
+          },
+          "delay": {
+            "$ref": "#/components/schemas/WorkflowDelayV2"
+          },
+          "expressions": {
+            "description": "Expressions that make variables available in the scope",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ExpressionV2"
+            },
+            "type": "array"
+          },
+          "folder": {
+            "description": "Folder to display the workflow in",
+            "example": "My folder 01",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the workflow",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "include_private_incidents": {
+            "description": "Whether to include private incidents",
+            "example": true,
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Name provided by the user when creating the workflow",
+            "example": "My little workflow",
+            "type": "string"
+          },
+          "once_for": {
+            "description": "This workflow will run 'once for' a list of references",
+            "example": [
+              {
+                "array": false,
+                "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                "label": "Incident -\u003e Affected Team",
+                "type": "IncidentSeverity"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/EngineReferenceV2"
+            },
+            "type": "array"
+          },
+          "runs_from": {
+            "description": "The time from which this workflow will run on incidents",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "runs_on_incident_modes": {
+            "description": "Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.",
+            "example": [
+              "standard",
+              "test",
+              "retrospective"
+            ],
+            "items": {
+              "description": "Incident mode that workflows can run on",
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ],
+              "example": "standard",
+              "type": "string",
+              "x-public-api-version": "v2"
+            },
+            "type": "array"
+          },
+          "runs_on_incidents": {
+            "description": "Which incidents should the workflow be applied to?",
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ],
+            "example": "newly_created",
+            "type": "string"
+          },
+          "shortform": {
+            "description": "The shortform used to trigger this workflow (only applicable for manual triggers)",
+            "example": "page-the-ceo",
+            "type": "string"
+          },
+          "state": {
+            "description": "What state this workflow is in",
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ],
+            "example": "active",
+            "type": "string"
+          },
+          "steps": {
+            "description": "Steps that are executed as part of the workflow",
+            "example": [
+              {
+                "label": "PagerDuty Escalate",
+                "name": "pagerduty.escalate"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StepConfigSlimV2"
+            },
+            "type": "array"
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/TriggerSlimV2"
+          },
+          "version": {
+            "description": "Revision of the workflow, uniquely identifying it's version",
+            "example": 3,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "organisation_id",
+          "name",
+          "trigger",
+          "once_for",
+          "version",
+          "expressions",
+          "condition_groups",
+          "steps",
+          "include_private_incidents",
+          "runs_on_incident_modes",
+          "continue_on_step_error",
+          "runs_on_incidents",
+          "state"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "WorkflowV2": {
+        "example": {
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": {
+                    "label": "Lawrence Jones",
+                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                  },
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": {
+                    "label": "Incident Severity",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ],
+          "continue_on_step_error": true,
+          "delay": {
+            "conditions_apply_over_delay": false,
+            "for_seconds": 60
+          },
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": {
+                              "label": "Lawrence Jones",
+                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                            },
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": {
+                              "label": "Incident Severity",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "1235",
+                    "reference_label": "Teams"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  },
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "returns": {
+                "array": true,
+                "type": "IncidentStatus"
+              },
+              "root_reference": "incident.status"
+            }
+          ],
+          "folder": "My folder 01",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "include_private_incidents": true,
+          "name": "My little workflow",
+          "once_for": [
+            {
+              "array": false,
+              "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+              "label": "Incident -\u003e Affected Team",
+              "type": "IncidentSeverity"
+            }
+          ],
+          "runs_from": "2021-08-17T13:28:57.801578Z",
+          "runs_on_incident_modes": [
+            "standard",
+            "test",
+            "retrospective"
+          ],
+          "runs_on_incidents": "newly_created",
+          "shortform": "page-the-ceo",
           "state": "active",
           "steps": [
             {
@@ -37281,7 +35757,7 @@
               }
             ],
             "items": {
-              "$ref": "#/components/schemas/ConditionGroupV5"
+              "$ref": "#/components/schemas/ConditionGroupV2"
             },
             "type": "array"
           },
@@ -37291,7 +35767,7 @@
             "type": "boolean"
           },
           "delay": {
-            "$ref": "#/components/schemas/WorkflowDelay"
+            "$ref": "#/components/schemas/WorkflowDelayV2"
           },
           "expressions": {
             "description": "Expressions that make variables available in the scope",
@@ -37433,7 +35909,7 @@
               }
             ],
             "items": {
-              "$ref": "#/components/schemas/ExpressionV3"
+              "$ref": "#/components/schemas/ExpressionV2"
             },
             "type": "array"
           },
@@ -37453,8 +35929,8 @@
             "type": "boolean"
           },
           "name": {
-            "description": "The human-readable name of the workflow",
-            "example": "My workflow",
+            "description": "Name provided by the user when creating the workflow",
+            "example": "My little workflow",
             "type": "string"
           },
           "once_for": {
@@ -37479,9 +35955,10 @@
             "type": "string"
           },
           "runs_on_incident_modes": {
-            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "description": "Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.",
             "example": [
               "standard",
+              "test",
               "retrospective"
             ],
             "items": {
@@ -37492,12 +35969,13 @@
                 "retrospective"
               ],
               "example": "standard",
-              "type": "string"
+              "type": "string",
+              "x-public-api-version": "v2"
             },
             "type": "array"
           },
           "runs_on_incidents": {
-            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+            "description": "Which incidents should the workflow be applied to?",
             "enum": [
               "newly_created",
               "newly_created_and_active"
@@ -37506,12 +35984,12 @@
             "type": "string"
           },
           "shortform": {
-            "description": "Shortform used to trigger manual workflows in Slack - e.g. `/inc workflows page-ceo`",
-            "example": "abc123",
+            "description": "The shortform used to trigger this workflow (only applicable for manual triggers)",
+            "example": "page-the-ceo",
             "type": "string"
           },
           "state": {
-            "description": "The state of the workflow (e.g. is it draft, or disabled)",
+            "description": "What state this workflow is in",
             "enum": [
               "active",
               "disabled",
@@ -37548,15 +36026,15 @@
               }
             ],
             "items": {
-              "$ref": "#/components/schemas/StepConfig"
+              "$ref": "#/components/schemas/StepConfigV2"
             },
             "type": "array"
           },
           "trigger": {
-            "$ref": "#/components/schemas/TriggerSlim"
+            "$ref": "#/components/schemas/TriggerSlimV2"
           },
           "version": {
-            "description": "Revision of the workflow, uniquely identifying its version",
+            "description": "Revision of the workflow, uniquely identifying it's version",
             "example": 3,
             "format": "int64",
             "type": "integer"
@@ -37564,8 +36042,10 @@
         },
         "required": [
           "id",
+          "organisation_id",
           "name",
           "trigger",
+          "once_for",
           "version",
           "expressions",
           "condition_groups",
@@ -37574,65 +36054,38 @@
           "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents",
-          "once_for",
+          "created_at",
+          "updated_at",
           "state"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
-      "WorkflowDelay": {
+      "WorkflowsCreateWorkflowPayloadV2": {
         "example": {
-          "conditions_apply_over_delay": false,
-          "for_seconds": 60
-        },
-        "properties": {
-          "conditions_apply_over_delay": {
-            "description": "If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution",
-            "example": false,
-            "type": "boolean"
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
           },
-          "for_seconds": {
-            "description": "Delay in seconds between trigger firing and running the workflow",
-            "example": 60,
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "for_seconds",
-          "conditions_apply_over_delay"
-        ],
-        "type": "object"
-      },
-      "WorkflowSlim": {
-        "example": {
           "condition_groups": [
             {
               "conditions": [
                 {
-                  "operation": {
-                    "label": "Lawrence Jones",
-                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                  },
+                  "operation": "one_of",
                   "param_bindings": [
                     {
                       "array_value": [
                         {
-                          "label": "Lawrence Jones",
                           "literal": "SEV123",
                           "reference": "incident.severity"
                         }
                       ],
                       "value": {
-                        "label": "Lawrence Jones",
                         "literal": "SEV123",
                         "reference": "incident.severity"
                       }
                     }
                   ],
-                  "subject": {
-                    "label": "Incident Severity",
-                    "reference": "incident.severity"
-                  }
+                  "subject": "incident.severity"
                 }
               ]
             }
@@ -37648,13 +36101,11 @@
                 "result": {
                   "array_value": [
                     {
-                      "label": "Lawrence Jones",
                       "literal": "SEV123",
                       "reference": "incident.severity"
                     }
                   ],
                   "value": {
-                    "label": "Lawrence Jones",
                     "literal": "SEV123",
                     "reference": "incident.severity"
                   }
@@ -37670,30 +36121,22 @@
                           {
                             "conditions": [
                               {
-                                "operation": {
-                                  "label": "Lawrence Jones",
-                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                                },
+                                "operation": "one_of",
                                 "param_bindings": [
                                   {
                                     "array_value": [
                                       {
-                                        "label": "Lawrence Jones",
                                         "literal": "SEV123",
                                         "reference": "incident.severity"
                                       }
                                     ],
                                     "value": {
-                                      "label": "Lawrence Jones",
                                       "literal": "SEV123",
                                       "reference": "incident.severity"
                                     }
                                   }
                                 ],
-                                "subject": {
-                                  "label": "Incident Severity",
-                                  "reference": "incident.severity"
-                                }
+                                "subject": "incident.severity"
                               }
                             ]
                           }
@@ -37701,13 +36144,11 @@
                         "result": {
                           "array_value": [
                             {
-                              "label": "Lawrence Jones",
                               "literal": "SEV123",
                               "reference": "incident.severity"
                             }
                           ],
                           "value": {
-                            "label": "Lawrence Jones",
                             "literal": "SEV123",
                             "reference": "incident.severity"
                           }
@@ -37724,38 +36165,29 @@
                       {
                         "conditions": [
                           {
-                            "operation": {
-                              "label": "Lawrence Jones",
-                              "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
-                            },
+                            "operation": "one_of",
                             "param_bindings": [
                               {
                                 "array_value": [
                                   {
-                                    "label": "Lawrence Jones",
                                     "literal": "SEV123",
                                     "reference": "incident.severity"
                                   }
                                 ],
                                 "value": {
-                                  "label": "Lawrence Jones",
                                   "literal": "SEV123",
                                   "reference": "incident.severity"
                                 }
                               }
                             ],
-                            "subject": {
-                              "label": "Incident Severity",
-                              "reference": "incident.severity"
-                            }
+                            "subject": "incident.severity"
                           }
                         ]
                       }
                     ]
                   },
                   "navigate": {
-                    "reference": "1235",
-                    "reference_label": "Teams"
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                   },
                   "operation_type": "navigate",
                   "parse": {
@@ -37764,57 +36196,344 @@
                       "type": "IncidentStatus"
                     },
                     "source": "metadata.annotations[\"github.com/repo\"]"
-                  },
-                  "returns": {
-                    "array": true,
-                    "type": "IncidentStatus"
                   }
                 }
               ],
               "reference": "abc123",
-              "returns": {
-                "array": true,
-                "type": "IncidentStatus"
-              },
               "root_reference": "incident.status"
             }
           ],
           "folder": "My folder 01",
-          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "include_private_incidents": true,
-          "name": "My workflow",
+          "name": "My little workflow",
           "once_for": [
-            {
-              "array": false,
-              "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
-              "label": "Incident -\u003e Affected Team",
-              "type": "IncidentSeverity"
-            }
+            "incident.url"
           ],
-          "runs_from": "2021-08-17T13:28:57.801578Z",
           "runs_on_incident_modes": [
             "standard",
+            "test",
             "retrospective"
           ],
           "runs_on_incidents": "newly_created",
-          "shortform": "abc123",
+          "shortform": "page-the-ceo",
           "state": "active",
           "steps": [
             {
-              "label": "PagerDuty Escalate",
-              "name": "pagerduty.escalate"
+              "for_each": "abc123",
+              "id": "abc123",
+              "name": "pagerduty.escalate",
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
             }
           ],
-          "trigger": {
-            "label": "Incident Updated",
-            "name": "incident.updated"
-          },
-          "version": 3
+          "trigger": "incident.updated"
         },
         "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "type": "object"
+          },
           "condition_groups": {
             "description": "Conditions that apply to the workflow trigger",
             "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "type": "array"
+          },
+          "continue_on_step_error": {
+            "description": "Whether to continue executing the workflow if a step fails",
+            "example": true,
+            "type": "boolean"
+          },
+          "delay": {
+            "$ref": "#/components/schemas/WorkflowDelayV2"
+          },
+          "expressions": {
+            "description": "The expressions to use in the workflow",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
+            },
+            "type": "array"
+          },
+          "folder": {
+            "description": "Folder to display the workflow in",
+            "example": "My folder 01",
+            "type": "string"
+          },
+          "include_private_incidents": {
+            "description": "Whether to include private incidents",
+            "example": true,
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Name provided by the user when creating the workflow",
+            "example": "My little workflow",
+            "type": "string"
+          },
+          "once_for": {
+            "description": "This workflow will run 'once for' a list of references",
+            "example": [
+              "incident.url"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "runs_on_incident_modes": {
+            "description": "Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.",
+            "example": [
+              "standard",
+              "test",
+              "retrospective"
+            ],
+            "items": {
+              "enum": [
+                "standard",
+                "test",
+                "retrospective"
+              ],
+              "example": "test",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "runs_on_incidents": {
+            "description": "Which incidents should the workflow be applied to?",
+            "enum": [
+              "newly_created",
+              "newly_created_and_active"
+            ],
+            "example": "newly_created",
+            "type": "string"
+          },
+          "shortform": {
+            "description": "The shortform used to trigger this workflow (only applicable for manual triggers)",
+            "example": "page-the-ceo",
+            "type": "string"
+          },
+          "state": {
+            "description": "What state this workflow is in",
+            "enum": [
+              "active",
+              "disabled",
+              "draft",
+              "error"
+            ],
+            "example": "active",
+            "type": "string"
+          },
+          "steps": {
+            "description": "Steps that are executed as part of the workflow",
+            "example": [
+              {
+                "for_each": "abc123",
+                "id": "abc123",
+                "name": "pagerduty.escalate",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StepConfigPayloadV2"
+            },
+            "type": "array"
+          },
+          "trigger": {
+            "description": "Trigger to set on the workflow",
+            "example": "incident.updated",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "trigger",
+          "once_for",
+          "condition_groups",
+          "steps",
+          "expressions",
+          "include_private_incidents",
+          "runs_on_incident_modes",
+          "continue_on_step_error",
+          "runs_on_incidents"
+        ],
+        "type": "object"
+      },
+      "WorkflowsCreateWorkflowResultV2": {
+        "example": {
+          "management_meta": {
+            "annotations": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "managed_by": "dashboard",
+            "source_url": "https://github.com/my-company/infrastructure"
+          },
+          "workflow": {
+            "condition_groups": [
               {
                 "conditions": [
                   {
@@ -37846,22 +36565,12 @@
                 ]
               }
             ],
-            "items": {
-              "$ref": "#/components/schemas/ConditionGroupV8"
+            "continue_on_step_error": true,
+            "delay": {
+              "conditions_apply_over_delay": false,
+              "for_seconds": 60
             },
-            "type": "array"
-          },
-          "continue_on_step_error": {
-            "description": "Whether to continue executing the workflow if a step fails",
-            "example": true,
-            "type": "boolean"
-          },
-          "delay": {
-            "$ref": "#/components/schemas/WorkflowDelay"
-          },
-          "expressions": {
-            "description": "Expressions that make variables available in the scope",
-            "example": [
+            "expressions": [
               {
                 "else_branch": {
                   "result": {
@@ -37998,8 +36707,1099 @@
                 "root_reference": "incident.status"
               }
             ],
+            "folder": "My folder 01",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "include_private_incidents": true,
+            "name": "My little workflow",
+            "once_for": [
+              {
+                "array": false,
+                "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                "label": "Incident -\u003e Affected Team",
+                "type": "IncidentSeverity"
+              }
+            ],
+            "runs_from": "2021-08-17T13:28:57.801578Z",
+            "runs_on_incident_modes": [
+              "standard",
+              "test",
+              "retrospective"
+            ],
+            "runs_on_incidents": "newly_created",
+            "shortform": "page-the-ceo",
+            "state": "active",
+            "steps": [
+              {
+                "for_each": "abc123",
+                "id": "abc123",
+                "label": "PagerDuty Escalate",
+                "name": "pagerduty.escalate",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "trigger": {
+              "label": "Incident Updated",
+              "name": "incident.updated"
+            },
+            "version": 3
+          }
+        },
+        "properties": {
+          "management_meta": {
+            "$ref": "#/components/schemas/ManagementMetaV2"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowV2"
+          }
+        },
+        "required": [
+          "workflow",
+          "management_meta"
+        ],
+        "type": "object"
+      },
+      "WorkflowsListWorkflowsResultV2": {
+        "example": {
+          "workflows": [
+            {
+              "condition_groups": [
+                {
+                  "conditions": [
+                    {
+                      "operation": {
+                        "label": "Lawrence Jones",
+                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                      },
+                      "param_bindings": [
+                        {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      ],
+                      "subject": {
+                        "label": "Incident Severity",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "continue_on_step_error": true,
+              "delay": {
+                "conditions_apply_over_delay": false,
+                "for_seconds": 60
+              },
+              "expressions": [
+                {
+                  "else_branch": {
+                    "result": {
+                      "array_value": [
+                        {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  },
+                  "label": "Team Slack channel",
+                  "operations": [
+                    {
+                      "branches": {
+                        "branches": [
+                          {
+                            "condition_groups": [
+                              {
+                                "conditions": [
+                                  {
+                                    "operation": {
+                                      "label": "Lawrence Jones",
+                                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                    },
+                                    "param_bindings": [
+                                      {
+                                        "array_value": [
+                                          {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        ],
+                                        "value": {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      }
+                                    ],
+                                    "subject": {
+                                      "label": "Incident Severity",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ]
+                              }
+                            ],
+                            "result": {
+                              "array_value": [
+                                {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              ],
+                              "value": {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          }
+                        ],
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        }
+                      },
+                      "filter": {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": {
+                                  "label": "Lawrence Jones",
+                                  "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                },
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": {
+                                  "label": "Incident Severity",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "navigate": {
+                        "reference": "1235",
+                        "reference_label": "Teams"
+                      },
+                      "operation_type": "navigate",
+                      "parse": {
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        },
+                        "source": "metadata.annotations[\"github.com/repo\"]"
+                      },
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    }
+                  ],
+                  "reference": "abc123",
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  },
+                  "root_reference": "incident.status"
+                }
+              ],
+              "folder": "My folder 01",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "include_private_incidents": true,
+              "name": "My little workflow",
+              "once_for": [
+                {
+                  "array": false,
+                  "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                  "label": "Incident -\u003e Affected Team",
+                  "type": "IncidentSeverity"
+                }
+              ],
+              "runs_from": "2021-08-17T13:28:57.801578Z",
+              "runs_on_incident_modes": [
+                "standard",
+                "test",
+                "retrospective"
+              ],
+              "runs_on_incidents": "newly_created",
+              "shortform": "page-the-ceo",
+              "state": "active",
+              "steps": [
+                {
+                  "label": "PagerDuty Escalate",
+                  "name": "pagerduty.escalate"
+                }
+              ],
+              "trigger": {
+                "label": "Incident Updated",
+                "name": "incident.updated"
+              },
+              "version": 3
+            }
+          ]
+        },
+        "properties": {
+          "workflows": {
+            "example": [
+              {
+                "condition_groups": [
+                  {
+                    "conditions": [
+                      {
+                        "operation": {
+                          "label": "Lawrence Jones",
+                          "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                        },
+                        "param_bindings": [
+                          {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        ],
+                        "subject": {
+                          "label": "Incident Severity",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "continue_on_step_error": true,
+                "delay": {
+                  "conditions_apply_over_delay": false,
+                  "for_seconds": 60
+                },
+                "expressions": [
+                  {
+                    "else_branch": {
+                      "result": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    },
+                    "label": "Team Slack channel",
+                    "operations": [
+                      {
+                        "branches": {
+                          "branches": [
+                            {
+                              "condition_groups": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "operation": {
+                                        "label": "Lawrence Jones",
+                                        "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                      },
+                                      "param_bindings": [
+                                        {
+                                          "array_value": [
+                                            {
+                                              "label": "Lawrence Jones",
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          ],
+                                          "value": {
+                                            "label": "Lawrence Jones",
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        }
+                                      ],
+                                      "subject": {
+                                        "label": "Incident Severity",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "result": {
+                                "array_value": [
+                                  {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "label": "Lawrence Jones",
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            }
+                          ],
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
+                        "filter": {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "navigate": {
+                          "reference": "1235",
+                          "reference_label": "Teams"
+                        },
+                        "operation_type": "navigate",
+                        "parse": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          },
+                          "source": "metadata.annotations[\"github.com/repo\"]"
+                        },
+                        "returns": {
+                          "array": true,
+                          "type": "IncidentStatus"
+                        }
+                      }
+                    ],
+                    "reference": "abc123",
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "root_reference": "incident.status"
+                  }
+                ],
+                "folder": "My folder 01",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "include_private_incidents": true,
+                "name": "My little workflow",
+                "once_for": [
+                  {
+                    "array": false,
+                    "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                    "label": "Incident -\u003e Affected Team",
+                    "type": "IncidentSeverity"
+                  }
+                ],
+                "runs_from": "2021-08-17T13:28:57.801578Z",
+                "runs_on_incident_modes": [
+                  "standard",
+                  "test",
+                  "retrospective"
+                ],
+                "runs_on_incidents": "newly_created",
+                "shortform": "page-the-ceo",
+                "state": "active",
+                "steps": [
+                  {
+                    "label": "PagerDuty Escalate",
+                    "name": "pagerduty.escalate"
+                  }
+                ],
+                "trigger": {
+                  "label": "Incident Updated",
+                  "name": "incident.updated"
+                },
+                "version": 3
+              }
+            ],
             "items": {
-              "$ref": "#/components/schemas/ExpressionV4"
+              "$ref": "#/components/schemas/WorkflowSlimV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "workflows"
+        ],
+        "type": "object"
+      },
+      "WorkflowsShowWorkflowResultV2": {
+        "example": {
+          "management_meta": {
+            "annotations": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "managed_by": "dashboard",
+            "source_url": "https://github.com/my-company/infrastructure"
+          },
+          "workflow": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "continue_on_step_error": true,
+            "delay": {
+              "conditions_apply_over_delay": false,
+              "for_seconds": 60
+            },
+            "expressions": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ],
+            "folder": "My folder 01",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "include_private_incidents": true,
+            "name": "My little workflow",
+            "once_for": [
+              {
+                "array": false,
+                "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                "label": "Incident -\u003e Affected Team",
+                "type": "IncidentSeverity"
+              }
+            ],
+            "runs_from": "2021-08-17T13:28:57.801578Z",
+            "runs_on_incident_modes": [
+              "standard",
+              "test",
+              "retrospective"
+            ],
+            "runs_on_incidents": "newly_created",
+            "shortform": "page-the-ceo",
+            "state": "active",
+            "steps": [
+              {
+                "for_each": "abc123",
+                "id": "abc123",
+                "label": "PagerDuty Escalate",
+                "name": "pagerduty.escalate",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "trigger": {
+              "label": "Incident Updated",
+              "name": "incident.updated"
+            },
+            "version": 3
+          }
+        },
+        "properties": {
+          "management_meta": {
+            "$ref": "#/components/schemas/ManagementMetaV2"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowV2"
+          }
+        },
+        "required": [
+          "workflow",
+          "management_meta"
+        ],
+        "type": "object"
+      },
+      "WorkflowsUpdateWorkflowPayloadV2": {
+        "example": {
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          },
+          "condition_groups": [
+            {
+              "conditions": [
+                {
+                  "operation": "one_of",
+                  "param_bindings": [
+                    {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  ],
+                  "subject": "incident.severity"
+                }
+              ]
+            }
+          ],
+          "continue_on_step_error": true,
+          "delay": {
+            "conditions_apply_over_delay": false,
+            "for_seconds": 60
+          },
+          "expressions": [
+            {
+              "else_branch": {
+                "result": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "label": "Team Slack channel",
+              "operations": [
+                {
+                  "branches": {
+                    "branches": [
+                      {
+                        "condition_groups": [
+                          {
+                            "conditions": [
+                              {
+                                "operation": "one_of",
+                                "param_bindings": [
+                                  {
+                                    "array_value": [
+                                      {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    ],
+                                    "value": {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  }
+                                ],
+                                "subject": "incident.severity"
+                              }
+                            ]
+                          }
+                        ],
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      }
+                    ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "filter": {
+                    "condition_groups": [
+                      {
+                        "conditions": [
+                          {
+                            "operation": "one_of",
+                            "param_bindings": [
+                              {
+                                "array_value": [
+                                  {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                ],
+                                "value": {
+                                  "literal": "SEV123",
+                                  "reference": "incident.severity"
+                                }
+                              }
+                            ],
+                            "subject": "incident.severity"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "navigate": {
+                    "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                  },
+                  "operation_type": "navigate",
+                  "parse": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    },
+                    "source": "metadata.annotations[\"github.com/repo\"]"
+                  }
+                }
+              ],
+              "reference": "abc123",
+              "root_reference": "incident.status"
+            }
+          ],
+          "folder": "My folder 01",
+          "include_private_incidents": true,
+          "name": "My little workflow",
+          "once_for": [
+            "incident.url"
+          ],
+          "runs_on_incident_modes": [
+            "standard",
+            "test",
+            "retrospective"
+          ],
+          "runs_on_incidents": "newly_created",
+          "shortform": "page-the-ceo",
+          "state": "active",
+          "steps": [
+            {
+              "for_each": "abc123",
+              "id": "abc123",
+              "name": "pagerduty.escalate",
+              "param_bindings": [
+                {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "type": "object"
+          },
+          "condition_groups": {
+            "description": "Conditions that apply to the workflow trigger",
+            "example": [
+              {
+                "conditions": [
+                  {
+                    "operation": "one_of",
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": "incident.severity"
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ConditionGroupPayloadV2"
+            },
+            "type": "array"
+          },
+          "continue_on_step_error": {
+            "description": "Whether to continue executing the workflow if a step fails",
+            "example": true,
+            "type": "boolean"
+          },
+          "delay": {
+            "$ref": "#/components/schemas/WorkflowDelayV2"
+          },
+          "expressions": {
+            "description": "The expressions to use in the workflow",
+            "example": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ExpressionPayloadV2"
             },
             "type": "array"
           },
@@ -38008,62 +37808,47 @@
             "example": "My folder 01",
             "type": "string"
           },
-          "id": {
-            "description": "Unique identifier for the workflow",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "type": "string"
-          },
           "include_private_incidents": {
             "description": "Whether to include private incidents",
             "example": true,
             "type": "boolean"
           },
           "name": {
-            "description": "The human-readable name of the workflow",
-            "example": "My workflow",
+            "description": "Name provided by the user when creating the workflow",
+            "example": "My little workflow",
             "type": "string"
           },
           "once_for": {
             "description": "This workflow will run 'once for' a list of references",
             "example": [
-              {
-                "array": false,
-                "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
-                "label": "Incident -\u003e Affected Team",
-                "type": "IncidentSeverity"
-              }
+              "incident.url"
             ],
             "items": {
-              "$ref": "#/components/schemas/EngineReferenceV2"
+              "example": "abc123",
+              "type": "string"
             },
             "type": "array"
           },
-          "runs_from": {
-            "description": "The time from which this workflow will run on incidents",
-            "example": "2021-08-17T13:28:57.801578Z",
-            "format": "date-time",
-            "type": "string"
-          },
           "runs_on_incident_modes": {
-            "description": "Which modes of incident this should run on (defaults to just standard incidents)",
+            "description": "Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.",
             "example": [
               "standard",
+              "test",
               "retrospective"
             ],
             "items": {
-              "description": "Incident mode that workflows can run on",
               "enum": [
                 "standard",
                 "test",
                 "retrospective"
               ],
-              "example": "standard",
+              "example": "test",
               "type": "string"
             },
             "type": "array"
           },
           "runs_on_incidents": {
-            "description": "Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)",
+            "description": "Which incidents should the workflow be applied to?",
             "enum": [
               "newly_created",
               "newly_created_and_active"
@@ -38072,12 +37857,12 @@
             "type": "string"
           },
           "shortform": {
-            "description": "Shortform used to trigger manual workflows in Slack - e.g. `/inc workflows page-ceo`",
-            "example": "abc123",
+            "description": "The shortform used to trigger this workflow (only applicable for manual triggers)",
+            "example": "page-the-ceo",
             "type": "string"
           },
           "state": {
-            "description": "The state of the workflow (e.g. is it draft, or disabled)",
+            "description": "What state this workflow is in",
             "enum": [
               "active",
               "disabled",
@@ -38091,39 +37876,291 @@
             "description": "Steps that are executed as part of the workflow",
             "example": [
               {
-                "label": "PagerDuty Escalate",
-                "name": "pagerduty.escalate"
+                "for_each": "abc123",
+                "id": "abc123",
+                "name": "pagerduty.escalate",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
               }
             ],
             "items": {
-              "$ref": "#/components/schemas/StepConfigSlim"
+              "$ref": "#/components/schemas/StepConfigPayloadV2"
             },
             "type": "array"
-          },
-          "trigger": {
-            "$ref": "#/components/schemas/TriggerSlim"
-          },
-          "version": {
-            "description": "Revision of the workflow, uniquely identifying its version",
-            "example": 3,
-            "format": "int64",
-            "type": "integer"
           }
         },
         "required": [
-          "id",
           "name",
-          "trigger",
-          "version",
-          "expressions",
+          "once_for",
           "condition_groups",
           "steps",
+          "expressions",
           "include_private_incidents",
           "runs_on_incident_modes",
           "continue_on_step_error",
-          "runs_on_incidents",
-          "once_for",
-          "state"
+          "runs_on_incidents"
+        ],
+        "type": "object"
+      },
+      "WorkflowsUpdateWorkflowResultV2": {
+        "example": {
+          "management_meta": {
+            "annotations": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "managed_by": "dashboard",
+            "source_url": "https://github.com/my-company/infrastructure"
+          },
+          "workflow": {
+            "condition_groups": [
+              {
+                "conditions": [
+                  {
+                    "operation": {
+                      "label": "Lawrence Jones",
+                      "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                    },
+                    "param_bindings": [
+                      {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    ],
+                    "subject": {
+                      "label": "Incident Severity",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "continue_on_step_error": true,
+            "delay": {
+              "conditions_apply_over_delay": false,
+              "for_seconds": 60
+            },
+            "expressions": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": {
+                                    "label": "Lawrence Jones",
+                                    "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                                  },
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "label": "Lawrence Jones",
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "label": "Lawrence Jones",
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": {
+                                    "label": "Incident Severity",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "label": "Lawrence Jones",
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": {
+                                "label": "Lawrence Jones",
+                                "value": "01FCQSP07Z74QMMYPDDGQB9FTG"
+                              },
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "label": "Lawrence Jones",
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "label": "Lawrence Jones",
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": {
+                                "label": "Incident Severity",
+                                "reference": "incident.severity"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "1235",
+                      "reference_label": "Teams"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    },
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                },
+                "root_reference": "incident.status"
+              }
+            ],
+            "folder": "My folder 01",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "include_private_incidents": true,
+            "name": "My little workflow",
+            "once_for": [
+              {
+                "array": false,
+                "key": "incident.custom_field[\"01FCNDV6P870EA6S7TK1DSYDG0\"]",
+                "label": "Incident -\u003e Affected Team",
+                "type": "IncidentSeverity"
+              }
+            ],
+            "runs_from": "2021-08-17T13:28:57.801578Z",
+            "runs_on_incident_modes": [
+              "standard",
+              "test",
+              "retrospective"
+            ],
+            "runs_on_incidents": "newly_created",
+            "shortform": "page-the-ceo",
+            "state": "active",
+            "steps": [
+              {
+                "for_each": "abc123",
+                "id": "abc123",
+                "label": "PagerDuty Escalate",
+                "name": "pagerduty.escalate",
+                "param_bindings": [
+                  {
+                    "array_value": [
+                      {
+                        "label": "Lawrence Jones",
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                ]
+              }
+            ],
+            "trigger": {
+              "label": "Incident Updated",
+              "name": "incident.updated"
+            },
+            "version": 3
+          }
+        },
+        "properties": {
+          "management_meta": {
+            "$ref": "#/components/schemas/ManagementMetaV2"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowV2"
+          }
+        },
+        "required": [
+          "workflow",
+          "management_meta"
         ],
         "type": "object"
       }
@@ -38926,6 +38963,7 @@
                 "zendesk_ticket",
                 "google_calendar_event",
                 "outlook_calendar_event",
+                "slack_file",
                 "scrubbed",
                 "statuspage_incident"
               ],
@@ -39002,7 +39040,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody2"
+                  "$ref": "#/components/schemas/CreateResponseBody"
                 }
               }
             },
@@ -39082,7 +39120,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody3"
+                  "$ref": "#/components/schemas/CreateResponseBody2"
                 }
               }
             },
@@ -39319,7 +39357,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody2"
+                "$ref": "#/components/schemas/UpdateRequestBody"
               }
             }
           },
@@ -39535,7 +39573,7 @@
                 "name": "Closed"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody4"
+                "$ref": "#/components/schemas/UpdateRequestBody3"
               }
             }
           },
@@ -40269,7 +40307,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody10"
+                  "$ref": "#/components/schemas/SeveritiesListResultV1"
                 }
               }
             },
@@ -40279,7 +40317,8 @@
         "summary": "List Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "post": {
         "description": "Create a new severity",
@@ -40293,7 +40332,7 @@
                 "rank": 1
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/SeveritiesCreatePayloadV1"
               }
             }
           },
@@ -40314,7 +40353,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody8"
+                  "$ref": "#/components/schemas/SeveritiesCreateResultV1"
                 }
               }
             },
@@ -40324,7 +40363,8 @@
         "summary": "Create Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/severities/{id}": {
@@ -40353,7 +40393,8 @@
         "summary": "Delete Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "get": {
         "description": "Get a single incident severity.",
@@ -40387,7 +40428,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody8"
+                  "$ref": "#/components/schemas/SeveritiesShowResultV1"
                 }
               }
             },
@@ -40397,7 +40438,8 @@
         "summary": "Show Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "put": {
         "description": "Update an existing severity",
@@ -40425,7 +40467,7 @@
                 "rank": 1
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody6"
+                "$ref": "#/components/schemas/SeveritiesUpdatePayloadV1"
               }
             }
           },
@@ -40446,7 +40488,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody8"
+                  "$ref": "#/components/schemas/SeveritiesUpdateResultV1"
                 }
               }
             },
@@ -40456,7 +40498,8 @@
         "summary": "Update Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v2/actions": {
@@ -41205,7 +41248,7 @@
                 }
               },
               "schema": {
-                "$ref": "#/components/schemas/AlertRoutePayloadV2"
+                "$ref": "#/components/schemas/AlertRoutesCreatePayloadV2"
               }
             }
           },
@@ -41522,7 +41565,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody"
+                  "$ref": "#/components/schemas/AlertRoutesCreateResultV2"
                 }
               }
             },
@@ -41532,7 +41575,8 @@
         "summary": "Create Alert Routes V2",
         "tags": [
           "Alert Routes V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/alert_routes/{id}": {
@@ -41561,7 +41605,8 @@
         "summary": "Destroy Alert Routes V2",
         "tags": [
           "Alert Routes V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "get": {
         "description": "Show an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
@@ -41891,7 +41936,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody"
+                  "$ref": "#/components/schemas/AlertRoutesShowResultV2"
                 }
               }
             },
@@ -41901,7 +41946,8 @@
         "summary": "Show Alert Routes V2",
         "tags": [
           "Alert Routes V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "put": {
         "description": "Updates an alert route.\n\nWe recommend you create alert routes in the incident.io dashboard where we allow\npreviewing filter and grouping rules.\n",
@@ -42242,7 +42288,7 @@
                 }
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody"
+                "$ref": "#/components/schemas/AlertRoutesUpdatePayloadV2"
               }
             }
           },
@@ -42559,7 +42605,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody"
+                  "$ref": "#/components/schemas/AlertRoutesUpdateResultV2"
                 }
               }
             },
@@ -42569,7 +42615,8 @@
         "summary": "Update Alert Routes V2",
         "tags": [
           "Alert Routes V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/alert_sources": {
@@ -43926,7 +43973,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListEntriesResponseBody"
+                  "$ref": "#/components/schemas/CatalogListEntriesResultV2"
                 }
               }
             },
@@ -43936,7 +43983,8 @@
         "summary": "ListEntries Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "post": {
         "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.\n\nIf you call this API with a payload where the external_id and catalog_type_id match an existing entry, the existing entry will be updated.",
@@ -43969,7 +44017,7 @@
                 "rank": 3
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateEntryRequestBody"
+                "$ref": "#/components/schemas/CatalogCreateEntryPayloadV2"
               }
             }
           },
@@ -44036,7 +44084,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateEntryResponseBody"
+                  "$ref": "#/components/schemas/CatalogCreateEntryResultV2"
                 }
               }
             },
@@ -44046,7 +44094,8 @@
         "summary": "CreateEntry Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/catalog_entries/{id}": {
@@ -44075,7 +44124,8 @@
         "summary": "DestroyEntry Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "get": {
         "description": "Show a single catalog entry.",
@@ -44201,7 +44251,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowEntryResponseBody"
+                  "$ref": "#/components/schemas/CatalogShowEntryResultV2"
                 }
               }
             },
@@ -44211,7 +44261,8 @@
         "summary": "ShowEntry Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "put": {
         "description": "Updates an existing catalog entry.",
@@ -44257,7 +44308,7 @@
                 "rank": 3
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateEntryRequestBody"
+                "$ref": "#/components/schemas/CatalogUpdateEntryPayloadV2"
               }
             }
           },
@@ -44370,7 +44421,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowEntryResponseBody"
+                  "$ref": "#/components/schemas/CatalogUpdateEntryResultV2"
                 }
               }
             },
@@ -44380,7 +44431,8 @@
         "summary": "UpdateEntry Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/catalog_resources": {
@@ -44403,7 +44455,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResourcesResponseBody"
+                  "$ref": "#/components/schemas/CatalogListResourcesResultV2"
                 }
               }
             },
@@ -44413,7 +44465,8 @@
         "summary": "ListResources Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/catalog_types": {
@@ -44475,7 +44528,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListTypesResponseBody"
+                  "$ref": "#/components/schemas/CatalogListTypesResultV2"
                 }
               }
             },
@@ -44485,7 +44538,8 @@
         "summary": "ListTypes Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "post": {
         "description": "Create a catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
@@ -44509,7 +44563,7 @@
                 "type_name": "Custom[\"BackstageGroup\"]"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateTypeRequestBody"
+                "$ref": "#/components/schemas/CatalogCreateTypePayloadV2"
               }
             }
           },
@@ -44568,7 +44622,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateTypeResponseBody"
+                  "$ref": "#/components/schemas/CatalogCreateTypeResultV2"
                 }
               }
             },
@@ -44578,7 +44632,8 @@
         "summary": "CreateType Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/catalog_types/{id}": {
@@ -44607,7 +44662,8 @@
         "summary": "DestroyType Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "get": {
         "description": "Show a single catalog type.",
@@ -44679,7 +44735,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateTypeResponseBody"
+                  "$ref": "#/components/schemas/CatalogShowTypeResultV2"
                 }
               }
             },
@@ -44689,7 +44745,8 @@
         "summary": "ShowType Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "put": {
         "description": "Updates an existing catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
@@ -44726,7 +44783,7 @@
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateTypeRequestBody"
+                "$ref": "#/components/schemas/CatalogUpdateTypePayloadV2"
               }
             }
           },
@@ -44785,7 +44842,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateTypeResponseBody"
+                  "$ref": "#/components/schemas/CatalogUpdateTypeResultV2"
                 }
               }
             },
@@ -44795,7 +44852,8 @@
         "summary": "UpdateType Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/catalog_types/{id}/actions/update_schema": {
@@ -44838,7 +44896,7 @@
                 "version": 1
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateTypeSchemaRequestBody"
+                "$ref": "#/components/schemas/CatalogUpdateTypeSchemaPayloadV2"
               }
             }
           },
@@ -44897,7 +44955,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateTypeResponseBody"
+                  "$ref": "#/components/schemas/CatalogUpdateTypeSchemaResultV2"
                 }
               }
             },
@@ -44907,7 +44965,8 @@
         "summary": "UpdateTypeSchema Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/custom_fields": {
@@ -46103,7 +46162,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody3"
+                "$ref": "#/components/schemas/UpdateRequestBody2"
               }
             }
           },
@@ -46323,7 +46382,7 @@
     },
     "/v2/incidents": {
       "get": {
-        "description": "List all incidents for an organisation.\n\nThis endpoint supports a number of filters, which can help find incidents matching certain\ncriteria.\n\nFilters are provided as query parameters, but due to the dynamic nature of what you can\nquery by (different accounts have different custom fields, statuses, etc) they are more\ncomplex than most.\n\nTo help, here are some exemplar curl requests with a human description of what they search\nfor.\n\nNote that:\n- Filters may be used together, and the result will be incidents that match all filters.\n- IDs are normally in UUID format, but have been replaced with shorter strings to improve\nreadability.\n- All query parameters must be URI encoded.\n\n### By status\n\nWith status of id=ABC, find all incidents that are set to that status:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[one_of]=ABC'\n\nOr all incidents that are not set to status with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[not_in]=ABC'\n\n### By created_at or updated_at\n\nFind all incidents that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to) and \"lte\" (less than or equal to). The\nfollowing example finds all incidents created before or on 2021-01-02T00:00:00Z:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[lte]=2021-01-02'\n\n### By status category\n\nFind all incidents that are in a status category. Possible values are \"triage\",\n\"declined\", \"merged\", \"canceled\", \"live\", \"learning\" and \"closed\":\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[one_of]=live'\n\nOr all incidents that are not in a status category:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[not_in]=live'\n\n\n### By severity\n\nWith severity of id=ABC, find all incidents that are set to that severity:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[one_of]=ABC'\n\nOr all incidents where severity rank is greater-than-or-equal-to the rank of severity\nid=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[gte]=ABC'\n\nOr all incidents where severity rank is less-than-or-equal-to the rank of severity id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[lte]=ABC'\n\n### By incident type\n\nWith incident type of id=ABC, find all incidents that are of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[one_of]=ABC'\n\nOr all incidents not of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[not_in]=ABC'\n\n### By incident mode\n\nBy default, we return standard and retrospective incidents. This means that test and\ntutorial incidents are filtered out. To override this behaviour, you can use the\nmode filter to specify which modes you want to get.\n\nTo find incidents of all modes:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=standard\u0026mode[one_of]=retrospective\u0026mode[one_of]=test\u0026mode[one_of]=tutorial'\n\nTo find just test incidents:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=test'\n\n\n### By incident role\n\nRoles and custom fields have another nested layer in the query parameter, to account for\noperations against any of the roles or custom fields created in the account.\n\nWith incident role id=ABC, find all incidents where that role is unset:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=true'\n\nOr where the role has been set:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=false'\n\n### By option custom fields\n\nWith an option custom field id=ABC, all incidents that have field ABC set to the custom\nfield option of id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][one_of]=XYZ'\n\nOr all incidents that do not have custom field id=ABC set to option id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][not_in]=XYZ'\n",
+        "description": "List all incidents for an organisation.\n\nThis endpoint supports a number of filters, which can help find incidents matching certain\ncriteria.\n\nFilters are provided as query parameters, but due to the dynamic nature of what you can\nquery by (different accounts have different custom fields, statuses, etc) they are more\ncomplex than most.\n\nThe maximum page size that can be requested is 250.\n\nTo help, here are some exemplar curl requests with a human description of what they search\nfor.\n\nNote that:\n- Filters may be used together, and the result will be incidents that match all filters.\n- IDs are normally in UUID format, but have been replaced with shorter strings to improve\nreadability.\n- All query parameters must be URI encoded.\n\n### By status\n\nWith status of id=ABC, find all incidents that are set to that status:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[one_of]=ABC'\n\nOr all incidents that are not set to status with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[not_in]=ABC'\n\n### By created_at or updated_at\n\nFind all incidents that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to) and \"lte\" (less than or equal to). The\nfollowing example finds all incidents created before or on 2021-01-02T00:00:00Z:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[lte]=2021-01-02'\n\n### By status category\n\nFind all incidents that are in a status category. Possible values are \"triage\",\n\"declined\", \"merged\", \"canceled\", \"live\", \"learning\" and \"closed\":\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[one_of]=live'\n\nOr all incidents that are not in a status category:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[not_in]=live'\n\n\n### By severity\n\nWith severity of id=ABC, find all incidents that are set to that severity:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[one_of]=ABC'\n\nOr all incidents where severity rank is greater-than-or-equal-to the rank of severity\nid=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[gte]=ABC'\n\nOr all incidents where severity rank is less-than-or-equal-to the rank of severity id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[lte]=ABC'\n\n### By incident type\n\nWith incident type of id=ABC, find all incidents that are of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[one_of]=ABC'\n\nOr all incidents not of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[not_in]=ABC'\n\n### By incident mode\n\nBy default, we return standard and retrospective incidents. This means that test and\ntutorial incidents are filtered out. To override this behaviour, you can use the\nmode filter to specify which modes you want to get.\n\nTo find incidents of all modes:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=standard\u0026mode[one_of]=retrospective\u0026mode[one_of]=test\u0026mode[one_of]=tutorial'\n\nTo find just test incidents:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=test'\n\n\n### By incident role\n\nRoles and custom fields have another nested layer in the query parameter, to account for\noperations against any of the roles or custom fields created in the account.\n\nWith incident role id=ABC, find all incidents where that role is unset:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=true'\n\nOr where the role has been set:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_blank]=false'\n\n### By option custom fields\n\nWith an option custom field id=ABC, all incidents that have field ABC set to the custom\nfield option of id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][one_of]=XYZ'\n\nOr all incidents that do not have custom field id=ABC set to option id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][not_in]=XYZ'\n",
         "operationId": "Incidents V2#List",
         "parameters": [
           {
@@ -48691,7 +48750,7 @@
                       "folder": "My folder 01",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "include_private_incidents": true,
-                      "name": "My workflow",
+                      "name": "My little workflow",
                       "once_for": [
                         {
                           "array": false,
@@ -48703,10 +48762,11 @@
                       "runs_from": "2021-08-17T13:28:57.801578Z",
                       "runs_on_incident_modes": [
                         "standard",
+                        "test",
                         "retrospective"
                       ],
                       "runs_on_incidents": "newly_created",
-                      "shortform": "abc123",
+                      "shortform": "page-the-ceo",
                       "state": "active",
                       "steps": [
                         {
@@ -48723,7 +48783,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListWorkflowsResponseBody"
+                  "$ref": "#/components/schemas/WorkflowsListWorkflowsResultV2"
                 }
               }
             },
@@ -48733,7 +48793,8 @@
         "summary": "ListWorkflows Workflows V2",
         "tags": [
           "Workflows V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "post": {
         "description": "Create a new workflow",
@@ -48884,16 +48945,17 @@
                 ],
                 "folder": "My folder 01",
                 "include_private_incidents": true,
-                "name": "My workflow",
+                "name": "My little workflow",
                 "once_for": [
                   "incident.url"
                 ],
                 "runs_on_incident_modes": [
                   "standard",
+                  "test",
                   "retrospective"
                 ],
                 "runs_on_incidents": "newly_created",
-                "shortform": "abc123",
+                "shortform": "page-the-ceo",
                 "state": "active",
                 "steps": [
                   {
@@ -48919,7 +48981,7 @@
                 "trigger": "incident.updated"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateWorkflowPayload"
+                "$ref": "#/components/schemas/WorkflowsCreateWorkflowPayloadV2"
               }
             }
           },
@@ -49115,7 +49177,7 @@
                     "folder": "My folder 01",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "include_private_incidents": true,
-                    "name": "My workflow",
+                    "name": "My little workflow",
                     "once_for": [
                       {
                         "array": false,
@@ -49127,10 +49189,11 @@
                     "runs_from": "2021-08-17T13:28:57.801578Z",
                     "runs_on_incident_modes": [
                       "standard",
+                      "test",
                       "retrospective"
                     ],
                     "runs_on_incidents": "newly_created",
-                    "shortform": "abc123",
+                    "shortform": "page-the-ceo",
                     "state": "active",
                     "steps": [
                       {
@@ -49164,7 +49227,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowWorkflowResponseBody"
+                  "$ref": "#/components/schemas/WorkflowsCreateWorkflowResultV2"
                 }
               }
             },
@@ -49174,7 +49237,8 @@
         "summary": "CreateWorkflow Workflows V2",
         "tags": [
           "Workflows V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/workflows/{id}": {
@@ -49203,7 +49267,8 @@
         "summary": "DestroyWorkflow Workflows V2",
         "tags": [
           "Workflows V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "get": {
         "description": "Show a workflow by ID",
@@ -49412,7 +49477,7 @@
                     "folder": "My folder 01",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "include_private_incidents": true,
-                    "name": "My workflow",
+                    "name": "My little workflow",
                     "once_for": [
                       {
                         "array": false,
@@ -49424,10 +49489,11 @@
                     "runs_from": "2021-08-17T13:28:57.801578Z",
                     "runs_on_incident_modes": [
                       "standard",
+                      "test",
                       "retrospective"
                     ],
                     "runs_on_incidents": "newly_created",
-                    "shortform": "abc123",
+                    "shortform": "page-the-ceo",
                     "state": "active",
                     "steps": [
                       {
@@ -49461,7 +49527,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowWorkflowResponseBody"
+                  "$ref": "#/components/schemas/WorkflowsShowWorkflowResultV2"
                 }
               }
             },
@@ -49471,7 +49537,8 @@
         "summary": "ShowWorkflow Workflows V2",
         "tags": [
           "Workflows V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "put": {
         "description": "Updates a workflow",
@@ -49641,16 +49708,17 @@
                 ],
                 "folder": "My folder 01",
                 "include_private_incidents": true,
-                "name": "My workflow",
+                "name": "My little workflow",
                 "once_for": [
                   "incident.url"
                 ],
                 "runs_on_incident_modes": [
                   "standard",
+                  "test",
                   "retrospective"
                 ],
                 "runs_on_incidents": "newly_created",
-                "shortform": "abc123",
+                "shortform": "page-the-ceo",
                 "state": "active",
                 "steps": [
                   {
@@ -49675,7 +49743,7 @@
                 ]
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateWorkflowPayload2"
+                "$ref": "#/components/schemas/WorkflowsUpdateWorkflowPayloadV2"
               }
             }
           },
@@ -49871,7 +49939,7 @@
                     "folder": "My folder 01",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "include_private_incidents": true,
-                    "name": "My workflow",
+                    "name": "My little workflow",
                     "once_for": [
                       {
                         "array": false,
@@ -49883,10 +49951,11 @@
                     "runs_from": "2021-08-17T13:28:57.801578Z",
                     "runs_on_incident_modes": [
                       "standard",
+                      "test",
                       "retrospective"
                     ],
                     "runs_on_incidents": "newly_created",
-                    "shortform": "abc123",
+                    "shortform": "page-the-ceo",
                     "state": "active",
                     "steps": [
                       {
@@ -49920,7 +49989,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowWorkflowResponseBody"
+                  "$ref": "#/components/schemas/WorkflowsUpdateWorkflowResultV2"
                 }
               }
             },
@@ -49930,7 +49999,1061 @@
         "summary": "UpdateWorkflow Workflows V2",
         "tags": [
           "Workflows V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
+      }
+    },
+    "/v3/catalog_entries": {
+      "get": {
+        "description": "List entries for a catalog type.",
+        "operationId": "Catalog V3#ListEntries",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "query",
+            "name": "catalog_type_id",
+            "required": true,
+            "schema": {
+              "description": "ID of this catalog type",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "The integer number of records to return",
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": 25
+              }
+            },
+            "in": "query",
+            "name": "page_size",
+            "required": true,
+            "schema": {
+              "default": 25,
+              "description": "The integer number of records to return",
+              "example": 25,
+              "format": "int64",
+              "maximum": 250,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": "01FDAG4SAP5TYPT98WGR2N7W91"
+              }
+            },
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "catalog_entries": [
+                    {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "archived_at": "2021-08-17T14:28:57.801578Z",
+                      "attribute_values": {
+                        "abc123": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123"
+                          }
+                        }
+                      },
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call",
+                      "rank": 3,
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ],
+                  "catalog_type": {
+                    "annotations": {
+                      "incident.io/catalog-importer/id": "id-of-config"
+                    },
+                    "categories": [
+                      "issue-tracker"
+                    ],
+                    "color": "yellow",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
+                    "estimated_count": 7,
+                    "icon": "alert",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                    "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "registry_type": "PagerDutyService",
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
+                    "schema": {
+                      "attributes": [
+                        {
+                          "array": false,
+                          "backlink_attribute": "abc123",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "api",
+                          "name": "tier",
+                          "path": [
+                            {
+                              "attribute_id": "abc123",
+                              "attribute_name": "abc123"
+                            }
+                          ],
+                          "type": "Custom[\"Service\"]"
+                        }
+                      ],
+                      "version": 1
+                    },
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                    "type_name": "Custom[\"BackstageGroup\"]",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  },
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogListEntriesResultV3"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ListEntries Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      },
+      "post": {
+        "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.\n\nIf you call this API with a payload where the external_id and catalog_type_id match an existing entry, the existing entry will be updated.",
+        "operationId": "Catalog V3#CreateEntry",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
+                "attribute_values": {
+                  "abc123": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123"
+                    }
+                  }
+                },
+                "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                "name": "Primary On-call",
+                "rank": 3
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CatalogCreateEntryPayloadV3"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "catalog_entry": {
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "attribute_values": {
+                      "abc123": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123"
+                        }
+                      }
+                    },
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Primary On-call",
+                    "rank": 3,
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogCreateEntryResultV3"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "CreateEntry Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      }
+    },
+    "/v3/catalog_entries/{id}": {
+      "delete": {
+        "description": "Archives a catalog entry.",
+        "operationId": "Catalog V3#DestroyEntry",
+        "parameters": [
+          {
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "ID of this catalog entry",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        },
+        "summary": "DestroyEntry Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      },
+      "get": {
+        "description": "Show a single catalog entry.",
+        "operationId": "Catalog V3#ShowEntry",
+        "parameters": [
+          {
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "ID of this catalog entry",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "catalog_entry": {
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "attribute_values": {
+                      "abc123": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123"
+                        }
+                      }
+                    },
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Primary On-call",
+                    "rank": 3,
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  },
+                  "catalog_type": {
+                    "annotations": {
+                      "incident.io/catalog-importer/id": "id-of-config"
+                    },
+                    "categories": [
+                      "issue-tracker"
+                    ],
+                    "color": "yellow",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
+                    "estimated_count": 7,
+                    "icon": "alert",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                    "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "registry_type": "PagerDutyService",
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
+                    "schema": {
+                      "attributes": [
+                        {
+                          "array": false,
+                          "backlink_attribute": "abc123",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "api",
+                          "name": "tier",
+                          "path": [
+                            {
+                              "attribute_id": "abc123",
+                              "attribute_name": "abc123"
+                            }
+                          ],
+                          "type": "Custom[\"Service\"]"
+                        }
+                      ],
+                      "version": 1
+                    },
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                    "type_name": "Custom[\"BackstageGroup\"]",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogShowEntryResultV3"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ShowEntry Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      },
+      "put": {
+        "description": "Updates an existing catalog entry.",
+        "operationId": "Catalog V3#UpdateEntry",
+        "parameters": [
+          {
+            "description": "ID of this catalog entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "ID of this catalog entry",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "aliases": [
+                  "lawrence@incident.io",
+                  "lawrence"
+                ],
+                "attribute_values": {
+                  "abc123": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123"
+                    }
+                  }
+                },
+                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                "name": "Primary On-call",
+                "rank": 3,
+                "update_attributes": [
+                  "abc123"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CatalogUpdateEntryPayloadV3"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "catalog_entry": {
+                    "aliases": [
+                      "lawrence@incident.io",
+                      "lawrence"
+                    ],
+                    "archived_at": "2021-08-17T14:28:57.801578Z",
+                    "attribute_values": {
+                      "abc123": {
+                        "array_value": [
+                          {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123"
+                          }
+                        ],
+                        "value": {
+                          "label": "Lawrence Jones",
+                          "literal": "SEV123"
+                        }
+                      }
+                    },
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Primary On-call",
+                    "rank": 3,
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  },
+                  "catalog_type": {
+                    "annotations": {
+                      "incident.io/catalog-importer/id": "id-of-config"
+                    },
+                    "categories": [
+                      "issue-tracker"
+                    ],
+                    "color": "yellow",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
+                    "estimated_count": 7,
+                    "icon": "alert",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                    "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "registry_type": "PagerDutyService",
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
+                    "schema": {
+                      "attributes": [
+                        {
+                          "array": false,
+                          "backlink_attribute": "abc123",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "api",
+                          "name": "tier",
+                          "path": [
+                            {
+                              "attribute_id": "abc123",
+                              "attribute_name": "abc123"
+                            }
+                          ],
+                          "type": "Custom[\"Service\"]"
+                        }
+                      ],
+                      "version": 1
+                    },
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                    "type_name": "Custom[\"BackstageGroup\"]",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogUpdateEntryResultV3"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "UpdateEntry Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      }
+    },
+    "/v3/catalog_resources": {
+      "get": {
+        "description": "List available engine resources for the catalog.\n\nA resource represents a type of data that can be held within the catalog, so this\nendpoint can be used to see what attribute types can be used when updating the\nschema of a catalog type.\n",
+        "operationId": "Catalog V3#ListResources",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "resources": [
+                    {
+                      "category": "custom",
+                      "description": "Boolean true or false value",
+                      "label": "GitHub Repository",
+                      "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+                      "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogListResourcesResultV3"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ListResources Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      }
+    },
+    "/v3/catalog_types": {
+      "get": {
+        "description": "List all catalog types for an organisation, including those synced from external resources.",
+        "operationId": "Catalog V3#ListTypes",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "catalog_types": [
+                    {
+                      "annotations": {
+                        "incident.io/catalog-importer/id": "id-of-config"
+                      },
+                      "categories": [
+                        "issue-tracker"
+                      ],
+                      "color": "yellow",
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                      "dynamic_resource_parameter": "abc123",
+                      "estimated_count": 7,
+                      "icon": "alert",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "is_editable": false,
+                      "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                      "name": "Kubernetes Cluster",
+                      "ranked": true,
+                      "registry_type": "PagerDutyService",
+                      "required_integrations": [
+                        "pager_duty"
+                      ],
+                      "schema": {
+                        "attributes": [
+                          {
+                            "array": false,
+                            "backlink_attribute": "abc123",
+                            "id": "01GW2G3V0S59R238FAHPDS1R66",
+                            "mode": "api",
+                            "name": "tier",
+                            "path": [
+                              {
+                                "attribute_id": "abc123",
+                                "attribute_name": "abc123"
+                              }
+                            ],
+                            "type": "Custom[\"Service\"]"
+                          }
+                        ],
+                        "version": 1
+                      },
+                      "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                      "type_name": "Custom[\"BackstageGroup\"]",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogListTypesResultV3"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ListTypes Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      },
+      "post": {
+        "description": "Create a catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
+        "operationId": "Catalog V3#CreateType",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "annotations": {
+                  "incident.io/catalog-importer/id": "id-of-config"
+                },
+                "categories": [
+                  "issue-tracker"
+                ],
+                "color": "yellow",
+                "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                "icon": "alert",
+                "name": "Kubernetes Cluster",
+                "ranked": true,
+                "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                "type_name": "Custom[\"BackstageGroup\"]"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CatalogCreateTypePayloadV3"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "catalog_type": {
+                    "annotations": {
+                      "incident.io/catalog-importer/id": "id-of-config"
+                    },
+                    "categories": [
+                      "issue-tracker"
+                    ],
+                    "color": "yellow",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
+                    "estimated_count": 7,
+                    "icon": "alert",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                    "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "registry_type": "PagerDutyService",
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
+                    "schema": {
+                      "attributes": [
+                        {
+                          "array": false,
+                          "backlink_attribute": "abc123",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "api",
+                          "name": "tier",
+                          "path": [
+                            {
+                              "attribute_id": "abc123",
+                              "attribute_name": "abc123"
+                            }
+                          ],
+                          "type": "Custom[\"Service\"]"
+                        }
+                      ],
+                      "version": 1
+                    },
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                    "type_name": "Custom[\"BackstageGroup\"]",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogCreateTypeResultV3"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "CreateType Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      }
+    },
+    "/v3/catalog_types/{id}": {
+      "delete": {
+        "description": "Archives a catalog type and associated entries.",
+        "operationId": "Catalog V3#DestroyType",
+        "parameters": [
+          {
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "ID of this catalog type",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        },
+        "summary": "DestroyType Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      },
+      "get": {
+        "description": "Show a single catalog type.",
+        "operationId": "Catalog V3#ShowType",
+        "parameters": [
+          {
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "ID of this catalog type",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "catalog_type": {
+                    "annotations": {
+                      "incident.io/catalog-importer/id": "id-of-config"
+                    },
+                    "categories": [
+                      "issue-tracker"
+                    ],
+                    "color": "yellow",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
+                    "estimated_count": 7,
+                    "icon": "alert",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                    "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "registry_type": "PagerDutyService",
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
+                    "schema": {
+                      "attributes": [
+                        {
+                          "array": false,
+                          "backlink_attribute": "abc123",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "api",
+                          "name": "tier",
+                          "path": [
+                            {
+                              "attribute_id": "abc123",
+                              "attribute_name": "abc123"
+                            }
+                          ],
+                          "type": "Custom[\"Service\"]"
+                        }
+                      ],
+                      "version": 1
+                    },
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                    "type_name": "Custom[\"BackstageGroup\"]",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogShowTypeResultV3"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ShowType Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      },
+      "put": {
+        "description": "Updates an existing catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
+        "operationId": "Catalog V3#UpdateType",
+        "parameters": [
+          {
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "ID of this catalog type",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "annotations": {
+                  "incident.io/catalog-importer/id": "id-of-config"
+                },
+                "categories": [
+                  "issue-tracker"
+                ],
+                "color": "yellow",
+                "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                "icon": "alert",
+                "name": "Kubernetes Cluster",
+                "ranked": true,
+                "source_repo_url": "https://github.com/my-company/incident-io-catalog"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CatalogUpdateTypePayloadV3"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "catalog_type": {
+                    "annotations": {
+                      "incident.io/catalog-importer/id": "id-of-config"
+                    },
+                    "categories": [
+                      "issue-tracker"
+                    ],
+                    "color": "yellow",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
+                    "estimated_count": 7,
+                    "icon": "alert",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                    "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "registry_type": "PagerDutyService",
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
+                    "schema": {
+                      "attributes": [
+                        {
+                          "array": false,
+                          "backlink_attribute": "abc123",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "api",
+                          "name": "tier",
+                          "path": [
+                            {
+                              "attribute_id": "abc123",
+                              "attribute_name": "abc123"
+                            }
+                          ],
+                          "type": "Custom[\"Service\"]"
+                        }
+                      ],
+                      "version": 1
+                    },
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                    "type_name": "Custom[\"BackstageGroup\"]",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogUpdateTypeResultV3"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "UpdateType Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
+      }
+    },
+    "/v3/catalog_types/{id}/actions/update_schema": {
+      "post": {
+        "description": "Update an existing catalog types schema, adding or removing attributes.\n\nUpdating the schema is handled separately from creating and updating types, so that you don't\nhave to worry about dependencies between types. For example, if type A has an attribute that\nrelies on type B, you would have to create type B first.\n\nBy allowing the creation of types without a schema, they can be created in any order, but it\nmeans that you need to make a separate call to this endpoint to update the schema.",
+        "operationId": "Catalog V3#UpdateTypeSchema",
+        "parameters": [
+          {
+            "description": "ID of this catalog type",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "ID of this catalog type",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "attributes": [
+                  {
+                    "array": false,
+                    "backlink_attribute": "abc123",
+                    "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "mode": "api",
+                    "name": "tier",
+                    "path": [
+                      {
+                        "attribute_id": "abc123"
+                      }
+                    ],
+                    "type": "Custom[\"Service\"]"
+                  }
+                ],
+                "version": 1
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CatalogUpdateTypeSchemaPayloadV3"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "catalog_type": {
+                    "annotations": {
+                      "incident.io/catalog-importer/id": "id-of-config"
+                    },
+                    "categories": [
+                      "issue-tracker"
+                    ],
+                    "color": "yellow",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Represents Kubernetes clusters that we run inside of GKE.",
+                    "dynamic_resource_parameter": "abc123",
+                    "estimated_count": 7,
+                    "icon": "alert",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "is_editable": false,
+                    "last_synced_at": "2021-08-17T13:28:57.801578Z",
+                    "name": "Kubernetes Cluster",
+                    "ranked": true,
+                    "registry_type": "PagerDutyService",
+                    "required_integrations": [
+                      "pager_duty"
+                    ],
+                    "schema": {
+                      "attributes": [
+                        {
+                          "array": false,
+                          "backlink_attribute": "abc123",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "mode": "api",
+                          "name": "tier",
+                          "path": [
+                            {
+                              "attribute_id": "abc123",
+                              "attribute_name": "abc123"
+                            }
+                          ],
+                          "type": "Custom[\"Service\"]"
+                        }
+                      ],
+                      "version": 1
+                    },
+                    "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                    "type_name": "Custom[\"BackstageGroup\"]",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogUpdateTypeSchemaResultV3"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "UpdateTypeSchema Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ],
+        "x-public-api-version": "v3"
       }
     }
   },
@@ -49965,8 +51088,12 @@
       "name": "Alert Sources V2"
     },
     {
-      "description": "Manage and browse catalog resources.\n\nUse the incident.io catalog to track services, teams, product features and anything\nelse that helps build a map of your organisation. These different categories of thing\nbecome catalog types, and each instance (like a particular service or team) is a\ncatalog entry.\n\nEach type is made up of a series of attributes, and each attribute has a type. Types\ncan even have attributes that refer to other catalog types.\n\nWe automatically create catalog types when you connect an integration, such as GitHub \nrepositories or PagerDuty services and teams. You can use this API to create custom\ntypes, that are specifically tailored to your organisation.\n\nExamples might be a 'Service' type with an 'Alert channel' which you can point at a \nSlack channel, or 'Team' which specifies its 'Manager' and 'Technical Lead' as Slack\nusers. You can then use these types to create powerful new workflows.\n\nConsider using our official [catalog importer](https://github.com/incident-io/catalog-importer).\nIt can be used to sync catalog data from sources like local files or GitHub and push \nthem into the incident.io catalog without having to directly interact with our public API.\n",
+      "description": "Manage and browse catalog resources.\n\nUse the incident.io catalog to track services, teams, product features and anything\nelse that helps build a map of your organisation. These different categories of thing\nbecome catalog types, and each instance (like a particular service or team) is a\ncatalog entry.\n\nEach type is made up of a series of attributes, and each attribute has a type. Types\ncan even have attributes that refer to other catalog types.\n\nWe automatically create catalog types when you connect an integration, such as GitHub\nrepositories or PagerDuty services and teams. You can use this API to create custom\ntypes, that are specifically tailored to your organisation.\n\nExamples might be a 'Service' type with an 'Alert channel' which you can point at a\nSlack channel, or 'Team' which specifies its 'Manager' and 'Technical Lead' as Slack\nusers. You can then use these types to create powerful new workflows.\n\nConsider using our official [catalog importer](https://github.com/incident-io/catalog-importer).\nIt can be used to sync catalog data from sources like local files or GitHub and push\nthem into the incident.io catalog without having to directly interact with our public API.\n",
       "name": "Catalog V2"
+    },
+    {
+      "description": "Manage and browse catalog resources.\n\nUse the incident.io catalog to track services, teams, product features and anything\nelse that helps build a map of your organisation. These different categories of thing\nbecome catalog types, and each instance (like a particular service or team) is a\ncatalog entry.\n\nEach type is made up of a series of attributes, and each attribute has a type. Types\ncan even have attributes that refer to other catalog types.\n\nWe automatically create catalog types when you connect an integration, such as GitHub\nrepositories or PagerDuty services and teams. You can use this API to create custom\ntypes, that are specifically tailored to your organisation.\n\nExamples might be a 'Service' type with an 'Alert channel' which you can point at a\nSlack channel, or 'Team' which specifies its 'Manager' and 'Technical Lead' as Slack\nusers. You can then use these types to create powerful new workflows.\n\nConsider using our official [catalog importer](https://github.com/incident-io/catalog-importer).\nIt can be used to sync catalog data from sources like local files or GitHub and push\nthem into the incident.io catalog without having to directly interact with our public API.\n",
+      "name": "Catalog V3"
     },
     {
       "description": "Manage custom field options.\n\nSingle- and multi-select custom fields have a list of all available options,\nwhich have a value, and a sort key. The value must be unique to the custom\nfield. For example, you might have an Incident Type custom field, with options\n\"Data breach\", \"Performance degradation\", \"API downtime\", etc.",
@@ -50021,7 +51148,7 @@
       "name": "Incident Updates V2"
     },
     {
-      "description": "Create and read incidents.\n\nIncidents are a core resource, on which many other resources (actions, etc) are created.\n\nCare should be taken around these endpoints, as automation that creates duplicate\nincidents can be distracting, and impact reporting.\n",
+      "description": "Create and read incidents.\n\nIncidents are a core resource, on which many other resources (actions, etc) are created.\n\nCare should be taken around these endpoints, as automation that creates duplicate\nincidents can be distracting, and impact reporting.\n\nThe maximum page size that can be requested is 250.\n",
       "name": "Incidents V1"
     },
     {

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -139,11 +139,124 @@ const (
 	AlertSourcesCreatePayloadV2SourceTypeZendesk           AlertSourcesCreatePayloadV2SourceType = "zendesk"
 )
 
+// Defines values for CatalogCreateTypePayloadV2Categories.
+const (
+	CatalogCreateTypePayloadV2CategoriesCustomer       CatalogCreateTypePayloadV2Categories = "customer"
+	CatalogCreateTypePayloadV2CategoriesIssueTracker   CatalogCreateTypePayloadV2Categories = "issue-tracker"
+	CatalogCreateTypePayloadV2CategoriesOnCall         CatalogCreateTypePayloadV2Categories = "on-call"
+	CatalogCreateTypePayloadV2CategoriesProductFeature CatalogCreateTypePayloadV2Categories = "product-feature"
+	CatalogCreateTypePayloadV2CategoriesService        CatalogCreateTypePayloadV2Categories = "service"
+	CatalogCreateTypePayloadV2CategoriesTeam           CatalogCreateTypePayloadV2Categories = "team"
+	CatalogCreateTypePayloadV2CategoriesUser           CatalogCreateTypePayloadV2Categories = "user"
+)
+
+// Defines values for CatalogCreateTypePayloadV2Color.
+const (
+	CatalogCreateTypePayloadV2ColorBlue   CatalogCreateTypePayloadV2Color = "blue"
+	CatalogCreateTypePayloadV2ColorCyan   CatalogCreateTypePayloadV2Color = "cyan"
+	CatalogCreateTypePayloadV2ColorGreen  CatalogCreateTypePayloadV2Color = "green"
+	CatalogCreateTypePayloadV2ColorOrange CatalogCreateTypePayloadV2Color = "orange"
+	CatalogCreateTypePayloadV2ColorPink   CatalogCreateTypePayloadV2Color = "pink"
+	CatalogCreateTypePayloadV2ColorViolet CatalogCreateTypePayloadV2Color = "violet"
+	CatalogCreateTypePayloadV2ColorYellow CatalogCreateTypePayloadV2Color = "yellow"
+)
+
+// Defines values for CatalogCreateTypePayloadV2Icon.
+const (
+	CatalogCreateTypePayloadV2IconAlert          CatalogCreateTypePayloadV2Icon = "alert"
+	CatalogCreateTypePayloadV2IconBolt           CatalogCreateTypePayloadV2Icon = "bolt"
+	CatalogCreateTypePayloadV2IconBox            CatalogCreateTypePayloadV2Icon = "box"
+	CatalogCreateTypePayloadV2IconBriefcase      CatalogCreateTypePayloadV2Icon = "briefcase"
+	CatalogCreateTypePayloadV2IconBrowser        CatalogCreateTypePayloadV2Icon = "browser"
+	CatalogCreateTypePayloadV2IconBulb           CatalogCreateTypePayloadV2Icon = "bulb"
+	CatalogCreateTypePayloadV2IconCalendar       CatalogCreateTypePayloadV2Icon = "calendar"
+	CatalogCreateTypePayloadV2IconClock          CatalogCreateTypePayloadV2Icon = "clock"
+	CatalogCreateTypePayloadV2IconCog            CatalogCreateTypePayloadV2Icon = "cog"
+	CatalogCreateTypePayloadV2IconComponents     CatalogCreateTypePayloadV2Icon = "components"
+	CatalogCreateTypePayloadV2IconDatabase       CatalogCreateTypePayloadV2Icon = "database"
+	CatalogCreateTypePayloadV2IconDoc            CatalogCreateTypePayloadV2Icon = "doc"
+	CatalogCreateTypePayloadV2IconEmail          CatalogCreateTypePayloadV2Icon = "email"
+	CatalogCreateTypePayloadV2IconEscalationPath CatalogCreateTypePayloadV2Icon = "escalation-path"
+	CatalogCreateTypePayloadV2IconFiles          CatalogCreateTypePayloadV2Icon = "files"
+	CatalogCreateTypePayloadV2IconFlag           CatalogCreateTypePayloadV2Icon = "flag"
+	CatalogCreateTypePayloadV2IconFolder         CatalogCreateTypePayloadV2Icon = "folder"
+	CatalogCreateTypePayloadV2IconGlobe          CatalogCreateTypePayloadV2Icon = "globe"
+	CatalogCreateTypePayloadV2IconMoney          CatalogCreateTypePayloadV2Icon = "money"
+	CatalogCreateTypePayloadV2IconServer         CatalogCreateTypePayloadV2Icon = "server"
+	CatalogCreateTypePayloadV2IconSeverity       CatalogCreateTypePayloadV2Icon = "severity"
+	CatalogCreateTypePayloadV2IconStar           CatalogCreateTypePayloadV2Icon = "star"
+	CatalogCreateTypePayloadV2IconStatusPage     CatalogCreateTypePayloadV2Icon = "status-page"
+	CatalogCreateTypePayloadV2IconStore          CatalogCreateTypePayloadV2Icon = "store"
+	CatalogCreateTypePayloadV2IconTag            CatalogCreateTypePayloadV2Icon = "tag"
+	CatalogCreateTypePayloadV2IconUser           CatalogCreateTypePayloadV2Icon = "user"
+	CatalogCreateTypePayloadV2IconUsers          CatalogCreateTypePayloadV2Icon = "users"
+)
+
+// Defines values for CatalogCreateTypePayloadV3Categories.
+const (
+	CatalogCreateTypePayloadV3CategoriesCustomer       CatalogCreateTypePayloadV3Categories = "customer"
+	CatalogCreateTypePayloadV3CategoriesIssueTracker   CatalogCreateTypePayloadV3Categories = "issue-tracker"
+	CatalogCreateTypePayloadV3CategoriesOnCall         CatalogCreateTypePayloadV3Categories = "on-call"
+	CatalogCreateTypePayloadV3CategoriesProductFeature CatalogCreateTypePayloadV3Categories = "product-feature"
+	CatalogCreateTypePayloadV3CategoriesService        CatalogCreateTypePayloadV3Categories = "service"
+	CatalogCreateTypePayloadV3CategoriesTeam           CatalogCreateTypePayloadV3Categories = "team"
+	CatalogCreateTypePayloadV3CategoriesUser           CatalogCreateTypePayloadV3Categories = "user"
+)
+
+// Defines values for CatalogCreateTypePayloadV3Color.
+const (
+	CatalogCreateTypePayloadV3ColorBlue   CatalogCreateTypePayloadV3Color = "blue"
+	CatalogCreateTypePayloadV3ColorCyan   CatalogCreateTypePayloadV3Color = "cyan"
+	CatalogCreateTypePayloadV3ColorGreen  CatalogCreateTypePayloadV3Color = "green"
+	CatalogCreateTypePayloadV3ColorOrange CatalogCreateTypePayloadV3Color = "orange"
+	CatalogCreateTypePayloadV3ColorPink   CatalogCreateTypePayloadV3Color = "pink"
+	CatalogCreateTypePayloadV3ColorViolet CatalogCreateTypePayloadV3Color = "violet"
+	CatalogCreateTypePayloadV3ColorYellow CatalogCreateTypePayloadV3Color = "yellow"
+)
+
+// Defines values for CatalogCreateTypePayloadV3Icon.
+const (
+	CatalogCreateTypePayloadV3IconAlert          CatalogCreateTypePayloadV3Icon = "alert"
+	CatalogCreateTypePayloadV3IconBolt           CatalogCreateTypePayloadV3Icon = "bolt"
+	CatalogCreateTypePayloadV3IconBox            CatalogCreateTypePayloadV3Icon = "box"
+	CatalogCreateTypePayloadV3IconBriefcase      CatalogCreateTypePayloadV3Icon = "briefcase"
+	CatalogCreateTypePayloadV3IconBrowser        CatalogCreateTypePayloadV3Icon = "browser"
+	CatalogCreateTypePayloadV3IconBulb           CatalogCreateTypePayloadV3Icon = "bulb"
+	CatalogCreateTypePayloadV3IconCalendar       CatalogCreateTypePayloadV3Icon = "calendar"
+	CatalogCreateTypePayloadV3IconClock          CatalogCreateTypePayloadV3Icon = "clock"
+	CatalogCreateTypePayloadV3IconCog            CatalogCreateTypePayloadV3Icon = "cog"
+	CatalogCreateTypePayloadV3IconComponents     CatalogCreateTypePayloadV3Icon = "components"
+	CatalogCreateTypePayloadV3IconDatabase       CatalogCreateTypePayloadV3Icon = "database"
+	CatalogCreateTypePayloadV3IconDoc            CatalogCreateTypePayloadV3Icon = "doc"
+	CatalogCreateTypePayloadV3IconEmail          CatalogCreateTypePayloadV3Icon = "email"
+	CatalogCreateTypePayloadV3IconEscalationPath CatalogCreateTypePayloadV3Icon = "escalation-path"
+	CatalogCreateTypePayloadV3IconFiles          CatalogCreateTypePayloadV3Icon = "files"
+	CatalogCreateTypePayloadV3IconFlag           CatalogCreateTypePayloadV3Icon = "flag"
+	CatalogCreateTypePayloadV3IconFolder         CatalogCreateTypePayloadV3Icon = "folder"
+	CatalogCreateTypePayloadV3IconGlobe          CatalogCreateTypePayloadV3Icon = "globe"
+	CatalogCreateTypePayloadV3IconMoney          CatalogCreateTypePayloadV3Icon = "money"
+	CatalogCreateTypePayloadV3IconServer         CatalogCreateTypePayloadV3Icon = "server"
+	CatalogCreateTypePayloadV3IconSeverity       CatalogCreateTypePayloadV3Icon = "severity"
+	CatalogCreateTypePayloadV3IconStar           CatalogCreateTypePayloadV3Icon = "star"
+	CatalogCreateTypePayloadV3IconStatusPage     CatalogCreateTypePayloadV3Icon = "status-page"
+	CatalogCreateTypePayloadV3IconStore          CatalogCreateTypePayloadV3Icon = "store"
+	CatalogCreateTypePayloadV3IconTag            CatalogCreateTypePayloadV3Icon = "tag"
+	CatalogCreateTypePayloadV3IconUser           CatalogCreateTypePayloadV3Icon = "user"
+	CatalogCreateTypePayloadV3IconUsers          CatalogCreateTypePayloadV3Icon = "users"
+)
+
 // Defines values for CatalogResourceV2Category.
 const (
 	CatalogResourceV2CategoryCustom    CatalogResourceV2Category = "custom"
 	CatalogResourceV2CategoryExternal  CatalogResourceV2Category = "external"
 	CatalogResourceV2CategoryPrimitive CatalogResourceV2Category = "primitive"
+)
+
+// Defines values for CatalogResourceV3Category.
+const (
+	CatalogResourceV3CategoryCustom    CatalogResourceV3Category = "custom"
+	CatalogResourceV3CategoryExternal  CatalogResourceV3Category = "external"
+	CatalogResourceV3CategoryPrimitive CatalogResourceV3Category = "primitive"
 )
 
 // Defines values for CatalogTypeAttributePayloadV2Mode.
@@ -157,6 +270,18 @@ const (
 	CatalogTypeAttributePayloadV2ModePath     CatalogTypeAttributePayloadV2Mode = "path"
 )
 
+// Defines values for CatalogTypeAttributePayloadV3Mode.
+const (
+	CatalogTypeAttributePayloadV3ModeApi       CatalogTypeAttributePayloadV3Mode = "api"
+	CatalogTypeAttributePayloadV3ModeBacklink  CatalogTypeAttributePayloadV3Mode = "backlink"
+	CatalogTypeAttributePayloadV3ModeDashboard CatalogTypeAttributePayloadV3Mode = "dashboard"
+	CatalogTypeAttributePayloadV3ModeDynamic   CatalogTypeAttributePayloadV3Mode = "dynamic"
+	CatalogTypeAttributePayloadV3ModeEmpty     CatalogTypeAttributePayloadV3Mode = ""
+	CatalogTypeAttributePayloadV3ModeExternal  CatalogTypeAttributePayloadV3Mode = "external"
+	CatalogTypeAttributePayloadV3ModeInternal  CatalogTypeAttributePayloadV3Mode = "internal"
+	CatalogTypeAttributePayloadV3ModePath      CatalogTypeAttributePayloadV3Mode = "path"
+)
+
 // Defines values for CatalogTypeAttributeV2Mode.
 const (
 	CatalogTypeAttributeV2ModeBacklink CatalogTypeAttributeV2Mode = "backlink"
@@ -166,6 +291,18 @@ const (
 	CatalogTypeAttributeV2ModeInternal CatalogTypeAttributeV2Mode = "internal"
 	CatalogTypeAttributeV2ModeManual   CatalogTypeAttributeV2Mode = "manual"
 	CatalogTypeAttributeV2ModePath     CatalogTypeAttributeV2Mode = "path"
+)
+
+// Defines values for CatalogTypeAttributeV3Mode.
+const (
+	CatalogTypeAttributeV3ModeApi       CatalogTypeAttributeV3Mode = "api"
+	CatalogTypeAttributeV3ModeBacklink  CatalogTypeAttributeV3Mode = "backlink"
+	CatalogTypeAttributeV3ModeDashboard CatalogTypeAttributeV3Mode = "dashboard"
+	CatalogTypeAttributeV3ModeDynamic   CatalogTypeAttributeV3Mode = "dynamic"
+	CatalogTypeAttributeV3ModeEmpty     CatalogTypeAttributeV3Mode = ""
+	CatalogTypeAttributeV3ModeExternal  CatalogTypeAttributeV3Mode = "external"
+	CatalogTypeAttributeV3ModeInternal  CatalogTypeAttributeV3Mode = "internal"
+	CatalogTypeAttributeV3ModePath      CatalogTypeAttributeV3Mode = "path"
 )
 
 // Defines values for CatalogTypeV2Categories.
@@ -221,6 +358,165 @@ const (
 	CatalogTypeV2IconUsers          CatalogTypeV2Icon = "users"
 )
 
+// Defines values for CatalogTypeV3Categories.
+const (
+	CatalogTypeV3CategoriesCustomer       CatalogTypeV3Categories = "customer"
+	CatalogTypeV3CategoriesIssueTracker   CatalogTypeV3Categories = "issue-tracker"
+	CatalogTypeV3CategoriesOnCall         CatalogTypeV3Categories = "on-call"
+	CatalogTypeV3CategoriesProductFeature CatalogTypeV3Categories = "product-feature"
+	CatalogTypeV3CategoriesService        CatalogTypeV3Categories = "service"
+	CatalogTypeV3CategoriesTeam           CatalogTypeV3Categories = "team"
+	CatalogTypeV3CategoriesUser           CatalogTypeV3Categories = "user"
+)
+
+// Defines values for CatalogTypeV3Color.
+const (
+	CatalogTypeV3ColorBlue   CatalogTypeV3Color = "blue"
+	CatalogTypeV3ColorCyan   CatalogTypeV3Color = "cyan"
+	CatalogTypeV3ColorGreen  CatalogTypeV3Color = "green"
+	CatalogTypeV3ColorOrange CatalogTypeV3Color = "orange"
+	CatalogTypeV3ColorPink   CatalogTypeV3Color = "pink"
+	CatalogTypeV3ColorViolet CatalogTypeV3Color = "violet"
+	CatalogTypeV3ColorYellow CatalogTypeV3Color = "yellow"
+)
+
+// Defines values for CatalogTypeV3Icon.
+const (
+	CatalogTypeV3IconAlert          CatalogTypeV3Icon = "alert"
+	CatalogTypeV3IconBolt           CatalogTypeV3Icon = "bolt"
+	CatalogTypeV3IconBox            CatalogTypeV3Icon = "box"
+	CatalogTypeV3IconBriefcase      CatalogTypeV3Icon = "briefcase"
+	CatalogTypeV3IconBrowser        CatalogTypeV3Icon = "browser"
+	CatalogTypeV3IconBulb           CatalogTypeV3Icon = "bulb"
+	CatalogTypeV3IconCalendar       CatalogTypeV3Icon = "calendar"
+	CatalogTypeV3IconClock          CatalogTypeV3Icon = "clock"
+	CatalogTypeV3IconCog            CatalogTypeV3Icon = "cog"
+	CatalogTypeV3IconComponents     CatalogTypeV3Icon = "components"
+	CatalogTypeV3IconDatabase       CatalogTypeV3Icon = "database"
+	CatalogTypeV3IconDoc            CatalogTypeV3Icon = "doc"
+	CatalogTypeV3IconEmail          CatalogTypeV3Icon = "email"
+	CatalogTypeV3IconEscalationPath CatalogTypeV3Icon = "escalation-path"
+	CatalogTypeV3IconFiles          CatalogTypeV3Icon = "files"
+	CatalogTypeV3IconFlag           CatalogTypeV3Icon = "flag"
+	CatalogTypeV3IconFolder         CatalogTypeV3Icon = "folder"
+	CatalogTypeV3IconGlobe          CatalogTypeV3Icon = "globe"
+	CatalogTypeV3IconMoney          CatalogTypeV3Icon = "money"
+	CatalogTypeV3IconServer         CatalogTypeV3Icon = "server"
+	CatalogTypeV3IconSeverity       CatalogTypeV3Icon = "severity"
+	CatalogTypeV3IconStar           CatalogTypeV3Icon = "star"
+	CatalogTypeV3IconStatusPage     CatalogTypeV3Icon = "status-page"
+	CatalogTypeV3IconStore          CatalogTypeV3Icon = "store"
+	CatalogTypeV3IconTag            CatalogTypeV3Icon = "tag"
+	CatalogTypeV3IconUser           CatalogTypeV3Icon = "user"
+	CatalogTypeV3IconUsers          CatalogTypeV3Icon = "users"
+)
+
+// Defines values for CatalogUpdateTypePayloadV2Categories.
+const (
+	CatalogUpdateTypePayloadV2CategoriesCustomer       CatalogUpdateTypePayloadV2Categories = "customer"
+	CatalogUpdateTypePayloadV2CategoriesIssueTracker   CatalogUpdateTypePayloadV2Categories = "issue-tracker"
+	CatalogUpdateTypePayloadV2CategoriesOnCall         CatalogUpdateTypePayloadV2Categories = "on-call"
+	CatalogUpdateTypePayloadV2CategoriesProductFeature CatalogUpdateTypePayloadV2Categories = "product-feature"
+	CatalogUpdateTypePayloadV2CategoriesService        CatalogUpdateTypePayloadV2Categories = "service"
+	CatalogUpdateTypePayloadV2CategoriesTeam           CatalogUpdateTypePayloadV2Categories = "team"
+	CatalogUpdateTypePayloadV2CategoriesUser           CatalogUpdateTypePayloadV2Categories = "user"
+)
+
+// Defines values for CatalogUpdateTypePayloadV2Color.
+const (
+	CatalogUpdateTypePayloadV2ColorBlue   CatalogUpdateTypePayloadV2Color = "blue"
+	CatalogUpdateTypePayloadV2ColorCyan   CatalogUpdateTypePayloadV2Color = "cyan"
+	CatalogUpdateTypePayloadV2ColorGreen  CatalogUpdateTypePayloadV2Color = "green"
+	CatalogUpdateTypePayloadV2ColorOrange CatalogUpdateTypePayloadV2Color = "orange"
+	CatalogUpdateTypePayloadV2ColorPink   CatalogUpdateTypePayloadV2Color = "pink"
+	CatalogUpdateTypePayloadV2ColorViolet CatalogUpdateTypePayloadV2Color = "violet"
+	CatalogUpdateTypePayloadV2ColorYellow CatalogUpdateTypePayloadV2Color = "yellow"
+)
+
+// Defines values for CatalogUpdateTypePayloadV2Icon.
+const (
+	CatalogUpdateTypePayloadV2IconAlert          CatalogUpdateTypePayloadV2Icon = "alert"
+	CatalogUpdateTypePayloadV2IconBolt           CatalogUpdateTypePayloadV2Icon = "bolt"
+	CatalogUpdateTypePayloadV2IconBox            CatalogUpdateTypePayloadV2Icon = "box"
+	CatalogUpdateTypePayloadV2IconBriefcase      CatalogUpdateTypePayloadV2Icon = "briefcase"
+	CatalogUpdateTypePayloadV2IconBrowser        CatalogUpdateTypePayloadV2Icon = "browser"
+	CatalogUpdateTypePayloadV2IconBulb           CatalogUpdateTypePayloadV2Icon = "bulb"
+	CatalogUpdateTypePayloadV2IconCalendar       CatalogUpdateTypePayloadV2Icon = "calendar"
+	CatalogUpdateTypePayloadV2IconClock          CatalogUpdateTypePayloadV2Icon = "clock"
+	CatalogUpdateTypePayloadV2IconCog            CatalogUpdateTypePayloadV2Icon = "cog"
+	CatalogUpdateTypePayloadV2IconComponents     CatalogUpdateTypePayloadV2Icon = "components"
+	CatalogUpdateTypePayloadV2IconDatabase       CatalogUpdateTypePayloadV2Icon = "database"
+	CatalogUpdateTypePayloadV2IconDoc            CatalogUpdateTypePayloadV2Icon = "doc"
+	CatalogUpdateTypePayloadV2IconEmail          CatalogUpdateTypePayloadV2Icon = "email"
+	CatalogUpdateTypePayloadV2IconEscalationPath CatalogUpdateTypePayloadV2Icon = "escalation-path"
+	CatalogUpdateTypePayloadV2IconFiles          CatalogUpdateTypePayloadV2Icon = "files"
+	CatalogUpdateTypePayloadV2IconFlag           CatalogUpdateTypePayloadV2Icon = "flag"
+	CatalogUpdateTypePayloadV2IconFolder         CatalogUpdateTypePayloadV2Icon = "folder"
+	CatalogUpdateTypePayloadV2IconGlobe          CatalogUpdateTypePayloadV2Icon = "globe"
+	CatalogUpdateTypePayloadV2IconMoney          CatalogUpdateTypePayloadV2Icon = "money"
+	CatalogUpdateTypePayloadV2IconServer         CatalogUpdateTypePayloadV2Icon = "server"
+	CatalogUpdateTypePayloadV2IconSeverity       CatalogUpdateTypePayloadV2Icon = "severity"
+	CatalogUpdateTypePayloadV2IconStar           CatalogUpdateTypePayloadV2Icon = "star"
+	CatalogUpdateTypePayloadV2IconStatusPage     CatalogUpdateTypePayloadV2Icon = "status-page"
+	CatalogUpdateTypePayloadV2IconStore          CatalogUpdateTypePayloadV2Icon = "store"
+	CatalogUpdateTypePayloadV2IconTag            CatalogUpdateTypePayloadV2Icon = "tag"
+	CatalogUpdateTypePayloadV2IconUser           CatalogUpdateTypePayloadV2Icon = "user"
+	CatalogUpdateTypePayloadV2IconUsers          CatalogUpdateTypePayloadV2Icon = "users"
+)
+
+// Defines values for CatalogUpdateTypePayloadV3Categories.
+const (
+	CatalogUpdateTypePayloadV3CategoriesCustomer       CatalogUpdateTypePayloadV3Categories = "customer"
+	CatalogUpdateTypePayloadV3CategoriesIssueTracker   CatalogUpdateTypePayloadV3Categories = "issue-tracker"
+	CatalogUpdateTypePayloadV3CategoriesOnCall         CatalogUpdateTypePayloadV3Categories = "on-call"
+	CatalogUpdateTypePayloadV3CategoriesProductFeature CatalogUpdateTypePayloadV3Categories = "product-feature"
+	CatalogUpdateTypePayloadV3CategoriesService        CatalogUpdateTypePayloadV3Categories = "service"
+	CatalogUpdateTypePayloadV3CategoriesTeam           CatalogUpdateTypePayloadV3Categories = "team"
+	CatalogUpdateTypePayloadV3CategoriesUser           CatalogUpdateTypePayloadV3Categories = "user"
+)
+
+// Defines values for CatalogUpdateTypePayloadV3Color.
+const (
+	CatalogUpdateTypePayloadV3ColorBlue   CatalogUpdateTypePayloadV3Color = "blue"
+	CatalogUpdateTypePayloadV3ColorCyan   CatalogUpdateTypePayloadV3Color = "cyan"
+	CatalogUpdateTypePayloadV3ColorGreen  CatalogUpdateTypePayloadV3Color = "green"
+	CatalogUpdateTypePayloadV3ColorOrange CatalogUpdateTypePayloadV3Color = "orange"
+	CatalogUpdateTypePayloadV3ColorPink   CatalogUpdateTypePayloadV3Color = "pink"
+	CatalogUpdateTypePayloadV3ColorViolet CatalogUpdateTypePayloadV3Color = "violet"
+	CatalogUpdateTypePayloadV3ColorYellow CatalogUpdateTypePayloadV3Color = "yellow"
+)
+
+// Defines values for CatalogUpdateTypePayloadV3Icon.
+const (
+	CatalogUpdateTypePayloadV3IconAlert          CatalogUpdateTypePayloadV3Icon = "alert"
+	CatalogUpdateTypePayloadV3IconBolt           CatalogUpdateTypePayloadV3Icon = "bolt"
+	CatalogUpdateTypePayloadV3IconBox            CatalogUpdateTypePayloadV3Icon = "box"
+	CatalogUpdateTypePayloadV3IconBriefcase      CatalogUpdateTypePayloadV3Icon = "briefcase"
+	CatalogUpdateTypePayloadV3IconBrowser        CatalogUpdateTypePayloadV3Icon = "browser"
+	CatalogUpdateTypePayloadV3IconBulb           CatalogUpdateTypePayloadV3Icon = "bulb"
+	CatalogUpdateTypePayloadV3IconCalendar       CatalogUpdateTypePayloadV3Icon = "calendar"
+	CatalogUpdateTypePayloadV3IconClock          CatalogUpdateTypePayloadV3Icon = "clock"
+	CatalogUpdateTypePayloadV3IconCog            CatalogUpdateTypePayloadV3Icon = "cog"
+	CatalogUpdateTypePayloadV3IconComponents     CatalogUpdateTypePayloadV3Icon = "components"
+	CatalogUpdateTypePayloadV3IconDatabase       CatalogUpdateTypePayloadV3Icon = "database"
+	CatalogUpdateTypePayloadV3IconDoc            CatalogUpdateTypePayloadV3Icon = "doc"
+	CatalogUpdateTypePayloadV3IconEmail          CatalogUpdateTypePayloadV3Icon = "email"
+	CatalogUpdateTypePayloadV3IconEscalationPath CatalogUpdateTypePayloadV3Icon = "escalation-path"
+	CatalogUpdateTypePayloadV3IconFiles          CatalogUpdateTypePayloadV3Icon = "files"
+	CatalogUpdateTypePayloadV3IconFlag           CatalogUpdateTypePayloadV3Icon = "flag"
+	CatalogUpdateTypePayloadV3IconFolder         CatalogUpdateTypePayloadV3Icon = "folder"
+	CatalogUpdateTypePayloadV3IconGlobe          CatalogUpdateTypePayloadV3Icon = "globe"
+	CatalogUpdateTypePayloadV3IconMoney          CatalogUpdateTypePayloadV3Icon = "money"
+	CatalogUpdateTypePayloadV3IconServer         CatalogUpdateTypePayloadV3Icon = "server"
+	CatalogUpdateTypePayloadV3IconSeverity       CatalogUpdateTypePayloadV3Icon = "severity"
+	CatalogUpdateTypePayloadV3IconStar           CatalogUpdateTypePayloadV3Icon = "star"
+	CatalogUpdateTypePayloadV3IconStatusPage     CatalogUpdateTypePayloadV3Icon = "status-page"
+	CatalogUpdateTypePayloadV3IconStore          CatalogUpdateTypePayloadV3Icon = "store"
+	CatalogUpdateTypePayloadV3IconTag            CatalogUpdateTypePayloadV3Icon = "tag"
+	CatalogUpdateTypePayloadV3IconUser           CatalogUpdateTypePayloadV3Icon = "user"
+	CatalogUpdateTypePayloadV3IconUsers          CatalogUpdateTypePayloadV3Icon = "users"
+)
+
 // Defines values for CreateHTTPRequestBodyStatus.
 const (
 	Firing   CreateHTTPRequestBodyStatus = "firing"
@@ -247,6 +543,7 @@ const (
 	CreateRequestBodyResourceResourceTypePagerDutyIncident           CreateRequestBodyResourceResourceType = "pager_duty_incident"
 	CreateRequestBodyResourceResourceTypeScrubbed                    CreateRequestBodyResourceResourceType = "scrubbed"
 	CreateRequestBodyResourceResourceTypeSentryIssue                 CreateRequestBodyResourceResourceType = "sentry_issue"
+	CreateRequestBodyResourceResourceTypeSlackFile                   CreateRequestBodyResourceResourceType = "slack_file"
 	CreateRequestBodyResourceResourceTypeStatuspageIncident          CreateRequestBodyResourceResourceType = "statuspage_incident"
 	CreateRequestBodyResourceResourceTypeZendeskTicket               CreateRequestBodyResourceResourceType = "zendesk_ticket"
 )
@@ -256,80 +553,6 @@ const (
 	CreateRequestBody5CategoryClosed   CreateRequestBody5Category = "closed"
 	CreateRequestBody5CategoryLearning CreateRequestBody5Category = "learning"
 	CreateRequestBody5CategoryLive     CreateRequestBody5Category = "live"
-)
-
-// Defines values for CreateTypeRequestBodyCategories.
-const (
-	CreateTypeRequestBodyCategoriesCustomer       CreateTypeRequestBodyCategories = "customer"
-	CreateTypeRequestBodyCategoriesIssueTracker   CreateTypeRequestBodyCategories = "issue-tracker"
-	CreateTypeRequestBodyCategoriesOnCall         CreateTypeRequestBodyCategories = "on-call"
-	CreateTypeRequestBodyCategoriesProductFeature CreateTypeRequestBodyCategories = "product-feature"
-	CreateTypeRequestBodyCategoriesService        CreateTypeRequestBodyCategories = "service"
-	CreateTypeRequestBodyCategoriesTeam           CreateTypeRequestBodyCategories = "team"
-	CreateTypeRequestBodyCategoriesUser           CreateTypeRequestBodyCategories = "user"
-)
-
-// Defines values for CreateTypeRequestBodyColor.
-const (
-	CreateTypeRequestBodyColorBlue   CreateTypeRequestBodyColor = "blue"
-	CreateTypeRequestBodyColorCyan   CreateTypeRequestBodyColor = "cyan"
-	CreateTypeRequestBodyColorGreen  CreateTypeRequestBodyColor = "green"
-	CreateTypeRequestBodyColorOrange CreateTypeRequestBodyColor = "orange"
-	CreateTypeRequestBodyColorPink   CreateTypeRequestBodyColor = "pink"
-	CreateTypeRequestBodyColorViolet CreateTypeRequestBodyColor = "violet"
-	CreateTypeRequestBodyColorYellow CreateTypeRequestBodyColor = "yellow"
-)
-
-// Defines values for CreateTypeRequestBodyIcon.
-const (
-	CreateTypeRequestBodyIconAlert          CreateTypeRequestBodyIcon = "alert"
-	CreateTypeRequestBodyIconBolt           CreateTypeRequestBodyIcon = "bolt"
-	CreateTypeRequestBodyIconBox            CreateTypeRequestBodyIcon = "box"
-	CreateTypeRequestBodyIconBriefcase      CreateTypeRequestBodyIcon = "briefcase"
-	CreateTypeRequestBodyIconBrowser        CreateTypeRequestBodyIcon = "browser"
-	CreateTypeRequestBodyIconBulb           CreateTypeRequestBodyIcon = "bulb"
-	CreateTypeRequestBodyIconCalendar       CreateTypeRequestBodyIcon = "calendar"
-	CreateTypeRequestBodyIconClock          CreateTypeRequestBodyIcon = "clock"
-	CreateTypeRequestBodyIconCog            CreateTypeRequestBodyIcon = "cog"
-	CreateTypeRequestBodyIconComponents     CreateTypeRequestBodyIcon = "components"
-	CreateTypeRequestBodyIconDatabase       CreateTypeRequestBodyIcon = "database"
-	CreateTypeRequestBodyIconDoc            CreateTypeRequestBodyIcon = "doc"
-	CreateTypeRequestBodyIconEmail          CreateTypeRequestBodyIcon = "email"
-	CreateTypeRequestBodyIconEscalationPath CreateTypeRequestBodyIcon = "escalation-path"
-	CreateTypeRequestBodyIconFiles          CreateTypeRequestBodyIcon = "files"
-	CreateTypeRequestBodyIconFlag           CreateTypeRequestBodyIcon = "flag"
-	CreateTypeRequestBodyIconFolder         CreateTypeRequestBodyIcon = "folder"
-	CreateTypeRequestBodyIconGlobe          CreateTypeRequestBodyIcon = "globe"
-	CreateTypeRequestBodyIconMoney          CreateTypeRequestBodyIcon = "money"
-	CreateTypeRequestBodyIconServer         CreateTypeRequestBodyIcon = "server"
-	CreateTypeRequestBodyIconSeverity       CreateTypeRequestBodyIcon = "severity"
-	CreateTypeRequestBodyIconStar           CreateTypeRequestBodyIcon = "star"
-	CreateTypeRequestBodyIconStatusPage     CreateTypeRequestBodyIcon = "status-page"
-	CreateTypeRequestBodyIconStore          CreateTypeRequestBodyIcon = "store"
-	CreateTypeRequestBodyIconTag            CreateTypeRequestBodyIcon = "tag"
-	CreateTypeRequestBodyIconUser           CreateTypeRequestBodyIcon = "user"
-	CreateTypeRequestBodyIconUsers          CreateTypeRequestBodyIcon = "users"
-)
-
-// Defines values for CreateWorkflowPayloadRunsOnIncidentModes.
-const (
-	CreateWorkflowPayloadRunsOnIncidentModesRetrospective CreateWorkflowPayloadRunsOnIncidentModes = "retrospective"
-	CreateWorkflowPayloadRunsOnIncidentModesStandard      CreateWorkflowPayloadRunsOnIncidentModes = "standard"
-	CreateWorkflowPayloadRunsOnIncidentModesTest          CreateWorkflowPayloadRunsOnIncidentModes = "test"
-)
-
-// Defines values for CreateWorkflowPayloadRunsOnIncidents.
-const (
-	CreateWorkflowPayloadRunsOnIncidentsNewlyCreated          CreateWorkflowPayloadRunsOnIncidents = "newly_created"
-	CreateWorkflowPayloadRunsOnIncidentsNewlyCreatedAndActive CreateWorkflowPayloadRunsOnIncidents = "newly_created_and_active"
-)
-
-// Defines values for CreateWorkflowPayloadState.
-const (
-	CreateWorkflowPayloadStateActive   CreateWorkflowPayloadState = "active"
-	CreateWorkflowPayloadStateDisabled CreateWorkflowPayloadState = "disabled"
-	CreateWorkflowPayloadStateDraft    CreateWorkflowPayloadState = "draft"
-	CreateWorkflowPayloadStateError    CreateWorkflowPayloadState = "error"
 )
 
 // Defines values for CustomFieldTypeInfoV1FieldType.
@@ -465,10 +688,10 @@ const (
 
 // Defines values for EscalationPathTargetV2ScheduleMode.
 const (
-	EscalationPathTargetV2ScheduleModeAllUsers        EscalationPathTargetV2ScheduleMode = "all_users"
-	EscalationPathTargetV2ScheduleModeAllUsersForRota EscalationPathTargetV2ScheduleMode = "all_users_for_rota"
-	EscalationPathTargetV2ScheduleModeCurrentlyOnCall EscalationPathTargetV2ScheduleMode = "currently_on_call"
-	EscalationPathTargetV2ScheduleModeEmpty           EscalationPathTargetV2ScheduleMode = ""
+	AllUsers        EscalationPathTargetV2ScheduleMode = "all_users"
+	AllUsersForRota EscalationPathTargetV2ScheduleMode = "all_users_for_rota"
+	CurrentlyOnCall EscalationPathTargetV2ScheduleMode = "currently_on_call"
+	Empty           EscalationPathTargetV2ScheduleMode = ""
 )
 
 // Defines values for EscalationPathTargetV2Type.
@@ -510,34 +733,6 @@ const (
 	ExpressionOperationV2OperationTypeParse    ExpressionOperationV2OperationType = "parse"
 	ExpressionOperationV2OperationTypeRandom   ExpressionOperationV2OperationType = "random"
 	ExpressionOperationV2OperationTypeSum      ExpressionOperationV2OperationType = "sum"
-)
-
-// Defines values for ExpressionOperationV3OperationType.
-const (
-	ExpressionOperationV3OperationTypeBranches ExpressionOperationV3OperationType = "branches"
-	ExpressionOperationV3OperationTypeCount    ExpressionOperationV3OperationType = "count"
-	ExpressionOperationV3OperationTypeFilter   ExpressionOperationV3OperationType = "filter"
-	ExpressionOperationV3OperationTypeFirst    ExpressionOperationV3OperationType = "first"
-	ExpressionOperationV3OperationTypeMax      ExpressionOperationV3OperationType = "max"
-	ExpressionOperationV3OperationTypeMin      ExpressionOperationV3OperationType = "min"
-	ExpressionOperationV3OperationTypeNavigate ExpressionOperationV3OperationType = "navigate"
-	ExpressionOperationV3OperationTypeParse    ExpressionOperationV3OperationType = "parse"
-	ExpressionOperationV3OperationTypeRandom   ExpressionOperationV3OperationType = "random"
-	ExpressionOperationV3OperationTypeSum      ExpressionOperationV3OperationType = "sum"
-)
-
-// Defines values for ExpressionOperationV4OperationType.
-const (
-	ExpressionOperationV4OperationTypeBranches ExpressionOperationV4OperationType = "branches"
-	ExpressionOperationV4OperationTypeCount    ExpressionOperationV4OperationType = "count"
-	ExpressionOperationV4OperationTypeFilter   ExpressionOperationV4OperationType = "filter"
-	ExpressionOperationV4OperationTypeFirst    ExpressionOperationV4OperationType = "first"
-	ExpressionOperationV4OperationTypeMax      ExpressionOperationV4OperationType = "max"
-	ExpressionOperationV4OperationTypeMin      ExpressionOperationV4OperationType = "min"
-	ExpressionOperationV4OperationTypeNavigate ExpressionOperationV4OperationType = "navigate"
-	ExpressionOperationV4OperationTypeParse    ExpressionOperationV4OperationType = "parse"
-	ExpressionOperationV4OperationTypeRandom   ExpressionOperationV4OperationType = "random"
-	ExpressionOperationV4OperationTypeSum      ExpressionOperationV4OperationType = "sum"
 )
 
 // Defines values for ExternalIssueReferenceV1Provider.
@@ -592,6 +787,7 @@ const (
 	ExternalResourceV1ResourceTypePagerDutyIncident           ExternalResourceV1ResourceType = "pager_duty_incident"
 	ExternalResourceV1ResourceTypeScrubbed                    ExternalResourceV1ResourceType = "scrubbed"
 	ExternalResourceV1ResourceTypeSentryIssue                 ExternalResourceV1ResourceType = "sentry_issue"
+	ExternalResourceV1ResourceTypeSlackFile                   ExternalResourceV1ResourceType = "slack_file"
 	ExternalResourceV1ResourceTypeStatuspageIncident          ExternalResourceV1ResourceType = "statuspage_incident"
 	ExternalResourceV1ResourceTypeZendeskTicket               ExternalResourceV1ResourceType = "zendesk_ticket"
 )
@@ -754,9 +950,9 @@ const (
 
 // Defines values for ManagedResourceV2ResourceType.
 const (
-	ManagedResourceV2ResourceTypeEscalationPath ManagedResourceV2ResourceType = "escalation_path"
-	ManagedResourceV2ResourceTypeSchedule       ManagedResourceV2ResourceType = "schedule"
-	ManagedResourceV2ResourceTypeWorkflow       ManagedResourceV2ResourceType = "workflow"
+	EscalationPath ManagedResourceV2ResourceType = "escalation_path"
+	Schedule       ManagedResourceV2ResourceType = "schedule"
+	Workflow       ManagedResourceV2ResourceType = "workflow"
 )
 
 // Defines values for ManagementMetaV2ManagedBy.
@@ -806,80 +1002,6 @@ const (
 	ScheduleRotationWorkingIntervalV2WeekdayWednesday ScheduleRotationWorkingIntervalV2Weekday = "wednesday"
 )
 
-// Defines values for UpdateTypeRequestBodyCategories.
-const (
-	Customer       UpdateTypeRequestBodyCategories = "customer"
-	IssueTracker   UpdateTypeRequestBodyCategories = "issue-tracker"
-	OnCall         UpdateTypeRequestBodyCategories = "on-call"
-	ProductFeature UpdateTypeRequestBodyCategories = "product-feature"
-	Service        UpdateTypeRequestBodyCategories = "service"
-	Team           UpdateTypeRequestBodyCategories = "team"
-	User           UpdateTypeRequestBodyCategories = "user"
-)
-
-// Defines values for UpdateTypeRequestBodyColor.
-const (
-	Blue   UpdateTypeRequestBodyColor = "blue"
-	Cyan   UpdateTypeRequestBodyColor = "cyan"
-	Green  UpdateTypeRequestBodyColor = "green"
-	Orange UpdateTypeRequestBodyColor = "orange"
-	Pink   UpdateTypeRequestBodyColor = "pink"
-	Violet UpdateTypeRequestBodyColor = "violet"
-	Yellow UpdateTypeRequestBodyColor = "yellow"
-)
-
-// Defines values for UpdateTypeRequestBodyIcon.
-const (
-	UpdateTypeRequestBodyIconAlert          UpdateTypeRequestBodyIcon = "alert"
-	UpdateTypeRequestBodyIconBolt           UpdateTypeRequestBodyIcon = "bolt"
-	UpdateTypeRequestBodyIconBox            UpdateTypeRequestBodyIcon = "box"
-	UpdateTypeRequestBodyIconBriefcase      UpdateTypeRequestBodyIcon = "briefcase"
-	UpdateTypeRequestBodyIconBrowser        UpdateTypeRequestBodyIcon = "browser"
-	UpdateTypeRequestBodyIconBulb           UpdateTypeRequestBodyIcon = "bulb"
-	UpdateTypeRequestBodyIconCalendar       UpdateTypeRequestBodyIcon = "calendar"
-	UpdateTypeRequestBodyIconClock          UpdateTypeRequestBodyIcon = "clock"
-	UpdateTypeRequestBodyIconCog            UpdateTypeRequestBodyIcon = "cog"
-	UpdateTypeRequestBodyIconComponents     UpdateTypeRequestBodyIcon = "components"
-	UpdateTypeRequestBodyIconDatabase       UpdateTypeRequestBodyIcon = "database"
-	UpdateTypeRequestBodyIconDoc            UpdateTypeRequestBodyIcon = "doc"
-	UpdateTypeRequestBodyIconEmail          UpdateTypeRequestBodyIcon = "email"
-	UpdateTypeRequestBodyIconEscalationPath UpdateTypeRequestBodyIcon = "escalation-path"
-	UpdateTypeRequestBodyIconFiles          UpdateTypeRequestBodyIcon = "files"
-	UpdateTypeRequestBodyIconFlag           UpdateTypeRequestBodyIcon = "flag"
-	UpdateTypeRequestBodyIconFolder         UpdateTypeRequestBodyIcon = "folder"
-	UpdateTypeRequestBodyIconGlobe          UpdateTypeRequestBodyIcon = "globe"
-	UpdateTypeRequestBodyIconMoney          UpdateTypeRequestBodyIcon = "money"
-	UpdateTypeRequestBodyIconServer         UpdateTypeRequestBodyIcon = "server"
-	UpdateTypeRequestBodyIconSeverity       UpdateTypeRequestBodyIcon = "severity"
-	UpdateTypeRequestBodyIconStar           UpdateTypeRequestBodyIcon = "star"
-	UpdateTypeRequestBodyIconStatusPage     UpdateTypeRequestBodyIcon = "status-page"
-	UpdateTypeRequestBodyIconStore          UpdateTypeRequestBodyIcon = "store"
-	UpdateTypeRequestBodyIconTag            UpdateTypeRequestBodyIcon = "tag"
-	UpdateTypeRequestBodyIconUser           UpdateTypeRequestBodyIcon = "user"
-	UpdateTypeRequestBodyIconUsers          UpdateTypeRequestBodyIcon = "users"
-)
-
-// Defines values for UpdateWorkflowPayload2RunsOnIncidentModes.
-const (
-	UpdateWorkflowPayload2RunsOnIncidentModesRetrospective UpdateWorkflowPayload2RunsOnIncidentModes = "retrospective"
-	UpdateWorkflowPayload2RunsOnIncidentModesStandard      UpdateWorkflowPayload2RunsOnIncidentModes = "standard"
-	UpdateWorkflowPayload2RunsOnIncidentModesTest          UpdateWorkflowPayload2RunsOnIncidentModes = "test"
-)
-
-// Defines values for UpdateWorkflowPayload2RunsOnIncidents.
-const (
-	UpdateWorkflowPayload2RunsOnIncidentsNewlyCreated          UpdateWorkflowPayload2RunsOnIncidents = "newly_created"
-	UpdateWorkflowPayload2RunsOnIncidentsNewlyCreatedAndActive UpdateWorkflowPayload2RunsOnIncidents = "newly_created_and_active"
-)
-
-// Defines values for UpdateWorkflowPayload2State.
-const (
-	UpdateWorkflowPayload2StateActive   UpdateWorkflowPayload2State = "active"
-	UpdateWorkflowPayload2StateDisabled UpdateWorkflowPayload2State = "disabled"
-	UpdateWorkflowPayload2StateDraft    UpdateWorkflowPayload2State = "draft"
-	UpdateWorkflowPayload2StateError    UpdateWorkflowPayload2State = "error"
-)
-
 // Defines values for UserV1Role.
 const (
 	UserV1RoleAdministrator UserV1Role = "administrator"
@@ -918,46 +1040,88 @@ const (
 	WeekdayIntervalV2WeekdayWednesday WeekdayIntervalV2Weekday = "wednesday"
 )
 
-// Defines values for WorkflowRunsOnIncidentModes.
+// Defines values for WorkflowSlimV2RunsOnIncidentModes.
 const (
-	WorkflowRunsOnIncidentModesRetrospective WorkflowRunsOnIncidentModes = "retrospective"
-	WorkflowRunsOnIncidentModesStandard      WorkflowRunsOnIncidentModes = "standard"
-	WorkflowRunsOnIncidentModesTest          WorkflowRunsOnIncidentModes = "test"
+	WorkflowSlimV2RunsOnIncidentModesRetrospective WorkflowSlimV2RunsOnIncidentModes = "retrospective"
+	WorkflowSlimV2RunsOnIncidentModesStandard      WorkflowSlimV2RunsOnIncidentModes = "standard"
+	WorkflowSlimV2RunsOnIncidentModesTest          WorkflowSlimV2RunsOnIncidentModes = "test"
 )
 
-// Defines values for WorkflowRunsOnIncidents.
+// Defines values for WorkflowSlimV2RunsOnIncidents.
 const (
-	WorkflowRunsOnIncidentsNewlyCreated          WorkflowRunsOnIncidents = "newly_created"
-	WorkflowRunsOnIncidentsNewlyCreatedAndActive WorkflowRunsOnIncidents = "newly_created_and_active"
+	WorkflowSlimV2RunsOnIncidentsNewlyCreated          WorkflowSlimV2RunsOnIncidents = "newly_created"
+	WorkflowSlimV2RunsOnIncidentsNewlyCreatedAndActive WorkflowSlimV2RunsOnIncidents = "newly_created_and_active"
 )
 
-// Defines values for WorkflowState.
+// Defines values for WorkflowSlimV2State.
 const (
-	WorkflowStateActive   WorkflowState = "active"
-	WorkflowStateDisabled WorkflowState = "disabled"
-	WorkflowStateDraft    WorkflowState = "draft"
-	WorkflowStateError    WorkflowState = "error"
+	WorkflowSlimV2StateActive   WorkflowSlimV2State = "active"
+	WorkflowSlimV2StateDisabled WorkflowSlimV2State = "disabled"
+	WorkflowSlimV2StateDraft    WorkflowSlimV2State = "draft"
+	WorkflowSlimV2StateError    WorkflowSlimV2State = "error"
 )
 
-// Defines values for WorkflowSlimRunsOnIncidentModes.
+// Defines values for WorkflowV2RunsOnIncidentModes.
 const (
-	WorkflowSlimRunsOnIncidentModesRetrospective WorkflowSlimRunsOnIncidentModes = "retrospective"
-	WorkflowSlimRunsOnIncidentModesStandard      WorkflowSlimRunsOnIncidentModes = "standard"
-	WorkflowSlimRunsOnIncidentModesTest          WorkflowSlimRunsOnIncidentModes = "test"
+	WorkflowV2RunsOnIncidentModesRetrospective WorkflowV2RunsOnIncidentModes = "retrospective"
+	WorkflowV2RunsOnIncidentModesStandard      WorkflowV2RunsOnIncidentModes = "standard"
+	WorkflowV2RunsOnIncidentModesTest          WorkflowV2RunsOnIncidentModes = "test"
 )
 
-// Defines values for WorkflowSlimRunsOnIncidents.
+// Defines values for WorkflowV2RunsOnIncidents.
 const (
-	WorkflowSlimRunsOnIncidentsNewlyCreated          WorkflowSlimRunsOnIncidents = "newly_created"
-	WorkflowSlimRunsOnIncidentsNewlyCreatedAndActive WorkflowSlimRunsOnIncidents = "newly_created_and_active"
+	WorkflowV2RunsOnIncidentsNewlyCreated          WorkflowV2RunsOnIncidents = "newly_created"
+	WorkflowV2RunsOnIncidentsNewlyCreatedAndActive WorkflowV2RunsOnIncidents = "newly_created_and_active"
 )
 
-// Defines values for WorkflowSlimState.
+// Defines values for WorkflowV2State.
 const (
-	WorkflowSlimStateActive   WorkflowSlimState = "active"
-	WorkflowSlimStateDisabled WorkflowSlimState = "disabled"
-	WorkflowSlimStateDraft    WorkflowSlimState = "draft"
-	WorkflowSlimStateError    WorkflowSlimState = "error"
+	WorkflowV2StateActive   WorkflowV2State = "active"
+	WorkflowV2StateDisabled WorkflowV2State = "disabled"
+	WorkflowV2StateDraft    WorkflowV2State = "draft"
+	WorkflowV2StateError    WorkflowV2State = "error"
+)
+
+// Defines values for WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes.
+const (
+	WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModesRetrospective WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes = "retrospective"
+	WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModesStandard      WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes = "standard"
+	WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModesTest          WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes = "test"
+)
+
+// Defines values for WorkflowsCreateWorkflowPayloadV2RunsOnIncidents.
+const (
+	WorkflowsCreateWorkflowPayloadV2RunsOnIncidentsNewlyCreated          WorkflowsCreateWorkflowPayloadV2RunsOnIncidents = "newly_created"
+	WorkflowsCreateWorkflowPayloadV2RunsOnIncidentsNewlyCreatedAndActive WorkflowsCreateWorkflowPayloadV2RunsOnIncidents = "newly_created_and_active"
+)
+
+// Defines values for WorkflowsCreateWorkflowPayloadV2State.
+const (
+	WorkflowsCreateWorkflowPayloadV2StateActive   WorkflowsCreateWorkflowPayloadV2State = "active"
+	WorkflowsCreateWorkflowPayloadV2StateDisabled WorkflowsCreateWorkflowPayloadV2State = "disabled"
+	WorkflowsCreateWorkflowPayloadV2StateDraft    WorkflowsCreateWorkflowPayloadV2State = "draft"
+	WorkflowsCreateWorkflowPayloadV2StateError    WorkflowsCreateWorkflowPayloadV2State = "error"
+)
+
+// Defines values for WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes.
+const (
+	WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModesRetrospective WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes = "retrospective"
+	WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModesStandard      WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes = "standard"
+	WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModesTest          WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes = "test"
+)
+
+// Defines values for WorkflowsUpdateWorkflowPayloadV2RunsOnIncidents.
+const (
+	WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentsNewlyCreated          WorkflowsUpdateWorkflowPayloadV2RunsOnIncidents = "newly_created"
+	WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentsNewlyCreatedAndActive WorkflowsUpdateWorkflowPayloadV2RunsOnIncidents = "newly_created_and_active"
+)
+
+// Defines values for WorkflowsUpdateWorkflowPayloadV2State.
+const (
+	WorkflowsUpdateWorkflowPayloadV2StateActive   WorkflowsUpdateWorkflowPayloadV2State = "active"
+	WorkflowsUpdateWorkflowPayloadV2StateDisabled WorkflowsUpdateWorkflowPayloadV2State = "disabled"
+	WorkflowsUpdateWorkflowPayloadV2StateDraft    WorkflowsUpdateWorkflowPayloadV2State = "draft"
+	WorkflowsUpdateWorkflowPayloadV2StateError    WorkflowsUpdateWorkflowPayloadV2State = "error"
 )
 
 // Defines values for ActionsV1ListParamsIncidentMode.
@@ -980,6 +1144,7 @@ const (
 	PagerDutyIncident           IncidentAttachmentsV1ListParamsResourceType = "pager_duty_incident"
 	Scrubbed                    IncidentAttachmentsV1ListParamsResourceType = "scrubbed"
 	SentryIssue                 IncidentAttachmentsV1ListParamsResourceType = "sentry_issue"
+	SlackFile                   IncidentAttachmentsV1ListParamsResourceType = "slack_file"
 	StatuspageIncident          IncidentAttachmentsV1ListParamsResourceType = "statuspage_incident"
 	ZendeskTicket               IncidentAttachmentsV1ListParamsResourceType = "zendesk_ticket"
 )
@@ -1259,46 +1424,6 @@ type AlertRouteIncidentTemplateV2CustomFieldPriorities string
 // AlertRouteIncidentTemplateV2PrioritySeverity binding to use to resolve the workspace to create an incident in
 type AlertRouteIncidentTemplateV2PrioritySeverity string
 
-// AlertRoutePayloadV2 defines model for AlertRoutePayloadV2.
-type AlertRoutePayloadV2 struct {
-	// AlertSources Which alert sources should this alert route match?
-	AlertSources *[]AlertRouteAlertSourcePayloadV2 `json:"alert_sources,omitempty"`
-
-	// AutoDeclineEnabled Should triage incidents be declined when alerts are resolved?
-	AutoDeclineEnabled *bool `json:"auto_decline_enabled,omitempty"`
-
-	// ConditionGroups What condition groups must be true for this alert route to fire?
-	ConditionGroups *[]ConditionGroupPayloadV2 `json:"condition_groups,omitempty"`
-
-	// DeferTimeSeconds How long should the escalation defer time be?
-	DeferTimeSeconds *int64 `json:"defer_time_seconds,omitempty"`
-
-	// Enabled Whether this alert route is enabled or not
-	Enabled *bool `json:"enabled,omitempty"`
-
-	// EscalationBindings Which escalation paths should this alert route escalate to?
-	EscalationBindings *[]AlertRouteEscalationBindingPayloadV2 `json:"escalation_bindings,omitempty"`
-
-	// Expressions The expressions used in this template
-	Expressions *[]ExpressionPayloadV2 `json:"expressions,omitempty"`
-
-	// GroupingKeys Which attributes should this alert route use to group alerts?
-	GroupingKeys *[]GroupingKeyV2 `json:"grouping_keys,omitempty"`
-
-	// GroupingWindowSeconds How large should the grouping window be?
-	GroupingWindowSeconds *int64 `json:"grouping_window_seconds,omitempty"`
-
-	// IncidentConditionGroups What condition groups must be true for this alert route to create an incident?
-	IncidentConditionGroups *[]ConditionGroupPayloadV2 `json:"incident_condition_groups,omitempty"`
-
-	// IncidentEnabled Whether this alert route will create incidents or not
-	IncidentEnabled *bool `json:"incident_enabled,omitempty"`
-
-	// Name The name of this alert route config, for the user's reference
-	Name     *string                              `json:"name,omitempty"`
-	Template *AlertRouteIncidentTemplatePayloadV2 `json:"template,omitempty"`
-}
-
 // AlertRouteV2 defines model for AlertRouteV2.
 type AlertRouteV2 struct {
 	// ConditionGroups What condition groups must be true for this alert route to fire?
@@ -1325,6 +1450,101 @@ type AlertRouteV2 struct {
 	// Name The name of this alert route config, for the user's reference
 	Name     string                        `json:"name"`
 	Template *AlertRouteIncidentTemplateV2 `json:"template,omitempty"`
+}
+
+// AlertRoutesCreatePayloadV2 defines model for AlertRoutesCreatePayloadV2.
+type AlertRoutesCreatePayloadV2 struct {
+	// AlertSources Which alert sources should this alert route match?
+	AlertSources []AlertRouteAlertSourcePayloadV2 `json:"alert_sources"`
+
+	// AutoDeclineEnabled Should triage incidents be declined when alerts are resolved?
+	AutoDeclineEnabled bool `json:"auto_decline_enabled"`
+
+	// ConditionGroups What condition groups must be true for this alert route to fire?
+	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
+
+	// DeferTimeSeconds How long should the escalation defer time be?
+	DeferTimeSeconds int64 `json:"defer_time_seconds"`
+
+	// Enabled Whether this alert route is enabled or not
+	Enabled bool `json:"enabled"`
+
+	// EscalationBindings Which escalation paths should this alert route escalate to?
+	EscalationBindings []AlertRouteEscalationBindingPayloadV2 `json:"escalation_bindings"`
+
+	// Expressions The expressions used in this template
+	Expressions *[]ExpressionPayloadV2 `json:"expressions,omitempty"`
+
+	// GroupingKeys Which attributes should this alert route use to group alerts?
+	GroupingKeys []GroupingKeyV2 `json:"grouping_keys"`
+
+	// GroupingWindowSeconds How large should the grouping window be?
+	GroupingWindowSeconds int64 `json:"grouping_window_seconds"`
+
+	// IncidentConditionGroups What condition groups must be true for this alert route to create an incident?
+	IncidentConditionGroups []ConditionGroupPayloadV2 `json:"incident_condition_groups"`
+
+	// IncidentEnabled Whether this alert route will create incidents or not
+	IncidentEnabled bool `json:"incident_enabled"`
+
+	// Name The name of this alert route config, for the user's reference
+	Name     string                               `json:"name"`
+	Template *AlertRouteIncidentTemplatePayloadV2 `json:"template,omitempty"`
+}
+
+// AlertRoutesCreateResultV2 defines model for AlertRoutesCreateResultV2.
+type AlertRoutesCreateResultV2 struct {
+	AlertRoute AlertRouteV2 `json:"alert_route"`
+}
+
+// AlertRoutesShowResultV2 defines model for AlertRoutesShowResultV2.
+type AlertRoutesShowResultV2 struct {
+	AlertRoute AlertRouteV2 `json:"alert_route"`
+}
+
+// AlertRoutesUpdatePayloadV2 defines model for AlertRoutesUpdatePayloadV2.
+type AlertRoutesUpdatePayloadV2 struct {
+	// AlertSources Which alert sources should this alert route match?
+	AlertSources []AlertRouteAlertSourcePayloadV2 `json:"alert_sources"`
+
+	// AutoDeclineEnabled Should triage incidents be declined when alerts are resolved?
+	AutoDeclineEnabled bool `json:"auto_decline_enabled"`
+
+	// ConditionGroups What condition groups must be true for this alert route to fire?
+	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
+
+	// DeferTimeSeconds How long should the escalation defer time be?
+	DeferTimeSeconds int64 `json:"defer_time_seconds"`
+
+	// Enabled Whether this alert route is enabled or not
+	Enabled bool `json:"enabled"`
+
+	// EscalationBindings Which escalation paths should this alert route escalate to?
+	EscalationBindings []AlertRouteEscalationBindingPayloadV2 `json:"escalation_bindings"`
+
+	// Expressions The expressions used in this template
+	Expressions *[]ExpressionPayloadV2 `json:"expressions,omitempty"`
+
+	// GroupingKeys Which attributes should this alert route use to group alerts?
+	GroupingKeys []GroupingKeyV2 `json:"grouping_keys"`
+
+	// GroupingWindowSeconds How large should the grouping window be?
+	GroupingWindowSeconds int64 `json:"grouping_window_seconds"`
+
+	// IncidentConditionGroups What condition groups must be true for this alert route to create an incident?
+	IncidentConditionGroups []ConditionGroupPayloadV2 `json:"incident_condition_groups"`
+
+	// IncidentEnabled Whether this alert route will create incidents or not
+	IncidentEnabled bool `json:"incident_enabled"`
+
+	// Name The name of this alert route config, for the user's reference
+	Name     string                               `json:"name"`
+	Template *AlertRouteIncidentTemplatePayloadV2 `json:"template,omitempty"`
+}
+
+// AlertRoutesUpdateResultV2 defines model for AlertRoutesUpdateResultV2.
+type AlertRoutesUpdateResultV2 struct {
+	AlertRoute AlertRouteV2 `json:"alert_route"`
 }
 
 // AlertSourceEmailOptionsV2 defines model for AlertSourceEmailOptionsV2.
@@ -1441,11 +1661,171 @@ type AlertTemplateV2 struct {
 	Title       EngineParamBindingValueV2 `json:"title"`
 }
 
+// CatalogCreateEntryPayloadV2 defines model for CatalogCreateEntryPayloadV2.
+type CatalogCreateEntryPayloadV2 struct {
+	// Aliases Optional aliases that can be used to reference this entry
+	Aliases *[]string `json:"aliases,omitempty"`
+
+	// AttributeValues Values of this entry
+	AttributeValues map[string]EngineParamBindingPayloadV2 `json:"attribute_values"`
+
+	// CatalogTypeId ID of this catalog type
+	CatalogTypeId string `json:"catalog_type_id"`
+
+	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Name Name is the human readable name of this entry
+	Name string `json:"name"`
+
+	// Rank When catalog type is ranked, this is used to help order things
+	Rank *int32 `json:"rank,omitempty"`
+}
+
+// CatalogCreateEntryPayloadV3 defines model for CatalogCreateEntryPayloadV3.
+type CatalogCreateEntryPayloadV3 struct {
+	// Aliases Optional aliases that can be used to reference this entry
+	Aliases *[]string `json:"aliases,omitempty"`
+
+	// AttributeValues Values of this entry
+	AttributeValues map[string]CatalogEngineParamBindingPayloadV3 `json:"attribute_values"`
+
+	// CatalogTypeId ID of this catalog type
+	CatalogTypeId string `json:"catalog_type_id"`
+
+	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Name Name is the human readable name of this entry
+	Name string `json:"name"`
+
+	// Rank When catalog type is ranked, this is used to help order things
+	Rank *int32 `json:"rank,omitempty"`
+}
+
+// CatalogCreateEntryResultV2 defines model for CatalogCreateEntryResultV2.
+type CatalogCreateEntryResultV2 struct {
+	CatalogEntry CatalogEntryV2 `json:"catalog_entry"`
+}
+
+// CatalogCreateEntryResultV3 defines model for CatalogCreateEntryResultV3.
+type CatalogCreateEntryResultV3 struct {
+	CatalogEntry CatalogEntryV3 `json:"catalog_entry"`
+}
+
+// CatalogCreateTypePayloadV2 defines model for CatalogCreateTypePayloadV2.
+type CatalogCreateTypePayloadV2 struct {
+	// Annotations Annotations that can track metadata about this type
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// Categories What categories is this type considered part of
+	Categories *[]CatalogCreateTypePayloadV2Categories `json:"categories,omitempty"`
+
+	// Color Sets the display color of this type in the dashboard
+	Color *CatalogCreateTypePayloadV2Color `json:"color,omitempty"`
+
+	// Description Human readble description of this type
+	Description string `json:"description"`
+
+	// Icon Sets the display icon of this type in the dashboard
+	Icon *CatalogCreateTypePayloadV2Icon `json:"icon,omitempty"`
+
+	// Name Name is the human readable name of this type
+	Name string `json:"name"`
+
+	// Ranked If this type should be ranked
+	Ranked *bool `json:"ranked,omitempty"`
+
+	// SourceRepoUrl The url of the external repository where this type is managed
+	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
+
+	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
+	TypeName *string `json:"type_name,omitempty"`
+}
+
+// CatalogCreateTypePayloadV2Categories defines model for CatalogCreateTypePayloadV2.Categories.
+type CatalogCreateTypePayloadV2Categories string
+
+// CatalogCreateTypePayloadV2Color Sets the display color of this type in the dashboard
+type CatalogCreateTypePayloadV2Color string
+
+// CatalogCreateTypePayloadV2Icon Sets the display icon of this type in the dashboard
+type CatalogCreateTypePayloadV2Icon string
+
+// CatalogCreateTypePayloadV3 defines model for CatalogCreateTypePayloadV3.
+type CatalogCreateTypePayloadV3 struct {
+	// Annotations Annotations that can track metadata about this type
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// Categories What categories is this type considered part of
+	Categories *[]CatalogCreateTypePayloadV3Categories `json:"categories,omitempty"`
+
+	// Color Sets the display color of this type in the dashboard
+	Color *CatalogCreateTypePayloadV3Color `json:"color,omitempty"`
+
+	// Description Human readble description of this type
+	Description string `json:"description"`
+
+	// Icon Sets the display icon of this type in the dashboard
+	Icon *CatalogCreateTypePayloadV3Icon `json:"icon,omitempty"`
+
+	// Name Name is the human readable name of this type
+	Name string `json:"name"`
+
+	// Ranked If this type should be ranked
+	Ranked *bool `json:"ranked,omitempty"`
+
+	// SourceRepoUrl The url of the external repository where this type is managed
+	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
+
+	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
+	TypeName *string `json:"type_name,omitempty"`
+}
+
+// CatalogCreateTypePayloadV3Categories defines model for CatalogCreateTypePayloadV3.Categories.
+type CatalogCreateTypePayloadV3Categories string
+
+// CatalogCreateTypePayloadV3Color Sets the display color of this type in the dashboard
+type CatalogCreateTypePayloadV3Color string
+
+// CatalogCreateTypePayloadV3Icon Sets the display icon of this type in the dashboard
+type CatalogCreateTypePayloadV3Icon string
+
+// CatalogCreateTypeResultV2 defines model for CatalogCreateTypeResultV2.
+type CatalogCreateTypeResultV2 struct {
+	CatalogType CatalogTypeV2 `json:"catalog_type"`
+}
+
+// CatalogCreateTypeResultV3 defines model for CatalogCreateTypeResultV3.
+type CatalogCreateTypeResultV3 struct {
+	CatalogType CatalogTypeV3 `json:"catalog_type"`
+}
+
+// CatalogEngineParamBindingPayloadV3 defines model for CatalogEngineParamBindingPayloadV3.
+type CatalogEngineParamBindingPayloadV3 struct {
+	// ArrayValue If set, this is the array value of the step parameter
+	ArrayValue *[]CatalogEngineParamBindingValuePayloadV3 `json:"array_value,omitempty"`
+	Value      *CatalogEngineParamBindingValuePayloadV3   `json:"value,omitempty"`
+}
+
+// CatalogEngineParamBindingValuePayloadV3 defines model for CatalogEngineParamBindingValuePayloadV3.
+type CatalogEngineParamBindingValuePayloadV3 struct {
+	// Literal If set, this is the literal value of the step parameter
+	Literal *string `json:"literal,omitempty"`
+}
+
 // CatalogEntryEngineParamBindingV2 defines model for CatalogEntryEngineParamBindingV2.
 type CatalogEntryEngineParamBindingV2 struct {
 	// ArrayValue If array_value is set, this helps render the values
 	ArrayValue *[]CatalogEntryEngineParamBindingValueV2 `json:"array_value,omitempty"`
 	Value      *CatalogEntryEngineParamBindingValueV2   `json:"value,omitempty"`
+}
+
+// CatalogEntryEngineParamBindingV3 defines model for CatalogEntryEngineParamBindingV3.
+type CatalogEntryEngineParamBindingV3 struct {
+	// ArrayValue If the attribute is multi-valued, the value will be returned here.
+	ArrayValue *[]CatalogEntryEngineParamBindingValueV3 `json:"array_value,omitempty"`
+	Value      *CatalogEntryEngineParamBindingValueV3   `json:"value,omitempty"`
 }
 
 // CatalogEntryEngineParamBindingValueV2 defines model for CatalogEntryEngineParamBindingValueV2.
@@ -1478,6 +1858,17 @@ type CatalogEntryEngineParamBindingValueV2 struct {
 
 	// Value This field is deprecated. It will not be present in any responses, and will be removed in a future version
 	Value *string `json:"value,omitempty"`
+}
+
+// CatalogEntryEngineParamBindingValueV3 defines model for CatalogEntryEngineParamBindingValueV3.
+type CatalogEntryEngineParamBindingValueV3 struct {
+	// Label A label for this attribute value. If the attribute refers to another Catalog entry, this will be the name of that entry.
+	Label string `json:"label"`
+
+	// Literal The underlying value of the attribute, serialized as a string.
+	//
+	// For String, Text, Number, and Bool typed attributes, this will be empty. For attributes that refer to another catalog entry, this can be the ID, external ID, or one of the aliases of that catalog entry.
+	Literal *string `json:"literal,omitempty"`
 }
 
 // CatalogEntryReferenceV2 defines model for CatalogEntryReferenceV2.
@@ -1528,6 +1919,73 @@ type CatalogEntryV2 struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// CatalogEntryV3 defines model for CatalogEntryV3.
+type CatalogEntryV3 struct {
+	// Aliases Optional aliases that can be used to reference this entry
+	Aliases []string `json:"aliases"`
+
+	// ArchivedAt When this entry was archived
+	ArchivedAt *time.Time `json:"archived_at,omitempty"`
+
+	// AttributeValues Values of this entry
+	AttributeValues map[string]CatalogEntryEngineParamBindingV3 `json:"attribute_values"`
+
+	// CatalogTypeId ID of this catalog type
+	CatalogTypeId string `json:"catalog_type_id"`
+
+	// CreatedAt When this entry was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Id ID of this catalog entry
+	Id string `json:"id"`
+
+	// Name Name is the human readable name of this entry
+	Name string `json:"name"`
+
+	// Rank When catalog type is ranked, this is used to help order things
+	Rank int32 `json:"rank"`
+
+	// UpdatedAt When this entry was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// CatalogListEntriesResultV2 defines model for CatalogListEntriesResultV2.
+type CatalogListEntriesResultV2 struct {
+	CatalogEntries []CatalogEntryV2       `json:"catalog_entries"`
+	CatalogType    CatalogTypeV2          `json:"catalog_type"`
+	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
+}
+
+// CatalogListEntriesResultV3 defines model for CatalogListEntriesResultV3.
+type CatalogListEntriesResultV3 struct {
+	CatalogEntries []CatalogEntryV3       `json:"catalog_entries"`
+	CatalogType    CatalogTypeV3          `json:"catalog_type"`
+	PaginationMeta PaginationMetaResultV3 `json:"pagination_meta"`
+}
+
+// CatalogListResourcesResultV2 defines model for CatalogListResourcesResultV2.
+type CatalogListResourcesResultV2 struct {
+	Resources []CatalogResourceV2 `json:"resources"`
+}
+
+// CatalogListResourcesResultV3 defines model for CatalogListResourcesResultV3.
+type CatalogListResourcesResultV3 struct {
+	Resources []CatalogResourceV3 `json:"resources"`
+}
+
+// CatalogListTypesResultV2 defines model for CatalogListTypesResultV2.
+type CatalogListTypesResultV2 struct {
+	CatalogTypes []CatalogTypeV2 `json:"catalog_types"`
+}
+
+// CatalogListTypesResultV3 defines model for CatalogListTypesResultV3.
+type CatalogListTypesResultV3 struct {
+	CatalogTypes []CatalogTypeV3 `json:"catalog_types"`
+}
+
 // CatalogResourceV2 defines model for CatalogResourceV2.
 type CatalogResourceV2 struct {
 	// Category Which category of resource
@@ -1549,14 +2007,72 @@ type CatalogResourceV2 struct {
 // CatalogResourceV2Category Which category of resource
 type CatalogResourceV2Category string
 
+// CatalogResourceV3 defines model for CatalogResourceV3.
+type CatalogResourceV3 struct {
+	// Category Which category of resource
+	Category CatalogResourceV3Category `json:"category"`
+
+	// Description Human readable description for this resource
+	Description string `json:"description"`
+
+	// Label Label for this catalog resource type
+	Label string `json:"label"`
+
+	// Type Catalog type name for this resource
+	Type string `json:"type"`
+
+	// ValueDocstring Documentation for the literal string value of this resource
+	ValueDocstring string `json:"value_docstring"`
+}
+
+// CatalogResourceV3Category Which category of resource
+type CatalogResourceV3Category string
+
+// CatalogShowEntryResultV2 defines model for CatalogShowEntryResultV2.
+type CatalogShowEntryResultV2 struct {
+	CatalogEntry CatalogEntryV2 `json:"catalog_entry"`
+	CatalogType  CatalogTypeV2  `json:"catalog_type"`
+}
+
+// CatalogShowEntryResultV3 defines model for CatalogShowEntryResultV3.
+type CatalogShowEntryResultV3 struct {
+	CatalogEntry CatalogEntryV3 `json:"catalog_entry"`
+	CatalogType  CatalogTypeV3  `json:"catalog_type"`
+}
+
+// CatalogShowTypeResultV2 defines model for CatalogShowTypeResultV2.
+type CatalogShowTypeResultV2 struct {
+	CatalogType CatalogTypeV2 `json:"catalog_type"`
+}
+
+// CatalogShowTypeResultV3 defines model for CatalogShowTypeResultV3.
+type CatalogShowTypeResultV3 struct {
+	CatalogType CatalogTypeV3 `json:"catalog_type"`
+}
+
 // CatalogTypeAttributePathItemPayloadV2 defines model for CatalogTypeAttributePathItemPayloadV2.
 type CatalogTypeAttributePathItemPayloadV2 struct {
 	// AttributeId the ID of the attribute to use
 	AttributeId string `json:"attribute_id"`
 }
 
+// CatalogTypeAttributePathItemPayloadV3 defines model for CatalogTypeAttributePathItemPayloadV3.
+type CatalogTypeAttributePathItemPayloadV3 struct {
+	// AttributeId the ID of the attribute to use
+	AttributeId string `json:"attribute_id"`
+}
+
 // CatalogTypeAttributePathItemV2 defines model for CatalogTypeAttributePathItemV2.
 type CatalogTypeAttributePathItemV2 struct {
+	// AttributeId the ID of the attribute to use
+	AttributeId string `json:"attribute_id"`
+
+	// AttributeName the name of the attribute to use
+	AttributeName string `json:"attribute_name"`
+}
+
+// CatalogTypeAttributePathItemV3 defines model for CatalogTypeAttributePathItemV3.
+type CatalogTypeAttributePathItemV3 struct {
 	// AttributeId the ID of the attribute to use
 	AttributeId string `json:"attribute_id"`
 
@@ -1591,6 +2107,33 @@ type CatalogTypeAttributePayloadV2 struct {
 // CatalogTypeAttributePayloadV2Mode Controls how this attribute is modified
 type CatalogTypeAttributePayloadV2Mode string
 
+// CatalogTypeAttributePayloadV3 defines model for CatalogTypeAttributePayloadV3.
+type CatalogTypeAttributePayloadV3 struct {
+	// Array Whether this attribute is an array
+	Array bool `json:"array"`
+
+	// BacklinkAttribute The attribute to use (if this is a backlink)
+	BacklinkAttribute *string `json:"backlink_attribute,omitempty"`
+
+	// Id The ID of this attribute
+	Id *string `json:"id,omitempty"`
+
+	// Mode Controls how this attribute is modified
+	Mode *CatalogTypeAttributePayloadV3Mode `json:"mode,omitempty"`
+
+	// Name Unique name of this attribute
+	Name string `json:"name"`
+
+	// Path The path to use (if this is an path)
+	Path *[]CatalogTypeAttributePathItemPayloadV3 `json:"path,omitempty"`
+
+	// Type Catalog type name for this attribute
+	Type string `json:"type"`
+}
+
+// CatalogTypeAttributePayloadV3Mode Controls how this attribute is modified
+type CatalogTypeAttributePayloadV3Mode string
+
 // CatalogTypeAttributeV2 defines model for CatalogTypeAttributeV2.
 type CatalogTypeAttributeV2 struct {
 	// Array Whether this attribute is an array
@@ -1618,10 +2161,46 @@ type CatalogTypeAttributeV2 struct {
 // CatalogTypeAttributeV2Mode Controls how this attribute is modified
 type CatalogTypeAttributeV2Mode string
 
+// CatalogTypeAttributeV3 defines model for CatalogTypeAttributeV3.
+type CatalogTypeAttributeV3 struct {
+	// Array Whether this attribute is an array
+	Array bool `json:"array"`
+
+	// BacklinkAttribute The attribute to use (if this is a backlink)
+	BacklinkAttribute *string `json:"backlink_attribute,omitempty"`
+
+	// Id The ID of this attribute
+	Id string `json:"id"`
+
+	// Mode Controls how this attribute is modified
+	Mode CatalogTypeAttributeV3Mode `json:"mode"`
+
+	// Name Unique name of this attribute
+	Name string `json:"name"`
+
+	// Path The path to use (if this is a path attribute)
+	Path *[]CatalogTypeAttributePathItemV3 `json:"path,omitempty"`
+
+	// Type Catalog type name for this attribute
+	Type string `json:"type"`
+}
+
+// CatalogTypeAttributeV3Mode Controls how this attribute is modified
+type CatalogTypeAttributeV3Mode string
+
 // CatalogTypeSchemaV2 defines model for CatalogTypeSchemaV2.
 type CatalogTypeSchemaV2 struct {
 	// Attributes Attributes of this catalog type
 	Attributes []CatalogTypeAttributeV2 `json:"attributes"`
+
+	// Version The version number of this schema
+	Version int64 `json:"version"`
+}
+
+// CatalogTypeSchemaV3 defines model for CatalogTypeSchemaV3.
+type CatalogTypeSchemaV3 struct {
+	// Attributes Attributes of this catalog type
+	Attributes []CatalogTypeAttributeV3 `json:"attributes"`
 
 	// Version The version number of this schema
 	Version int64 `json:"version"`
@@ -1675,13 +2254,13 @@ type CatalogTypeV2 struct {
 	RequiredIntegrations *[]string           `json:"required_integrations,omitempty"`
 	Schema               CatalogTypeSchemaV2 `json:"schema"`
 
-	// SemanticType What type of resource this catalog type should be understodd as
+	// SemanticType This type has been deprecated, and will always be empty.
 	SemanticType string `json:"semantic_type"`
 
 	// SourceRepoUrl The url of the external repository where this type is managed
 	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
 
-	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName "]
+	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
 	TypeName string `json:"type_name"`
 
 	// UpdatedAt When this type was last updated
@@ -1697,6 +2276,229 @@ type CatalogTypeV2Color string
 // CatalogTypeV2Icon Sets the display icon of this type in the dashboard
 type CatalogTypeV2Icon string
 
+// CatalogTypeV3 defines model for CatalogTypeV3.
+type CatalogTypeV3 struct {
+	// Annotations Annotations that can track metadata about this type
+	Annotations map[string]string `json:"annotations"`
+
+	// Categories What categories is this type considered part of
+	Categories []CatalogTypeV3Categories `json:"categories"`
+
+	// Color Sets the display color of this type in the dashboard
+	Color CatalogTypeV3Color `json:"color"`
+
+	// CreatedAt When this type was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Description Human readble description of this type
+	Description string `json:"description"`
+
+	// DynamicResourceParameter If this is a dynamic catalog type, this will be the unique parameter for identitfying this resource externally.
+	DynamicResourceParameter *string `json:"dynamic_resource_parameter,omitempty"`
+
+	// EstimatedCount If populated, gives an estimated count of entries for this type
+	EstimatedCount *int64 `json:"estimated_count,omitempty"`
+
+	// Icon Sets the display icon of this type in the dashboard
+	Icon CatalogTypeV3Icon `json:"icon"`
+
+	// Id ID of this catalog type
+	Id string `json:"id"`
+
+	// IsEditable Catalog types that are synced with external resources can't be edited
+	IsEditable bool `json:"is_editable"`
+
+	// LastSyncedAt When this type was last synced (if it's ever been sync'd)
+	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
+
+	// Name Name is the human readable name of this type
+	Name string `json:"name"`
+
+	// Ranked If this type should be ranked
+	Ranked bool `json:"ranked"`
+
+	// RegistryType The registry resource this type is synced from, if any
+	RegistryType *string `json:"registry_type,omitempty"`
+
+	// RequiredIntegrations If populated, the integrations required for this type
+	RequiredIntegrations *[]string           `json:"required_integrations,omitempty"`
+	Schema               CatalogTypeSchemaV3 `json:"schema"`
+
+	// SourceRepoUrl The url of the external repository where this type is managed
+	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
+
+	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
+	TypeName string `json:"type_name"`
+
+	// UpdatedAt When this type was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// CatalogTypeV3Categories defines model for CatalogTypeV3.Categories.
+type CatalogTypeV3Categories string
+
+// CatalogTypeV3Color Sets the display color of this type in the dashboard
+type CatalogTypeV3Color string
+
+// CatalogTypeV3Icon Sets the display icon of this type in the dashboard
+type CatalogTypeV3Icon string
+
+// CatalogUpdateEntryPayloadV2 defines model for CatalogUpdateEntryPayloadV2.
+type CatalogUpdateEntryPayloadV2 struct {
+	// Aliases Optional aliases that can be used to reference this entry
+	Aliases *[]string `json:"aliases,omitempty"`
+
+	// AttributeValues Values of this entry
+	AttributeValues map[string]EngineParamBindingPayloadV2 `json:"attribute_values"`
+
+	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Name Name is the human readable name of this entry
+	Name string `json:"name"`
+
+	// Rank When catalog type is ranked, this is used to help order things
+	Rank *int32 `json:"rank,omitempty"`
+}
+
+// CatalogUpdateEntryPayloadV3 defines model for CatalogUpdateEntryPayloadV3.
+type CatalogUpdateEntryPayloadV3 struct {
+	// Aliases Optional aliases that can be used to reference this entry
+	Aliases *[]string `json:"aliases,omitempty"`
+
+	// AttributeValues Values of this entry
+	AttributeValues map[string]CatalogEngineParamBindingPayloadV3 `json:"attribute_values"`
+
+	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Name Name is the human readable name of this entry
+	Name string `json:"name"`
+
+	// Rank When catalog type is ranked, this is used to help order things
+	Rank *int32 `json:"rank,omitempty"`
+
+	// UpdateAttributes If provided, only update these attribute_values keys. If not provided, update all attribute values.
+	// If you specify an attribute key that's not in your payload, the associated attribute value will be cleared.
+	UpdateAttributes *[]string `json:"update_attributes,omitempty"`
+}
+
+// CatalogUpdateEntryResultV2 defines model for CatalogUpdateEntryResultV2.
+type CatalogUpdateEntryResultV2 struct {
+	CatalogEntry CatalogEntryV2 `json:"catalog_entry"`
+	CatalogType  CatalogTypeV2  `json:"catalog_type"`
+}
+
+// CatalogUpdateEntryResultV3 defines model for CatalogUpdateEntryResultV3.
+type CatalogUpdateEntryResultV3 struct {
+	CatalogEntry CatalogEntryV3 `json:"catalog_entry"`
+	CatalogType  CatalogTypeV3  `json:"catalog_type"`
+}
+
+// CatalogUpdateTypePayloadV2 defines model for CatalogUpdateTypePayloadV2.
+type CatalogUpdateTypePayloadV2 struct {
+	// Annotations Annotations that can track metadata about this type
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// Categories What categories is this type considered part of
+	Categories *[]CatalogUpdateTypePayloadV2Categories `json:"categories,omitempty"`
+
+	// Color Sets the display color of this type in the dashboard
+	Color *CatalogUpdateTypePayloadV2Color `json:"color,omitempty"`
+
+	// Description Human readble description of this type
+	Description string `json:"description"`
+
+	// Icon Sets the display icon of this type in the dashboard
+	Icon *CatalogUpdateTypePayloadV2Icon `json:"icon,omitempty"`
+
+	// Name Name is the human readable name of this type
+	Name string `json:"name"`
+
+	// Ranked If this type should be ranked
+	Ranked *bool `json:"ranked,omitempty"`
+
+	// SourceRepoUrl The url of the external repository where this type is managed
+	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
+}
+
+// CatalogUpdateTypePayloadV2Categories defines model for CatalogUpdateTypePayloadV2.Categories.
+type CatalogUpdateTypePayloadV2Categories string
+
+// CatalogUpdateTypePayloadV2Color Sets the display color of this type in the dashboard
+type CatalogUpdateTypePayloadV2Color string
+
+// CatalogUpdateTypePayloadV2Icon Sets the display icon of this type in the dashboard
+type CatalogUpdateTypePayloadV2Icon string
+
+// CatalogUpdateTypePayloadV3 defines model for CatalogUpdateTypePayloadV3.
+type CatalogUpdateTypePayloadV3 struct {
+	// Annotations Annotations that can track metadata about this type
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// Categories What categories is this type considered part of
+	Categories *[]CatalogUpdateTypePayloadV3Categories `json:"categories,omitempty"`
+
+	// Color Sets the display color of this type in the dashboard
+	Color *CatalogUpdateTypePayloadV3Color `json:"color,omitempty"`
+
+	// Description Human readble description of this type
+	Description string `json:"description"`
+
+	// Icon Sets the display icon of this type in the dashboard
+	Icon *CatalogUpdateTypePayloadV3Icon `json:"icon,omitempty"`
+
+	// Name Name is the human readable name of this type
+	Name string `json:"name"`
+
+	// Ranked If this type should be ranked
+	Ranked *bool `json:"ranked,omitempty"`
+
+	// SourceRepoUrl The url of the external repository where this type is managed
+	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
+}
+
+// CatalogUpdateTypePayloadV3Categories defines model for CatalogUpdateTypePayloadV3.Categories.
+type CatalogUpdateTypePayloadV3Categories string
+
+// CatalogUpdateTypePayloadV3Color Sets the display color of this type in the dashboard
+type CatalogUpdateTypePayloadV3Color string
+
+// CatalogUpdateTypePayloadV3Icon Sets the display icon of this type in the dashboard
+type CatalogUpdateTypePayloadV3Icon string
+
+// CatalogUpdateTypeResultV2 defines model for CatalogUpdateTypeResultV2.
+type CatalogUpdateTypeResultV2 struct {
+	CatalogType CatalogTypeV2 `json:"catalog_type"`
+}
+
+// CatalogUpdateTypeResultV3 defines model for CatalogUpdateTypeResultV3.
+type CatalogUpdateTypeResultV3 struct {
+	CatalogType CatalogTypeV3 `json:"catalog_type"`
+}
+
+// CatalogUpdateTypeSchemaPayloadV2 defines model for CatalogUpdateTypeSchemaPayloadV2.
+type CatalogUpdateTypeSchemaPayloadV2 struct {
+	Attributes []CatalogTypeAttributePayloadV2 `json:"attributes"`
+	Version    int64                           `json:"version"`
+}
+
+// CatalogUpdateTypeSchemaPayloadV3 defines model for CatalogUpdateTypeSchemaPayloadV3.
+type CatalogUpdateTypeSchemaPayloadV3 struct {
+	Attributes []CatalogTypeAttributePayloadV3 `json:"attributes"`
+	Version    int64                           `json:"version"`
+}
+
+// CatalogUpdateTypeSchemaResultV2 defines model for CatalogUpdateTypeSchemaResultV2.
+type CatalogUpdateTypeSchemaResultV2 struct {
+	CatalogType CatalogTypeV2 `json:"catalog_type"`
+}
+
+// CatalogUpdateTypeSchemaResultV3 defines model for CatalogUpdateTypeSchemaResultV3.
+type CatalogUpdateTypeSchemaResultV3 struct {
+	CatalogType CatalogTypeV3 `json:"catalog_type"`
+}
+
 // ConditionGroupPayloadV2 defines model for ConditionGroupPayloadV2.
 type ConditionGroupPayloadV2 struct {
 	// Conditions All conditions in this list must be satisfied for the group to be satisfied
@@ -1709,98 +2511,8 @@ type ConditionGroupV2 struct {
 	Conditions []ConditionV2 `json:"conditions"`
 }
 
-// ConditionGroupV3 defines model for ConditionGroupV3.
-type ConditionGroupV3 struct {
-	// Conditions All conditions in this list must be satisfied for the group to be satisfied
-	Conditions []ConditionV3 `json:"conditions"`
-}
-
-// ConditionGroupV4 defines model for ConditionGroupV4.
-type ConditionGroupV4 struct {
-	// Conditions All conditions in this list must be satisfied for the group to be satisfied
-	Conditions []ConditionV4 `json:"conditions"`
-}
-
-// ConditionGroupV5 defines model for ConditionGroupV5.
-type ConditionGroupV5 struct {
-	// Conditions All conditions in this list must be satisfied for the group to be satisfied
-	Conditions []ConditionV5 `json:"conditions"`
-}
-
-// ConditionGroupV6 defines model for ConditionGroupV6.
-type ConditionGroupV6 struct {
-	// Conditions All conditions in this list must be satisfied for the group to be satisfied
-	Conditions []ConditionV6 `json:"conditions"`
-}
-
-// ConditionGroupV7 defines model for ConditionGroupV7.
-type ConditionGroupV7 struct {
-	// Conditions All conditions in this list must be satisfied for the group to be satisfied
-	Conditions []ConditionV7 `json:"conditions"`
-}
-
-// ConditionGroupV8 defines model for ConditionGroupV8.
-type ConditionGroupV8 struct {
-	// Conditions All conditions in this list must be satisfied for the group to be satisfied
-	Conditions []ConditionV8 `json:"conditions"`
-}
-
 // ConditionOperationV2 defines model for ConditionOperationV2.
 type ConditionOperationV2 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Value Unique identifier for this option
-	Value string `json:"value"`
-}
-
-// ConditionOperationV3 defines model for ConditionOperationV3.
-type ConditionOperationV3 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Value Unique identifier for this option
-	Value string `json:"value"`
-}
-
-// ConditionOperationV4 defines model for ConditionOperationV4.
-type ConditionOperationV4 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Value Unique identifier for this option
-	Value string `json:"value"`
-}
-
-// ConditionOperationV5 defines model for ConditionOperationV5.
-type ConditionOperationV5 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Value Unique identifier for this option
-	Value string `json:"value"`
-}
-
-// ConditionOperationV6 defines model for ConditionOperationV6.
-type ConditionOperationV6 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Value Unique identifier for this option
-	Value string `json:"value"`
-}
-
-// ConditionOperationV7 defines model for ConditionOperationV7.
-type ConditionOperationV7 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Value Unique identifier for this option
-	Value string `json:"value"`
-}
-
-// ConditionOperationV8 defines model for ConditionOperationV8.
-type ConditionOperationV8 struct {
 	// Label Human readable label to be displayed for user to select
 	Label string `json:"label"`
 
@@ -1829,60 +2541,6 @@ type ConditionSubjectV2 struct {
 	Reference string `json:"reference"`
 }
 
-// ConditionSubjectV3 defines model for ConditionSubjectV3.
-type ConditionSubjectV3 struct {
-	// Label Human readable identifier for the subject
-	Label string `json:"label"`
-
-	// Reference Reference into the scope for the value of the subject
-	Reference string `json:"reference"`
-}
-
-// ConditionSubjectV4 defines model for ConditionSubjectV4.
-type ConditionSubjectV4 struct {
-	// Label Human readable identifier for the subject
-	Label string `json:"label"`
-
-	// Reference Reference into the scope for the value of the subject
-	Reference string `json:"reference"`
-}
-
-// ConditionSubjectV5 defines model for ConditionSubjectV5.
-type ConditionSubjectV5 struct {
-	// Label Human readable identifier for the subject
-	Label string `json:"label"`
-
-	// Reference Reference into the scope for the value of the subject
-	Reference string `json:"reference"`
-}
-
-// ConditionSubjectV6 defines model for ConditionSubjectV6.
-type ConditionSubjectV6 struct {
-	// Label Human readable identifier for the subject
-	Label string `json:"label"`
-
-	// Reference Reference into the scope for the value of the subject
-	Reference string `json:"reference"`
-}
-
-// ConditionSubjectV7 defines model for ConditionSubjectV7.
-type ConditionSubjectV7 struct {
-	// Label Human readable identifier for the subject
-	Label string `json:"label"`
-
-	// Reference Reference into the scope for the value of the subject
-	Reference string `json:"reference"`
-}
-
-// ConditionSubjectV8 defines model for ConditionSubjectV8.
-type ConditionSubjectV8 struct {
-	// Label Human readable identifier for the subject
-	Label string `json:"label"`
-
-	// Reference Reference into the scope for the value of the subject
-	Reference string `json:"reference"`
-}
-
 // ConditionV2 defines model for ConditionV2.
 type ConditionV2 struct {
 	Operation ConditionOperationV2 `json:"operation"`
@@ -1890,86 +2548,6 @@ type ConditionV2 struct {
 	// ParamBindings Bindings for the operation parameters
 	ParamBindings []EngineParamBindingV2 `json:"param_bindings"`
 	Subject       ConditionSubjectV2     `json:"subject"`
-}
-
-// ConditionV3 defines model for ConditionV3.
-type ConditionV3 struct {
-	Operation ConditionOperationV3 `json:"operation"`
-
-	// ParamBindings Bindings for the operation parameters
-	ParamBindings []EngineParamBindingV4 `json:"param_bindings"`
-	Subject       ConditionSubjectV3     `json:"subject"`
-}
-
-// ConditionV4 defines model for ConditionV4.
-type ConditionV4 struct {
-	Operation ConditionOperationV4 `json:"operation"`
-
-	// ParamBindings Bindings for the operation parameters
-	ParamBindings []EngineParamBindingV5 `json:"param_bindings"`
-	Subject       ConditionSubjectV4     `json:"subject"`
-}
-
-// ConditionV5 defines model for ConditionV5.
-type ConditionV5 struct {
-	Operation ConditionOperationV5 `json:"operation"`
-
-	// ParamBindings Bindings for the operation parameters
-	ParamBindings []EngineParamBindingV7 `json:"param_bindings"`
-	Subject       ConditionSubjectV5     `json:"subject"`
-}
-
-// ConditionV6 defines model for ConditionV6.
-type ConditionV6 struct {
-	Operation ConditionOperationV6 `json:"operation"`
-
-	// ParamBindings Bindings for the operation parameters
-	ParamBindings []EngineParamBindingV9 `json:"param_bindings"`
-	Subject       ConditionSubjectV6     `json:"subject"`
-}
-
-// ConditionV7 defines model for ConditionV7.
-type ConditionV7 struct {
-	Operation ConditionOperationV7 `json:"operation"`
-
-	// ParamBindings Bindings for the operation parameters
-	ParamBindings []EngineParamBindingV10 `json:"param_bindings"`
-	Subject       ConditionSubjectV7      `json:"subject"`
-}
-
-// ConditionV8 defines model for ConditionV8.
-type ConditionV8 struct {
-	Operation ConditionOperationV8 `json:"operation"`
-
-	// ParamBindings Bindings for the operation parameters
-	ParamBindings []EngineParamBindingV12 `json:"param_bindings"`
-	Subject       ConditionSubjectV8      `json:"subject"`
-}
-
-// CreateEntryRequestBody defines model for CreateEntryRequestBody.
-type CreateEntryRequestBody struct {
-	// Aliases Optional aliases that can be used to reference this entry
-	Aliases *[]string `json:"aliases,omitempty"`
-
-	// AttributeValues Values of this entry
-	AttributeValues map[string]EngineParamBindingPayloadV2 `json:"attribute_values"`
-
-	// CatalogTypeId ID of this catalog type
-	CatalogTypeId string `json:"catalog_type_id"`
-
-	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
-	ExternalId *string `json:"external_id,omitempty"`
-
-	// Name Name is the human readable name of this entry
-	Name string `json:"name"`
-
-	// Rank When catalog type is ranked, this is used to help order things
-	Rank *int32 `json:"rank,omitempty"`
-}
-
-// CreateEntryResponseBody defines model for CreateEntryResponseBody.
-type CreateEntryResponseBody struct {
-	CatalogEntry CatalogEntryV2 `json:"catalog_entry"`
 }
 
 // CreateHTTPRequestBody defines model for CreateHTTPRequestBody.
@@ -2091,131 +2669,15 @@ type CreateRequestBody5 struct {
 // CreateRequestBody5Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
 type CreateRequestBody5Category string
 
-// CreateRequestBody6 defines model for CreateRequestBody6.
-type CreateRequestBody6 struct {
-	// Description Description of the severity
-	Description string `json:"description"`
-
-	// Name Human readable name of the severity
-	Name string `json:"name"`
-
-	// Rank Rank to help sort severities (lower numbers are less severe)
-	Rank *int64 `json:"rank,omitempty"`
-}
-
 // CreateResponseBody defines model for CreateResponseBody.
 type CreateResponseBody struct {
-	AlertRoute AlertRouteV2 `json:"alert_route"`
+	IncidentAttachment IncidentAttachmentV1 `json:"incident_attachment"`
 }
 
 // CreateResponseBody2 defines model for CreateResponseBody2.
 type CreateResponseBody2 struct {
-	IncidentAttachment IncidentAttachmentV1 `json:"incident_attachment"`
-}
-
-// CreateResponseBody3 defines model for CreateResponseBody3.
-type CreateResponseBody3 struct {
 	IncidentMembership IncidentMembership `json:"incident_membership"`
 }
-
-// CreateTypeRequestBody defines model for CreateTypeRequestBody.
-type CreateTypeRequestBody struct {
-	// Annotations Annotations that can track metadata about this type
-	Annotations *map[string]string `json:"annotations,omitempty"`
-
-	// Categories What categories is this type considered part of
-	Categories *[]CreateTypeRequestBodyCategories `json:"categories,omitempty"`
-
-	// Color Sets the display color of this type in the dashboard
-	Color *CreateTypeRequestBodyColor `json:"color,omitempty"`
-
-	// Description Human readble description of this type
-	Description string `json:"description"`
-
-	// Icon Sets the display icon of this type in the dashboard
-	Icon *CreateTypeRequestBodyIcon `json:"icon,omitempty"`
-
-	// Name Name is the human readable name of this type
-	Name string `json:"name"`
-
-	// Ranked If this type should be ranked
-	Ranked *bool `json:"ranked,omitempty"`
-
-	// SourceRepoUrl The url of the external repository where this type is managed
-	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
-
-	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName "]
-	TypeName *string `json:"type_name,omitempty"`
-}
-
-// CreateTypeRequestBodyCategories defines model for CreateTypeRequestBody.Categories.
-type CreateTypeRequestBodyCategories string
-
-// CreateTypeRequestBodyColor Sets the display color of this type in the dashboard
-type CreateTypeRequestBodyColor string
-
-// CreateTypeRequestBodyIcon Sets the display icon of this type in the dashboard
-type CreateTypeRequestBodyIcon string
-
-// CreateTypeResponseBody defines model for CreateTypeResponseBody.
-type CreateTypeResponseBody struct {
-	CatalogType CatalogTypeV2 `json:"catalog_type"`
-}
-
-// CreateWorkflowPayload defines model for CreateWorkflowPayload.
-type CreateWorkflowPayload struct {
-	// Annotations Annotations that track metadata about this resource
-	Annotations *map[string]string `json:"annotations,omitempty"`
-
-	// ConditionGroups List of conditions to apply to the workflow
-	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
-
-	// ContinueOnStepError Whether to continue executing the workflow if a step fails
-	ContinueOnStepError bool           `json:"continue_on_step_error"`
-	Delay               *WorkflowDelay `json:"delay,omitempty"`
-
-	// Expressions The expressions used in the workflow
-	Expressions []ExpressionPayloadV2 `json:"expressions"`
-
-	// Folder Folder to display the workflow in
-	Folder *string `json:"folder,omitempty"`
-
-	// IncludePrivateIncidents Whether to include private incidents
-	IncludePrivateIncidents bool `json:"include_private_incidents"`
-
-	// Name The human-readable name of the workflow
-	Name string `json:"name"`
-
-	// OnceFor Once For strategy to apply to this workflow
-	OnceFor []string `json:"once_for"`
-
-	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
-	RunsOnIncidentModes []CreateWorkflowPayloadRunsOnIncidentModes `json:"runs_on_incident_modes"`
-
-	// RunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-	RunsOnIncidents CreateWorkflowPayloadRunsOnIncidents `json:"runs_on_incidents"`
-
-	// Shortform Shortform used to trigger manual workflows in Slack - e.g. `/inc workflows page-ceo`
-	Shortform *string `json:"shortform,omitempty"`
-
-	// State The state of the workflow (e.g. is it draft, or disabled)
-	State *CreateWorkflowPayloadState `json:"state,omitempty"`
-
-	// Steps List of step to execute as part of the workflow
-	Steps []StepConfigPayload `json:"steps"`
-
-	// Trigger Trigger to set on the workflow
-	Trigger string `json:"trigger"`
-}
-
-// CreateWorkflowPayloadRunsOnIncidentModes Incident mode that workflows can run on
-type CreateWorkflowPayloadRunsOnIncidentModes string
-
-// CreateWorkflowPayloadRunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-type CreateWorkflowPayloadRunsOnIncidents string
-
-// CreateWorkflowPayloadState The state of the workflow (e.g. is it draft, or disabled)
-type CreateWorkflowPayloadState string
 
 // CustomFieldEntryPayloadV1 defines model for CustomFieldEntryPayloadV1.
 type CustomFieldEntryPayloadV1 struct {
@@ -2773,27 +3235,6 @@ type EngineParamBindingPayloadV2 struct {
 	Value      *EngineParamBindingValuePayloadV2   `json:"value,omitempty"`
 }
 
-// EngineParamBindingV10 defines model for EngineParamBindingV10.
-type EngineParamBindingV10 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV18 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV17   `json:"value,omitempty"`
-}
-
-// EngineParamBindingV11 defines model for EngineParamBindingV11.
-type EngineParamBindingV11 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV20 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV19   `json:"value,omitempty"`
-}
-
-// EngineParamBindingV12 defines model for EngineParamBindingV12.
-type EngineParamBindingV12 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV22 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV21   `json:"value,omitempty"`
-}
-
 // EngineParamBindingV2 defines model for EngineParamBindingV2.
 type EngineParamBindingV2 struct {
 	// ArrayValue If array_value is set, this helps render the values
@@ -2801,177 +3242,8 @@ type EngineParamBindingV2 struct {
 	Value      *EngineParamBindingValueV2   `json:"value,omitempty"`
 }
 
-// EngineParamBindingV3 defines model for EngineParamBindingV3.
-type EngineParamBindingV3 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV4 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV3   `json:"value,omitempty"`
-}
-
-// EngineParamBindingV4 defines model for EngineParamBindingV4.
-type EngineParamBindingV4 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV6 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV5   `json:"value,omitempty"`
-}
-
-// EngineParamBindingV5 defines model for EngineParamBindingV5.
-type EngineParamBindingV5 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV8 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV7   `json:"value,omitempty"`
-}
-
-// EngineParamBindingV6 defines model for EngineParamBindingV6.
-type EngineParamBindingV6 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV10 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV9    `json:"value,omitempty"`
-}
-
-// EngineParamBindingV7 defines model for EngineParamBindingV7.
-type EngineParamBindingV7 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV12 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV11   `json:"value,omitempty"`
-}
-
-// EngineParamBindingV8 defines model for EngineParamBindingV8.
-type EngineParamBindingV8 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV14 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV13   `json:"value,omitempty"`
-}
-
-// EngineParamBindingV9 defines model for EngineParamBindingV9.
-type EngineParamBindingV9 struct {
-	// ArrayValue If array_value is set, this helps render the values
-	ArrayValue *[]EngineParamBindingValueV16 `json:"array_value,omitempty"`
-	Value      *EngineParamBindingValueV15   `json:"value,omitempty"`
-}
-
 // EngineParamBindingValuePayloadV2 defines model for EngineParamBindingValuePayloadV2.
 type EngineParamBindingValuePayloadV2 struct {
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV10 defines model for EngineParamBindingValueV10.
-type EngineParamBindingValueV10 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV11 defines model for EngineParamBindingValueV11.
-type EngineParamBindingValueV11 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV12 defines model for EngineParamBindingValueV12.
-type EngineParamBindingValueV12 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV13 defines model for EngineParamBindingValueV13.
-type EngineParamBindingValueV13 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV14 defines model for EngineParamBindingValueV14.
-type EngineParamBindingValueV14 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV15 defines model for EngineParamBindingValueV15.
-type EngineParamBindingValueV15 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV16 defines model for EngineParamBindingValueV16.
-type EngineParamBindingValueV16 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV17 defines model for EngineParamBindingValueV17.
-type EngineParamBindingValueV17 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV18 defines model for EngineParamBindingValueV18.
-type EngineParamBindingValueV18 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV19 defines model for EngineParamBindingValueV19.
-type EngineParamBindingValueV19 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
 	// Literal If set, this is the literal value of the step parameter
 	Literal *string `json:"literal,omitempty"`
 
@@ -2991,132 +3263,12 @@ type EngineParamBindingValueV2 struct {
 	Reference *string `json:"reference,omitempty"`
 }
 
-// EngineParamBindingValueV20 defines model for EngineParamBindingValueV20.
-type EngineParamBindingValueV20 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV21 defines model for EngineParamBindingValueV21.
-type EngineParamBindingValueV21 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV22 defines model for EngineParamBindingValueV22.
-type EngineParamBindingValueV22 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV3 defines model for EngineParamBindingValueV3.
-type EngineParamBindingValueV3 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV4 defines model for EngineParamBindingValueV4.
-type EngineParamBindingValueV4 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV5 defines model for EngineParamBindingValueV5.
-type EngineParamBindingValueV5 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV6 defines model for EngineParamBindingValueV6.
-type EngineParamBindingValueV6 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV7 defines model for EngineParamBindingValueV7.
-type EngineParamBindingValueV7 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV8 defines model for EngineParamBindingValueV8.
-type EngineParamBindingValueV8 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
-// EngineParamBindingValueV9 defines model for EngineParamBindingValueV9.
-type EngineParamBindingValueV9 struct {
-	// Label Human readable label to be displayed for user to select
-	Label string `json:"label"`
-
-	// Literal If set, this is the literal value of the step parameter
-	Literal *string `json:"literal,omitempty"`
-
-	// Reference If set, this is the reference into the trigger scope that is the value of this parameter
-	Reference *string `json:"reference,omitempty"`
-}
-
 // EngineReferenceV2 defines model for EngineReferenceV2.
 type EngineReferenceV2 struct {
 	// Array If true, the reference can refer to 0 to many items
 	Array bool `json:"array"`
 
-	// Key The key of the field this is a reference to
+	// Key Unique identifier of field will set
 	Key string `json:"key"`
 
 	// Label Human readable label for the field (with context)
@@ -3323,20 +3475,6 @@ type ExpressionBranchV2 struct {
 	Result          EngineParamBindingV2 `json:"result"`
 }
 
-// ExpressionBranchV3 defines model for ExpressionBranchV3.
-type ExpressionBranchV3 struct {
-	// ConditionGroups When one of these condition groups are satisfied, this branch will be evaluated
-	ConditionGroups []ConditionGroupV4   `json:"condition_groups"`
-	Result          EngineParamBindingV6 `json:"result"`
-}
-
-// ExpressionBranchV4 defines model for ExpressionBranchV4.
-type ExpressionBranchV4 struct {
-	// ConditionGroups When one of these condition groups are satisfied, this branch will be evaluated
-	ConditionGroups []ConditionGroupV7    `json:"condition_groups"`
-	Result          EngineParamBindingV11 `json:"result"`
-}
-
 // ExpressionBranchesOptsPayloadV2 defines model for ExpressionBranchesOptsPayloadV2.
 type ExpressionBranchesOptsPayloadV2 struct {
 	// Branches The branches to apply for this operation
@@ -3351,20 +3489,6 @@ type ExpressionBranchesOptsV2 struct {
 	Returns  ReturnsMetaV2        `json:"returns"`
 }
 
-// ExpressionBranchesOptsV3 defines model for ExpressionBranchesOptsV3.
-type ExpressionBranchesOptsV3 struct {
-	// Branches The branches to apply for this operation
-	Branches []ExpressionBranchV3 `json:"branches"`
-	Returns  ReturnsMetaV2        `json:"returns"`
-}
-
-// ExpressionBranchesOptsV4 defines model for ExpressionBranchesOptsV4.
-type ExpressionBranchesOptsV4 struct {
-	// Branches The branches to apply for this operation
-	Branches []ExpressionBranchV4 `json:"branches"`
-	Returns  ReturnsMetaV2        `json:"returns"`
-}
-
 // ExpressionElseBranchPayloadV2 defines model for ExpressionElseBranchPayloadV2.
 type ExpressionElseBranchPayloadV2 struct {
 	Result EngineParamBindingPayloadV2 `json:"result"`
@@ -3373,16 +3497,6 @@ type ExpressionElseBranchPayloadV2 struct {
 // ExpressionElseBranchV2 defines model for ExpressionElseBranchV2.
 type ExpressionElseBranchV2 struct {
 	Result EngineParamBindingV2 `json:"result"`
-}
-
-// ExpressionElseBranchV3 defines model for ExpressionElseBranchV3.
-type ExpressionElseBranchV3 struct {
-	Result EngineParamBindingV3 `json:"result"`
-}
-
-// ExpressionElseBranchV4 defines model for ExpressionElseBranchV4.
-type ExpressionElseBranchV4 struct {
-	Result EngineParamBindingV8 `json:"result"`
 }
 
 // ExpressionFilterOptsPayloadV2 defines model for ExpressionFilterOptsPayloadV2.
@@ -3395,18 +3509,6 @@ type ExpressionFilterOptsPayloadV2 struct {
 type ExpressionFilterOptsV2 struct {
 	// ConditionGroups The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
 	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
-}
-
-// ExpressionFilterOptsV3 defines model for ExpressionFilterOptsV3.
-type ExpressionFilterOptsV3 struct {
-	// ConditionGroups The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
-	ConditionGroups []ConditionGroupV3 `json:"condition_groups"`
-}
-
-// ExpressionFilterOptsV4 defines model for ExpressionFilterOptsV4.
-type ExpressionFilterOptsV4 struct {
-	// ConditionGroups The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass.
-	ConditionGroups []ConditionGroupV6 `json:"condition_groups"`
 }
 
 // ExpressionNavigateOptsPayloadV2 defines model for ExpressionNavigateOptsPayloadV2.
@@ -3453,36 +3555,6 @@ type ExpressionOperationV2 struct {
 // ExpressionOperationV2OperationType The type of the operation
 type ExpressionOperationV2OperationType string
 
-// ExpressionOperationV3 defines model for ExpressionOperationV3.
-type ExpressionOperationV3 struct {
-	Branches *ExpressionBranchesOptsV3 `json:"branches,omitempty"`
-	Filter   *ExpressionFilterOptsV3   `json:"filter,omitempty"`
-	Navigate *ExpressionNavigateOptsV2 `json:"navigate,omitempty"`
-
-	// OperationType The type of the operation
-	OperationType ExpressionOperationV3OperationType `json:"operation_type"`
-	Parse         *ExpressionParseOptsV2             `json:"parse,omitempty"`
-	Returns       ReturnsMetaV2                      `json:"returns"`
-}
-
-// ExpressionOperationV3OperationType The type of the operation
-type ExpressionOperationV3OperationType string
-
-// ExpressionOperationV4 defines model for ExpressionOperationV4.
-type ExpressionOperationV4 struct {
-	Branches *ExpressionBranchesOptsV4 `json:"branches,omitempty"`
-	Filter   *ExpressionFilterOptsV4   `json:"filter,omitempty"`
-	Navigate *ExpressionNavigateOptsV2 `json:"navigate,omitempty"`
-
-	// OperationType The type of the operation
-	OperationType ExpressionOperationV4OperationType `json:"operation_type"`
-	Parse         *ExpressionParseOptsV2             `json:"parse,omitempty"`
-	Returns       ReturnsMetaV2                      `json:"returns"`
-}
-
-// ExpressionOperationV4OperationType The type of the operation
-type ExpressionOperationV4OperationType string
-
 // ExpressionParseOptsPayloadV2 defines model for ExpressionParseOptsPayloadV2.
 type ExpressionParseOptsPayloadV2 struct {
 	Returns ReturnsMetaV2 `json:"returns"`
@@ -3521,38 +3593,6 @@ type ExpressionV2 struct {
 	// Label The human readable label of the expression
 	Label      string                  `json:"label"`
 	Operations []ExpressionOperationV2 `json:"operations"`
-
-	// Reference A short ID that can be used to reference the expression
-	Reference string        `json:"reference"`
-	Returns   ReturnsMetaV2 `json:"returns"`
-
-	// RootReference The root reference for this expression (i.e. where the expression starts)
-	RootReference string `json:"root_reference"`
-}
-
-// ExpressionV3 defines model for ExpressionV3.
-type ExpressionV3 struct {
-	ElseBranch *ExpressionElseBranchV3 `json:"else_branch,omitempty"`
-
-	// Label The human readable label of the expression
-	Label      string                  `json:"label"`
-	Operations []ExpressionOperationV3 `json:"operations"`
-
-	// Reference A short ID that can be used to reference the expression
-	Reference string        `json:"reference"`
-	Returns   ReturnsMetaV2 `json:"returns"`
-
-	// RootReference The root reference for this expression (i.e. where the expression starts)
-	RootReference string `json:"root_reference"`
-}
-
-// ExpressionV4 defines model for ExpressionV4.
-type ExpressionV4 struct {
-	ElseBranch *ExpressionElseBranchV4 `json:"else_branch,omitempty"`
-
-	// Label The human readable label of the expression
-	Label      string                  `json:"label"`
-	Operations []ExpressionOperationV4 `json:"operations"`
 
 	// Reference A short ID that can be used to reference the expression
 	Reference string        `json:"reference"`
@@ -4290,26 +4330,9 @@ type IncidentV2Mode string
 // IncidentV2Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/articles/5905558102-can-we-mark-incidents-as-sensitive-and-restrict-access).
 type IncidentV2Visibility string
 
-// ListEntriesResponseBody defines model for ListEntriesResponseBody.
-type ListEntriesResponseBody struct {
-	CatalogEntries []CatalogEntryV2     `json:"catalog_entries"`
-	CatalogType    CatalogTypeV2        `json:"catalog_type"`
-	PaginationMeta PaginationMetaResult `json:"pagination_meta"`
-}
-
-// ListResourcesResponseBody defines model for ListResourcesResponseBody.
-type ListResourcesResponseBody struct {
-	Resources []CatalogResourceV2 `json:"resources"`
-}
-
 // ListResponseBody defines model for ListResponseBody.
 type ListResponseBody struct {
 	IncidentAttachments []IncidentAttachmentV1 `json:"incident_attachments"`
-}
-
-// ListResponseBody10 defines model for ListResponseBody10.
-type ListResponseBody10 struct {
-	Severities []SeverityV1 `json:"severities"`
 }
 
 // ListResponseBody2 defines model for ListResponseBody2.
@@ -4353,16 +4376,6 @@ type ListResponseBody8 struct {
 type ListResponseBody9 struct {
 	Incidents      []IncidentV2                   `json:"incidents"`
 	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
-}
-
-// ListTypesResponseBody defines model for ListTypesResponseBody.
-type ListTypesResponseBody struct {
-	CatalogTypes []CatalogTypeV2 `json:"catalog_types"`
-}
-
-// ListWorkflowsResponseBody defines model for ListWorkflowsResponseBody.
-type ListWorkflowsResponseBody struct {
-	Workflows []WorkflowSlim `json:"workflows"`
 }
 
 // ManagedResourceV2 defines model for ManagedResourceV2.
@@ -4422,6 +4435,15 @@ type PaginationMetaResultV1 struct {
 
 // PaginationMetaResultV2 defines model for PaginationMetaResultV2.
 type PaginationMetaResultV2 struct {
+	// After If provided, pass this as the 'after' param to load the next page
+	After *string `json:"after,omitempty"`
+
+	// PageSize What was the maximum number of results requested
+	PageSize int64 `json:"page_size"`
+}
+
+// PaginationMetaResultV3 defines model for PaginationMetaResultV3.
+type PaginationMetaResultV3 struct {
 	// After If provided, pass this as the 'after' param to load the next page
 	After *string `json:"after,omitempty"`
 
@@ -4821,6 +4843,50 @@ type SchedulesUpdateResultV2 struct {
 	Schedule ScheduleV2 `json:"schedule"`
 }
 
+// SeveritiesCreatePayloadV1 defines model for SeveritiesCreatePayloadV1.
+type SeveritiesCreatePayloadV1 struct {
+	// Description Description of the severity
+	Description string `json:"description"`
+
+	// Name Human readable name of the severity
+	Name string `json:"name"`
+
+	// Rank Rank to help sort severities (lower numbers are less severe)
+	Rank *int64 `json:"rank,omitempty"`
+}
+
+// SeveritiesCreateResultV1 defines model for SeveritiesCreateResultV1.
+type SeveritiesCreateResultV1 struct {
+	Severity SeverityV1 `json:"severity"`
+}
+
+// SeveritiesListResultV1 defines model for SeveritiesListResultV1.
+type SeveritiesListResultV1 struct {
+	Severities []SeverityV1 `json:"severities"`
+}
+
+// SeveritiesShowResultV1 defines model for SeveritiesShowResultV1.
+type SeveritiesShowResultV1 struct {
+	Severity SeverityV1 `json:"severity"`
+}
+
+// SeveritiesUpdatePayloadV1 defines model for SeveritiesUpdatePayloadV1.
+type SeveritiesUpdatePayloadV1 struct {
+	// Description Description of the severity
+	Description string `json:"description"`
+
+	// Name Human readable name of the severity
+	Name string `json:"name"`
+
+	// Rank Rank to help sort severities (lower numbers are less severe)
+	Rank *int64 `json:"rank,omitempty"`
+}
+
+// SeveritiesUpdateResultV1 defines model for SeveritiesUpdateResultV1.
+type SeveritiesUpdateResultV1 struct {
+	Severity SeverityV1 `json:"severity"`
+}
+
 // SeverityV1 defines model for SeverityV1.
 type SeverityV1 struct {
 	// CreatedAt When the action was created
@@ -4863,12 +4929,6 @@ type SeverityV2 struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// ShowEntryResponseBody defines model for ShowEntryResponseBody.
-type ShowEntryResponseBody struct {
-	CatalogEntry CatalogEntryV2 `json:"catalog_entry"`
-	CatalogType  CatalogTypeV2  `json:"catalog_type"`
-}
-
 // ShowResponseBody defines model for ShowResponseBody.
 type ShowResponseBody struct {
 	IncidentRole IncidentRoleV1 `json:"incident_role"`
@@ -4904,20 +4964,33 @@ type ShowResponseBody7 struct {
 	Incident IncidentV2 `json:"incident"`
 }
 
-// ShowResponseBody8 defines model for ShowResponseBody8.
-type ShowResponseBody8 struct {
-	Severity SeverityV1 `json:"severity"`
+// StepConfigPayloadV2 defines model for StepConfigPayloadV2.
+type StepConfigPayloadV2 struct {
+	// ForEach Reference to an expression that returns resources to run this step over
+	ForEach *string `json:"for_each,omitempty"`
+
+	// Id Unique ID of this step in a workflow
+	Id string `json:"id"`
+
+	// Name Unique name of the step in the engine
+	Name string `json:"name"`
+
+	// ParamBindings List of parameter bindings
+	ParamBindings []EngineParamBindingPayloadV2 `json:"param_bindings"`
 }
 
-// ShowWorkflowResponseBody defines model for ShowWorkflowResponseBody.
-type ShowWorkflowResponseBody struct {
-	ManagementMeta ManagementMetaV2 `json:"management_meta"`
-	Workflow       Workflow         `json:"workflow"`
+// StepConfigSlimV2 defines model for StepConfigSlimV2.
+type StepConfigSlimV2 struct {
+	// Label Human readable identifier for this step
+	Label string `json:"label"`
+
+	// Name Unique name of the step in the engine
+	Name string `json:"name"`
 }
 
-// StepConfig defines model for StepConfig.
-type StepConfig struct {
-	// ForEach Reference to the loop variable to run this step over
+// StepConfigV2 defines model for StepConfigV2.
+type StepConfigV2 struct {
+	// ForEach Reference to an expression that returns resources to run this step over
 	ForEach *string `json:"for_each,omitempty"`
 
 	// Id Unique ID of this step in a workflow
@@ -4933,32 +5006,8 @@ type StepConfig struct {
 	ParamBindings []EngineParamBindingV2 `json:"param_bindings"`
 }
 
-// StepConfigPayload defines model for StepConfigPayload.
-type StepConfigPayload struct {
-	// ForEach Reference to an expression that returns resources to run this step over
-	ForEach *string `json:"for_each,omitempty"`
-
-	// Id Unique ID of this step in a workflow. This must be a valid ULID.
-	Id string `json:"id"`
-
-	// Name Unique name of the step in the engine
-	Name string `json:"name"`
-
-	// ParamBindings List of parameter bindings
-	ParamBindings []EngineParamBindingPayloadV2 `json:"param_bindings"`
-}
-
-// StepConfigSlim defines model for StepConfigSlim.
-type StepConfigSlim struct {
-	// Label Human readable identifier for this step
-	Label string `json:"label"`
-
-	// Name Unique name of the step in the engine
-	Name string `json:"name"`
-}
-
-// TriggerSlim defines model for TriggerSlim.
-type TriggerSlim struct {
+// TriggerSlimV2 defines model for TriggerSlimV2.
+type TriggerSlimV2 struct {
 	// Label Human readable identifier for this trigger
 	Label string `json:"label"`
 
@@ -4966,66 +5015,8 @@ type TriggerSlim struct {
 	Name string `json:"name"`
 }
 
-// UpdateEntryRequestBody defines model for UpdateEntryRequestBody.
-type UpdateEntryRequestBody struct {
-	// Aliases Optional aliases that can be used to reference this entry
-	Aliases *[]string `json:"aliases,omitempty"`
-
-	// AttributeValues Values of this entry
-	AttributeValues map[string]EngineParamBindingPayloadV2 `json:"attribute_values"`
-
-	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
-	ExternalId *string `json:"external_id,omitempty"`
-
-	// Name Name is the human readable name of this entry
-	Name string `json:"name"`
-
-	// Rank When catalog type is ranked, this is used to help order things
-	Rank *int32 `json:"rank,omitempty"`
-}
-
 // UpdateRequestBody defines model for UpdateRequestBody.
 type UpdateRequestBody struct {
-	// AlertSources Which alert sources should this alert route match?
-	AlertSources []AlertRouteAlertSourcePayloadV2 `json:"alert_sources"`
-
-	// AutoDeclineEnabled Should triage incidents be declined when alerts are resolved?
-	AutoDeclineEnabled bool `json:"auto_decline_enabled"`
-
-	// ConditionGroups What condition groups must be true for this alert route to fire?
-	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
-
-	// DeferTimeSeconds How long should the escalation defer time be?
-	DeferTimeSeconds int64 `json:"defer_time_seconds"`
-
-	// Enabled Whether this alert route is enabled or not
-	Enabled bool `json:"enabled"`
-
-	// EscalationBindings Which escalation paths should this alert route escalate to?
-	EscalationBindings []AlertRouteEscalationBindingPayloadV2 `json:"escalation_bindings"`
-
-	// Expressions The expressions used in this template
-	Expressions *[]ExpressionPayloadV2 `json:"expressions,omitempty"`
-
-	// GroupingKeys Which attributes should this alert route use to group alerts?
-	GroupingKeys []GroupingKeyV2 `json:"grouping_keys"`
-
-	// GroupingWindowSeconds How large should the grouping window be?
-	GroupingWindowSeconds int64 `json:"grouping_window_seconds"`
-
-	// IncidentConditionGroups What condition groups must be true for this alert route to create an incident?
-	IncidentConditionGroups []ConditionGroupPayloadV2 `json:"incident_condition_groups"`
-
-	// IncidentEnabled Whether this alert route will create incidents or not
-	IncidentEnabled bool `json:"incident_enabled"`
-
-	// Name The name of this alert route config, for the user's reference
-	Name     string                               `json:"name"`
-	Template *AlertRouteIncidentTemplatePayloadV2 `json:"template,omitempty"`
-}
-
-// UpdateRequestBody2 defines model for UpdateRequestBody2.
-type UpdateRequestBody2 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -5042,8 +5033,8 @@ type UpdateRequestBody2 struct {
 	Shortform string `json:"shortform"`
 }
 
-// UpdateRequestBody3 defines model for UpdateRequestBody3.
-type UpdateRequestBody3 struct {
+// UpdateRequestBody2 defines model for UpdateRequestBody2.
+type UpdateRequestBody2 struct {
 	// Description Describes the purpose of the role
 	Description string `json:"description"`
 
@@ -5057,108 +5048,14 @@ type UpdateRequestBody3 struct {
 	Shortform string `json:"shortform"`
 }
 
-// UpdateRequestBody4 defines model for UpdateRequestBody4.
-type UpdateRequestBody4 struct {
+// UpdateRequestBody3 defines model for UpdateRequestBody3.
+type UpdateRequestBody3 struct {
 	// Description Rich text description of the incident status
 	Description string `json:"description"`
 
 	// Name Unique name of this status
 	Name string `json:"name"`
 }
-
-// UpdateTypeRequestBody defines model for UpdateTypeRequestBody.
-type UpdateTypeRequestBody struct {
-	// Annotations Annotations that can track metadata about this type
-	Annotations *map[string]string `json:"annotations,omitempty"`
-
-	// Categories What categories is this type considered part of
-	Categories *[]UpdateTypeRequestBodyCategories `json:"categories,omitempty"`
-
-	// Color Sets the display color of this type in the dashboard
-	Color *UpdateTypeRequestBodyColor `json:"color,omitempty"`
-
-	// Description Human readble description of this type
-	Description string `json:"description"`
-
-	// Icon Sets the display icon of this type in the dashboard
-	Icon *UpdateTypeRequestBodyIcon `json:"icon,omitempty"`
-
-	// Name Name is the human readable name of this type
-	Name string `json:"name"`
-
-	// Ranked If this type should be ranked
-	Ranked *bool `json:"ranked,omitempty"`
-
-	// SourceRepoUrl The url of the external repository where this type is managed
-	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
-}
-
-// UpdateTypeRequestBodyCategories defines model for UpdateTypeRequestBody.Categories.
-type UpdateTypeRequestBodyCategories string
-
-// UpdateTypeRequestBodyColor Sets the display color of this type in the dashboard
-type UpdateTypeRequestBodyColor string
-
-// UpdateTypeRequestBodyIcon Sets the display icon of this type in the dashboard
-type UpdateTypeRequestBodyIcon string
-
-// UpdateTypeSchemaRequestBody defines model for UpdateTypeSchemaRequestBody.
-type UpdateTypeSchemaRequestBody struct {
-	Attributes []CatalogTypeAttributePayloadV2 `json:"attributes"`
-	Version    int64                           `json:"version"`
-}
-
-// UpdateWorkflowPayload2 defines model for UpdateWorkflowPayload2.
-type UpdateWorkflowPayload2 struct {
-	// Annotations Annotations that track metadata about this resource
-	Annotations *map[string]string `json:"annotations,omitempty"`
-
-	// ConditionGroups List of conditions to apply to the workflow
-	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
-
-	// ContinueOnStepError Whether to continue executing the workflow if a step fails
-	ContinueOnStepError bool           `json:"continue_on_step_error"`
-	Delay               *WorkflowDelay `json:"delay,omitempty"`
-
-	// Expressions The expressions used in the workflow
-	Expressions []ExpressionPayloadV2 `json:"expressions"`
-
-	// Folder Folder to display the workflow in
-	Folder *string `json:"folder,omitempty"`
-
-	// IncludePrivateIncidents Whether to include private incidents
-	IncludePrivateIncidents bool `json:"include_private_incidents"`
-
-	// Name The human-readable name of the workflow
-	Name string `json:"name"`
-
-	// OnceFor Once For strategy to apply to this workflow
-	OnceFor []string `json:"once_for"`
-
-	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
-	RunsOnIncidentModes []UpdateWorkflowPayload2RunsOnIncidentModes `json:"runs_on_incident_modes"`
-
-	// RunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-	RunsOnIncidents UpdateWorkflowPayload2RunsOnIncidents `json:"runs_on_incidents"`
-
-	// Shortform Shortform used to trigger manual workflows in Slack - e.g. `/inc workflows page-ceo`
-	Shortform *string `json:"shortform,omitempty"`
-
-	// State The state of the workflow (e.g. is it draft, or disabled)
-	State *UpdateWorkflowPayload2State `json:"state,omitempty"`
-
-	// Steps List of step to execute as part of the workflow
-	Steps []StepConfigPayload `json:"steps"`
-}
-
-// UpdateWorkflowPayload2RunsOnIncidentModes defines model for UpdateWorkflowPayload2.RunsOnIncidentModes.
-type UpdateWorkflowPayload2RunsOnIncidentModes string
-
-// UpdateWorkflowPayload2RunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-type UpdateWorkflowPayload2RunsOnIncidents string
-
-// UpdateWorkflowPayload2State The state of the workflow (e.g. is it draft, or disabled)
-type UpdateWorkflowPayload2State string
 
 // UserReferencePayloadV1 defines model for UserReferencePayloadV1.
 type UserReferencePayloadV1 struct {
@@ -5294,67 +5191,8 @@ type WeekdayIntervalV2 struct {
 // WeekdayIntervalV2Weekday Weekdays for use within a schedule or escalation path
 type WeekdayIntervalV2Weekday string
 
-// Workflow defines model for Workflow.
-type Workflow struct {
-	// ConditionGroups Conditions that apply to the workflow trigger
-	ConditionGroups []ConditionGroupV5 `json:"condition_groups"`
-
-	// ContinueOnStepError Whether to continue executing the workflow if a step fails
-	ContinueOnStepError bool           `json:"continue_on_step_error"`
-	Delay               *WorkflowDelay `json:"delay,omitempty"`
-
-	// Expressions Expressions that make variables available in the scope
-	Expressions []ExpressionV3 `json:"expressions"`
-
-	// Folder Folder to display the workflow in
-	Folder *string `json:"folder,omitempty"`
-
-	// Id Unique identifier for the workflow
-	Id string `json:"id"`
-
-	// IncludePrivateIncidents Whether to include private incidents
-	IncludePrivateIncidents bool `json:"include_private_incidents"`
-
-	// Name The human-readable name of the workflow
-	Name string `json:"name"`
-
-	// OnceFor This workflow will run 'once for' a list of references
-	OnceFor []EngineReferenceV2 `json:"once_for"`
-
-	// RunsFrom The time from which this workflow will run on incidents
-	RunsFrom *time.Time `json:"runs_from,omitempty"`
-
-	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
-	RunsOnIncidentModes []WorkflowRunsOnIncidentModes `json:"runs_on_incident_modes"`
-
-	// RunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-	RunsOnIncidents WorkflowRunsOnIncidents `json:"runs_on_incidents"`
-
-	// Shortform Shortform used to trigger manual workflows in Slack - e.g. `/inc workflows page-ceo`
-	Shortform *string `json:"shortform,omitempty"`
-
-	// State The state of the workflow (e.g. is it draft, or disabled)
-	State WorkflowState `json:"state"`
-
-	// Steps Steps that are executed as part of the workflow
-	Steps   []StepConfig `json:"steps"`
-	Trigger TriggerSlim  `json:"trigger"`
-
-	// Version Revision of the workflow, uniquely identifying its version
-	Version int64 `json:"version"`
-}
-
-// WorkflowRunsOnIncidentModes Incident mode that workflows can run on
-type WorkflowRunsOnIncidentModes string
-
-// WorkflowRunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-type WorkflowRunsOnIncidents string
-
-// WorkflowState The state of the workflow (e.g. is it draft, or disabled)
-type WorkflowState string
-
-// WorkflowDelay defines model for WorkflowDelay.
-type WorkflowDelay struct {
+// WorkflowDelayV2 defines model for WorkflowDelayV2.
+type WorkflowDelayV2 struct {
 	// ConditionsApplyOverDelay If this workflow is delayed, whether the conditions should be rechecked between trigger firing and execution
 	ConditionsApplyOverDelay bool `json:"conditions_apply_over_delay"`
 
@@ -5362,17 +5200,17 @@ type WorkflowDelay struct {
 	ForSeconds int64 `json:"for_seconds"`
 }
 
-// WorkflowSlim defines model for WorkflowSlim.
-type WorkflowSlim struct {
+// WorkflowSlimV2 defines model for WorkflowSlimV2.
+type WorkflowSlimV2 struct {
 	// ConditionGroups Conditions that apply to the workflow trigger
-	ConditionGroups []ConditionGroupV8 `json:"condition_groups"`
+	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
 
 	// ContinueOnStepError Whether to continue executing the workflow if a step fails
-	ContinueOnStepError bool           `json:"continue_on_step_error"`
-	Delay               *WorkflowDelay `json:"delay,omitempty"`
+	ContinueOnStepError bool             `json:"continue_on_step_error"`
+	Delay               *WorkflowDelayV2 `json:"delay,omitempty"`
 
 	// Expressions Expressions that make variables available in the scope
-	Expressions []ExpressionV4 `json:"expressions"`
+	Expressions []ExpressionV2 `json:"expressions"`
 
 	// Folder Folder to display the workflow in
 	Folder *string `json:"folder,omitempty"`
@@ -5383,7 +5221,7 @@ type WorkflowSlim struct {
 	// IncludePrivateIncidents Whether to include private incidents
 	IncludePrivateIncidents bool `json:"include_private_incidents"`
 
-	// Name The human-readable name of the workflow
+	// Name Name provided by the user when creating the workflow
 	Name string `json:"name"`
 
 	// OnceFor This workflow will run 'once for' a list of references
@@ -5392,34 +5230,223 @@ type WorkflowSlim struct {
 	// RunsFrom The time from which this workflow will run on incidents
 	RunsFrom *time.Time `json:"runs_from,omitempty"`
 
-	// RunsOnIncidentModes Which modes of incident this should run on (defaults to just standard incidents)
-	RunsOnIncidentModes []WorkflowSlimRunsOnIncidentModes `json:"runs_on_incident_modes"`
+	// RunsOnIncidentModes Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
+	RunsOnIncidentModes []WorkflowSlimV2RunsOnIncidentModes `json:"runs_on_incident_modes"`
 
-	// RunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-	RunsOnIncidents WorkflowSlimRunsOnIncidents `json:"runs_on_incidents"`
+	// RunsOnIncidents Which incidents should the workflow be applied to?
+	RunsOnIncidents WorkflowSlimV2RunsOnIncidents `json:"runs_on_incidents"`
 
-	// Shortform Shortform used to trigger manual workflows in Slack - e.g. `/inc workflows page-ceo`
+	// Shortform The shortform used to trigger this workflow (only applicable for manual triggers)
 	Shortform *string `json:"shortform,omitempty"`
 
-	// State The state of the workflow (e.g. is it draft, or disabled)
-	State WorkflowSlimState `json:"state"`
+	// State What state this workflow is in
+	State WorkflowSlimV2State `json:"state"`
 
 	// Steps Steps that are executed as part of the workflow
-	Steps   []StepConfigSlim `json:"steps"`
-	Trigger TriggerSlim      `json:"trigger"`
+	Steps   []StepConfigSlimV2 `json:"steps"`
+	Trigger TriggerSlimV2      `json:"trigger"`
 
-	// Version Revision of the workflow, uniquely identifying its version
+	// Version Revision of the workflow, uniquely identifying it's version
 	Version int64 `json:"version"`
 }
 
-// WorkflowSlimRunsOnIncidentModes Incident mode that workflows can run on
-type WorkflowSlimRunsOnIncidentModes string
+// WorkflowSlimV2RunsOnIncidentModes Incident mode that workflows can run on
+type WorkflowSlimV2RunsOnIncidentModes string
 
-// WorkflowSlimRunsOnIncidents Which incidents should the workflow be applied to? (newly_created or newly_created_and_active)
-type WorkflowSlimRunsOnIncidents string
+// WorkflowSlimV2RunsOnIncidents Which incidents should the workflow be applied to?
+type WorkflowSlimV2RunsOnIncidents string
 
-// WorkflowSlimState The state of the workflow (e.g. is it draft, or disabled)
-type WorkflowSlimState string
+// WorkflowSlimV2State What state this workflow is in
+type WorkflowSlimV2State string
+
+// WorkflowV2 defines model for WorkflowV2.
+type WorkflowV2 struct {
+	// ConditionGroups Conditions that apply to the workflow trigger
+	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
+
+	// ContinueOnStepError Whether to continue executing the workflow if a step fails
+	ContinueOnStepError bool             `json:"continue_on_step_error"`
+	Delay               *WorkflowDelayV2 `json:"delay,omitempty"`
+
+	// Expressions Expressions that make variables available in the scope
+	Expressions []ExpressionV2 `json:"expressions"`
+
+	// Folder Folder to display the workflow in
+	Folder *string `json:"folder,omitempty"`
+
+	// Id Unique identifier for the workflow
+	Id string `json:"id"`
+
+	// IncludePrivateIncidents Whether to include private incidents
+	IncludePrivateIncidents bool `json:"include_private_incidents"`
+
+	// Name Name provided by the user when creating the workflow
+	Name string `json:"name"`
+
+	// OnceFor This workflow will run 'once for' a list of references
+	OnceFor []EngineReferenceV2 `json:"once_for"`
+
+	// RunsFrom The time from which this workflow will run on incidents
+	RunsFrom *time.Time `json:"runs_from,omitempty"`
+
+	// RunsOnIncidentModes Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
+	RunsOnIncidentModes []WorkflowV2RunsOnIncidentModes `json:"runs_on_incident_modes"`
+
+	// RunsOnIncidents Which incidents should the workflow be applied to?
+	RunsOnIncidents WorkflowV2RunsOnIncidents `json:"runs_on_incidents"`
+
+	// Shortform The shortform used to trigger this workflow (only applicable for manual triggers)
+	Shortform *string `json:"shortform,omitempty"`
+
+	// State What state this workflow is in
+	State WorkflowV2State `json:"state"`
+
+	// Steps Steps that are executed as part of the workflow
+	Steps   []StepConfigV2 `json:"steps"`
+	Trigger TriggerSlimV2  `json:"trigger"`
+
+	// Version Revision of the workflow, uniquely identifying it's version
+	Version int64 `json:"version"`
+}
+
+// WorkflowV2RunsOnIncidentModes Incident mode that workflows can run on
+type WorkflowV2RunsOnIncidentModes string
+
+// WorkflowV2RunsOnIncidents Which incidents should the workflow be applied to?
+type WorkflowV2RunsOnIncidents string
+
+// WorkflowV2State What state this workflow is in
+type WorkflowV2State string
+
+// WorkflowsCreateWorkflowPayloadV2 defines model for WorkflowsCreateWorkflowPayloadV2.
+type WorkflowsCreateWorkflowPayloadV2 struct {
+	// Annotations Annotations that track metadata about this resource
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// ConditionGroups Conditions that apply to the workflow trigger
+	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
+
+	// ContinueOnStepError Whether to continue executing the workflow if a step fails
+	ContinueOnStepError bool             `json:"continue_on_step_error"`
+	Delay               *WorkflowDelayV2 `json:"delay,omitempty"`
+
+	// Expressions The expressions to use in the workflow
+	Expressions []ExpressionPayloadV2 `json:"expressions"`
+
+	// Folder Folder to display the workflow in
+	Folder *string `json:"folder,omitempty"`
+
+	// IncludePrivateIncidents Whether to include private incidents
+	IncludePrivateIncidents bool `json:"include_private_incidents"`
+
+	// Name Name provided by the user when creating the workflow
+	Name string `json:"name"`
+
+	// OnceFor This workflow will run 'once for' a list of references
+	OnceFor []string `json:"once_for"`
+
+	// RunsOnIncidentModes Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
+	RunsOnIncidentModes []WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes `json:"runs_on_incident_modes"`
+
+	// RunsOnIncidents Which incidents should the workflow be applied to?
+	RunsOnIncidents WorkflowsCreateWorkflowPayloadV2RunsOnIncidents `json:"runs_on_incidents"`
+
+	// Shortform The shortform used to trigger this workflow (only applicable for manual triggers)
+	Shortform *string `json:"shortform,omitempty"`
+
+	// State What state this workflow is in
+	State *WorkflowsCreateWorkflowPayloadV2State `json:"state,omitempty"`
+
+	// Steps Steps that are executed as part of the workflow
+	Steps []StepConfigPayloadV2 `json:"steps"`
+
+	// Trigger Trigger to set on the workflow
+	Trigger string `json:"trigger"`
+}
+
+// WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes defines model for WorkflowsCreateWorkflowPayloadV2.RunsOnIncidentModes.
+type WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes string
+
+// WorkflowsCreateWorkflowPayloadV2RunsOnIncidents Which incidents should the workflow be applied to?
+type WorkflowsCreateWorkflowPayloadV2RunsOnIncidents string
+
+// WorkflowsCreateWorkflowPayloadV2State What state this workflow is in
+type WorkflowsCreateWorkflowPayloadV2State string
+
+// WorkflowsCreateWorkflowResultV2 defines model for WorkflowsCreateWorkflowResultV2.
+type WorkflowsCreateWorkflowResultV2 struct {
+	ManagementMeta ManagementMetaV2 `json:"management_meta"`
+	Workflow       WorkflowV2       `json:"workflow"`
+}
+
+// WorkflowsListWorkflowsResultV2 defines model for WorkflowsListWorkflowsResultV2.
+type WorkflowsListWorkflowsResultV2 struct {
+	Workflows []WorkflowSlimV2 `json:"workflows"`
+}
+
+// WorkflowsShowWorkflowResultV2 defines model for WorkflowsShowWorkflowResultV2.
+type WorkflowsShowWorkflowResultV2 struct {
+	ManagementMeta ManagementMetaV2 `json:"management_meta"`
+	Workflow       WorkflowV2       `json:"workflow"`
+}
+
+// WorkflowsUpdateWorkflowPayloadV2 defines model for WorkflowsUpdateWorkflowPayloadV2.
+type WorkflowsUpdateWorkflowPayloadV2 struct {
+	// Annotations Annotations that track metadata about this resource
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
+	// ConditionGroups Conditions that apply to the workflow trigger
+	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
+
+	// ContinueOnStepError Whether to continue executing the workflow if a step fails
+	ContinueOnStepError bool             `json:"continue_on_step_error"`
+	Delay               *WorkflowDelayV2 `json:"delay,omitempty"`
+
+	// Expressions The expressions to use in the workflow
+	Expressions []ExpressionPayloadV2 `json:"expressions"`
+
+	// Folder Folder to display the workflow in
+	Folder *string `json:"folder,omitempty"`
+
+	// IncludePrivateIncidents Whether to include private incidents
+	IncludePrivateIncidents bool `json:"include_private_incidents"`
+
+	// Name Name provided by the user when creating the workflow
+	Name string `json:"name"`
+
+	// OnceFor This workflow will run 'once for' a list of references
+	OnceFor []string `json:"once_for"`
+
+	// RunsOnIncidentModes Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
+	RunsOnIncidentModes []WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes `json:"runs_on_incident_modes"`
+
+	// RunsOnIncidents Which incidents should the workflow be applied to?
+	RunsOnIncidents WorkflowsUpdateWorkflowPayloadV2RunsOnIncidents `json:"runs_on_incidents"`
+
+	// Shortform The shortform used to trigger this workflow (only applicable for manual triggers)
+	Shortform *string `json:"shortform,omitempty"`
+
+	// State What state this workflow is in
+	State *WorkflowsUpdateWorkflowPayloadV2State `json:"state,omitempty"`
+
+	// Steps Steps that are executed as part of the workflow
+	Steps []StepConfigPayloadV2 `json:"steps"`
+}
+
+// WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes defines model for WorkflowsUpdateWorkflowPayloadV2.RunsOnIncidentModes.
+type WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes string
+
+// WorkflowsUpdateWorkflowPayloadV2RunsOnIncidents Which incidents should the workflow be applied to?
+type WorkflowsUpdateWorkflowPayloadV2RunsOnIncidents string
+
+// WorkflowsUpdateWorkflowPayloadV2State What state this workflow is in
+type WorkflowsUpdateWorkflowPayloadV2State string
+
+// WorkflowsUpdateWorkflowResultV2 defines model for WorkflowsUpdateWorkflowResultV2.
+type WorkflowsUpdateWorkflowResultV2 struct {
+	ManagementMeta ManagementMetaV2 `json:"management_meta"`
+	Workflow       WorkflowV2       `json:"workflow"`
+}
 
 // ActionsV1ListParams defines parameters for ActionsV1List.
 type ActionsV1ListParams struct {
@@ -5601,6 +5628,18 @@ type UsersV2ListParams struct {
 	After *string `form:"after,omitempty" json:"after,omitempty"`
 }
 
+// CatalogV3ListEntriesParams defines parameters for CatalogV3ListEntries.
+type CatalogV3ListEntriesParams struct {
+	// CatalogTypeId ID of this catalog type
+	CatalogTypeId string `form:"catalog_type_id" json:"catalog_type_id"`
+
+	// PageSize The integer number of records to return
+	PageSize int64 `form:"page_size" json:"page_size"`
+
+	// After An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
+}
+
 // CustomFieldOptionsV1CreateJSONRequestBody defines body for CustomFieldOptionsV1Create for application/json ContentType.
 type CustomFieldOptionsV1CreateJSONRequestBody = CustomFieldOptionsCreatePayloadV1
 
@@ -5626,22 +5665,22 @@ type IncidentMembershipsV1RevokeJSONRequestBody = CreateRequestBody2
 type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody3
 
 // IncidentRolesV1UpdateJSONRequestBody defines body for IncidentRolesV1Update for application/json ContentType.
-type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody2
+type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody
 
 // IncidentStatusesV1CreateJSONRequestBody defines body for IncidentStatusesV1Create for application/json ContentType.
 type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody5
 
 // IncidentStatusesV1UpdateJSONRequestBody defines body for IncidentStatusesV1Update for application/json ContentType.
-type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody4
+type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody3
 
 // IncidentsV1CreateJSONRequestBody defines body for IncidentsV1Create for application/json ContentType.
 type IncidentsV1CreateJSONRequestBody = IncidentCreatePayloadV1
 
 // SeveritiesV1CreateJSONRequestBody defines body for SeveritiesV1Create for application/json ContentType.
-type SeveritiesV1CreateJSONRequestBody = CreateRequestBody6
+type SeveritiesV1CreateJSONRequestBody = SeveritiesCreatePayloadV1
 
 // SeveritiesV1UpdateJSONRequestBody defines body for SeveritiesV1Update for application/json ContentType.
-type SeveritiesV1UpdateJSONRequestBody = CreateRequestBody6
+type SeveritiesV1UpdateJSONRequestBody = SeveritiesUpdatePayloadV1
 
 // AlertAttributesV2CreateJSONRequestBody defines body for AlertAttributesV2Create for application/json ContentType.
 type AlertAttributesV2CreateJSONRequestBody = AlertAttributesCreatePayloadV2
@@ -5653,10 +5692,10 @@ type AlertAttributesV2UpdateJSONRequestBody = AlertAttributesUpdatePayloadV2
 type AlertEventsV2CreateHTTPJSONRequestBody = CreateHTTPRequestBody
 
 // AlertRoutesV2CreateJSONRequestBody defines body for AlertRoutesV2Create for application/json ContentType.
-type AlertRoutesV2CreateJSONRequestBody = AlertRoutePayloadV2
+type AlertRoutesV2CreateJSONRequestBody = AlertRoutesCreatePayloadV2
 
 // AlertRoutesV2UpdateJSONRequestBody defines body for AlertRoutesV2Update for application/json ContentType.
-type AlertRoutesV2UpdateJSONRequestBody = UpdateRequestBody
+type AlertRoutesV2UpdateJSONRequestBody = AlertRoutesUpdatePayloadV2
 
 // AlertSourcesV2CreateJSONRequestBody defines body for AlertSourcesV2Create for application/json ContentType.
 type AlertSourcesV2CreateJSONRequestBody = AlertSourcesCreatePayloadV2
@@ -5665,19 +5704,19 @@ type AlertSourcesV2CreateJSONRequestBody = AlertSourcesCreatePayloadV2
 type AlertSourcesV2UpdateJSONRequestBody = AlertSourcesUpdatePayloadV2
 
 // CatalogV2CreateEntryJSONRequestBody defines body for CatalogV2CreateEntry for application/json ContentType.
-type CatalogV2CreateEntryJSONRequestBody = CreateEntryRequestBody
+type CatalogV2CreateEntryJSONRequestBody = CatalogCreateEntryPayloadV2
 
 // CatalogV2UpdateEntryJSONRequestBody defines body for CatalogV2UpdateEntry for application/json ContentType.
-type CatalogV2UpdateEntryJSONRequestBody = UpdateEntryRequestBody
+type CatalogV2UpdateEntryJSONRequestBody = CatalogUpdateEntryPayloadV2
 
 // CatalogV2CreateTypeJSONRequestBody defines body for CatalogV2CreateType for application/json ContentType.
-type CatalogV2CreateTypeJSONRequestBody = CreateTypeRequestBody
+type CatalogV2CreateTypeJSONRequestBody = CatalogCreateTypePayloadV2
 
 // CatalogV2UpdateTypeJSONRequestBody defines body for CatalogV2UpdateType for application/json ContentType.
-type CatalogV2UpdateTypeJSONRequestBody = UpdateTypeRequestBody
+type CatalogV2UpdateTypeJSONRequestBody = CatalogUpdateTypePayloadV2
 
 // CatalogV2UpdateTypeSchemaJSONRequestBody defines body for CatalogV2UpdateTypeSchema for application/json ContentType.
-type CatalogV2UpdateTypeSchemaJSONRequestBody = UpdateTypeSchemaRequestBody
+type CatalogV2UpdateTypeSchemaJSONRequestBody = CatalogUpdateTypeSchemaPayloadV2
 
 // CustomFieldsV2CreateJSONRequestBody defines body for CustomFieldsV2Create for application/json ContentType.
 type CustomFieldsV2CreateJSONRequestBody = CustomFieldsCreatePayloadV2
@@ -5695,7 +5734,7 @@ type EscalationsV2UpdatePathJSONRequestBody = EscalationPathPayloadV2
 type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody4
 
 // IncidentRolesV2UpdateJSONRequestBody defines body for IncidentRolesV2Update for application/json ContentType.
-type IncidentRolesV2UpdateJSONRequestBody = UpdateRequestBody3
+type IncidentRolesV2UpdateJSONRequestBody = UpdateRequestBody2
 
 // IncidentsV2CreateJSONRequestBody defines body for IncidentsV2Create for application/json ContentType.
 type IncidentsV2CreateJSONRequestBody = IncidentCreatePayloadV2
@@ -5716,10 +5755,25 @@ type SchedulesV2CreateJSONRequestBody = SchedulesCreatePayloadV2
 type SchedulesV2UpdateJSONRequestBody = SchedulesUpdatePayloadV2
 
 // WorkflowsV2CreateWorkflowJSONRequestBody defines body for WorkflowsV2CreateWorkflow for application/json ContentType.
-type WorkflowsV2CreateWorkflowJSONRequestBody = CreateWorkflowPayload
+type WorkflowsV2CreateWorkflowJSONRequestBody = WorkflowsCreateWorkflowPayloadV2
 
 // WorkflowsV2UpdateWorkflowJSONRequestBody defines body for WorkflowsV2UpdateWorkflow for application/json ContentType.
-type WorkflowsV2UpdateWorkflowJSONRequestBody = UpdateWorkflowPayload2
+type WorkflowsV2UpdateWorkflowJSONRequestBody = WorkflowsUpdateWorkflowPayloadV2
+
+// CatalogV3CreateEntryJSONRequestBody defines body for CatalogV3CreateEntry for application/json ContentType.
+type CatalogV3CreateEntryJSONRequestBody = CatalogCreateEntryPayloadV3
+
+// CatalogV3UpdateEntryJSONRequestBody defines body for CatalogV3UpdateEntry for application/json ContentType.
+type CatalogV3UpdateEntryJSONRequestBody = CatalogUpdateEntryPayloadV3
+
+// CatalogV3CreateTypeJSONRequestBody defines body for CatalogV3CreateType for application/json ContentType.
+type CatalogV3CreateTypeJSONRequestBody = CatalogCreateTypePayloadV3
+
+// CatalogV3UpdateTypeJSONRequestBody defines body for CatalogV3UpdateType for application/json ContentType.
+type CatalogV3UpdateTypeJSONRequestBody = CatalogUpdateTypePayloadV3
+
+// CatalogV3UpdateTypeSchemaJSONRequestBody defines body for CatalogV3UpdateTypeSchema for application/json ContentType.
+type CatalogV3UpdateTypeSchemaJSONRequestBody = CatalogUpdateTypeSchemaPayloadV3
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -6194,6 +6248,52 @@ type ClientInterface interface {
 	WorkflowsV2UpdateWorkflowWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	WorkflowsV2UpdateWorkflow(ctx context.Context, id string, body WorkflowsV2UpdateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3ListEntries request
+	CatalogV3ListEntries(ctx context.Context, params *CatalogV3ListEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3CreateEntryWithBody request with any body
+	CatalogV3CreateEntryWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CatalogV3CreateEntry(ctx context.Context, body CatalogV3CreateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3DestroyEntry request
+	CatalogV3DestroyEntry(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3ShowEntry request
+	CatalogV3ShowEntry(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3UpdateEntryWithBody request with any body
+	CatalogV3UpdateEntryWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CatalogV3UpdateEntry(ctx context.Context, id string, body CatalogV3UpdateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3ListResources request
+	CatalogV3ListResources(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3ListTypes request
+	CatalogV3ListTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3CreateTypeWithBody request with any body
+	CatalogV3CreateTypeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CatalogV3CreateType(ctx context.Context, body CatalogV3CreateTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3DestroyType request
+	CatalogV3DestroyType(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3ShowType request
+	CatalogV3ShowType(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3UpdateTypeWithBody request with any body
+	CatalogV3UpdateTypeWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CatalogV3UpdateType(ctx context.Context, id string, body CatalogV3UpdateTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3UpdateTypeSchemaWithBody request with any body
+	CatalogV3UpdateTypeSchemaWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CatalogV3UpdateTypeSchema(ctx context.Context, id string, body CatalogV3UpdateTypeSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) ActionsV1List(ctx context.Context, params *ActionsV1ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -7950,6 +8050,210 @@ func (c *Client) WorkflowsV2UpdateWorkflowWithBody(ctx context.Context, id strin
 
 func (c *Client) WorkflowsV2UpdateWorkflow(ctx context.Context, id string, body WorkflowsV2UpdateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewWorkflowsV2UpdateWorkflowRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3ListEntries(ctx context.Context, params *CatalogV3ListEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3ListEntriesRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3CreateEntryWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3CreateEntryRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3CreateEntry(ctx context.Context, body CatalogV3CreateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3CreateEntryRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3DestroyEntry(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3DestroyEntryRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3ShowEntry(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3ShowEntryRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3UpdateEntryWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3UpdateEntryRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3UpdateEntry(ctx context.Context, id string, body CatalogV3UpdateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3UpdateEntryRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3ListResources(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3ListResourcesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3ListTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3ListTypesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3CreateTypeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3CreateTypeRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3CreateType(ctx context.Context, body CatalogV3CreateTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3CreateTypeRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3DestroyType(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3DestroyTypeRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3ShowType(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3ShowTypeRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3UpdateTypeWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3UpdateTypeRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3UpdateType(ctx context.Context, id string, body CatalogV3UpdateTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3UpdateTypeRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3UpdateTypeSchemaWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3UpdateTypeSchemaRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3UpdateTypeSchema(ctx context.Context, id string, body CatalogV3UpdateTypeSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3UpdateTypeSchemaRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -12522,6 +12826,490 @@ func NewWorkflowsV2UpdateWorkflowRequestWithBody(server string, id string, conte
 	return req, nil
 }
 
+// NewCatalogV3ListEntriesRequest generates requests for CatalogV3ListEntries
+func NewCatalogV3ListEntriesRequest(server string, params *CatalogV3ListEntriesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_entries")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "catalog_type_id", runtime.ParamLocationQuery, params.CatalogTypeId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page_size", runtime.ParamLocationQuery, params.PageSize); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if params.After != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCatalogV3CreateEntryRequest calls the generic CatalogV3CreateEntry builder with application/json body
+func NewCatalogV3CreateEntryRequest(server string, body CatalogV3CreateEntryJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCatalogV3CreateEntryRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCatalogV3CreateEntryRequestWithBody generates requests for CatalogV3CreateEntry with any type of body
+func NewCatalogV3CreateEntryRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_entries")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCatalogV3DestroyEntryRequest generates requests for CatalogV3DestroyEntry
+func NewCatalogV3DestroyEntryRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_entries/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCatalogV3ShowEntryRequest generates requests for CatalogV3ShowEntry
+func NewCatalogV3ShowEntryRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_entries/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCatalogV3UpdateEntryRequest calls the generic CatalogV3UpdateEntry builder with application/json body
+func NewCatalogV3UpdateEntryRequest(server string, id string, body CatalogV3UpdateEntryJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCatalogV3UpdateEntryRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewCatalogV3UpdateEntryRequestWithBody generates requests for CatalogV3UpdateEntry with any type of body
+func NewCatalogV3UpdateEntryRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_entries/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCatalogV3ListResourcesRequest generates requests for CatalogV3ListResources
+func NewCatalogV3ListResourcesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_resources")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCatalogV3ListTypesRequest generates requests for CatalogV3ListTypes
+func NewCatalogV3ListTypesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_types")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCatalogV3CreateTypeRequest calls the generic CatalogV3CreateType builder with application/json body
+func NewCatalogV3CreateTypeRequest(server string, body CatalogV3CreateTypeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCatalogV3CreateTypeRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCatalogV3CreateTypeRequestWithBody generates requests for CatalogV3CreateType with any type of body
+func NewCatalogV3CreateTypeRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_types")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCatalogV3DestroyTypeRequest generates requests for CatalogV3DestroyType
+func NewCatalogV3DestroyTypeRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_types/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCatalogV3ShowTypeRequest generates requests for CatalogV3ShowType
+func NewCatalogV3ShowTypeRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_types/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCatalogV3UpdateTypeRequest calls the generic CatalogV3UpdateType builder with application/json body
+func NewCatalogV3UpdateTypeRequest(server string, id string, body CatalogV3UpdateTypeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCatalogV3UpdateTypeRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewCatalogV3UpdateTypeRequestWithBody generates requests for CatalogV3UpdateType with any type of body
+func NewCatalogV3UpdateTypeRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_types/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCatalogV3UpdateTypeSchemaRequest calls the generic CatalogV3UpdateTypeSchema builder with application/json body
+func NewCatalogV3UpdateTypeSchemaRequest(server string, id string, body CatalogV3UpdateTypeSchemaJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCatalogV3UpdateTypeSchemaRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewCatalogV3UpdateTypeSchemaRequestWithBody generates requests for CatalogV3UpdateTypeSchema with any type of body
+func NewCatalogV3UpdateTypeSchemaRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_types/%s/actions/update_schema", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -12965,6 +13753,52 @@ type ClientWithResponsesInterface interface {
 	WorkflowsV2UpdateWorkflowWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*WorkflowsV2UpdateWorkflowResponse, error)
 
 	WorkflowsV2UpdateWorkflowWithResponse(ctx context.Context, id string, body WorkflowsV2UpdateWorkflowJSONRequestBody, reqEditors ...RequestEditorFn) (*WorkflowsV2UpdateWorkflowResponse, error)
+
+	// CatalogV3ListEntriesWithResponse request
+	CatalogV3ListEntriesWithResponse(ctx context.Context, params *CatalogV3ListEntriesParams, reqEditors ...RequestEditorFn) (*CatalogV3ListEntriesResponse, error)
+
+	// CatalogV3CreateEntryWithBodyWithResponse request with any body
+	CatalogV3CreateEntryWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3CreateEntryResponse, error)
+
+	CatalogV3CreateEntryWithResponse(ctx context.Context, body CatalogV3CreateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3CreateEntryResponse, error)
+
+	// CatalogV3DestroyEntryWithResponse request
+	CatalogV3DestroyEntryWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CatalogV3DestroyEntryResponse, error)
+
+	// CatalogV3ShowEntryWithResponse request
+	CatalogV3ShowEntryWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CatalogV3ShowEntryResponse, error)
+
+	// CatalogV3UpdateEntryWithBodyWithResponse request with any body
+	CatalogV3UpdateEntryWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3UpdateEntryResponse, error)
+
+	CatalogV3UpdateEntryWithResponse(ctx context.Context, id string, body CatalogV3UpdateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3UpdateEntryResponse, error)
+
+	// CatalogV3ListResourcesWithResponse request
+	CatalogV3ListResourcesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CatalogV3ListResourcesResponse, error)
+
+	// CatalogV3ListTypesWithResponse request
+	CatalogV3ListTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CatalogV3ListTypesResponse, error)
+
+	// CatalogV3CreateTypeWithBodyWithResponse request with any body
+	CatalogV3CreateTypeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3CreateTypeResponse, error)
+
+	CatalogV3CreateTypeWithResponse(ctx context.Context, body CatalogV3CreateTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3CreateTypeResponse, error)
+
+	// CatalogV3DestroyTypeWithResponse request
+	CatalogV3DestroyTypeWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CatalogV3DestroyTypeResponse, error)
+
+	// CatalogV3ShowTypeWithResponse request
+	CatalogV3ShowTypeWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CatalogV3ShowTypeResponse, error)
+
+	// CatalogV3UpdateTypeWithBodyWithResponse request with any body
+	CatalogV3UpdateTypeWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3UpdateTypeResponse, error)
+
+	CatalogV3UpdateTypeWithResponse(ctx context.Context, id string, body CatalogV3UpdateTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3UpdateTypeResponse, error)
+
+	// CatalogV3UpdateTypeSchemaWithBodyWithResponse request with any body
+	CatalogV3UpdateTypeSchemaWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3UpdateTypeSchemaResponse, error)
+
+	CatalogV3UpdateTypeSchemaWithResponse(ctx context.Context, id string, body CatalogV3UpdateTypeSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3UpdateTypeSchemaResponse, error)
 }
 
 type ActionsV1ListResponse struct {
@@ -13276,7 +14110,7 @@ func (r IncidentAttachmentsV1ListResponse) StatusCode() int {
 type IncidentAttachmentsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *CreateResponseBody2
+	JSON201      *CreateResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -13319,7 +14153,7 @@ func (r IncidentAttachmentsV1DeleteResponse) StatusCode() int {
 type IncidentMembershipsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *CreateResponseBody3
+	JSON201      *CreateResponseBody2
 }
 
 // Status returns HTTPResponse.Status
@@ -13734,7 +14568,7 @@ func (r UtilitiesV1OpenAPIV3Response) StatusCode() int {
 type SeveritiesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody10
+	JSON200      *SeveritiesListResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -13756,7 +14590,7 @@ func (r SeveritiesV1ListResponse) StatusCode() int {
 type SeveritiesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody8
+	JSON201      *SeveritiesCreateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -13799,7 +14633,7 @@ func (r SeveritiesV1DeleteResponse) StatusCode() int {
 type SeveritiesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody8
+	JSON200      *SeveritiesShowResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -13821,7 +14655,7 @@ func (r SeveritiesV1ShowResponse) StatusCode() int {
 type SeveritiesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody8
+	JSON200      *SeveritiesUpdateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14018,7 +14852,7 @@ func (r AlertEventsV2CreateHTTPResponse) StatusCode() int {
 type AlertRoutesV2CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *CreateResponseBody
+	JSON201      *AlertRoutesCreateResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14061,7 +14895,7 @@ func (r AlertRoutesV2DestroyResponse) StatusCode() int {
 type AlertRoutesV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *CreateResponseBody
+	JSON200      *AlertRoutesShowResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14083,7 +14917,7 @@ func (r AlertRoutesV2ShowResponse) StatusCode() int {
 type AlertRoutesV2UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *CreateResponseBody
+	JSON200      *AlertRoutesUpdateResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14214,7 +15048,7 @@ func (r AlertSourcesV2UpdateResponse) StatusCode() int {
 type CatalogV2ListEntriesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListEntriesResponseBody
+	JSON200      *CatalogListEntriesResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14236,7 +15070,7 @@ func (r CatalogV2ListEntriesResponse) StatusCode() int {
 type CatalogV2CreateEntryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *CreateEntryResponseBody
+	JSON201      *CatalogCreateEntryResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14279,7 +15113,7 @@ func (r CatalogV2DestroyEntryResponse) StatusCode() int {
 type CatalogV2ShowEntryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowEntryResponseBody
+	JSON200      *CatalogShowEntryResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14301,7 +15135,7 @@ func (r CatalogV2ShowEntryResponse) StatusCode() int {
 type CatalogV2UpdateEntryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowEntryResponseBody
+	JSON200      *CatalogUpdateEntryResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14323,7 +15157,7 @@ func (r CatalogV2UpdateEntryResponse) StatusCode() int {
 type CatalogV2ListResourcesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResourcesResponseBody
+	JSON200      *CatalogListResourcesResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14345,7 +15179,7 @@ func (r CatalogV2ListResourcesResponse) StatusCode() int {
 type CatalogV2ListTypesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListTypesResponseBody
+	JSON200      *CatalogListTypesResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14367,7 +15201,7 @@ func (r CatalogV2ListTypesResponse) StatusCode() int {
 type CatalogV2CreateTypeResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *CreateTypeResponseBody
+	JSON201      *CatalogCreateTypeResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14410,7 +15244,7 @@ func (r CatalogV2DestroyTypeResponse) StatusCode() int {
 type CatalogV2ShowTypeResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *CreateTypeResponseBody
+	JSON200      *CatalogShowTypeResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14432,7 +15266,7 @@ func (r CatalogV2ShowTypeResponse) StatusCode() int {
 type CatalogV2UpdateTypeResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *CreateTypeResponseBody
+	JSON200      *CatalogUpdateTypeResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -14454,7 +15288,7 @@ func (r CatalogV2UpdateTypeResponse) StatusCode() int {
 type CatalogV2UpdateTypeSchemaResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *CreateTypeResponseBody
+	JSON200      *CatalogUpdateTypeSchemaResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15198,7 +16032,7 @@ func (r UsersV2ShowResponse) StatusCode() int {
 type WorkflowsV2ListWorkflowsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListWorkflowsResponseBody
+	JSON200      *WorkflowsListWorkflowsResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15220,7 +16054,7 @@ func (r WorkflowsV2ListWorkflowsResponse) StatusCode() int {
 type WorkflowsV2CreateWorkflowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowWorkflowResponseBody
+	JSON201      *WorkflowsCreateWorkflowResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15263,7 +16097,7 @@ func (r WorkflowsV2DestroyWorkflowResponse) StatusCode() int {
 type WorkflowsV2ShowWorkflowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowWorkflowResponseBody
+	JSON200      *WorkflowsShowWorkflowResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15285,7 +16119,7 @@ func (r WorkflowsV2ShowWorkflowResponse) StatusCode() int {
 type WorkflowsV2UpdateWorkflowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowWorkflowResponseBody
+	JSON200      *WorkflowsUpdateWorkflowResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15298,6 +16132,268 @@ func (r WorkflowsV2UpdateWorkflowResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r WorkflowsV2UpdateWorkflowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3ListEntriesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CatalogListEntriesResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3ListEntriesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3ListEntriesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3CreateEntryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *CatalogCreateEntryResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3CreateEntryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3CreateEntryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3DestroyEntryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3DestroyEntryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3DestroyEntryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3ShowEntryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CatalogShowEntryResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3ShowEntryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3ShowEntryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3UpdateEntryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CatalogUpdateEntryResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3UpdateEntryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3UpdateEntryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3ListResourcesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CatalogListResourcesResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3ListResourcesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3ListResourcesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3ListTypesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CatalogListTypesResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3ListTypesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3ListTypesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3CreateTypeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *CatalogCreateTypeResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3CreateTypeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3CreateTypeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3DestroyTypeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3DestroyTypeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3DestroyTypeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3ShowTypeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CatalogShowTypeResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3ShowTypeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3ShowTypeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3UpdateTypeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CatalogUpdateTypeResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3UpdateTypeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3UpdateTypeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3UpdateTypeSchemaResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CatalogUpdateTypeSchemaResultV3
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3UpdateTypeSchemaResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3UpdateTypeSchemaResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -16587,6 +17683,154 @@ func (c *ClientWithResponses) WorkflowsV2UpdateWorkflowWithResponse(ctx context.
 	return ParseWorkflowsV2UpdateWorkflowResponse(rsp)
 }
 
+// CatalogV3ListEntriesWithResponse request returning *CatalogV3ListEntriesResponse
+func (c *ClientWithResponses) CatalogV3ListEntriesWithResponse(ctx context.Context, params *CatalogV3ListEntriesParams, reqEditors ...RequestEditorFn) (*CatalogV3ListEntriesResponse, error) {
+	rsp, err := c.CatalogV3ListEntries(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3ListEntriesResponse(rsp)
+}
+
+// CatalogV3CreateEntryWithBodyWithResponse request with arbitrary body returning *CatalogV3CreateEntryResponse
+func (c *ClientWithResponses) CatalogV3CreateEntryWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3CreateEntryResponse, error) {
+	rsp, err := c.CatalogV3CreateEntryWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3CreateEntryResponse(rsp)
+}
+
+func (c *ClientWithResponses) CatalogV3CreateEntryWithResponse(ctx context.Context, body CatalogV3CreateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3CreateEntryResponse, error) {
+	rsp, err := c.CatalogV3CreateEntry(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3CreateEntryResponse(rsp)
+}
+
+// CatalogV3DestroyEntryWithResponse request returning *CatalogV3DestroyEntryResponse
+func (c *ClientWithResponses) CatalogV3DestroyEntryWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CatalogV3DestroyEntryResponse, error) {
+	rsp, err := c.CatalogV3DestroyEntry(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3DestroyEntryResponse(rsp)
+}
+
+// CatalogV3ShowEntryWithResponse request returning *CatalogV3ShowEntryResponse
+func (c *ClientWithResponses) CatalogV3ShowEntryWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CatalogV3ShowEntryResponse, error) {
+	rsp, err := c.CatalogV3ShowEntry(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3ShowEntryResponse(rsp)
+}
+
+// CatalogV3UpdateEntryWithBodyWithResponse request with arbitrary body returning *CatalogV3UpdateEntryResponse
+func (c *ClientWithResponses) CatalogV3UpdateEntryWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3UpdateEntryResponse, error) {
+	rsp, err := c.CatalogV3UpdateEntryWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3UpdateEntryResponse(rsp)
+}
+
+func (c *ClientWithResponses) CatalogV3UpdateEntryWithResponse(ctx context.Context, id string, body CatalogV3UpdateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3UpdateEntryResponse, error) {
+	rsp, err := c.CatalogV3UpdateEntry(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3UpdateEntryResponse(rsp)
+}
+
+// CatalogV3ListResourcesWithResponse request returning *CatalogV3ListResourcesResponse
+func (c *ClientWithResponses) CatalogV3ListResourcesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CatalogV3ListResourcesResponse, error) {
+	rsp, err := c.CatalogV3ListResources(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3ListResourcesResponse(rsp)
+}
+
+// CatalogV3ListTypesWithResponse request returning *CatalogV3ListTypesResponse
+func (c *ClientWithResponses) CatalogV3ListTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CatalogV3ListTypesResponse, error) {
+	rsp, err := c.CatalogV3ListTypes(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3ListTypesResponse(rsp)
+}
+
+// CatalogV3CreateTypeWithBodyWithResponse request with arbitrary body returning *CatalogV3CreateTypeResponse
+func (c *ClientWithResponses) CatalogV3CreateTypeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3CreateTypeResponse, error) {
+	rsp, err := c.CatalogV3CreateTypeWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3CreateTypeResponse(rsp)
+}
+
+func (c *ClientWithResponses) CatalogV3CreateTypeWithResponse(ctx context.Context, body CatalogV3CreateTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3CreateTypeResponse, error) {
+	rsp, err := c.CatalogV3CreateType(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3CreateTypeResponse(rsp)
+}
+
+// CatalogV3DestroyTypeWithResponse request returning *CatalogV3DestroyTypeResponse
+func (c *ClientWithResponses) CatalogV3DestroyTypeWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CatalogV3DestroyTypeResponse, error) {
+	rsp, err := c.CatalogV3DestroyType(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3DestroyTypeResponse(rsp)
+}
+
+// CatalogV3ShowTypeWithResponse request returning *CatalogV3ShowTypeResponse
+func (c *ClientWithResponses) CatalogV3ShowTypeWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CatalogV3ShowTypeResponse, error) {
+	rsp, err := c.CatalogV3ShowType(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3ShowTypeResponse(rsp)
+}
+
+// CatalogV3UpdateTypeWithBodyWithResponse request with arbitrary body returning *CatalogV3UpdateTypeResponse
+func (c *ClientWithResponses) CatalogV3UpdateTypeWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3UpdateTypeResponse, error) {
+	rsp, err := c.CatalogV3UpdateTypeWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3UpdateTypeResponse(rsp)
+}
+
+func (c *ClientWithResponses) CatalogV3UpdateTypeWithResponse(ctx context.Context, id string, body CatalogV3UpdateTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3UpdateTypeResponse, error) {
+	rsp, err := c.CatalogV3UpdateType(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3UpdateTypeResponse(rsp)
+}
+
+// CatalogV3UpdateTypeSchemaWithBodyWithResponse request with arbitrary body returning *CatalogV3UpdateTypeSchemaResponse
+func (c *ClientWithResponses) CatalogV3UpdateTypeSchemaWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3UpdateTypeSchemaResponse, error) {
+	rsp, err := c.CatalogV3UpdateTypeSchemaWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3UpdateTypeSchemaResponse(rsp)
+}
+
+func (c *ClientWithResponses) CatalogV3UpdateTypeSchemaWithResponse(ctx context.Context, id string, body CatalogV3UpdateTypeSchemaJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3UpdateTypeSchemaResponse, error) {
+	rsp, err := c.CatalogV3UpdateTypeSchema(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3UpdateTypeSchemaResponse(rsp)
+}
+
 // ParseActionsV1ListResponse parses an HTTP response from a ActionsV1ListWithResponse call
 func ParseActionsV1ListResponse(rsp *http.Response) (*ActionsV1ListResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -16946,7 +18190,7 @@ func ParseIncidentAttachmentsV1CreateResponse(rsp *http.Response) (*IncidentAtta
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest CreateResponseBody2
+		var dest CreateResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -16988,7 +18232,7 @@ func ParseIncidentMembershipsV1CreateResponse(rsp *http.Response) (*IncidentMemb
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest CreateResponseBody3
+		var dest CreateResponseBody2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17452,7 +18696,7 @@ func ParseSeveritiesV1ListResponse(rsp *http.Response) (*SeveritiesV1ListRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody10
+		var dest SeveritiesListResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17478,7 +18722,7 @@ func ParseSeveritiesV1CreateResponse(rsp *http.Response) (*SeveritiesV1CreateRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody8
+		var dest SeveritiesCreateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17520,7 +18764,7 @@ func ParseSeveritiesV1ShowResponse(rsp *http.Response) (*SeveritiesV1ShowRespons
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody8
+		var dest SeveritiesShowResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17546,7 +18790,7 @@ func ParseSeveritiesV1UpdateResponse(rsp *http.Response) (*SeveritiesV1UpdateRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody8
+		var dest SeveritiesUpdateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17770,7 +19014,7 @@ func ParseAlertRoutesV2CreateResponse(rsp *http.Response) (*AlertRoutesV2CreateR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest CreateResponseBody
+		var dest AlertRoutesCreateResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17812,7 +19056,7 @@ func ParseAlertRoutesV2ShowResponse(rsp *http.Response) (*AlertRoutesV2ShowRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CreateResponseBody
+		var dest AlertRoutesShowResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17838,7 +19082,7 @@ func ParseAlertRoutesV2UpdateResponse(rsp *http.Response) (*AlertRoutesV2UpdateR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CreateResponseBody
+		var dest AlertRoutesUpdateResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17984,7 +19228,7 @@ func ParseCatalogV2ListEntriesResponse(rsp *http.Response) (*CatalogV2ListEntrie
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListEntriesResponseBody
+		var dest CatalogListEntriesResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18010,7 +19254,7 @@ func ParseCatalogV2CreateEntryResponse(rsp *http.Response) (*CatalogV2CreateEntr
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest CreateEntryResponseBody
+		var dest CatalogCreateEntryResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18052,7 +19296,7 @@ func ParseCatalogV2ShowEntryResponse(rsp *http.Response) (*CatalogV2ShowEntryRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowEntryResponseBody
+		var dest CatalogShowEntryResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18078,7 +19322,7 @@ func ParseCatalogV2UpdateEntryResponse(rsp *http.Response) (*CatalogV2UpdateEntr
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowEntryResponseBody
+		var dest CatalogUpdateEntryResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18104,7 +19348,7 @@ func ParseCatalogV2ListResourcesResponse(rsp *http.Response) (*CatalogV2ListReso
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResourcesResponseBody
+		var dest CatalogListResourcesResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18130,7 +19374,7 @@ func ParseCatalogV2ListTypesResponse(rsp *http.Response) (*CatalogV2ListTypesRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListTypesResponseBody
+		var dest CatalogListTypesResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18156,7 +19400,7 @@ func ParseCatalogV2CreateTypeResponse(rsp *http.Response) (*CatalogV2CreateTypeR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest CreateTypeResponseBody
+		var dest CatalogCreateTypeResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18198,7 +19442,7 @@ func ParseCatalogV2ShowTypeResponse(rsp *http.Response) (*CatalogV2ShowTypeRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CreateTypeResponseBody
+		var dest CatalogShowTypeResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18224,7 +19468,7 @@ func ParseCatalogV2UpdateTypeResponse(rsp *http.Response) (*CatalogV2UpdateTypeR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CreateTypeResponseBody
+		var dest CatalogUpdateTypeResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18250,7 +19494,7 @@ func ParseCatalogV2UpdateTypeSchemaResponse(rsp *http.Response) (*CatalogV2Updat
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CreateTypeResponseBody
+		var dest CatalogUpdateTypeSchemaResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19094,7 +20338,7 @@ func ParseWorkflowsV2ListWorkflowsResponse(rsp *http.Response) (*WorkflowsV2List
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListWorkflowsResponseBody
+		var dest WorkflowsListWorkflowsResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19120,7 +20364,7 @@ func ParseWorkflowsV2CreateWorkflowResponse(rsp *http.Response) (*WorkflowsV2Cre
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowWorkflowResponseBody
+		var dest WorkflowsCreateWorkflowResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19162,7 +20406,7 @@ func ParseWorkflowsV2ShowWorkflowResponse(rsp *http.Response) (*WorkflowsV2ShowW
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowWorkflowResponseBody
+		var dest WorkflowsShowWorkflowResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19188,7 +20432,299 @@ func ParseWorkflowsV2UpdateWorkflowResponse(rsp *http.Response) (*WorkflowsV2Upd
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowWorkflowResponseBody
+		var dest WorkflowsUpdateWorkflowResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3ListEntriesResponse parses an HTTP response from a CatalogV3ListEntriesWithResponse call
+func ParseCatalogV3ListEntriesResponse(rsp *http.Response) (*CatalogV3ListEntriesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3ListEntriesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CatalogListEntriesResultV3
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3CreateEntryResponse parses an HTTP response from a CatalogV3CreateEntryWithResponse call
+func ParseCatalogV3CreateEntryResponse(rsp *http.Response) (*CatalogV3CreateEntryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3CreateEntryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest CatalogCreateEntryResultV3
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3DestroyEntryResponse parses an HTTP response from a CatalogV3DestroyEntryWithResponse call
+func ParseCatalogV3DestroyEntryResponse(rsp *http.Response) (*CatalogV3DestroyEntryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3DestroyEntryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3ShowEntryResponse parses an HTTP response from a CatalogV3ShowEntryWithResponse call
+func ParseCatalogV3ShowEntryResponse(rsp *http.Response) (*CatalogV3ShowEntryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3ShowEntryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CatalogShowEntryResultV3
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3UpdateEntryResponse parses an HTTP response from a CatalogV3UpdateEntryWithResponse call
+func ParseCatalogV3UpdateEntryResponse(rsp *http.Response) (*CatalogV3UpdateEntryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3UpdateEntryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CatalogUpdateEntryResultV3
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3ListResourcesResponse parses an HTTP response from a CatalogV3ListResourcesWithResponse call
+func ParseCatalogV3ListResourcesResponse(rsp *http.Response) (*CatalogV3ListResourcesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3ListResourcesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CatalogListResourcesResultV3
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3ListTypesResponse parses an HTTP response from a CatalogV3ListTypesWithResponse call
+func ParseCatalogV3ListTypesResponse(rsp *http.Response) (*CatalogV3ListTypesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3ListTypesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CatalogListTypesResultV3
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3CreateTypeResponse parses an HTTP response from a CatalogV3CreateTypeWithResponse call
+func ParseCatalogV3CreateTypeResponse(rsp *http.Response) (*CatalogV3CreateTypeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3CreateTypeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest CatalogCreateTypeResultV3
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3DestroyTypeResponse parses an HTTP response from a CatalogV3DestroyTypeWithResponse call
+func ParseCatalogV3DestroyTypeResponse(rsp *http.Response) (*CatalogV3DestroyTypeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3DestroyTypeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3ShowTypeResponse parses an HTTP response from a CatalogV3ShowTypeWithResponse call
+func ParseCatalogV3ShowTypeResponse(rsp *http.Response) (*CatalogV3ShowTypeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3ShowTypeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CatalogShowTypeResultV3
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3UpdateTypeResponse parses an HTTP response from a CatalogV3UpdateTypeWithResponse call
+func ParseCatalogV3UpdateTypeResponse(rsp *http.Response) (*CatalogV3UpdateTypeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3UpdateTypeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CatalogUpdateTypeResultV3
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3UpdateTypeSchemaResponse parses an HTTP response from a CatalogV3UpdateTypeSchemaWithResponse call
+func ParseCatalogV3UpdateTypeSchemaResponse(rsp *http.Response) (*CatalogV3UpdateTypeSchemaResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3UpdateTypeSchemaResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CatalogUpdateTypeSchemaResultV3
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/incident_catalog_entries_resource.go
+++ b/internal/provider/incident_catalog_entries_resource.go
@@ -649,7 +649,13 @@ func (m *IncidentCatalogEntriesResourceModel) managedAttributesSet() (map[string
 			return nil, false
 		}
 
-		managedAttrSet[attrElem.(types.String).ValueString()] = true
+		attrIDStr, ok := attrElem.(types.String)
+		if !ok {
+			// Weird but ok
+			return nil, false
+		}
+
+		managedAttrSet[attrIDStr.ValueString()] = true
 	}
 
 	// Technically this isn't race-safe, since multiple goroutines _could_ try to set this at once.

--- a/internal/provider/incident_catalog_entries_resource.go
+++ b/internal/provider/incident_catalog_entries_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -34,8 +35,12 @@ type IncidentCatalogEntriesResource struct {
 }
 
 type IncidentCatalogEntriesResourceModel struct {
-	ID      types.String                 `tfsdk:"id"` // Catalog Type ID
-	Entries map[string]CatalogEntryModel `tfsdk:"entries"`
+	ID                types.String                 `tfsdk:"id"` // Catalog Type ID
+	Entries           map[string]CatalogEntryModel `tfsdk:"entries"`
+	ManagedAttributes types.Set                    `tfsdk:"managed_attributes"`
+
+	// This caches a lookup of the managed attributes set
+	managedAttrSet map[string]bool
 }
 
 type CatalogEntryModel struct {
@@ -44,8 +49,6 @@ type CatalogEntryModel struct {
 	Aliases         types.List                                   `tfsdk:"aliases"`
 	Rank            types.Int64                                  `tfsdk:"rank"`
 	AttributeValues map[string]CatalogEntryAttributeBindingModel `tfsdk:"attribute_values"`
-
-	externalID string // tracks the external ID for our internal book-keeping
 }
 
 type CatalogEntryAttributeBindingModel struct {
@@ -89,7 +92,7 @@ changes to one entry to an update to that same entry when the upstream changes.
 		`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "catalog_type_id"),
+				MarkdownDescription: apischema.Docstring("CatalogEntryV3", "catalog_type_id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -101,14 +104,14 @@ changes to one entry to an update to that same entry when the upstream changes.
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "id"),
+							MarkdownDescription: apischema.Docstring("CatalogEntryV3", "id"),
 							Computed:            true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),
 							},
 						},
 						"name": schema.StringAttribute{
-							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "name"),
+							MarkdownDescription: apischema.Docstring("CatalogEntryV3", "name"),
 							Required:            true,
 						},
 						"aliases": schema.ListAttribute{
@@ -116,12 +119,12 @@ changes to one entry to an update to that same entry when the upstream changes.
 							PlanModifiers: []planmodifier.List{
 								listplanmodifier.UseStateForUnknown(),
 							},
-							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "aliases"),
+							MarkdownDescription: apischema.Docstring("CatalogEntryV3", "aliases"),
 							Optional:            true,
 							Computed:            true,
 						},
 						"rank": schema.Int64Attribute{
-							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "rank"),
+							MarkdownDescription: apischema.Docstring("CatalogEntryV3", "rank"),
 							Optional:            true,
 							Computed:            true,
 							Default:             int64default.StaticInt64(0),
@@ -143,6 +146,16 @@ changes to one entry to an update to that same entry when the upstream changes.
 							},
 						},
 					},
+				},
+			},
+			"managed_attributes": schema.SetAttribute{
+				ElementType: types.StringType,
+				MarkdownDescription: `The set of attributes that are managed by this resource. By default, all attributes are managed by this resource.
+
+This can be used to allow other attributes of a catalog entry to be managed elsewhere, for example in another Terraform repository or the incident.io web UI.`,
+				Optional: true,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
 				},
 			},
 		},
@@ -245,7 +258,7 @@ func (r *IncidentCatalogEntriesResource) ImportState(ctx context.Context, req re
 
 // buildModel generates a terraform model from a catalog type and current list of all
 // entries, as received from getEntries.
-func (r *IncidentCatalogEntriesResource) buildModel(catalogType client.CatalogTypeV2, entries []client.CatalogEntryV2, plan *IncidentCatalogEntriesResourceModel) *IncidentCatalogEntriesResourceModel {
+func (r *IncidentCatalogEntriesResource) buildModel(catalogType client.CatalogTypeV3, entries []client.CatalogEntryV3, plan *IncidentCatalogEntriesResourceModel) *IncidentCatalogEntriesResourceModel {
 	modelEntries := map[string]CatalogEntryModel{}
 	for _, entry := range entries {
 		// Skip all entries that come with no external ID, as these can't have been created by
@@ -256,6 +269,11 @@ func (r *IncidentCatalogEntriesResource) buildModel(catalogType client.CatalogTy
 
 		values := map[string]CatalogEntryAttributeBindingModel{}
 		for attributeID, binding := range entry.AttributeValues {
+			// Don't include unmanaged attributes in the result - that produces diffs!
+			if !plan.isAttributeManaged(attributeID) {
+				continue
+			}
+
 			// For terraform to serialize a list, it must know the type of the list. It's
 			// possible that we won't have any values from the API response that we'd populate
 			// our ArrayValue with, so we default allocate it as a string list so we know how to
@@ -317,13 +335,13 @@ func (r *IncidentCatalogEntriesResource) buildModel(catalogType client.CatalogTy
 			Aliases:         types.ListValueMust(types.StringType, aliases),
 			Rank:            types.Int64Value(int64(entry.Rank)),
 			AttributeValues: values,
-			externalID:      *entry.ExternalId,
 		}
 	}
 
 	return &IncidentCatalogEntriesResourceModel{
-		ID:      types.StringValue(catalogType.Id),
-		Entries: modelEntries,
+		ID:                types.StringValue(catalogType.Id),
+		Entries:           modelEntries,
+		ManagedAttributes: plan.ManagedAttributes,
 	}
 }
 
@@ -392,15 +410,15 @@ func (m IncidentCatalogEntriesResourceModel) buildPayloads(ctx context.Context) 
 	return payloads
 }
 
-func (r *IncidentCatalogEntriesResource) getEntries(ctx context.Context, catalogTypeID string) (catalogType *client.CatalogTypeV2, entries []client.CatalogEntryV2, err error) {
+func (r *IncidentCatalogEntriesResource) getEntries(ctx context.Context, catalogTypeID string) (catalogType *client.CatalogTypeV3, entries []client.CatalogEntryV3, err error) {
 	var (
 		after *string
 	)
 
 	for {
-		result, err := r.client.CatalogV2ListEntriesWithResponse(ctx, &client.CatalogV2ListEntriesParams{
+		result, err := r.client.CatalogV3ListEntriesWithResponse(ctx, &client.CatalogV3ListEntriesParams{
 			CatalogTypeId: catalogTypeID,
-			PageSize:      lo.ToPtr(int64(250)),
+			PageSize:      250,
 			After:         after,
 		})
 		if err == nil && result.StatusCode() >= 400 {
@@ -433,14 +451,14 @@ func (r *IncidentCatalogEntriesResource) getEntries(ctx context.Context, catalog
 // house before starting over fresh.
 //
 // This is how we create, update and destroy this terraform resource.
-func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *IncidentCatalogEntriesResourceModel) (*client.CatalogTypeV2, []client.CatalogEntryV2, error) {
+func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *IncidentCatalogEntriesResourceModel) (*client.CatalogTypeV3, []client.CatalogEntryV3, error) {
 	_, entries, err := r.getEntries(ctx, data.ID.ValueString())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "listing entries")
 	}
 
 	{
-		toDelete := []client.CatalogEntryV2{}
+		toDelete := []client.CatalogEntryV3{}
 	eachEntry:
 		for _, entry := range entries {
 			if entry.ExternalId != nil {
@@ -465,7 +483,7 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 				entry = entry // avoid shadow loop variable
 			)
 			g.Go(func() error {
-				result, err := r.client.CatalogV2DestroyEntryWithResponse(ctx, entry.Id)
+				result, err := r.client.CatalogV3DestroyEntryWithResponse(ctx, entry.Id)
 				if err == nil && result.StatusCode() >= 400 {
 					err = fmt.Errorf(string(result.Body))
 				}
@@ -487,7 +505,7 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 	// We only care about entries with an external ID, as we should have deleted all that
 	// didn't have one above. We also want this lookup to be fast to help when the entry
 	// list is very long.
-	entriesByExternalID := map[string]*client.CatalogEntryV2{}
+	entriesByExternalID := map[string]*client.CatalogEntryV3{}
 	for _, entry := range entries {
 		if entry.ExternalId == nil {
 			continue
@@ -506,7 +524,7 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 			var (
 				payload      = payload              // alias this for concurrent loop
 				shouldUpdate bool                   // mark this if we think we should update things
-				entry        *client.CatalogEntryV2 // existing entry
+				entry        *client.CatalogEntryV3 // existing entry
 			)
 
 			entry, alreadyExists := entriesByExternalID[*payload.Payload.ExternalId]
@@ -519,26 +537,29 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 							reflect.DeepEqual(payload.Payload.Aliases, entry.Aliases) &&
 							(payload.Payload.Rank == nil || (*payload.Payload.Rank == entry.Rank))
 
-					currentBindings := map[string]client.EngineParamBindingPayloadV2{}
 					for attributeID, value := range entry.AttributeValues {
-						current := client.EngineParamBindingPayloadV2{}
+						current := client.CatalogEngineParamBindingPayloadV3{}
 						if value.ArrayValue != nil {
-							current.ArrayValue = lo.ToPtr(lo.Map(*value.ArrayValue, func(binding client.CatalogEntryEngineParamBindingValueV2, _ int) client.EngineParamBindingValuePayloadV2 {
-								return client.EngineParamBindingValuePayloadV2{
+							current.ArrayValue = lo.ToPtr(lo.Map(*value.ArrayValue, func(binding client.CatalogEntryEngineParamBindingValueV3, _ int) client.CatalogEngineParamBindingValuePayloadV3 {
+								return client.CatalogEngineParamBindingValuePayloadV3{
 									Literal: binding.Literal,
 								}
 							}))
 						}
 						if value.Value != nil {
-							current.Value = &client.EngineParamBindingValuePayloadV2{
+							current.Value = &client.CatalogEngineParamBindingValuePayloadV3{
 								Literal: value.Value.Literal,
 							}
 						}
 
-						currentBindings[attributeID] = current
+						if data.isAttributeManaged(attributeID) && !reflect.DeepEqual(payload.Payload.AttributeValues[attributeID], current) {
+							tflog.Debug(ctx, fmt.Sprintf("catalog entry with id=%s has changed, scheduling for update", entry.Id))
+							isSame = false
+						}
+
 					}
 
-					if isSame && reflect.DeepEqual(payload.Payload.AttributeValues, currentBindings) {
+					if isSame {
 						tflog.Debug(ctx, fmt.Sprintf("catalog entry with id=%s has not changed, not updating", entry.Id))
 						continue eachPayload
 					} else {
@@ -551,11 +572,12 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 			g.Go(func() error {
 				if shouldUpdate {
 					result, err := r.client.CatalogV3UpdateEntryWithResponse(ctx, entry.Id, client.CatalogUpdateEntryPayloadV3{
-						Name:            payload.Payload.Name,
-						ExternalId:      payload.Payload.ExternalId,
-						Rank:            payload.Payload.Rank,
-						Aliases:         payload.Payload.Aliases,
-						AttributeValues: payload.Payload.AttributeValues,
+						Name:             payload.Payload.Name,
+						ExternalId:       payload.Payload.ExternalId,
+						Rank:             payload.Payload.Rank,
+						Aliases:          payload.Payload.Aliases,
+						AttributeValues:  payload.Payload.AttributeValues,
+						UpdateAttributes: data.buildUpdateAttributes(),
 					})
 					if err == nil && result.StatusCode() >= 400 {
 						err = fmt.Errorf(string(result.Body))
@@ -599,4 +621,53 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 	}
 
 	return catalogType, entries, nil
+}
+
+// isAttributeManaged checks if the given attribute should be managed by this resource.
+func (m *IncidentCatalogEntriesResourceModel) isAttributeManaged(attributeID string) bool {
+	if m.ManagedAttributes.IsNull() || m.ManagedAttributes.IsUnknown() {
+		return true
+	}
+
+	// Check if the attribute is in the managed list
+	return m.managedAttributesSet()[attributeID]
+}
+
+func (m *IncidentCatalogEntriesResourceModel) managedAttributesSet() map[string]bool {
+	if m.ManagedAttributes.IsNull() || m.ManagedAttributes.IsUnknown() {
+		return nil
+	}
+
+	if m.managedAttrSet != nil {
+		return m.managedAttrSet
+	}
+
+	var managedAttributeIDs []string
+	diags := m.ManagedAttributes.ElementsAs(context.Background(), &managedAttributeIDs, false)
+	if diags.HasError() {
+		panic(diags.Errors())
+	}
+
+	managedAttrSet := map[string]bool{}
+	for _, id := range managedAttributeIDs {
+		managedAttrSet[id] = true
+	}
+	// Technically this isn't race-safe, since multiple goroutines _could_ try to set this at once.
+	// However, it's a static value that will be the same however it's built, so not worried about this right now.
+	m.managedAttrSet = managedAttrSet
+	return managedAttrSet
+}
+
+func (m *IncidentCatalogEntriesResourceModel) buildUpdateAttributes() *[]string {
+	if m.ManagedAttributes.IsNull() || m.ManagedAttributes.IsUnknown() {
+		return nil
+	}
+
+	var managedAttributeIDs []string
+	diags := m.ManagedAttributes.ElementsAs(context.Background(), &managedAttributeIDs, false)
+	if diags.HasError() {
+		panic(diags.Errors())
+	}
+
+	return &managedAttributeIDs
 }

--- a/internal/provider/incident_catalog_entries_resource_test.go
+++ b/internal/provider/incident_catalog_entries_resource_test.go
@@ -73,6 +73,8 @@ var catalogEntriesTemplate = template.Must(template.New("incident_catalog_entrie
 resource "incident_catalog_type" "example" {
   name        = "Catalog Entry Acceptance Test ({{ .ID }})"
   description = "Used in terraform acceptance tests for incident_catalog_entry"
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
 }
 
 resource "incident_catalog_type_attribute" "example_description" {

--- a/internal/provider/incident_catalog_entries_resource_test.go
+++ b/internal/provider/incident_catalog_entries_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 	"text/template"
 
@@ -70,6 +71,48 @@ func TestAccIncidentCatalogEntriesResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"incident_catalog_entries.example", "entries.two.name", "Three"),
 				),
+			},
+		},
+	})
+}
+
+func TestIncidentCatalogEntriesResource_ValidateConfig(t *testing.T) {
+	description := "desc-123"
+	priority := "priority-456"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Test validation error when attribute isn't in managed_attributes
+			{
+				Config: fmt.Sprintf(`
+resource "incident_catalog_entries" "test" {
+  id = "catalog-type-id-123"
+
+  # Only manage the description attribute
+  managed_attributes = ["%s"]
+
+  entries = {
+    "test-entry" = {
+      name = "Test Entry"
+
+      attribute_values = {
+        # This is managed, should be fine
+        "%s" = {
+          value = "A description"
+        }
+        # This is not managed, should cause an error
+        "%s" = {
+          value = "High"
+        }
+      }
+    }
+  }
+}
+`, description, description, priority),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`not in the managed_attributes set`),
 			},
 		},
 	})

--- a/internal/provider/incident_catalog_entries_resource_test.go
+++ b/internal/provider/incident_catalog_entries_resource_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 	"text/template"
 
@@ -71,48 +70,6 @@ func TestAccIncidentCatalogEntriesResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"incident_catalog_entries.example", "entries.two.name", "Three"),
 				),
-			},
-		},
-	})
-}
-
-func TestIncidentCatalogEntriesResource_ValidateConfig(t *testing.T) {
-	description := "desc-123"
-	priority := "priority-456"
-
-	resource.Test(t, resource.TestCase{
-		IsUnitTest:               true,
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Test validation error when attribute isn't in managed_attributes
-			{
-				Config: fmt.Sprintf(`
-resource "incident_catalog_entries" "test" {
-  id = "catalog-type-id-123"
-
-  # Only manage the description attribute
-  managed_attributes = ["%s"]
-
-  entries = {
-    "test-entry" = {
-      name = "Test Entry"
-
-      attribute_values = {
-        # This is managed, should be fine
-        "%s" = {
-          value = "A description"
-        }
-        # This is not managed, should cause an error
-        "%s" = {
-          value = "High"
-        }
-      }
-    }
-  }
-}
-`, description, description, priority),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`not in the managed_attributes set`),
 			},
 		},
 	})
@@ -314,7 +271,7 @@ resource "incident_catalog_entries" "example" {
         }
         {{ if not $.ManagedAttributes }}
         (incident_catalog_type_attribute.example_bool.id) = {
-          value = {{ .UsefulValue }}
+          value = {{ quote .UsefulValue }}
         }
         {{ end }}
       }

--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -348,8 +348,12 @@ func (r *IncidentCatalogEntryResource) ValidateConfig(ctx context.Context, req r
 			continue
 		}
 
-		attrID := attrIDElem.(types.String).ValueString()
-		managedAttributesMap[attrID] = true
+		attrIDStr, ok := attrIDElem.(types.String)
+		if !ok {
+			continue
+		}
+
+		managedAttributesMap[attrIDStr.ValueString()] = true
 	}
 
 	// Check that each attribute in attribute_values is managed

--- a/internal/provider/incident_catalog_entry_resource_test.go
+++ b/internal/provider/incident_catalog_entry_resource_test.go
@@ -79,45 +79,6 @@ func TestAccIncidentCatalogEntryResourceWithAlias(t *testing.T) {
 	})
 }
 
-func TestIncidentCatalogEntryResource_ValidateConfig(t *testing.T) {
-	description := "desc-123"
-	priority := "priority-456"
-
-	resource.Test(t, resource.TestCase{
-		IsUnitTest:               true,
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Test validation error when attribute isn't in managed_attributes
-			{
-				Config: fmt.Sprintf(`
-resource "incident_catalog_entry" "test" {
-  catalog_type_id = "catalog-type-id-123"
-  name = "Test Entry"
-
-  # Only manage the description attribute
-  managed_attributes = ["%s"]
-
-  attribute_values = [
-    {
-      # This is managed, should be fine
-      attribute = "%s"
-      value = "A description"
-    },
-    {
-      # This is not managed, should cause an error
-      attribute = "%s"
-      value = "High"
-    }
-  ]
-}
-`, description, description, priority),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`specified in attribute_values`),
-			},
-		},
-	})
-}
-
 func TestAccIncidentCatalogEntryResourceWithManagedAttributes(t *testing.T) {
 	// Use a stable ID across steps - we want to edit the same one over and over
 	testEntryID := uuid.NewString()
@@ -204,6 +165,9 @@ func TestAccIncidentCatalogEntryResourceWithManagedAttributes(t *testing.T) {
 		}
 	}
 
+	conf := testAccIncidentCatalogEntryResourceConfigWithID(testEntryID, "Partial Update", "Updated description only", []string{}, true)
+
+	_ = conf
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -233,6 +197,45 @@ func TestAccIncidentCatalogEntryResourceWithManagedAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr("incident_catalog_entry.example", "name", "Another Update"),
 					checkUsefulIsTrue("Another description change"),
 				),
+			},
+		},
+	})
+}
+
+func TestIncidentCatalogEntryResource_ValidateConfig(t *testing.T) {
+	description := "desc-123"
+	priority := "priority-456"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Test validation error when attribute isn't in managed_attributes
+			{
+				Config: fmt.Sprintf(`
+resource "incident_catalog_entry" "test" {
+  catalog_type_id = "catalog-type-id-123"
+  name = "Test Entry"
+
+  # Only manage the description attribute
+  managed_attributes = ["%s"]
+
+  attribute_values = [
+    {
+      # This is managed, should be fine
+      attribute = "%s"
+      value = "A description"
+    },
+    {
+      # This is not managed, should cause an error
+      attribute = "%s"
+      value = "High"
+    }
+  ]
+}
+`, description, description, priority),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`specified in attribute_values`),
 			},
 		},
 	})

--- a/internal/provider/incident_catalog_entry_resource_test.go
+++ b/internal/provider/incident_catalog_entry_resource_test.go
@@ -24,7 +24,7 @@ func TestAccIncidentCatalogEntryResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and read
 			{
-				Config: testAccIncidentCatalogEntryResourceConfig("One", "This is the first entry", []string{}, false),
+				Config: testAccIncidentCatalogEntryResourceConfig("One", "This is the first entry", []string{}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"incident_catalog_entry.example", "name", "One"),
@@ -38,7 +38,7 @@ func TestAccIncidentCatalogEntryResource(t *testing.T) {
 			},
 			// Update and read
 			{
-				Config: testAccIncidentCatalogEntryResourceConfig("Two", "This is the second entry", []string{}, false),
+				Config: testAccIncidentCatalogEntryResourceConfig("Two", "This is the second entry", []string{}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"incident_catalog_entry.example", "name", "Two"),
@@ -55,7 +55,7 @@ func TestAccIncidentCatalogEntryResourceWithAlias(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and read
 			{
-				Config: testAccIncidentCatalogEntryResourceConfig("One", "This is the first entry", []string{"one"}, false),
+				Config: testAccIncidentCatalogEntryResourceConfig("One", "This is the first entry", []string{"one"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"incident_catalog_entry.example", "name", "One"),
@@ -69,7 +69,7 @@ func TestAccIncidentCatalogEntryResourceWithAlias(t *testing.T) {
 			},
 			// Update and read
 			{
-				Config: testAccIncidentCatalogEntryResourceConfig("Two", "This is the second entry", []string{"two"}, false),
+				Config: testAccIncidentCatalogEntryResourceConfig("Two", "This is the second entry", []string{"two"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"incident_catalog_entry.example", "name", "Two"),
@@ -306,6 +306,6 @@ func testAccIncidentCatalogEntryResourceConfigWithID(id, name, description strin
 	return buf.String()
 }
 
-func testAccIncidentCatalogEntryResourceConfig(name, description string, aliases []string, onlyManageDescription bool) string {
-	return testAccIncidentCatalogEntryResourceConfigWithID(uuid.NewString(), name, description, aliases, onlyManageDescription)
+func testAccIncidentCatalogEntryResourceConfig(name, description string, aliases []string) string {
+	return testAccIncidentCatalogEntryResourceConfigWithID(uuid.NewString(), name, description, aliases, false)
 }

--- a/internal/provider/incident_catalog_entry_resource_test.go
+++ b/internal/provider/incident_catalog_entry_resource_test.go
@@ -76,6 +76,8 @@ var catalogEntryTemplate = template.Must(template.New("incident_catalog_entry").
 resource "incident_catalog_type" "example" {
   name        = "Catalog Entry Acceptance Test ({{ .ID }})"
   description = "Used in terraform acceptance tests for incident_catalog_entry"
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
 }
 
 resource "incident_catalog_type_attribute" "example_description" {

--- a/internal/provider/incident_catalog_type_attribute_resource.go
+++ b/internal/provider/incident_catalog_type_attribute_resource.go
@@ -151,9 +151,11 @@ func (r *IncidentCatalogTypeAttributeResource) Schema(ctx context.Context, req r
 				Optional: true,
 			},
 			"schema_only": schema.BoolAttribute{
-				Description: "If true, Terraform will only manage the schema of the attribute. Values for this attribute can be managed from the incident.io web dashboard.",
-				Optional:    true,
-				Computed:    true,
+				Description: `If true, Terraform will only manage the schema of the attribute. Values for this attribute can be managed from the incident.io web dashboard.
+
+NOTE: When enabled, you should use the ` + "`managed_attributes`" + ` argument on either ` + "`incident_catalog_entry`" + ` or ` + "`incident_catalog_entries`" + ` to manage the values of other attributes on this type, without Terraform overwriting values set in the dashboard.`,
+				Optional: true,
+				Computed: true,
 			},
 		},
 	}

--- a/internal/provider/incident_catalog_type_attribute_resource_test.go
+++ b/internal/provider/incident_catalog_type_attribute_resource_test.go
@@ -55,6 +55,8 @@ var catalogTypeAttributeTemplate = template.Must(template.New("incident_catalog_
 resource "incident_catalog_type" "example" {
   name        = "Example ({{ .ID }})"
   description = "Used in terraform acceptance tests"
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
 }
 
 resource "incident_catalog_type_attribute" "example" {

--- a/internal/provider/incident_catalog_type_attribute_resource_test.go
+++ b/internal/provider/incident_catalog_type_attribute_resource_test.go
@@ -47,6 +47,22 @@ func TestAccIncidentCatalogTypeAttributeResource(t *testing.T) {
 						"incident_catalog_type_attribute.example", "array", "true"),
 				),
 			},
+			// Schema-only
+			{
+				Config: testAccIncidentCatalogTypeAttributeResourceConfig(client.CatalogTypeAttributeV2{
+					Name: "Description",
+					Type: "String",
+					Mode: "dashboard",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_catalog_type_attribute.example", "name", "Description"),
+					resource.TestCheckResourceAttr(
+						"incident_catalog_type_attribute.example", "type", "String"),
+					resource.TestCheckResourceAttr(
+						"incident_catalog_type_attribute.example", "schema_only", "true"),
+				),
+			},
 		},
 	})
 }
@@ -66,6 +82,9 @@ resource "incident_catalog_type_attribute" "example" {
   type = {{ quote .Attribute.Type }}
   {{ if .Attribute.Array }}
   array = true
+  {{ end }}
+  {{ if eq .Attribute.Mode "dashboard" }}
+  schema_only = true
   {{ end }}
 }
 `))

--- a/internal/provider/incident_catalog_type_data_source.go
+++ b/internal/provider/incident_catalog_type_data_source.go
@@ -31,21 +31,21 @@ func (i *IncidentCatalogTypeDataSource) Schema(ctx context.Context, req datasour
 		MarkdownDescription: "This data source provides information about a catalog type.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "id"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "id"),
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "name"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "name"),
 				Optional:            true,
 				Computed:            true,
 			},
 			"type_name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "type_name"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "type_name"),
 				Optional:            true,
 				Computed:            true,
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "description"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "description"),
 				Computed:            true,
 			},
 			"categories": schema.ListAttribute{
@@ -90,7 +90,7 @@ func (i *IncidentCatalogTypeDataSource) Read(ctx context.Context, req datasource
 		return
 	}
 
-	result, err := i.client.CatalogV2ListTypesWithResponse(ctx)
+	result, err := i.client.CatalogV3ListTypesWithResponse(ctx)
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))
 	}
@@ -106,17 +106,17 @@ func (i *IncidentCatalogTypeDataSource) Read(ctx context.Context, req datasource
 
 	catalogTypes := result.JSON200.CatalogTypes
 	if !data.Name.IsNull() {
-		catalogTypes = lo.Filter(catalogTypes, func(ct client.CatalogTypeV2, _ int) bool {
+		catalogTypes = lo.Filter(catalogTypes, func(ct client.CatalogTypeV3, _ int) bool {
 			return ct.Name == data.Name.ValueString()
 		})
 	}
 	if !data.TypeName.IsNull() {
-		catalogTypes = lo.Filter(catalogTypes, func(ct client.CatalogTypeV2, _ int) bool {
+		catalogTypes = lo.Filter(catalogTypes, func(ct client.CatalogTypeV3, _ int) bool {
 			return ct.TypeName == data.TypeName.ValueString()
 		})
 	}
 
-	var catalogType *client.CatalogTypeV2
+	var catalogType *client.CatalogTypeV3
 	if len(catalogTypes) > 0 {
 		catalogType = lo.ToPtr(catalogTypes[0])
 	}

--- a/internal/provider/incident_catalog_type_data_source_test.go
+++ b/internal/provider/incident_catalog_type_data_source_test.go
@@ -42,6 +42,8 @@ resource "incident_catalog_type" "example" {
   name        = {{ quote .ResourceName }}
   type_name    = {{ quote .ResourceTypeName }}
   description = {{ quote .ResourceDescription }}
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
 }
 data "incident_catalog_type" "by_name" {
   name = incident_catalog_type.example.name

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -90,7 +90,7 @@ func (r *IncidentCatalogTypeResource) Schema(ctx context.Context, req resource.S
 			},
 			"source_repo_url": schema.StringAttribute{
 				MarkdownDescription: "The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.",
-				Optional:            true,
+				Required:            true,
 			},
 		},
 	}

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -48,7 +48,7 @@ func (r *IncidentCatalogTypeResource) Metadata(ctx context.Context, req resource
 func (r IncidentCatalogTypeResource) CategoryDescription() string {
 	// Make a category description where we list all the possible values of categories
 	categories := []string{}
-	for _, category := range apischema.Property("CatalogTypeV2", "categories").Value.Items.Value.Enum {
+	for _, category := range apischema.Property("CatalogTypeV3", "categories").Value.Items.Value.Enum {
 		categoryAsString, _ := category.(string)
 		categories = append(categories, "`"+categoryAsString+"`")
 	}
@@ -58,29 +58,29 @@ func (r IncidentCatalogTypeResource) CategoryDescription() string {
 
 func (r *IncidentCatalogTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: apischema.TagDocstring("Catalog V2"),
+		MarkdownDescription: apischema.TagDocstring("Catalog V3"),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "id"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "id"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "name"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "name"),
 				Required:            true,
 			},
 			"type_name": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true, // If not provided, we'll use the generated ID
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "type_name"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "type_name"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("CatalogTypeV2", "description"),
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "description"),
 				Required:            true,
 			},
 			"categories": schema.ListAttribute{
@@ -122,7 +122,7 @@ func (r *IncidentCatalogTypeResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	requestBody := client.CreateTypeRequestBody{
+	requestBody := client.CatalogCreateTypePayloadV3{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
 		Annotations: &map[string]string{
@@ -136,14 +136,14 @@ func (r *IncidentCatalogTypeResource) Create(ctx context.Context, req resource.C
 		requestBody.SourceRepoUrl = &sourceRepoURL
 	}
 
-	categories := []client.CreateTypeRequestBodyCategories{}
+	categories := []client.CatalogCreateTypePayloadV3Categories{}
 	for _, category := range data.Categories {
 		categories = append(categories,
-			client.CreateTypeRequestBodyCategories(category.ValueString()))
+			client.CatalogCreateTypePayloadV3Categories(category.ValueString()))
 	}
 	requestBody.Categories = lo.ToPtr(categories)
 
-	result, err := r.client.CatalogV2CreateTypeWithResponse(ctx, requestBody)
+	result, err := r.client.CatalogV3CreateTypeWithResponse(ctx, requestBody)
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))
 	}
@@ -164,7 +164,7 @@ func (r *IncidentCatalogTypeResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	result, err := r.client.CatalogV2ShowTypeWithResponse(ctx, data.ID.ValueString())
+	result, err := r.client.CatalogV3ShowTypeWithResponse(ctx, data.ID.ValueString())
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))
 	}
@@ -184,7 +184,7 @@ func (r *IncidentCatalogTypeResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	requestBody := client.CatalogV2UpdateTypeJSONRequestBody{
+	requestBody := client.CatalogV3UpdateTypeJSONRequestBody{
 		Name: data.Name.ValueString(),
 		// TypeName cannot be changed once set
 		Description: data.Description.ValueString(),
@@ -197,14 +197,14 @@ func (r *IncidentCatalogTypeResource) Update(ctx context.Context, req resource.U
 		requestBody.SourceRepoUrl = &sourceRepoURL
 	}
 
-	categories := []client.UpdateTypeRequestBodyCategories{}
+	categories := []client.CatalogUpdateTypePayloadV3Categories{}
 	for _, category := range data.Categories {
 		categories = append(categories,
-			client.UpdateTypeRequestBodyCategories(category.ValueString()))
+			client.CatalogUpdateTypePayloadV3Categories(category.ValueString()))
 	}
 	requestBody.Categories = lo.ToPtr(categories)
 
-	result, err := r.client.CatalogV2UpdateTypeWithResponse(ctx, data.ID.ValueString(), requestBody)
+	result, err := r.client.CatalogV3UpdateTypeWithResponse(ctx, data.ID.ValueString(), requestBody)
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))
 	}
@@ -224,7 +224,7 @@ func (r *IncidentCatalogTypeResource) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	_, err := r.client.CatalogV2DestroyTypeWithResponse(ctx, data.ID.ValueString())
+	_, err := r.client.CatalogV3DestroyTypeWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete catalog type, got error: %s", err))
 		return
@@ -235,7 +235,7 @@ func (r *IncidentCatalogTypeResource) ImportState(ctx context.Context, req resou
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *IncidentCatalogTypeResource) buildModel(catalogType client.CatalogTypeV2) *IncidentCatalogTypeResourceModel {
+func (r *IncidentCatalogTypeResource) buildModel(catalogType client.CatalogTypeV3) *IncidentCatalogTypeResourceModel {
 	model := &IncidentCatalogTypeResourceModel{
 		ID:          types.StringValue(catalogType.Id),
 		Name:        types.StringValue(catalogType.Name),

--- a/internal/provider/incident_catalog_type_resource_test.go
+++ b/internal/provider/incident_catalog_type_resource_test.go
@@ -108,6 +108,8 @@ resource "incident_catalog_type" "example" {
   name        = {{ quote .Name }}
   {{ if ne .TypeName "" }}type_name   = {{ quote .TypeName }}{{ end }}
   description = {{ quote .Description }}
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
 }
 `))
 

--- a/internal/provider/incident_custom_field_resource_test.go
+++ b/internal/provider/incident_custom_field_resource_test.go
@@ -94,6 +94,8 @@ var customFieldTemplate = template.Must(template.New("incident_custom_field").Fu
 resource "incident_catalog_type" "example" {
   name = "My type"
   description = "My type description"
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
 }
 
 resource "incident_catalog_type_attribute" "example_string_attr" {
@@ -105,6 +107,8 @@ resource "incident_catalog_type_attribute" "example_string_attr" {
 resource "incident_catalog_type" "other" {
   name = "My other type"
   description = "My other type description"
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
 }
 
 resource "incident_catalog_type_attribute" "example_catalog_attr" {

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -332,7 +332,7 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 		return
 	}
 
-	claimResource(ctx, r.client, result.JSON201.EscalationPath.Id, resp.Diagnostics, client.ManagedResourceV2ResourceTypeEscalationPath, r.terraformVersion)
+	claimResource(ctx, r.client, result.JSON201.EscalationPath.Id, resp.Diagnostics, client.EscalationPath, r.terraformVersion)
 
 	tflog.Trace(ctx, fmt.Sprintf("created an escalation path resource with id=%s", result.JSON201.EscalationPath.Id))
 	data = r.buildModel(result.JSON201.EscalationPath)
@@ -395,7 +395,7 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 		return
 	}
 
-	claimResource(ctx, r.client, result.JSON200.EscalationPath.Id, resp.Diagnostics, client.ManagedResourceV2ResourceTypeEscalationPath, r.terraformVersion)
+	claimResource(ctx, r.client, result.JSON200.EscalationPath.Id, resp.Diagnostics, client.EscalationPath, r.terraformVersion)
 
 	data = r.buildModel(result.JSON200.EscalationPath)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -416,7 +416,7 @@ func (r *IncidentEscalationPathResource) Delete(ctx context.Context, req resourc
 }
 
 func (r *IncidentEscalationPathResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.ManagedResourceV2ResourceTypeEscalationPath, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.EscalationPath, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -314,7 +314,7 @@ func (r *IncidentScheduleResource) Delete(ctx context.Context, req resource.Dele
 }
 
 func (r *IncidentScheduleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.ManagedResourceV2ResourceTypeSchedule, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.Schedule, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -73,26 +73,26 @@ func (r *IncidentWorkflowResource) Schema(ctx context.Context, req resource.Sche
 We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this [Loom](https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448).`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "id"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "id"),
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "name"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "name"),
 				Required:            true,
 			},
 			"folder": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "folder"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "folder"),
 				Optional:            true,
 			},
 			"shortform": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "shortform"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "shortform"),
 				Optional:            true,
 			},
 			"trigger": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("TriggerSlim", "name"),
+				MarkdownDescription: apischema.Docstring("TriggerSlimV2", "name"),
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -100,7 +100,7 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 			},
 			"condition_groups": models.ConditionGroupsAttribute(),
 			"steps": schema.ListNestedAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "steps"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "steps"),
 				Required:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -119,16 +119,16 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 			},
 			"expressions": models.ExpressionsAttribute(),
 			"once_for": schema.ListAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "once_for"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "once_for"),
 				Required:            true,
 				ElementType:         types.StringType,
 			},
 			"include_private_incidents": schema.BoolAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "include_private_incidents"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "include_private_incidents"),
 				Required:            true,
 			},
 			"continue_on_step_error": schema.BoolAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "continue_on_step_error"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "continue_on_step_error"),
 				Required:            true,
 			},
 			"delay": schema.SingleNestedAttribute{
@@ -136,17 +136,17 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"conditions_apply_over_delay": schema.BoolAttribute{
-						MarkdownDescription: apischema.Docstring("WorkflowDelay", "conditions_apply_over_delay"),
+						MarkdownDescription: apischema.Docstring("WorkflowDelayV2", "conditions_apply_over_delay"),
 						Required:            true,
 					},
 					"for_seconds": schema.Int64Attribute{
-						MarkdownDescription: apischema.Docstring("WorkflowDelay", "for_seconds"),
+						MarkdownDescription: apischema.Docstring("WorkflowDelayV2", "for_seconds"),
 						Required:            true,
 					},
 				},
 			},
 			"runs_on_incidents": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "runs_on_incidents"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "runs_on_incidents"),
 				Required:            true,
 			},
 			"runs_on_incident_modes": schema.ListAttribute{
@@ -155,7 +155,7 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 				ElementType:         types.StringType,
 			},
 			"state": schema.StringAttribute{
-				MarkdownDescription: apischema.Docstring("Workflow", "state"),
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "state"),
 				Required:            true,
 			},
 		},
@@ -174,32 +174,32 @@ func (r *IncidentWorkflowResource) Create(ctx context.Context, req resource.Crea
 		onceFor = append(onceFor, v.ValueString())
 	}
 
-	runsOnIncidentModes := []client.CreateWorkflowPayloadRunsOnIncidentModes{}
+	runsOnIncidentModes := []client.WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes{}
 	for _, v := range data.RunsOnIncidentModes {
-		runsOnIncidentModes = append(runsOnIncidentModes, client.CreateWorkflowPayloadRunsOnIncidentModes(v.ValueString()))
+		runsOnIncidentModes = append(runsOnIncidentModes, client.WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes(v.ValueString()))
 	}
 
-	payload := client.CreateWorkflowPayload{
+	payload := client.WorkflowsCreateWorkflowPayloadV2{
 		Trigger:                 data.Trigger.ValueString(),
 		Name:                    data.Name.ValueString(),
 		OnceFor:                 onceFor,
 		ConditionGroups:         data.ConditionGroups.ToPayload(),
 		Steps:                   toPayloadSteps(data.Steps),
 		Expressions:             data.Expressions.ToPayload(),
-		RunsOnIncidents:         client.CreateWorkflowPayloadRunsOnIncidents(data.RunsOnIncidents.ValueString()),
+		RunsOnIncidents:         client.WorkflowsCreateWorkflowPayloadV2RunsOnIncidents(data.RunsOnIncidents.ValueString()),
 		RunsOnIncidentModes:     runsOnIncidentModes,
 		Folder:                  data.Folder.ValueStringPointer(),
 		Shortform:               data.Shortform.ValueStringPointer(),
 		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
 		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
-		State:                   lo.ToPtr(client.CreateWorkflowPayloadState(data.State.ValueString())),
+		State:                   lo.ToPtr(client.WorkflowsCreateWorkflowPayloadV2State(data.State.ValueString())),
 		Annotations: &map[string]string{
 			"incident.io/terraform/version": r.terraformVersion,
 		},
 	}
 
 	if data.Delay != nil {
-		payload.Delay = &client.WorkflowDelay{
+		payload.Delay = &client.WorkflowDelayV2{
 			ConditionsApplyOverDelay: data.Delay.ConditionsApplyOverDelay.ValueBool(),
 			ForSeconds:               data.Delay.ForSeconds.ValueInt64(),
 		}
@@ -237,9 +237,9 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		onceFor = append(onceFor, v.ValueString())
 	}
 
-	runsOnIncidentModes := []client.UpdateWorkflowPayload2RunsOnIncidentModes{}
+	runsOnIncidentModes := []client.WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes{}
 	for _, v := range data.RunsOnIncidentModes {
-		runsOnIncidentModes = append(runsOnIncidentModes, client.UpdateWorkflowPayload2RunsOnIncidentModes(v.ValueString()))
+		runsOnIncidentModes = append(runsOnIncidentModes, client.WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes(v.ValueString()))
 	}
 
 	payload := client.WorkflowsV2UpdateWorkflowJSONRequestBody{
@@ -248,20 +248,20 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		Steps:                   toPayloadSteps(data.Steps),
 		Expressions:             data.Expressions.ToPayload(),
 		OnceFor:                 onceFor,
-		RunsOnIncidents:         client.UpdateWorkflowPayload2RunsOnIncidents(data.RunsOnIncidents.ValueString()),
+		RunsOnIncidents:         client.WorkflowsUpdateWorkflowPayloadV2RunsOnIncidents(data.RunsOnIncidents.ValueString()),
 		RunsOnIncidentModes:     runsOnIncidentModes,
 		Folder:                  data.Folder.ValueStringPointer(),
 		Shortform:               data.Shortform.ValueStringPointer(),
 		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
 		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
-		State:                   lo.ToPtr(client.UpdateWorkflowPayload2State(data.State.ValueString())),
+		State:                   lo.ToPtr(client.WorkflowsUpdateWorkflowPayloadV2State(data.State.ValueString())),
 		Annotations: &map[string]string{
 			"incident.io/terraform/version": r.terraformVersion,
 		},
 	}
 
 	if data.Delay != nil {
-		payload.Delay = &client.WorkflowDelay{
+		payload.Delay = &client.WorkflowDelayV2{
 			ConditionsApplyOverDelay: data.Delay.ConditionsApplyOverDelay.ValueBool(),
 			ForSeconds:               data.Delay.ForSeconds.ValueInt64(),
 		}
@@ -315,7 +315,7 @@ func (r *IncidentWorkflowResource) Delete(ctx context.Context, req resource.Dele
 }
 
 func (r *IncidentWorkflowResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.ManagedResourceV2ResourceTypeWorkflow, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.Workflow, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
@@ -338,11 +338,11 @@ func (r *IncidentWorkflowResource) Configure(ctx context.Context, req resource.C
 	r.terraformVersion = client.TerraformVersion
 }
 
-func toPayloadSteps(steps []IncidentWorkflowStep) []client.StepConfigPayload {
-	out := []client.StepConfigPayload{}
+func toPayloadSteps(steps []IncidentWorkflowStep) []client.StepConfigPayloadV2 {
+	out := []client.StepConfigPayloadV2{}
 
 	for _, step := range steps {
-		out = append(out, client.StepConfigPayload{
+		out = append(out, client.StepConfigPayloadV2{
 			ForEach:       step.ForEach.ValueStringPointer(),
 			Id:            step.ID.ValueString(),
 			Name:          step.Name.ValueString(),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
 
 var testRunID = uuid.NewString()
@@ -23,5 +25,18 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 func testAccPreCheck(t *testing.T) {
 	if os.Getenv("INCIDENT_API_KEY") == "" {
 		t.Skip("No INCIDENT_API_KEY environment variable set, skipping")
+	} else {
+		apiKey := os.Getenv("INCIDENT_API_KEY")
+		endpoint := os.Getenv("INCIDENT_ENDPOINT")
+		if endpoint == "" {
+			endpoint = "https://api.incident.io"
+		}
+		var err error
+		testClient, err = client.New(context.Background(), apiKey, endpoint, "test")
+		if err != nil {
+			t.Fatalf("Error creating client: %s", err)
+		}
 	}
 }
+
+var testClient *client.ClientWithResponses

--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -28,7 +28,7 @@ func forceCoerce[T any](input any) T {
 }
 
 // buildModel converts from the response type to the terraform model/schema type.
-func (r *IncidentWorkflowResource) buildModel(workflow client.Workflow) *IncidentWorkflowResourceModel {
+func (r *IncidentWorkflowResource) buildModel(workflow client.WorkflowV2) *IncidentWorkflowResourceModel {
 	model := &IncidentWorkflowResourceModel{
 		ID:                      types.StringValue(workflow.Id),
 		Name:                    types.StringValue(workflow.Name),
@@ -68,7 +68,7 @@ func buildOnceFor(onceFor []client.EngineReferenceV2) []basetypes.StringValue {
 	return out
 }
 
-func buildRunsOnIncidentModes(modes []client.WorkflowRunsOnIncidentModes) []basetypes.StringValue {
+func buildRunsOnIncidentModes(modes []client.WorkflowV2RunsOnIncidentModes) []basetypes.StringValue {
 	out := []basetypes.StringValue{}
 
 	for _, mode := range modes {
@@ -78,7 +78,7 @@ func buildRunsOnIncidentModes(modes []client.WorkflowRunsOnIncidentModes) []base
 	return out
 }
 
-func buildSteps(steps []client.StepConfig) []IncidentWorkflowStep {
+func buildSteps(steps []client.StepConfigV2) []IncidentWorkflowStep {
 	out := []IncidentWorkflowStep{}
 
 	for _, s := range steps {


### PR DESCRIPTION
Bunch of commits here:
- update the OpenAPIv3 schema and regen the client
- [BREAKING] Make `source_repo_url` required on `incident_catalog_type`: this means that all types managed in Terraform will get locked in the UI, and minimises the chance of state drift
- Add `schema_only` to `incident_catalog_attribute`: this allows attributes to be managed in Terraform, but leaves their _values_ to be managed in the incident.io dashboard.
- Add `managed_attributes` to `incident_catalog_entries` and `incident_catalog_entry`: this allows schema-only attributes' values to be left unchanged when `terraform apply` is run