### PR TITLE
Add support for setting team IDs on escalation paths and schedules

### DIFF
--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -116,6 +116,9 @@ resource "incident_escalation_path" "urgent_support" {
       ]
     }
   ]
+
+  # Teams that use this escalation path
+  team_ids = ["01FCNDV6P870EA6S7TK1DSYD00", "01FCNDV6P870EA6S7TK1DSYD01"]
 }
 ```
 
@@ -129,6 +132,7 @@ resource "incident_escalation_path" "urgent_support" {
 
 ### Optional
 
+- `team_ids` (Set of String) IDs of teams that own this schedule
 - `working_hours` (Attributes List) The working hours for this escalation path. (see [below for nested schema](#nestedatt--working_hours))
 
 ### Read-Only

--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -126,6 +126,7 @@ resource "incident_schedule" "primary_on_call" {
 ### Optional
 
 - `holidays_public_config` (Attributes) (see [below for nested schema](#nestedatt--holidays_public_config))
+- `team_ids` (Set of String) IDs of teams that own this schedule
 
 ### Read-Only
 

--- a/examples/resources/incident_escalation_path/resource.tf
+++ b/examples/resources/incident_escalation_path/resource.tf
@@ -94,4 +94,7 @@ resource "incident_escalation_path" "urgent_support" {
       ]
     }
   ]
+
+  # Teams that use this escalation path
+  team_ids = ["01FCNDV6P870EA6S7TK1DSYD00", "01FCNDV6P870EA6S7TK1DSYD01"]
 }

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -49,7 +49,8 @@
           "roles",
           "created_by"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "ActionV1": {
         "example": {
@@ -446,7 +447,8 @@
             "$ref": "#/components/schemas/UserV2"
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "AfterPaginationMetaResultV2": {
         "example": {
@@ -659,7 +661,69 @@
         ],
         "type": "object"
       },
-      "AlertResult": {
+      "AlertEventsCreateHTTPPayloadV2": {
+        "example": {
+          "deduplication_key": "4293868629",
+          "description": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix...",
+          "metadata": {
+            "service": "hello.world.com",
+            "team": [
+              "my-team"
+            ]
+          },
+          "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+          "status": "firing",
+          "title": "*errors.withMessage: PG::Error failed to connect"
+        },
+        "properties": {
+          "deduplication_key": {
+            "description": "A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.",
+            "example": "4293868629",
+            "type": "string"
+          },
+          "description": {
+            "description": "Description that optionally adds more detail to title. Supports markdown.",
+            "example": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix...",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "description": "Any additional metadata that you've configured your alert source to parse",
+            "example": {
+              "service": "hello.world.com",
+              "team": [
+                "my-team"
+              ]
+            },
+            "type": "object"
+          },
+          "source_url": {
+            "description": "If applicable, a link to the alert in the upstream system",
+            "example": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current status of this alert",
+            "enum": [
+              "firing",
+              "resolved"
+            ],
+            "example": "firing",
+            "type": "string"
+          },
+          "title": {
+            "description": "Alert title which is used when summarising the alert",
+            "example": "*errors.withMessage: PG::Error failed to connect",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "status"
+        ],
+        "type": "object"
+      },
+      "AlertEventsCreateHTTPResultV2": {
         "example": {
           "deduplication_key": "unique-key",
           "message": "Event accepted for processing",
@@ -6336,676 +6400,6 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "AllResponseBody": {
-        "example": {
-          "event_type": "public_incident.incident_created_v2",
-          "private_incident.action_created_v1": {
-            "id": "abc123"
-          },
-          "private_incident.action_updated_v1": {
-            "id": "abc123"
-          },
-          "private_incident.follow_up_created_v1": {
-            "id": "abc123"
-          },
-          "private_incident.follow_up_updated_v1": {
-            "id": "abc123"
-          },
-          "private_incident.incident_created_v2": {
-            "id": "abc123"
-          },
-          "private_incident.incident_updated_v2": {
-            "id": "abc123"
-          },
-          "private_incident.membership_granted_v1": {
-            "actor_user_id": "abc123",
-            "incident_id": "abc123",
-            "user_id": "abc123"
-          },
-          "private_incident.membership_revoked_v1": {
-            "actor_user_id": "abc123",
-            "incident_id": "abc123",
-            "user_id": "abc123"
-          },
-          "public_incident.action_created_v1": {
-            "assignee": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            },
-            "completed_at": "2021-08-17T13:28:57.801578Z",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Call the fire brigade",
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "follow_up": true,
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "status": "outstanding",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          },
-          "public_incident.action_updated_v1": {
-            "assignee": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            },
-            "completed_at": "2021-08-17T13:28:57.801578Z",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Call the fire brigade",
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "follow_up": true,
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "status": "outstanding",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          },
-          "public_incident.follow_up_created_v1": {
-            "assignee": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            },
-            "completed_at": "2021-08-17T13:28:57.801578Z",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Call the fire brigade",
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "follow_up": true,
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "status": "outstanding",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          },
-          "public_incident.follow_up_updated_v1": {
-            "assignee": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            },
-            "completed_at": "2021-08-17T13:28:57.801578Z",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Call the fire brigade",
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "follow_up": true,
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "status": "outstanding",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          },
-          "public_incident.incident_created_v2": {
-            "call_url": "https://zoom.us/foo",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "creator": {
-              "api_key": {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "My test API key"
-              },
-              "user": {
-                "email": "lisa@incident.io",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Lisa Karlin Curtis",
-                "role": "viewer",
-                "slack_user_id": "U02AYNF2XJM"
-              }
-            },
-            "custom_field_entries": [
-              {
-                "custom_field": {
-                  "description": "Which team is impacted by this issue",
-                  "field_type": "single_select",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Affected Team",
-                  "options": [
-                    {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    }
-                  ]
-                },
-                "values": [
-                  {
-                    "value_catalog_entry": {
-                      "aliases": [
-                        "lawrence@incident.io",
-                        "lawrence"
-                      ],
-                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "name": "Primary On-call"
-                    },
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option": {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    },
-                    "value_text": "This is my text field, I hope you like it"
-                  }
-                ]
-              }
-            ],
-            "duration_metrics": [
-              {
-                "duration_metric": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Lasted"
-                },
-                "value_seconds": 1
-              }
-            ],
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "has_debrief": false,
-            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-            "incident_role_assignments": [
-              {
-                "assignee": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                },
-                "role": {
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "The person currently coordinating the incident",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                  "name": "Incident Lead",
-                  "required": false,
-                  "role_type": "lead",
-                  "shortform": "lead",
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_status": {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "incident_timestamp_values": [
-              {
-                "incident_timestamp": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Impact started",
-                  "rank": 1
-                },
-                "value": {
-                  "value": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_type": {
-              "create_in_triage": "always",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Customer facing production outages",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_default": false,
-              "name": "Production Outage",
-              "private_incidents_only": false,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "mode": "standard",
-            "most_recent_update_message": "We're working on a fix, hoping to ship in the next 30 minutes",
-            "name": "Our database is sad",
-            "permalink": "https://app.incident.io/incidents/123",
-            "postmortem_document_url": "https://docs.google.com/my_doc_id",
-            "reference": "INC-123",
-            "related_incidents": [
-              "INC-237"
-            ],
-            "severity": {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Issues with **low impact**.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Minor",
-              "rank": 1,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "slack_channel_id": "C02AW36C1M5",
-            "slack_channel_name": "inc-165-green-parrot",
-            "slack_team_id": "T02A1FSLE8J",
-            "summary": "Our database is really really sad, and we don't know why yet.",
-            "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public",
-            "workload_minutes_late": 40.7,
-            "workload_minutes_sleeping": 0,
-            "workload_minutes_total": 60.7,
-            "workload_minutes_working": 20
-          },
-          "public_incident.incident_status_updated_v2": {
-            "incident": {
-              "call_url": "https://zoom.us/foo",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "creator": {
-                "api_key": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "My test API key"
-                },
-                "user": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                }
-              },
-              "custom_field_entries": [
-                {
-                  "custom_field": {
-                    "description": "Which team is impacted by this issue",
-                    "field_type": "single_select",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "Affected Team",
-                    "options": [
-                      {
-                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "sort_key": 10,
-                        "value": "Product"
-                      }
-                    ]
-                  },
-                  "values": [
-                    {
-                      "value_catalog_entry": {
-                        "aliases": [
-                          "lawrence@incident.io",
-                          "lawrence"
-                        ],
-                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "name": "Primary On-call"
-                      },
-                      "value_link": "https://google.com/",
-                      "value_numeric": "123.456",
-                      "value_option": {
-                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "sort_key": 10,
-                        "value": "Product"
-                      },
-                      "value_text": "This is my text field, I hope you like it"
-                    }
-                  ]
-                }
-              ],
-              "duration_metrics": [
-                {
-                  "duration_metric": {
-                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                    "name": "Lasted"
-                  },
-                  "value_seconds": 1
-                }
-              ],
-              "external_issue_reference": {
-                "issue_name": "INC-123",
-                "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-                "provider": "asana"
-              },
-              "has_debrief": false,
-              "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-              "incident_role_assignments": [
-                {
-                  "assignee": {
-                    "email": "lisa@incident.io",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "Lisa Karlin Curtis",
-                    "role": "viewer",
-                    "slack_user_id": "U02AYNF2XJM"
-                  },
-                  "role": {
-                    "created_at": "2021-08-17T13:28:57.801578Z",
-                    "description": "The person currently coordinating the incident",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                    "name": "Incident Lead",
-                    "required": false,
-                    "role_type": "lead",
-                    "shortform": "lead",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
-                  }
-                }
-              ],
-              "incident_status": {
-                "category": "triage",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Closed",
-                "rank": 4,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "incident_timestamp_values": [
-                {
-                  "incident_timestamp": {
-                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                    "name": "Impact started",
-                    "rank": 1
-                  },
-                  "value": {
-                    "value": "2021-08-17T13:28:57.801578Z"
-                  }
-                }
-              ],
-              "incident_type": {
-                "create_in_triage": "always",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Customer facing production outages",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "is_default": false,
-                "name": "Production Outage",
-                "private_incidents_only": false,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "mode": "standard",
-              "name": "Our database is sad",
-              "permalink": "https://app.incident.io/incidents/123",
-              "postmortem_document_url": "https://docs.google.com/my_doc_id",
-              "reference": "INC-123",
-              "severity": {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Issues with **low impact**.",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Minor",
-                "rank": 1,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "slack_channel_id": "C02AW36C1M5",
-              "slack_channel_name": "inc-165-green-parrot",
-              "slack_team_id": "T02A1FSLE8J",
-              "summary": "Our database is really really sad, and we don't know why yet.",
-              "updated_at": "2021-08-17T13:28:57.801578Z",
-              "visibility": "public",
-              "workload_minutes_late": 40.7,
-              "workload_minutes_sleeping": 0,
-              "workload_minutes_total": 60.7,
-              "workload_minutes_working": 20
-            },
-            "message": "We're working on a fix, hoping to ship in the next 30 minutes",
-            "new_status": {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "previous_status": {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          },
-          "public_incident.incident_updated_v2": {
-            "call_url": "https://zoom.us/foo",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "creator": {
-              "api_key": {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "My test API key"
-              },
-              "user": {
-                "email": "lisa@incident.io",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Lisa Karlin Curtis",
-                "role": "viewer",
-                "slack_user_id": "U02AYNF2XJM"
-              }
-            },
-            "custom_field_entries": [
-              {
-                "custom_field": {
-                  "description": "Which team is impacted by this issue",
-                  "field_type": "single_select",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Affected Team",
-                  "options": [
-                    {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    }
-                  ]
-                },
-                "values": [
-                  {
-                    "value_catalog_entry": {
-                      "aliases": [
-                        "lawrence@incident.io",
-                        "lawrence"
-                      ],
-                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "name": "Primary On-call"
-                    },
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option": {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    },
-                    "value_text": "This is my text field, I hope you like it"
-                  }
-                ]
-              }
-            ],
-            "duration_metrics": [
-              {
-                "duration_metric": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Lasted"
-                },
-                "value_seconds": 1
-              }
-            ],
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "has_debrief": false,
-            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-            "incident_role_assignments": [
-              {
-                "assignee": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                },
-                "role": {
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "The person currently coordinating the incident",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                  "name": "Incident Lead",
-                  "required": false,
-                  "role_type": "lead",
-                  "shortform": "lead",
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_status": {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "incident_timestamp_values": [
-              {
-                "incident_timestamp": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Impact started",
-                  "rank": 1
-                },
-                "value": {
-                  "value": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_type": {
-              "create_in_triage": "always",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Customer facing production outages",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_default": false,
-              "name": "Production Outage",
-              "private_incidents_only": false,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "mode": "standard",
-            "most_recent_update_message": "We're working on a fix, hoping to ship in the next 30 minutes",
-            "name": "Our database is sad",
-            "permalink": "https://app.incident.io/incidents/123",
-            "postmortem_document_url": "https://docs.google.com/my_doc_id",
-            "reference": "INC-123",
-            "related_incidents": [
-              "INC-237"
-            ],
-            "severity": {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Issues with **low impact**.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Minor",
-              "rank": 1,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "slack_channel_id": "C02AW36C1M5",
-            "slack_channel_name": "inc-165-green-parrot",
-            "slack_team_id": "T02A1FSLE8J",
-            "summary": "Our database is really really sad, and we don't know why yet.",
-            "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public",
-            "workload_minutes_late": 40.7,
-            "workload_minutes_sleeping": 0,
-            "workload_minutes_total": 60.7,
-            "workload_minutes_working": 20
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "public_incident.incident_created_v2",
-            "type": "string"
-          },
-          "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          },
-          "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          },
-          "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          },
-          "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          },
-          "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          },
-          "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          },
-          "private_incident.membership_granted_v1": {
-            "$ref": "#/components/schemas/WebhookIncidentUserV2"
-          },
-          "private_incident.membership_revoked_v1": {
-            "$ref": "#/components/schemas/WebhookIncidentUserV2"
-          },
-          "public_incident.action_created_v1": {
-            "$ref": "#/components/schemas/ActionV1"
-          },
-          "public_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/ActionV1"
-          },
-          "public_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/ActionV1"
-          },
-          "public_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/ActionV1"
-          },
-          "public_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/WebhookIncidentV2"
-          },
-          "public_incident.incident_status_updated_v2": {
-            "$ref": "#/components/schemas/IncidentWithStatusChangeV2"
-          },
-          "public_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/WebhookIncidentV2"
-          }
-        },
-        "required": [
-          "event_type"
-        ],
-        "type": "object"
       },
       "AuditLogActorMetadataV2": {
         "example": {
@@ -19818,404 +19212,6 @@
         "type": "object",
         "x-public-api-version": "v2"
       },
-      "CreateHTTPRequestBody": {
-        "example": {
-          "deduplication_key": "4293868629",
-          "description": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix...",
-          "metadata": {
-            "service": "hello.world.com",
-            "team": [
-              "my-team"
-            ]
-          },
-          "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
-          "status": "firing",
-          "title": "*errors.withMessage: PG::Error failed to connect"
-        },
-        "properties": {
-          "deduplication_key": {
-            "description": "A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.",
-            "example": "4293868629",
-            "type": "string"
-          },
-          "description": {
-            "description": "Description that optionally adds more detail to title. Supports markdown.",
-            "example": "We've detected a number of timeouts on hello.world.com, the service may be down. To fix...",
-            "type": "string"
-          },
-          "metadata": {
-            "additionalProperties": true,
-            "description": "Any additional metadata that you've configured your alert source to parse",
-            "example": {
-              "service": "hello.world.com",
-              "team": [
-                "my-team"
-              ]
-            },
-            "type": "object"
-          },
-          "source_url": {
-            "description": "If applicable, a link to the alert in the upstream system",
-            "example": "https://www.my-alerting-platform.com/alerts/my-alert-123",
-            "type": "string"
-          },
-          "status": {
-            "description": "Current status of this alert",
-            "enum": [
-              "firing",
-              "resolved"
-            ],
-            "example": "firing",
-            "type": "string"
-          },
-          "title": {
-            "description": "Alert title which is used when summarising the alert",
-            "example": "*errors.withMessage: PG::Error failed to connect",
-            "type": "string"
-          }
-        },
-        "required": [
-          "title",
-          "status"
-        ],
-        "type": "object"
-      },
-      "CreateManagedResourceRequestBody": {
-        "example": {
-          "annotations": {
-            "incident.io/terraform/version": "3.0.0"
-          },
-          "resource_id": "abc123",
-          "resource_type": "schedule"
-        },
-        "properties": {
-          "annotations": {
-            "additionalProperties": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "description": "Annotations that track metadata about this resource",
-            "example": {
-              "incident.io/terraform/version": "3.0.0"
-            },
-            "type": "object"
-          },
-          "resource_id": {
-            "description": "The ID of the related resource",
-            "example": "abc123",
-            "type": "string"
-          },
-          "resource_type": {
-            "description": "The type of the related resource",
-            "enum": [
-              "escalation_path",
-              "schedule",
-              "workflow"
-            ],
-            "example": "schedule",
-            "type": "string"
-          }
-        },
-        "required": [
-          "annotations",
-          "resource_type",
-          "resource_id",
-          "managed_by"
-        ],
-        "type": "object"
-      },
-      "CreateManagedResourceResponseBody": {
-        "example": {
-          "managed_resource": {
-            "annotations": {
-              "incident.io/terraform/version": "3.0.0"
-            },
-            "managed_by": "dashboard",
-            "resource_id": "abc123",
-            "resource_type": "schedule",
-            "source_url": "https://github.com/my-company/infrastructure"
-          }
-        },
-        "properties": {
-          "managed_resource": {
-            "$ref": "#/components/schemas/ManagedResourceV2"
-          }
-        },
-        "required": [
-          "managed_resource"
-        ],
-        "type": "object"
-      },
-      "CreateRequestBody": {
-        "example": {
-          "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
-          "resource": {
-            "external_id": "123",
-            "resource_type": "pager_duty_incident"
-          }
-        },
-        "properties": {
-          "incident_id": {
-            "description": "ID of the incident to add an attachment to",
-            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
-            "type": "string"
-          },
-          "resource": {
-            "example": {
-              "external_id": "123",
-              "resource_type": "pager_duty_incident"
-            },
-            "properties": {
-              "external_id": {
-                "description": "ID of the resource in the external system",
-                "example": "123",
-                "type": "string"
-              },
-              "resource_type": {
-                "description": "E.g. PagerDuty: the external system that holds the resource",
-                "enum": [
-                  "pager_duty_incident",
-                  "opsgenie_alert",
-                  "datadog_monitor_alert",
-                  "github_pull_request",
-                  "gitlab_merge_request",
-                  "sentry_issue",
-                  "jira_issue",
-                  "atlassian_statuspage_incident",
-                  "zendesk_ticket",
-                  "google_calendar_event",
-                  "outlook_calendar_event",
-                  "slack_file",
-                  "scrubbed",
-                  "statuspage_incident"
-                ],
-                "example": "pager_duty_incident",
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "permalink",
-              "external_id",
-              "title",
-              "resource_type",
-              "resource_type_label",
-              "created_at",
-              "updated_at"
-            ],
-            "type": "object"
-          }
-        },
-        "required": [
-          "incident_id",
-          "resource"
-        ],
-        "type": "object"
-      },
-      "CreateRequestBody2": {
-        "example": {
-          "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
-          "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
-        },
-        "properties": {
-          "incident_id": {
-            "example": "01ET65M7ZADYFCKD4K1AE2QNMC",
-            "type": "string"
-          },
-          "user_id": {
-            "example": "01FCQSP07Z74QMMYPDDGQB9FTG",
-            "type": "string"
-          }
-        },
-        "required": [
-          "user_id",
-          "incident_id"
-        ],
-        "type": "object"
-      },
-      "CreateRequestBody3": {
-        "example": {
-          "description": "The person currently coordinating the incident",
-          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-          "name": "Incident Lead",
-          "required": false,
-          "shortform": "lead"
-        },
-        "properties": {
-          "description": {
-            "description": "Describes the purpose of the role",
-            "example": "The person currently coordinating the incident",
-            "minLength": 1,
-            "type": "string"
-          },
-          "instructions": {
-            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
-            "example": "Take point on the incident; Make sure people are clear on responsibilities",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human readable name of the incident role",
-            "example": "Incident Lead",
-            "minLength": 1,
-            "type": "string"
-          },
-          "required": {
-            "description": "DEPRECATED: this will always be false.",
-            "example": false,
-            "type": "boolean"
-          },
-          "shortform": {
-            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "shortform",
-          "description",
-          "instructions",
-          "required",
-          "condition_groups",
-          "id",
-          "role_type",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
-      },
-      "CreateRequestBody4": {
-        "example": {
-          "description": "The person currently coordinating the incident",
-          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-          "name": "Incident Lead",
-          "shortform": "lead"
-        },
-        "properties": {
-          "description": {
-            "description": "Describes the purpose of the role",
-            "example": "The person currently coordinating the incident",
-            "minLength": 1,
-            "type": "string"
-          },
-          "instructions": {
-            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
-            "example": "Take point on the incident; Make sure people are clear on responsibilities",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human readable name of the incident role",
-            "example": "Incident Lead",
-            "minLength": 1,
-            "type": "string"
-          },
-          "shortform": {
-            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "shortform",
-          "description",
-          "instructions",
-          "condition_groups",
-          "id",
-          "role_type",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
-      },
-      "CreateRequestBody5": {
-        "example": {
-          "category": "live",
-          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-          "name": "Closed"
-        },
-        "properties": {
-          "category": {
-            "description": "Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.",
-            "enum": [
-              "live",
-              "learning",
-              "closed"
-            ],
-            "example": "live",
-            "type": "string"
-          },
-          "description": {
-            "description": "Rich text description of the incident status",
-            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-            "type": "string"
-          },
-          "name": {
-            "description": "Unique name of this status",
-            "example": "Closed",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "category",
-          "id",
-          "rank",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
-      },
-      "CreateResponseBody": {
-        "example": {
-          "incident_attachment": {
-            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "resource": {
-              "external_id": "123",
-              "permalink": "https://my.pagerduty.com/incidents/ABC",
-              "resource_type": "pager_duty_incident",
-              "title": "The database has gone down"
-            }
-          }
-        },
-        "properties": {
-          "incident_attachment": {
-            "$ref": "#/components/schemas/IncidentAttachmentV1"
-          }
-        },
-        "required": [
-          "incident_attachment"
-        ],
-        "type": "object"
-      },
-      "CreateResponseBody2": {
-        "example": {
-          "incident_membership": {
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "updated_at": "2021-08-17T13:28:57.801578Z",
-            "user": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            }
-          }
-        },
-        "properties": {
-          "incident_membership": {
-            "$ref": "#/components/schemas/IncidentMembership"
-          }
-        },
-        "required": [
-          "incident_membership"
-        ],
-        "type": "object"
-      },
       "CustomFieldEntryPayloadV1": {
         "example": {
           "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -21888,66 +20884,6 @@
         ],
         "type": "object"
       },
-      "EditRequestBody": {
-        "example": {
-          "incident": {
-            "call_url": "https://zoom.us/foo",
-            "custom_field_entries": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "values": [
-                  {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_text": "This is my text field, I hope you like it",
-                    "value_timestamp": ""
-                  }
-                ]
-              }
-            ],
-            "incident_role_assignments": [
-              {
-                "assignee": {
-                  "email": "bob@example.com",
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "slack_user_id": "USER123"
-                },
-                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-              }
-            ],
-            "incident_status_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-            "incident_timestamp_values": [
-              {
-                "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "value": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "name": "Our database is sad",
-            "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-            "slack_channel_name_override": "inc-123-database-down",
-            "summary": "Our database is really really sad, and we don't know why yet."
-          },
-          "notify_incident_channel": true
-        },
-        "properties": {
-          "incident": {
-            "$ref": "#/components/schemas/IncidentEditPayloadV2"
-          },
-          "notify_incident_channel": {
-            "description": "Should we send Slack channel notifications to inform responders of this update? Note that this won't work if the Slack channel has already been archived.",
-            "example": true,
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "incident",
-          "notify_incident_channel"
-        ],
-        "type": "object"
-      },
       "EmbeddedCatalogEntryV1": {
         "example": {
           "aliases": [
@@ -23540,6 +22476,9 @@
               "type": "if_else"
             }
           ],
+          "team_ids": [
+            "01JPQA75EPNEES4479P16P4XAB"
+          ],
           "working_hours": [
             {
               "id": "abc123",
@@ -23649,6 +22588,17 @@
             },
             "type": "array"
           },
+          "team_ids": {
+            "description": "IDs of teams that own this escalation path",
+            "example": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "working_hours": {
             "description": "The working hours for this escalation path.",
             "example": [
@@ -23676,7 +22626,8 @@
           "name",
           "path",
           "levels",
-          "repeat_times"
+          "repeat_times",
+          "team_ids"
         ],
         "type": "object",
         "x-public-api-version": "v2"
@@ -23751,6 +22702,9 @@
               },
               "type": "if_else"
             }
+          ],
+          "team_ids": [
+            "01JPQA75EPNEES4479P16P4XAB"
           ],
           "working_hours": [
             {
@@ -23845,6 +22799,17 @@
             ],
             "items": {
               "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
+            },
+            "type": "array"
+          },
+          "team_ids": {
+            "description": "IDs of the teams that own this escalation path",
+            "example": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
             },
             "type": "array"
           },
@@ -23957,6 +22922,9 @@
                 "type": "if_else"
               }
             ],
+            "team_ids": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
             "working_hours": [
               {
                 "id": "abc123",
@@ -24064,6 +23032,9 @@
                 "type": "if_else"
               }
             ],
+            "team_ids": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
             "working_hours": [
               {
                 "id": "abc123",
@@ -24161,6 +23132,9 @@
               "type": "if_else"
             }
           ],
+          "team_ids": [
+            "01JPQA75EPNEES4479P16P4XAB"
+          ],
           "working_hours": [
             {
               "id": "abc123",
@@ -24254,6 +23228,17 @@
             ],
             "items": {
               "$ref": "#/components/schemas/EscalationPathNodePayloadV2"
+            },
+            "type": "array"
+          },
+          "team_ids": {
+            "description": "IDs of the teams that own this escalation path",
+            "example": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
             },
             "type": "array"
           },
@@ -24365,6 +23350,9 @@
                 },
                 "type": "if_else"
               }
+            ],
+            "team_ids": [
+              "01JPQA75EPNEES4479P16P4XAB"
             ],
             "working_hours": [
               {
@@ -26108,7 +25096,8 @@
           "created_at",
           "updated_at"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v1"
       },
       "FollowUpPriorityV2": {
         "example": {
@@ -26473,164 +25462,135 @@
           "creator",
           "created_at"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v1"
       },
-      "IncidentCreatePayloadV1": {
+      "IncidentAttachmentsCreatePayloadV1": {
         "example": {
-          "custom_field_entries": [
-            {
-              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "values": [
-                {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_link": "https://google.com/",
-                  "value_numeric": "123.456",
-                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "value_text": "This is my text field, I hope you like it",
-                  "value_timestamp": ""
-                }
-              ]
-            }
-          ],
-          "idempotency_key": "alert-uuid",
-          "incident_role_assignments": [
-            {
-              "assignee": {
-                "email": "bob@example.com",
-                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                "slack_user_id": "USER123"
-              },
-              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
-            }
-          ],
-          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "mode": "real",
-          "name": "Our database is sad",
-          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
-          "slack_team_id": "T02A1FSLE8J",
-          "source_message_channel_id": "C02AW36C1M5",
-          "source_message_timestamp": "1653650280.526509",
-          "status": "triage",
-          "summary": "Our database is really really sad, and we don't know why yet.",
-          "visibility": "public"
+          "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
+          "resource": {
+            "external_id": "123",
+            "resource_type": "pager_duty_incident"
+          }
         },
         "properties": {
-          "custom_field_entries": {
-            "description": "Set the incident's custom fields to these values",
-            "example": [
-              {
-                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "values": [
-                  {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "value_text": "This is my text field, I hope you like it",
-                    "value_timestamp": ""
-                  }
-                ]
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+          "incident_id": {
+            "description": "ID of the incident to add an attachment to",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "type": "string"
+          },
+          "resource": {
+            "example": {
+              "external_id": "123",
+              "resource_type": "pager_duty_incident"
             },
-            "type": "array"
-          },
-          "idempotency_key": {
-            "description": "Unique string used to de-duplicate incident create requests",
-            "example": "alert-uuid",
-            "type": "string"
-          },
-          "incident_role_assignments": {
-            "description": "Assign incident roles to these people",
-            "example": [
-              {
-                "assignee": {
-                  "email": "bob@example.com",
-                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
-                  "slack_user_id": "USER123"
-                },
-                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            "properties": {
+              "external_id": {
+                "description": "ID of the resource in the external system",
+                "example": "123",
+                "type": "string"
+              },
+              "resource_type": {
+                "description": "E.g. PagerDuty: the external system that holds the resource",
+                "enum": [
+                  "pager_duty_incident",
+                  "opsgenie_alert",
+                  "datadog_monitor_alert",
+                  "github_pull_request",
+                  "gitlab_merge_request",
+                  "sentry_issue",
+                  "jira_issue",
+                  "atlassian_statuspage_incident",
+                  "zendesk_ticket",
+                  "google_calendar_event",
+                  "outlook_calendar_event",
+                  "slack_file",
+                  "scrubbed",
+                  "statuspage_incident"
+                ],
+                "example": "pager_duty_incident",
+                "type": "string"
               }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
             },
-            "type": "array"
-          },
-          "incident_type_id": {
-            "description": "Incident type to create this incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96",
-            "type": "string"
-          },
-          "mode": {
-            "description": "Whether the incident is real or test",
-            "enum": [
-              "real",
-              "test"
+            "required": [
+              "id",
+              "permalink",
+              "external_id",
+              "title",
+              "resource_type",
+              "resource_type_label",
+              "created_at",
+              "updated_at"
             ],
-            "example": "real",
-            "type": "string"
-          },
-          "name": {
-            "description": "Explanation of the incident",
-            "example": "Our database is sad",
-            "type": "string"
-          },
-          "severity_id": {
-            "description": "Severity to create incident as",
-            "example": "01FH5TZRWMNAFB0DZ23FD1TV96",
-            "type": "string"
-          },
-          "slack_team_id": {
-            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
-            "example": "T02A1FSLE8J",
-            "type": "string"
-          },
-          "source_message_channel_id": {
-            "description": "Channel ID of the source message, if this incident was created from one",
-            "example": "C02AW36C1M5",
-            "type": "string"
-          },
-          "source_message_timestamp": {
-            "description": "Timestamp of the source message, if this incident was created from one",
-            "example": "1653650280.526509",
-            "type": "string"
-          },
-          "status": {
-            "description": "Current status of the incident",
-            "enum": [
-              "triage",
-              "investigating",
-              "fixing",
-              "monitoring",
-              "closed",
-              "declined"
-            ],
-            "example": "triage",
-            "type": "string"
-          },
-          "summary": {
-            "description": "Detailed description of the incident",
-            "example": "Our database is really really sad, and we don't know why yet.",
-            "type": "string"
-          },
-          "visibility": {
-            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/articles/5905558102-can-we-mark-incidents-as-sensitive-and-restrict-access).",
-            "enum": [
-              "public",
-              "private"
-            ],
-            "example": "public",
-            "type": "string"
+            "type": "object"
           }
         },
         "required": [
-          "idempotency_key",
-          "visibility"
+          "incident_id",
+          "resource"
+        ],
+        "type": "object"
+      },
+      "IncidentAttachmentsCreateResultV1": {
+        "example": {
+          "incident_attachment": {
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "resource": {
+              "external_id": "123",
+              "permalink": "https://my.pagerduty.com/incidents/ABC",
+              "resource_type": "pager_duty_incident",
+              "title": "The database has gone down"
+            }
+          }
+        },
+        "properties": {
+          "incident_attachment": {
+            "$ref": "#/components/schemas/IncidentAttachmentV1"
+          }
+        },
+        "required": [
+          "incident_attachment"
+        ],
+        "type": "object"
+      },
+      "IncidentAttachmentsListResultV1": {
+        "example": {
+          "incident_attachments": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "resource": {
+                "external_id": "123",
+                "permalink": "https://my.pagerduty.com/incidents/ABC",
+                "resource_type": "pager_duty_incident",
+                "title": "The database has gone down"
+              }
+            }
+          ]
+        },
+        "properties": {
+          "incident_attachments": {
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "resource": {
+                  "external_id": "123",
+                  "permalink": "https://my.pagerduty.com/incidents/ABC",
+                  "resource_type": "pager_duty_incident",
+                  "title": "The database has gone down"
+                }
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentAttachmentV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_attachments"
         ],
         "type": "object"
       },
@@ -26991,7 +25951,7 @@
         },
         "type": "object"
       },
-      "IncidentMembership": {
+      "IncidentMembershipV1": {
         "example": {
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01FCNDV6P870EA6S7TK1DSYD5H",
@@ -27029,15 +25989,86 @@
             "type": "string"
           },
           "user": {
-            "$ref": "#/components/schemas/UserV2"
+            "$ref": "#/components/schemas/UserV1"
           }
         },
         "required": [
           "id",
+          "organisation_id",
           "user",
           "incident_id",
           "created_at",
           "updated_at"
+        ],
+        "type": "object",
+        "x-public-api-version": "v1"
+      },
+      "IncidentMembershipsCreatePayloadV1": {
+        "example": {
+          "incident_id": "01ET65M7ZADYFCKD4K1AE2QNMC",
+          "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "properties": {
+          "incident_id": {
+            "example": "01ET65M7ZADYFCKD4K1AE2QNMC",
+            "type": "string"
+          },
+          "user_id": {
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "incident_id"
+        ],
+        "type": "object"
+      },
+      "IncidentMembershipsCreateResultV1": {
+        "example": {
+          "incident_membership": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          }
+        },
+        "properties": {
+          "incident_membership": {
+            "$ref": "#/components/schemas/IncidentMembershipV1"
+          }
+        },
+        "required": [
+          "incident_membership"
+        ],
+        "type": "object"
+      },
+      "IncidentMembershipsRevokePayloadV1": {
+        "example": {
+          "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+          "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
+        },
+        "properties": {
+          "incident_id": {
+            "description": "Revoke memberships to incident",
+            "example": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "type": "string"
+          },
+          "user_id": {
+            "example": "01FCQSP07Z74QMMYPDDGQB9FTG",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "incident_id"
         ],
         "type": "object"
       },
@@ -27237,7 +26268,8 @@
           "created_at",
           "updated_at"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v1"
       },
       "IncidentRoleV2": {
         "example": {
@@ -27312,6 +26344,417 @@
           "created_at",
           "updated_at"
         ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "IncidentRolesCreatePayloadV1": {
+        "example": {
+          "description": "The person currently coordinating the incident",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "required": false,
+          "shortform": "lead"
+        },
+        "properties": {
+          "description": {
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1,
+            "type": "string"
+          },
+          "instructions": {
+            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1,
+            "type": "string"
+          },
+          "required": {
+            "description": "DEPRECATED: this will always be false.",
+            "example": false,
+            "type": "boolean"
+          },
+          "shortform": {
+            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
+            "example": "lead",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "shortform",
+          "description",
+          "instructions",
+          "required",
+          "condition_groups",
+          "id",
+          "role_type",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesCreatePayloadV2": {
+        "example": {
+          "description": "The person currently coordinating the incident",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "shortform": "lead"
+        },
+        "properties": {
+          "description": {
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1,
+            "type": "string"
+          },
+          "instructions": {
+            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1,
+            "type": "string"
+          },
+          "shortform": {
+            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
+            "example": "lead",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "shortform",
+          "description",
+          "instructions",
+          "condition_groups",
+          "id",
+          "role_type",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesCreateResultV1": {
+        "example": {
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "required": false,
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV1"
+          }
+        },
+        "required": [
+          "incident_role"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesCreateResultV2": {
+        "example": {
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV2"
+          }
+        },
+        "required": [
+          "incident_role"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesListResultV1": {
+        "example": {
+          "incident_roles": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "The person currently coordinating the incident",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+              "name": "Incident Lead",
+              "required": false,
+              "role_type": "lead",
+              "shortform": "lead",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "incident_roles": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "The person currently coordinating the incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "required": false,
+                "role_type": "lead",
+                "shortform": "lead",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_roles"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesListResultV2": {
+        "example": {
+          "incident_roles": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "The person currently coordinating the incident",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+              "name": "Incident Lead",
+              "role_type": "lead",
+              "shortform": "lead",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "incident_roles": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "The person currently coordinating the incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                "name": "Incident Lead",
+                "role_type": "lead",
+                "shortform": "lead",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_roles"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesShowResultV1": {
+        "example": {
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "required": false,
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV1"
+          }
+        },
+        "required": [
+          "incident_role"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesShowResultV2": {
+        "example": {
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV2"
+          }
+        },
+        "required": [
+          "incident_role"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesUpdatePayloadV1": {
+        "example": {
+          "description": "The person currently coordinating the incident",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "required": false,
+          "shortform": "lead"
+        },
+        "properties": {
+          "description": {
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1,
+            "type": "string"
+          },
+          "instructions": {
+            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1,
+            "type": "string"
+          },
+          "required": {
+            "description": "DEPRECATED: this will always be false.",
+            "example": false,
+            "type": "boolean"
+          },
+          "shortform": {
+            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
+            "example": "lead",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "shortform",
+          "description",
+          "instructions",
+          "condition_groups",
+          "role_type",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesUpdatePayloadV2": {
+        "example": {
+          "description": "The person currently coordinating the incident",
+          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+          "name": "Incident Lead",
+          "shortform": "lead"
+        },
+        "properties": {
+          "description": {
+            "description": "Describes the purpose of the role",
+            "example": "The person currently coordinating the incident",
+            "minLength": 1,
+            "type": "string"
+          },
+          "instructions": {
+            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
+            "example": "Take point on the incident; Make sure people are clear on responsibilities",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name of the incident role",
+            "example": "Incident Lead",
+            "minLength": 1,
+            "type": "string"
+          },
+          "shortform": {
+            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
+            "example": "lead",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "shortform",
+          "description",
+          "instructions",
+          "condition_groups",
+          "role_type",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesUpdateResultV1": {
+        "example": {
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "required": false,
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV1"
+          }
+        },
+        "required": [
+          "incident_role"
+        ],
+        "type": "object"
+      },
+      "IncidentRolesUpdateResultV2": {
+        "example": {
+          "incident_role": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "The person currently coordinating the incident",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+            "name": "Incident Lead",
+            "role_type": "lead",
+            "shortform": "lead",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_role": {
+            "$ref": "#/components/schemas/IncidentRoleV2"
+          }
+        },
+        "required": [
+          "incident_role"
+        ],
         "type": "object"
       },
       "IncidentStatusV1": {
@@ -27381,7 +26824,8 @@
           "created_at",
           "updated_at"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v1"
       },
       "IncidentStatusV2": {
         "example": {
@@ -27450,6 +26894,177 @@
           "created_at",
           "updated_at"
         ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "IncidentStatusesCreatePayloadV1": {
+        "example": {
+          "category": "live",
+          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+          "name": "Closed"
+        },
+        "properties": {
+          "category": {
+            "description": "Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.",
+            "enum": [
+              "live",
+              "learning",
+              "closed"
+            ],
+            "example": "live",
+            "type": "string"
+          },
+          "description": {
+            "description": "Rich text description of the incident status",
+            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Unique name of this status",
+            "example": "Closed",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "category",
+          "id",
+          "rank",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "IncidentStatusesCreateResultV1": {
+        "example": {
+          "incident_status": {
+            "category": "triage",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Closed",
+            "rank": 4,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_status": {
+            "$ref": "#/components/schemas/IncidentStatusV1"
+          }
+        },
+        "required": [
+          "incident_status"
+        ],
+        "type": "object"
+      },
+      "IncidentStatusesListResultV1": {
+        "example": {
+          "incident_statuses": [
+            {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "incident_statuses": {
+            "example": [
+              {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentStatusV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_statuses"
+        ],
+        "type": "object"
+      },
+      "IncidentStatusesShowResultV1": {
+        "example": {
+          "incident_status": {
+            "category": "triage",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Closed",
+            "rank": 4,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_status": {
+            "$ref": "#/components/schemas/IncidentStatusV1"
+          }
+        },
+        "required": [
+          "incident_status"
+        ],
+        "type": "object"
+      },
+      "IncidentStatusesUpdatePayloadV1": {
+        "example": {
+          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+          "name": "Closed"
+        },
+        "properties": {
+          "description": {
+            "description": "Rich text description of the incident status",
+            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Unique name of this status",
+            "example": "Closed",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "rank",
+          "category",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "IncidentStatusesUpdateResultV1": {
+        "example": {
+          "incident_status": {
+            "category": "triage",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Closed",
+            "rank": 4,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_status": {
+            "$ref": "#/components/schemas/IncidentStatusV1"
+          }
+        },
+        "required": [
+          "incident_status"
+        ],
         "type": "object"
       },
       "IncidentTimestampV1": {
@@ -27512,7 +27127,8 @@
           "created_at",
           "updated_at"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "IncidentTimestampValuePayloadV2": {
         "example": {
@@ -27577,6 +27193,54 @@
           },
           "value": {
             "$ref": "#/components/schemas/IncidentTimestampValueV2"
+          }
+        },
+        "required": [
+          "incident_timestamp"
+        ],
+        "type": "object"
+      },
+      "IncidentTimestampsListResultV2": {
+        "example": {
+          "incident_timestamps": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Impact started",
+              "rank": 1
+            }
+          ]
+        },
+        "properties": {
+          "incident_timestamps": {
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Impact started",
+                "rank": 1
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentTimestampV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_timestamps"
+        ],
+        "type": "object"
+      },
+      "IncidentTimestampsShowResultV2": {
+        "example": {
+          "incident_timestamp": {
+            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+            "name": "Impact started",
+            "rank": 1
+          }
+        },
+        "properties": {
+          "incident_timestamp": {
+            "$ref": "#/components/schemas/IncidentTimestampV2"
           }
         },
         "required": [
@@ -27661,7 +27325,8 @@
           "auto_archive_slack_channels",
           "auto_archive_slack_channels_delay_days"
         ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v1"
       },
       "IncidentTypeV2": {
         "example": {
@@ -27742,12 +27407,75 @@
         ],
         "type": "object"
       },
+      "IncidentTypesListResultV1": {
+        "example": {
+          "incident_types": [
+            {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "incident_types": {
+            "example": [
+              {
+                "create_in_triage": "always",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Customer facing production outages",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_default": false,
+                "name": "Production Outage",
+                "private_incidents_only": false,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentTypeV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "incident_types"
+        ],
+        "type": "object"
+      },
+      "IncidentTypesShowResultV1": {
+        "example": {
+          "incident_type": {
+            "create_in_triage": "always",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Customer facing production outages",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_default": false,
+            "name": "Production Outage",
+            "private_incidents_only": false,
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "incident_type": {
+            "$ref": "#/components/schemas/IncidentTypeV1"
+          }
+        },
+        "required": [
+          "incident_type"
+        ],
+        "type": "object"
+      },
       "IncidentUpdateV2": {
         "example": {
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "merged_into_incident_id": "abc123",
+          "merged_into_incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "message": "We're working on a fix, hoping to ship in the next 30 minutes",
           "new_incident_status": {
             "category": "triage",
@@ -27798,8 +27526,8 @@
             "type": "string"
           },
           "merged_into_incident_id": {
-            "description": "The ID of the incident that this incident was merged into, if it was merged in to another incident",
-            "example": "abc123",
+            "description": "The ID of the incident this incident was merged into, if the to state of this update is 'merged'.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
             "type": "string"
           },
           "message": {
@@ -27824,6 +27552,108 @@
           "updater",
           "created_at",
           "next_update_in_minutes"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "IncidentUpdatesListResultV2": {
+        "example": {
+          "incident_updates": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "merged_into_incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "message": "We're working on a fix, hoping to ship in the next 30 minutes",
+              "new_incident_status": {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "new_severity": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "updater": {
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            }
+          ],
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          }
+        },
+        "properties": {
+          "incident_updates": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "merged_into_incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "message": "We're working on a fix, hoping to ship in the next 30 minutes",
+                "new_incident_status": {
+                  "category": "triage",
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Closed",
+                  "rank": 4,
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                },
+                "new_severity": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "Issues with **low impact**.",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Minor",
+                  "rank": 1,
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                },
+                "updater": {
+                  "api_key": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My test API key"
+                  },
+                  "user": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                }
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentUpdateV2"
+            },
+            "type": "array"
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          }
+        },
+        "required": [
+          "incident_updates"
         ],
         "type": "object"
       },
@@ -28770,200 +28600,247 @@
         ],
         "type": "object"
       },
-      "ListResponseBody": {
+      "IncidentsV1CreateRequestBody": {
         "example": {
-          "incident_attachments": [
+          "custom_field_entries": [
             {
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "resource": {
-                "external_id": "123",
-                "permalink": "https://my.pagerduty.com/incidents/ABC",
-                "resource_type": "pager_duty_incident",
-                "title": "The database has gone down"
-              }
+              "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "values": [
+                {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_link": "https://google.com/",
+                  "value_numeric": "123.456",
+                  "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "value_text": "This is my text field, I hope you like it",
+                  "value_timestamp": ""
+                }
+              ]
             }
-          ]
+          ],
+          "idempotency_key": "alert-uuid",
+          "incident_role_assignments": [
+            {
+              "assignee": {
+                "email": "bob@example.com",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "slack_user_id": "USER123"
+              },
+              "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+            }
+          ],
+          "incident_type_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "mode": "real",
+          "name": "Our database is sad",
+          "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+          "slack_team_id": "T02A1FSLE8J",
+          "source_message_channel_id": "C02AW36C1M5",
+          "source_message_timestamp": "1653650280.526509",
+          "status": "triage",
+          "summary": "Our database is really really sad, and we don't know why yet.",
+          "visibility": "public"
         },
         "properties": {
-          "incident_attachments": {
+          "custom_field_entries": {
+            "description": "Set the incident's custom fields to these values",
             "example": [
               {
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "incident_id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "resource": {
-                  "external_id": "123",
-                  "permalink": "https://my.pagerduty.com/incidents/ABC",
-                  "resource_type": "pager_duty_incident",
-                  "title": "The database has gone down"
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CustomFieldEntryPayloadV1"
+            },
+            "type": "array"
+          },
+          "idempotency_key": {
+            "description": "Unique string used to de-duplicate incident create requests",
+            "example": "alert-uuid",
+            "type": "string"
+          },
+          "incident_role_assignments": {
+            "description": "Assign incident roles to these people",
+            "example": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IncidentRoleAssignmentPayloadV1"
+            },
+            "type": "array"
+          },
+          "incident_type_id": {
+            "description": "Incident type to create this incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96",
+            "type": "string"
+          },
+          "mode": {
+            "description": "Whether the incident is real or test",
+            "enum": [
+              "real",
+              "test"
+            ],
+            "example": "real",
+            "type": "string"
+          },
+          "name": {
+            "description": "Explanation of the incident",
+            "example": "Our database is sad",
+            "type": "string"
+          },
+          "severity_id": {
+            "description": "Severity to create incident as",
+            "example": "01FH5TZRWMNAFB0DZ23FD1TV96",
+            "type": "string"
+          },
+          "slack_team_id": {
+            "description": "ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.",
+            "example": "T02A1FSLE8J",
+            "type": "string"
+          },
+          "source_message_channel_id": {
+            "description": "Channel ID of the source message, if this incident was created from one",
+            "example": "C02AW36C1M5",
+            "type": "string"
+          },
+          "source_message_timestamp": {
+            "description": "Timestamp of the source message, if this incident was created from one",
+            "example": "1653650280.526509",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current status of the incident",
+            "enum": [
+              "triage",
+              "investigating",
+              "fixing",
+              "monitoring",
+              "closed",
+              "declined"
+            ],
+            "example": "triage",
+            "type": "string"
+          },
+          "summary": {
+            "description": "Detailed description of the incident",
+            "example": "Our database is really really sad, and we don't know why yet.",
+            "type": "string"
+          },
+          "visibility": {
+            "description": "Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/articles/5905558102-can-we-mark-incidents-as-sensitive-and-restrict-access).",
+            "enum": [
+              "public",
+              "private"
+            ],
+            "example": "public",
+            "type": "string"
+          }
+        },
+        "required": [
+          "idempotency_key",
+          "visibility"
+        ],
+        "type": "object"
+      },
+      "IncidentsV1CreateResponseBody": {
+        "example": {
+          "incident": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
                 }
               }
             ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentAttachmentV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_attachments"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody2": {
-        "example": {
-          "incident_roles": [
-            {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "The person currently coordinating the incident",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-              "name": "Incident Lead",
-              "required": false,
-              "role_type": "lead",
-              "shortform": "lead",
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "incident_roles": {
-            "example": [
-              {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "The person currently coordinating the incident",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                "name": "Incident Lead",
-                "required": false,
-                "role_type": "lead",
-                "shortform": "lead",
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_roles"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody3": {
-        "example": {
-          "incident_roles": [
-            {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "The person currently coordinating the incident",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-              "name": "Incident Lead",
-              "role_type": "lead",
-              "shortform": "lead",
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "incident_roles": {
-            "example": [
-              {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "The person currently coordinating the incident",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                "name": "Incident Lead",
-                "role_type": "lead",
-                "shortform": "lead",
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentRoleV2"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_roles"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody4": {
-        "example": {
-          "incident_statuses": [
-            {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "incident_statuses": {
-            "example": [
-              {
-                "category": "triage",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Closed",
-                "rank": 4,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentStatusV1"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_statuses"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody5": {
-        "example": {
-          "incident_timestamps": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Impact started",
-              "rank": 1
-            }
-          ]
-        },
-        "properties": {
-          "incident_timestamps": {
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Impact started",
-                "rank": 1
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentTimestampV2"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_timestamps"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody6": {
-        "example": {
-          "incident_types": [
-            {
+            "incident_type": {
               "create_in_triage": "always",
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Customer facing production outages",
@@ -28972,136 +28849,46 @@
               "name": "Production Outage",
               "private_incidents_only": false,
               "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          ]
-        },
-        "properties": {
-          "incident_types": {
-            "example": [
-              {
-                "create_in_triage": "always",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Customer facing production outages",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "is_default": false,
-                "name": "Production Outage",
-                "private_incidents_only": false,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentTypeV1"
             },
-            "type": "array"
-          }
-        },
-        "required": [
-          "incident_types"
-        ],
-        "type": "object"
-      },
-      "ListResponseBody7": {
-        "example": {
-          "incident_updates": [
-            {
+            "mode": "real",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "severity": {
               "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "merged_into_incident_id": "abc123",
-              "message": "We're working on a fix, hoping to ship in the next 30 minutes",
-              "new_incident_status": {
-                "category": "triage",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Closed",
-                "rank": 4,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "new_severity": {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Issues with **low impact**.",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Minor",
-                "rank": 1,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "updater": {
-                "api_key": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "My test API key"
-                },
-                "user": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                }
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "status": "triage",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "timestamps": [
+              {
+                "last_occurred_at": "2021-08-17T13:28:57.801578Z",
+                "name": "last_activity"
               }
-            }
-          ],
-          "pagination_meta": {
-            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "page_size": 25
+            ],
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public"
           }
         },
         "properties": {
-          "incident_updates": {
-            "example": [
-              {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "merged_into_incident_id": "abc123",
-                "message": "We're working on a fix, hoping to ship in the next 30 minutes",
-                "new_incident_status": {
-                  "category": "triage",
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Closed",
-                  "rank": 4,
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                },
-                "new_severity": {
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "Issues with **low impact**.",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Minor",
-                  "rank": 1,
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                },
-                "updater": {
-                  "api_key": {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "My test API key"
-                  },
-                  "user": {
-                    "email": "lisa@incident.io",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "Lisa Karlin Curtis",
-                    "role": "viewer",
-                    "slack_user_id": "U02AYNF2XJM"
-                  }
-                }
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/IncidentUpdateV2"
-            },
-            "type": "array"
-          },
-          "pagination_meta": {
-            "$ref": "#/components/schemas/PaginationMetaResult"
+          "incident": {
+            "$ref": "#/components/schemas/IncidentV1"
           }
         },
         "required": [
-          "incident_updates"
+          "incident"
         ],
         "type": "object"
       },
-      "ListResponseBody8": {
+      "IncidentsV1ListResponseBody": {
         "example": {
           "incidents": [
             {
@@ -29361,7 +29148,520 @@
         ],
         "type": "object"
       },
-      "ListResponseBody9": {
+      "IncidentsV1ShowResponseBody": {
+        "example": {
+          "incident": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "real",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "status": "triage",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "timestamps": [
+              {
+                "last_occurred_at": "2021-08-17T13:28:57.801578Z",
+                "name": "last_activity"
+              }
+            ],
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public"
+          }
+        },
+        "properties": {
+          "incident": {
+            "$ref": "#/components/schemas/IncidentV1"
+          }
+        },
+        "required": [
+          "incident"
+        ],
+        "type": "object"
+      },
+      "IncidentsV2CreateResponseBody": {
+        "example": {
+          "incident": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "has_debrief": false,
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          }
+        },
+        "properties": {
+          "incident": {
+            "$ref": "#/components/schemas/IncidentV2"
+          }
+        },
+        "required": [
+          "incident"
+        ],
+        "type": "object"
+      },
+      "IncidentsV2EditRequestBody": {
+        "example": {
+          "incident": {
+            "call_url": "https://zoom.us/foo",
+            "custom_field_entries": [
+              {
+                "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "values": [
+                  {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_catalog_entry_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "value_text": "This is my text field, I hope you like it",
+                    "value_timestamp": ""
+                  }
+                ]
+              }
+            ],
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "bob@example.com",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "slack_user_id": "USER123"
+                },
+                "incident_role_id": "01FH5TZRWMNAFB0DZ23FD1TV96"
+              }
+            ],
+            "incident_status_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp_id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "value": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "name": "Our database is sad",
+            "severity_id": "01FH5TZRWMNAFB0DZ23FD1TV96",
+            "slack_channel_name_override": "inc-123-database-down",
+            "summary": "Our database is really really sad, and we don't know why yet."
+          },
+          "notify_incident_channel": true
+        },
+        "properties": {
+          "incident": {
+            "$ref": "#/components/schemas/IncidentEditPayloadV2"
+          },
+          "notify_incident_channel": {
+            "description": "Should we send Slack channel notifications to inform responders of this update? Note that this won't work if the Slack channel has already been archived.",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "incident",
+          "notify_incident_channel"
+        ],
+        "type": "object"
+      },
+      "IncidentsV2EditResponseBody": {
+        "example": {
+          "incident": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "has_debrief": false,
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          }
+        },
+        "properties": {
+          "incident": {
+            "$ref": "#/components/schemas/IncidentV2"
+          }
+        },
+        "required": [
+          "incident"
+        ],
+        "type": "object"
+      },
+      "IncidentsV2ListResponseBody": {
         "example": {
           "incidents": [
             {
@@ -29687,6 +29987,168 @@
         ],
         "type": "object"
       },
+      "IncidentsV2ShowResponseBody": {
+        "example": {
+          "incident": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "has_debrief": false,
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          }
+        },
+        "properties": {
+          "incident": {
+            "$ref": "#/components/schemas/IncidentV2"
+          }
+        },
+        "required": [
+          "incident"
+        ],
+        "type": "object"
+      },
       "ManagedResourceV2": {
         "example": {
           "annotations": {
@@ -29720,7 +30182,7 @@
             "type": "string"
           },
           "resource_id": {
-            "description": "The ID of the related resource",
+            "description": "The ID of the resource that this relates to",
             "example": "abc123",
             "type": "string"
           },
@@ -29731,7 +30193,8 @@
               "workflow"
             ],
             "example": "escalation_path",
-            "type": "string"
+            "type": "string",
+            "x-public-api-version": "v2"
           },
           "source_url": {
             "description": "The url of the external repository where this resource is managed (if there is one)",
@@ -29744,6 +30207,73 @@
           "resource_id",
           "managed_by",
           "annotations"
+        ],
+        "type": "object",
+        "x-public-api-version": "v2"
+      },
+      "ManagedResourcesCreateManagedResourcePayloadV2": {
+        "example": {
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          },
+          "resource_id": "abc123",
+          "resource_type": "schedule"
+        },
+        "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "type": "object"
+          },
+          "resource_id": {
+            "description": "The ID of the resource that this relates to",
+            "example": "abc123",
+            "type": "string"
+          },
+          "resource_type": {
+            "description": "The type of the related resource",
+            "enum": [
+              "escalation_path",
+              "schedule",
+              "workflow"
+            ],
+            "example": "schedule",
+            "type": "string"
+          }
+        },
+        "required": [
+          "annotations",
+          "resource_type",
+          "resource_id",
+          "managed_by"
+        ],
+        "type": "object"
+      },
+      "ManagedResourcesCreateManagedResourceResultV2": {
+        "example": {
+          "managed_resource": {
+            "annotations": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "managed_by": "dashboard",
+            "resource_id": "abc123",
+            "resource_type": "schedule",
+            "source_url": "https://github.com/my-company/infrastructure"
+          }
+        },
+        "properties": {
+          "managed_resource": {
+            "$ref": "#/components/schemas/ManagedResourceV2"
+          }
+        },
+        "required": [
+          "managed_resource"
         ],
         "type": "object"
       },
@@ -29789,30 +30319,6 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "PaginationMetaResult": {
-        "example": {
-          "after": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "page_size": 25
-        },
-        "properties": {
-          "after": {
-            "description": "If provided, pass this as the 'after' param to load the next page",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "type": "string"
-          },
-          "page_size": {
-            "default": 25,
-            "description": "What was the maximum number of results requested",
-            "example": 25,
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "page_size"
-        ],
-        "type": "object"
       },
       "PaginationMetaResultV1": {
         "example": {
@@ -29951,1153 +30457,6 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "PrivateIncidentActionCreatedV1ResponseBody": {
-        "example": {
-          "event_type": "private_incident.action_created_v1",
-          "private_incident.action_created_v1": {
-            "id": "abc123"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "private_incident.action_created_v1",
-            "type": "string"
-          },
-          "private_incident.action_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "private_incident.action_created_v1"
-        ],
-        "type": "object"
-      },
-      "PrivateIncidentActionUpdatedV1ResponseBody": {
-        "example": {
-          "event_type": "private_incident.action_updated_v1",
-          "private_incident.action_updated_v1": {
-            "id": "abc123"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "private_incident.action_updated_v1",
-            "type": "string"
-          },
-          "private_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "private_incident.action_updated_v1"
-        ],
-        "type": "object"
-      },
-      "PrivateIncidentFollowUpCreatedV1ResponseBody": {
-        "example": {
-          "event_type": "private_incident.follow_up_created_v1",
-          "private_incident.follow_up_created_v1": {
-            "id": "abc123"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "private_incident.follow_up_created_v1",
-            "type": "string"
-          },
-          "private_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "private_incident.follow_up_created_v1"
-        ],
-        "type": "object"
-      },
-      "PrivateIncidentFollowUpUpdatedV1ResponseBody": {
-        "example": {
-          "event_type": "private_incident.follow_up_updated_v1",
-          "private_incident.follow_up_updated_v1": {
-            "id": "abc123"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "private_incident.follow_up_updated_v1",
-            "type": "string"
-          },
-          "private_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "private_incident.follow_up_updated_v1"
-        ],
-        "type": "object"
-      },
-      "PrivateIncidentIncidentCreatedV2ResponseBody": {
-        "example": {
-          "event_type": "private_incident.incident_created_v2",
-          "private_incident.incident_created_v2": {
-            "id": "abc123"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "private_incident.incident_created_v2",
-            "type": "string"
-          },
-          "private_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "private_incident.incident_created_v2"
-        ],
-        "type": "object"
-      },
-      "PrivateIncidentIncidentUpdatedV2ResponseBody": {
-        "example": {
-          "event_type": "private_incident.incident_updated_v2",
-          "private_incident.incident_updated_v2": {
-            "id": "abc123"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "private_incident.incident_updated_v2",
-            "type": "string"
-          },
-          "private_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "private_incident.incident_updated_v2"
-        ],
-        "type": "object"
-      },
-      "PrivateIncidentMembershipGrantedV1ResponseBody": {
-        "example": {
-          "event_type": "private_incident.membership_granted_v1",
-          "private_incident.membership_granted_v1": {
-            "actor_user_id": "abc123",
-            "incident_id": "abc123",
-            "user_id": "abc123"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "private_incident.membership_granted_v1",
-            "type": "string"
-          },
-          "private_incident.membership_granted_v1": {
-            "$ref": "#/components/schemas/WebhookIncidentUserV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "private_incident.membership_granted_v1"
-        ],
-        "type": "object"
-      },
-      "PrivateIncidentMembershipRevokedV1ResponseBody": {
-        "example": {
-          "event_type": "private_incident.membership_revoked_v1",
-          "private_incident.membership_revoked_v1": {
-            "actor_user_id": "abc123",
-            "incident_id": "abc123",
-            "user_id": "abc123"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "private_incident.membership_revoked_v1",
-            "type": "string"
-          },
-          "private_incident.membership_revoked_v1": {
-            "$ref": "#/components/schemas/WebhookIncidentUserV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "private_incident.membership_revoked_v1"
-        ],
-        "type": "object"
-      },
-      "PublicIncidentActionCreatedV1ResponseBody": {
-        "example": {
-          "event_type": "public_incident.action_created_v1",
-          "public_incident.action_created_v1": {
-            "assignee": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            },
-            "completed_at": "2021-08-17T13:28:57.801578Z",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Call the fire brigade",
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "follow_up": true,
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "status": "outstanding",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "public_incident.action_created_v1",
-            "type": "string"
-          },
-          "public_incident.action_created_v1": {
-            "$ref": "#/components/schemas/ActionV1"
-          }
-        },
-        "required": [
-          "event_type",
-          "public_incident.action_created_v1"
-        ],
-        "type": "object"
-      },
-      "PublicIncidentActionUpdatedV1ResponseBody": {
-        "example": {
-          "event_type": "public_incident.action_updated_v1",
-          "public_incident.action_updated_v1": {
-            "assignee": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            },
-            "completed_at": "2021-08-17T13:28:57.801578Z",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Call the fire brigade",
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "follow_up": true,
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "status": "outstanding",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "public_incident.action_updated_v1",
-            "type": "string"
-          },
-          "public_incident.action_updated_v1": {
-            "$ref": "#/components/schemas/ActionV1"
-          }
-        },
-        "required": [
-          "event_type",
-          "public_incident.action_updated_v1"
-        ],
-        "type": "object"
-      },
-      "PublicIncidentFollowUpCreatedV1ResponseBody": {
-        "example": {
-          "event_type": "public_incident.follow_up_created_v1",
-          "public_incident.follow_up_created_v1": {
-            "assignee": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            },
-            "completed_at": "2021-08-17T13:28:57.801578Z",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Call the fire brigade",
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "follow_up": true,
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "status": "outstanding",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "public_incident.follow_up_created_v1",
-            "type": "string"
-          },
-          "public_incident.follow_up_created_v1": {
-            "$ref": "#/components/schemas/ActionV1"
-          }
-        },
-        "required": [
-          "event_type",
-          "public_incident.follow_up_created_v1"
-        ],
-        "type": "object"
-      },
-      "PublicIncidentFollowUpUpdatedV1ResponseBody": {
-        "example": {
-          "event_type": "public_incident.follow_up_updated_v1",
-          "public_incident.follow_up_updated_v1": {
-            "assignee": {
-              "email": "lisa@incident.io",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Lisa Karlin Curtis",
-              "role": "viewer",
-              "slack_user_id": "U02AYNF2XJM"
-            },
-            "completed_at": "2021-08-17T13:28:57.801578Z",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Call the fire brigade",
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "follow_up": true,
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "status": "outstanding",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "public_incident.follow_up_updated_v1",
-            "type": "string"
-          },
-          "public_incident.follow_up_updated_v1": {
-            "$ref": "#/components/schemas/ActionV1"
-          }
-        },
-        "required": [
-          "event_type",
-          "public_incident.follow_up_updated_v1"
-        ],
-        "type": "object"
-      },
-      "PublicIncidentIncidentCreatedV2ResponseBody": {
-        "example": {
-          "event_type": "public_incident.incident_created_v2",
-          "public_incident.incident_created_v2": {
-            "call_url": "https://zoom.us/foo",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "creator": {
-              "api_key": {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "My test API key"
-              },
-              "user": {
-                "email": "lisa@incident.io",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Lisa Karlin Curtis",
-                "role": "viewer",
-                "slack_user_id": "U02AYNF2XJM"
-              }
-            },
-            "custom_field_entries": [
-              {
-                "custom_field": {
-                  "description": "Which team is impacted by this issue",
-                  "field_type": "single_select",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Affected Team",
-                  "options": [
-                    {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    }
-                  ]
-                },
-                "values": [
-                  {
-                    "value_catalog_entry": {
-                      "aliases": [
-                        "lawrence@incident.io",
-                        "lawrence"
-                      ],
-                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "name": "Primary On-call"
-                    },
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option": {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    },
-                    "value_text": "This is my text field, I hope you like it"
-                  }
-                ]
-              }
-            ],
-            "duration_metrics": [
-              {
-                "duration_metric": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Lasted"
-                },
-                "value_seconds": 1
-              }
-            ],
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "has_debrief": false,
-            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-            "incident_role_assignments": [
-              {
-                "assignee": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                },
-                "role": {
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "The person currently coordinating the incident",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                  "name": "Incident Lead",
-                  "required": false,
-                  "role_type": "lead",
-                  "shortform": "lead",
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_status": {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "incident_timestamp_values": [
-              {
-                "incident_timestamp": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Impact started",
-                  "rank": 1
-                },
-                "value": {
-                  "value": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_type": {
-              "create_in_triage": "always",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Customer facing production outages",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_default": false,
-              "name": "Production Outage",
-              "private_incidents_only": false,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "mode": "standard",
-            "most_recent_update_message": "We're working on a fix, hoping to ship in the next 30 minutes",
-            "name": "Our database is sad",
-            "permalink": "https://app.incident.io/incidents/123",
-            "postmortem_document_url": "https://docs.google.com/my_doc_id",
-            "reference": "INC-123",
-            "related_incidents": [
-              "INC-237"
-            ],
-            "severity": {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Issues with **low impact**.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Minor",
-              "rank": 1,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "slack_channel_id": "C02AW36C1M5",
-            "slack_channel_name": "inc-165-green-parrot",
-            "slack_team_id": "T02A1FSLE8J",
-            "summary": "Our database is really really sad, and we don't know why yet.",
-            "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public",
-            "workload_minutes_late": 40.7,
-            "workload_minutes_sleeping": 0,
-            "workload_minutes_total": 60.7,
-            "workload_minutes_working": 20
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "public_incident.incident_created_v2",
-            "type": "string"
-          },
-          "public_incident.incident_created_v2": {
-            "$ref": "#/components/schemas/WebhookIncidentV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "public_incident.incident_created_v2"
-        ],
-        "type": "object"
-      },
-      "PublicIncidentIncidentStatusUpdatedV2ResponseBody": {
-        "example": {
-          "event_type": "public_incident.incident_status_updated_v2",
-          "public_incident.incident_status_updated_v2": {
-            "incident": {
-              "call_url": "https://zoom.us/foo",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "creator": {
-                "api_key": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "My test API key"
-                },
-                "user": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                }
-              },
-              "custom_field_entries": [
-                {
-                  "custom_field": {
-                    "description": "Which team is impacted by this issue",
-                    "field_type": "single_select",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "Affected Team",
-                    "options": [
-                      {
-                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "sort_key": 10,
-                        "value": "Product"
-                      }
-                    ]
-                  },
-                  "values": [
-                    {
-                      "value_catalog_entry": {
-                        "aliases": [
-                          "lawrence@incident.io",
-                          "lawrence"
-                        ],
-                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "name": "Primary On-call"
-                      },
-                      "value_link": "https://google.com/",
-                      "value_numeric": "123.456",
-                      "value_option": {
-                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                        "sort_key": 10,
-                        "value": "Product"
-                      },
-                      "value_text": "This is my text field, I hope you like it"
-                    }
-                  ]
-                }
-              ],
-              "duration_metrics": [
-                {
-                  "duration_metric": {
-                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                    "name": "Lasted"
-                  },
-                  "value_seconds": 1
-                }
-              ],
-              "external_issue_reference": {
-                "issue_name": "INC-123",
-                "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-                "provider": "asana"
-              },
-              "has_debrief": false,
-              "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-              "incident_role_assignments": [
-                {
-                  "assignee": {
-                    "email": "lisa@incident.io",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "name": "Lisa Karlin Curtis",
-                    "role": "viewer",
-                    "slack_user_id": "U02AYNF2XJM"
-                  },
-                  "role": {
-                    "created_at": "2021-08-17T13:28:57.801578Z",
-                    "description": "The person currently coordinating the incident",
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                    "name": "Incident Lead",
-                    "required": false,
-                    "role_type": "lead",
-                    "shortform": "lead",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
-                  }
-                }
-              ],
-              "incident_status": {
-                "category": "triage",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                "name": "Closed",
-                "rank": 4,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "incident_timestamp_values": [
-                {
-                  "incident_timestamp": {
-                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                    "name": "Impact started",
-                    "rank": 1
-                  },
-                  "value": {
-                    "value": "2021-08-17T13:28:57.801578Z"
-                  }
-                }
-              ],
-              "incident_type": {
-                "create_in_triage": "always",
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Customer facing production outages",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "is_default": false,
-                "name": "Production Outage",
-                "private_incidents_only": false,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "mode": "standard",
-              "name": "Our database is sad",
-              "permalink": "https://app.incident.io/incidents/123",
-              "postmortem_document_url": "https://docs.google.com/my_doc_id",
-              "reference": "INC-123",
-              "severity": {
-                "created_at": "2021-08-17T13:28:57.801578Z",
-                "description": "Issues with **low impact**.",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Minor",
-                "rank": 1,
-                "updated_at": "2021-08-17T13:28:57.801578Z"
-              },
-              "slack_channel_id": "C02AW36C1M5",
-              "slack_channel_name": "inc-165-green-parrot",
-              "slack_team_id": "T02A1FSLE8J",
-              "summary": "Our database is really really sad, and we don't know why yet.",
-              "updated_at": "2021-08-17T13:28:57.801578Z",
-              "visibility": "public",
-              "workload_minutes_late": 40.7,
-              "workload_minutes_sleeping": 0,
-              "workload_minutes_total": 60.7,
-              "workload_minutes_working": 20
-            },
-            "message": "We're working on a fix, hoping to ship in the next 30 minutes",
-            "new_status": {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "previous_status": {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            }
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "public_incident.incident_status_updated_v2",
-            "type": "string"
-          },
-          "public_incident.incident_status_updated_v2": {
-            "$ref": "#/components/schemas/IncidentWithStatusChangeV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "public_incident.incident_status_updated_v2"
-        ],
-        "type": "object"
-      },
-      "PublicIncidentIncidentUpdatedV2ResponseBody": {
-        "example": {
-          "event_type": "public_incident.incident_updated_v2",
-          "public_incident.incident_updated_v2": {
-            "call_url": "https://zoom.us/foo",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "creator": {
-              "api_key": {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "My test API key"
-              },
-              "user": {
-                "email": "lisa@incident.io",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Lisa Karlin Curtis",
-                "role": "viewer",
-                "slack_user_id": "U02AYNF2XJM"
-              }
-            },
-            "custom_field_entries": [
-              {
-                "custom_field": {
-                  "description": "Which team is impacted by this issue",
-                  "field_type": "single_select",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Affected Team",
-                  "options": [
-                    {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    }
-                  ]
-                },
-                "values": [
-                  {
-                    "value_catalog_entry": {
-                      "aliases": [
-                        "lawrence@incident.io",
-                        "lawrence"
-                      ],
-                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "name": "Primary On-call"
-                    },
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option": {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    },
-                    "value_text": "This is my text field, I hope you like it"
-                  }
-                ]
-              }
-            ],
-            "duration_metrics": [
-              {
-                "duration_metric": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Lasted"
-                },
-                "value_seconds": 1
-              }
-            ],
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "has_debrief": false,
-            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-            "incident_role_assignments": [
-              {
-                "assignee": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                },
-                "role": {
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "The person currently coordinating the incident",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                  "name": "Incident Lead",
-                  "required": false,
-                  "role_type": "lead",
-                  "shortform": "lead",
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_status": {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "incident_timestamp_values": [
-              {
-                "incident_timestamp": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Impact started",
-                  "rank": 1
-                },
-                "value": {
-                  "value": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_type": {
-              "create_in_triage": "always",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Customer facing production outages",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_default": false,
-              "name": "Production Outage",
-              "private_incidents_only": false,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "mode": "standard",
-            "most_recent_update_message": "We're working on a fix, hoping to ship in the next 30 minutes",
-            "name": "Our database is sad",
-            "permalink": "https://app.incident.io/incidents/123",
-            "postmortem_document_url": "https://docs.google.com/my_doc_id",
-            "reference": "INC-123",
-            "related_incidents": [
-              "INC-237"
-            ],
-            "severity": {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Issues with **low impact**.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Minor",
-              "rank": 1,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "slack_channel_id": "C02AW36C1M5",
-            "slack_channel_name": "inc-165-green-parrot",
-            "slack_team_id": "T02A1FSLE8J",
-            "summary": "Our database is really really sad, and we don't know why yet.",
-            "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public",
-            "workload_minutes_late": 40.7,
-            "workload_minutes_sleeping": 0,
-            "workload_minutes_total": 60.7,
-            "workload_minutes_working": 20
-          }
-        },
-        "properties": {
-          "event_type": {
-            "description": "What type of event is this webhook for?",
-            "enum": [
-              "public_incident.incident_created_v2",
-              "private_incident.incident_created_v2",
-              "public_incident.incident_updated_v2",
-              "private_incident.incident_updated_v2",
-              "public_incident.incident_status_updated_v2",
-              "public_incident.follow_up_created_v1",
-              "private_incident.follow_up_created_v1",
-              "public_incident.follow_up_updated_v1",
-              "private_incident.follow_up_updated_v1",
-              "public_incident.action_created_v1",
-              "private_incident.action_created_v1",
-              "public_incident.action_updated_v1",
-              "private_incident.action_updated_v1",
-              "private_incident.membership_granted_v1",
-              "private_incident.membership_revoked_v1"
-            ],
-            "example": "public_incident.incident_updated_v2",
-            "type": "string"
-          },
-          "public_incident.incident_updated_v2": {
-            "$ref": "#/components/schemas/WebhookIncidentV2"
-          }
-        },
-        "required": [
-          "event_type",
-          "public_incident.incident_updated_v2"
-        ],
-        "type": "object"
       },
       "RBACRoleV2": {
         "example": {
@@ -31507,7 +30866,10 @@
               "abc123"
             ]
           },
-          "name": "My Schedule",
+          "name": "Primary On-call Schedule",
+          "team_ids": [
+            "01JPQA75EPNEES4479P16P4XAB"
+          ],
           "timezone": "America/Los_Angeles"
         },
         "properties": {
@@ -31530,8 +30892,19 @@
           },
           "name": {
             "description": "Name of the schedule",
-            "example": "My Schedule",
+            "example": "Primary On-call Schedule",
             "type": "string"
+          },
+          "team_ids": {
+            "description": "IDs of teams that own this schedule",
+            "example": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
           },
           "timezone": {
             "description": "Timezone of the schedule",
@@ -32487,7 +31860,10 @@
               "abc123"
             ]
           },
-          "name": "My Schedule",
+          "name": "Primary On-call Schedule",
+          "team_ids": [
+            "01JPQA75EPNEES4479P16P4XAB"
+          ],
           "timezone": "America/Los_Angeles"
         },
         "properties": {
@@ -32510,8 +31886,19 @@
           },
           "name": {
             "description": "Name of the schedule",
-            "example": "My Schedule",
+            "example": "Primary On-call Schedule",
             "type": "string"
+          },
+          "team_ids": {
+            "description": "IDs of teams that own this schedule",
+            "example": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
           },
           "timezone": {
             "description": "Timezone of the schedule",
@@ -32598,6 +31985,9 @@
           },
           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
           "name": "Primary On-Call Schedule",
+          "team_ids": [
+            "01JPQA75EPNEES4479P16P4XAB"
+          ],
           "timezone": "Europe/London",
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
@@ -32658,6 +32048,17 @@
             "example": "Primary On-Call Schedule",
             "type": "string"
           },
+          "team_ids": {
+            "description": "IDs of teams that own this schedule",
+            "example": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "timezone": {
             "description": "Timezone of the schedule, as interpreted at the point of generating the report",
             "example": "Europe/London",
@@ -32675,6 +32076,7 @@
           "timezone",
           "external_provider",
           "external_provider_id",
+          "team_ids",
           "created_at",
           "updated_at",
           "annotations",
@@ -32815,7 +32217,10 @@
                 "abc123"
               ]
             },
-            "name": "My Schedule",
+            "name": "Primary On-call Schedule",
+            "team_ids": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
             "timezone": "America/Los_Angeles"
           }
         },
@@ -32906,6 +32311,9 @@
             },
             "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "name": "Primary On-Call Schedule",
+            "team_ids": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
             "timezone": "Europe/London",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
@@ -33003,6 +32411,9 @@
               },
               "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
               "name": "Primary On-Call Schedule",
+              "team_ids": [
+                "01JPQA75EPNEES4479P16P4XAB"
+              ],
               "timezone": "Europe/London",
               "updated_at": "2021-08-17T13:28:57.801578Z"
             }
@@ -33089,6 +32500,9 @@
                 },
                 "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                 "name": "Primary On-Call Schedule",
+                "team_ids": [
+                  "01JPQA75EPNEES4479P16P4XAB"
+                ],
                 "timezone": "Europe/London",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
               }
@@ -33254,6 +32668,9 @@
             },
             "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "name": "Primary On-Call Schedule",
+            "team_ids": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
             "timezone": "Europe/London",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
@@ -33315,7 +32732,10 @@
                 "abc123"
               ]
             },
-            "name": "My Schedule",
+            "name": "Primary On-call Schedule",
+            "team_ids": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
             "timezone": "America/Los_Angeles"
           }
         },
@@ -33330,6 +32750,7 @@
           "timezone",
           "external_provider",
           "external_provider_id",
+          "team_ids",
           "created_at",
           "updated_at",
           "annotations",
@@ -33414,6 +32835,9 @@
             },
             "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
             "name": "Primary On-Call Schedule",
+            "team_ids": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
             "timezone": "Europe/London",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
@@ -33699,408 +33123,8 @@
           "created_at",
           "updated_at"
         ],
-        "type": "object"
-      },
-      "ShowResponseBody": {
-        "example": {
-          "incident_role": {
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "The person currently coordinating the incident",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-            "name": "Incident Lead",
-            "required": false,
-            "role_type": "lead",
-            "shortform": "lead",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "incident_role": {
-            "$ref": "#/components/schemas/IncidentRoleV1"
-          }
-        },
-        "required": [
-          "incident_role"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody2": {
-        "example": {
-          "incident_role": {
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "The person currently coordinating the incident",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-            "name": "Incident Lead",
-            "role_type": "lead",
-            "shortform": "lead",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "incident_role": {
-            "$ref": "#/components/schemas/IncidentRoleV2"
-          }
-        },
-        "required": [
-          "incident_role"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody3": {
-        "example": {
-          "incident_status": {
-            "category": "triage",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "name": "Closed",
-            "rank": 4,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "incident_status": {
-            "$ref": "#/components/schemas/IncidentStatusV1"
-          }
-        },
-        "required": [
-          "incident_status"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody4": {
-        "example": {
-          "incident_timestamp": {
-            "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-            "name": "Impact started",
-            "rank": 1
-          }
-        },
-        "properties": {
-          "incident_timestamp": {
-            "$ref": "#/components/schemas/IncidentTimestampV2"
-          }
-        },
-        "required": [
-          "incident_timestamp"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody5": {
-        "example": {
-          "incident_type": {
-            "create_in_triage": "always",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "description": "Customer facing production outages",
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "is_default": false,
-            "name": "Production Outage",
-            "private_incidents_only": false,
-            "updated_at": "2021-08-17T13:28:57.801578Z"
-          }
-        },
-        "properties": {
-          "incident_type": {
-            "$ref": "#/components/schemas/IncidentTypeV1"
-          }
-        },
-        "required": [
-          "incident_type"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody6": {
-        "example": {
-          "incident": {
-            "call_url": "https://zoom.us/foo",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "creator": {
-              "api_key": {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "My test API key"
-              },
-              "user": {
-                "email": "lisa@incident.io",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Lisa Karlin Curtis",
-                "role": "viewer",
-                "slack_user_id": "U02AYNF2XJM"
-              }
-            },
-            "custom_field_entries": [
-              {
-                "custom_field": {
-                  "description": "Which team is impacted by this issue",
-                  "field_type": "single_select",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Affected Team",
-                  "options": [
-                    {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    }
-                  ]
-                },
-                "values": [
-                  {
-                    "value_catalog_entry": {
-                      "aliases": [
-                        "lawrence@incident.io",
-                        "lawrence"
-                      ],
-                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "name": "Primary On-call"
-                    },
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option": {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    },
-                    "value_text": "This is my text field, I hope you like it"
-                  }
-                ]
-              }
-            ],
-            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-            "incident_role_assignments": [
-              {
-                "assignee": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                },
-                "role": {
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "The person currently coordinating the incident",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                  "name": "Incident Lead",
-                  "required": false,
-                  "role_type": "lead",
-                  "shortform": "lead",
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_type": {
-              "create_in_triage": "always",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Customer facing production outages",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_default": false,
-              "name": "Production Outage",
-              "private_incidents_only": false,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "mode": "real",
-            "name": "Our database is sad",
-            "permalink": "https://app.incident.io/incidents/123",
-            "postmortem_document_url": "https://docs.google.com/my_doc_id",
-            "reference": "INC-123",
-            "severity": {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Issues with **low impact**.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Minor",
-              "rank": 1,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "slack_channel_id": "C02AW36C1M5",
-            "slack_channel_name": "inc-165-green-parrot",
-            "slack_team_id": "T02A1FSLE8J",
-            "status": "triage",
-            "summary": "Our database is really really sad, and we don't know why yet.",
-            "timestamps": [
-              {
-                "last_occurred_at": "2021-08-17T13:28:57.801578Z",
-                "name": "last_activity"
-              }
-            ],
-            "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public"
-          }
-        },
-        "properties": {
-          "incident": {
-            "$ref": "#/components/schemas/IncidentV1"
-          }
-        },
-        "required": [
-          "incident"
-        ],
-        "type": "object"
-      },
-      "ShowResponseBody7": {
-        "example": {
-          "incident": {
-            "call_url": "https://zoom.us/foo",
-            "created_at": "2021-08-17T13:28:57.801578Z",
-            "creator": {
-              "api_key": {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "My test API key"
-              },
-              "user": {
-                "email": "lisa@incident.io",
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Lisa Karlin Curtis",
-                "role": "viewer",
-                "slack_user_id": "U02AYNF2XJM"
-              }
-            },
-            "custom_field_entries": [
-              {
-                "custom_field": {
-                  "description": "Which team is impacted by this issue",
-                  "field_type": "single_select",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Affected Team",
-                  "options": [
-                    {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    }
-                  ]
-                },
-                "values": [
-                  {
-                    "value_catalog_entry": {
-                      "aliases": [
-                        "lawrence@incident.io",
-                        "lawrence"
-                      ],
-                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "name": "Primary On-call"
-                    },
-                    "value_link": "https://google.com/",
-                    "value_numeric": "123.456",
-                    "value_option": {
-                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "sort_key": 10,
-                      "value": "Product"
-                    },
-                    "value_text": "This is my text field, I hope you like it"
-                  }
-                ]
-              }
-            ],
-            "duration_metrics": [
-              {
-                "duration_metric": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Lasted"
-                },
-                "value_seconds": 1
-              }
-            ],
-            "external_issue_reference": {
-              "issue_name": "INC-123",
-              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
-              "provider": "asana"
-            },
-            "has_debrief": false,
-            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
-            "incident_role_assignments": [
-              {
-                "assignee": {
-                  "email": "lisa@incident.io",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "name": "Lisa Karlin Curtis",
-                  "role": "viewer",
-                  "slack_user_id": "U02AYNF2XJM"
-                },
-                "role": {
-                  "created_at": "2021-08-17T13:28:57.801578Z",
-                  "description": "The person currently coordinating the incident",
-                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-                  "name": "Incident Lead",
-                  "required": false,
-                  "role_type": "lead",
-                  "shortform": "lead",
-                  "updated_at": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_status": {
-              "category": "triage",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-              "name": "Closed",
-              "rank": 4,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "incident_timestamp_values": [
-              {
-                "incident_timestamp": {
-                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
-                  "name": "Impact started",
-                  "rank": 1
-                },
-                "value": {
-                  "value": "2021-08-17T13:28:57.801578Z"
-                }
-              }
-            ],
-            "incident_type": {
-              "create_in_triage": "always",
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Customer facing production outages",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "is_default": false,
-              "name": "Production Outage",
-              "private_incidents_only": false,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "mode": "standard",
-            "name": "Our database is sad",
-            "permalink": "https://app.incident.io/incidents/123",
-            "postmortem_document_url": "https://docs.google.com/my_doc_id",
-            "reference": "INC-123",
-            "severity": {
-              "created_at": "2021-08-17T13:28:57.801578Z",
-              "description": "Issues with **low impact**.",
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Minor",
-              "rank": 1,
-              "updated_at": "2021-08-17T13:28:57.801578Z"
-            },
-            "slack_channel_id": "C02AW36C1M5",
-            "slack_channel_name": "inc-165-green-parrot",
-            "slack_team_id": "T02A1FSLE8J",
-            "summary": "Our database is really really sad, and we don't know why yet.",
-            "updated_at": "2021-08-17T13:28:57.801578Z",
-            "visibility": "public",
-            "workload_minutes_late": 40.7,
-            "workload_minutes_sleeping": 0,
-            "workload_minutes_total": 60.7,
-            "workload_minutes_working": 20
-          }
-        },
-        "properties": {
-          "incident": {
-            "$ref": "#/components/schemas/IncidentV2"
-          }
-        },
-        "required": [
-          "incident"
-        ],
-        "type": "object"
+        "type": "object",
+        "x-public-api-version": "v2"
       },
       "StepConfigPayloadV2": {
         "example": {
@@ -34314,125 +33338,6 @@
         ],
         "type": "object",
         "x-public-api-version": "v2"
-      },
-      "UpdateRequestBody": {
-        "example": {
-          "description": "The person currently coordinating the incident",
-          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-          "name": "Incident Lead",
-          "required": false,
-          "shortform": "lead"
-        },
-        "properties": {
-          "description": {
-            "description": "Describes the purpose of the role",
-            "example": "The person currently coordinating the incident",
-            "minLength": 1,
-            "type": "string"
-          },
-          "instructions": {
-            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
-            "example": "Take point on the incident; Make sure people are clear on responsibilities",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human readable name of the incident role",
-            "example": "Incident Lead",
-            "minLength": 1,
-            "type": "string"
-          },
-          "required": {
-            "description": "DEPRECATED: this will always be false.",
-            "example": false,
-            "type": "boolean"
-          },
-          "shortform": {
-            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "shortform",
-          "description",
-          "instructions",
-          "condition_groups",
-          "role_type",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
-      },
-      "UpdateRequestBody2": {
-        "example": {
-          "description": "The person currently coordinating the incident",
-          "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
-          "name": "Incident Lead",
-          "shortform": "lead"
-        },
-        "properties": {
-          "description": {
-            "description": "Describes the purpose of the role",
-            "example": "The person currently coordinating the incident",
-            "minLength": 1,
-            "type": "string"
-          },
-          "instructions": {
-            "description": "Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.",
-            "example": "Take point on the incident; Make sure people are clear on responsibilities",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human readable name of the incident role",
-            "example": "Incident Lead",
-            "minLength": 1,
-            "type": "string"
-          },
-          "shortform": {
-            "description": "Short human readable name for Slack. Note that this will be empty for the 'reporter' role.",
-            "example": "lead",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "shortform",
-          "description",
-          "instructions",
-          "condition_groups",
-          "role_type",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
-      },
-      "UpdateRequestBody3": {
-        "example": {
-          "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-          "name": "Closed"
-        },
-        "properties": {
-          "description": {
-            "description": "Rich text description of the incident status",
-            "example": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
-            "type": "string"
-          },
-          "name": {
-            "description": "Unique name of this status",
-            "example": "Closed",
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "rank",
-          "category",
-          "created_at",
-          "updated_at"
-        ],
-        "type": "object"
       },
       "UserReferencePayloadV1": {
         "example": {
@@ -35276,6 +34181,1823 @@
         },
         "required": [
           "id"
+        ],
+        "type": "object"
+      },
+      "WebhooksAllResponseBody": {
+        "example": {
+          "event_type": "public_incident.incident_created_v2",
+          "private_incident.action_created_v1": {
+            "id": "abc123"
+          },
+          "private_incident.action_updated_v1": {
+            "id": "abc123"
+          },
+          "private_incident.follow_up_created_v1": {
+            "id": "abc123"
+          },
+          "private_incident.follow_up_updated_v1": {
+            "id": "abc123"
+          },
+          "private_incident.incident_created_v2": {
+            "id": "abc123"
+          },
+          "private_incident.incident_updated_v2": {
+            "id": "abc123"
+          },
+          "private_incident.membership_granted_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          },
+          "private_incident.membership_revoked_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          },
+          "public_incident.action_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.action_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.follow_up_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.follow_up_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_incident.incident_created_v2": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "has_debrief": false,
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "most_recent_update_message": "We're working on a fix, hoping to ship in the next 30 minutes",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          },
+          "public_incident.incident_status_updated_v2": {
+            "incident": {
+              "call_url": "https://zoom.us/foo",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              },
+              "custom_field_entries": [
+                {
+                  "custom_field": {
+                    "description": "Which team is impacted by this issue",
+                    "field_type": "single_select",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Affected Team",
+                    "options": [
+                      {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      }
+                    ]
+                  },
+                  "values": [
+                    {
+                      "value_catalog_entry": {
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
+                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Primary On-call"
+                      },
+                      "value_link": "https://google.com/",
+                      "value_numeric": "123.456",
+                      "value_option": {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      },
+                      "value_text": "This is my text field, I hope you like it"
+                    }
+                  ]
+                }
+              ],
+              "duration_metrics": [
+                {
+                  "duration_metric": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Lasted"
+                  },
+                  "value_seconds": 1
+                }
+              ],
+              "external_issue_reference": {
+                "issue_name": "INC-123",
+                "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                "provider": "asana"
+              },
+              "has_debrief": false,
+              "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "incident_role_assignments": [
+                {
+                  "assignee": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "required": false,
+                    "role_type": "lead",
+                    "shortform": "lead",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_status": {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "incident_timestamp_values": [
+                {
+                  "incident_timestamp": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Impact started",
+                    "rank": 1
+                  },
+                  "value": {
+                    "value": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_type": {
+                "create_in_triage": "always",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Customer facing production outages",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_default": false,
+                "name": "Production Outage",
+                "private_incidents_only": false,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "mode": "standard",
+              "name": "Our database is sad",
+              "permalink": "https://app.incident.io/incidents/123",
+              "postmortem_document_url": "https://docs.google.com/my_doc_id",
+              "reference": "INC-123",
+              "severity": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "slack_channel_id": "C02AW36C1M5",
+              "slack_channel_name": "inc-165-green-parrot",
+              "slack_team_id": "T02A1FSLE8J",
+              "summary": "Our database is really really sad, and we don't know why yet.",
+              "updated_at": "2021-08-17T13:28:57.801578Z",
+              "visibility": "public",
+              "workload_minutes_late": 40.7,
+              "workload_minutes_sleeping": 0,
+              "workload_minutes_total": 60.7,
+              "workload_minutes_working": 20
+            },
+            "message": "We're working on a fix, hoping to ship in the next 30 minutes",
+            "new_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "previous_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          },
+          "public_incident.incident_updated_v2": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "has_debrief": false,
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "most_recent_update_message": "We're working on a fix, hoping to ship in the next 30 minutes",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.incident_created_v2",
+            "type": "string"
+          },
+          "private_incident.action_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.follow_up_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.follow_up_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.incident_created_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.incident_updated_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.membership_granted_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          },
+          "private_incident.membership_revoked_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          },
+          "public_incident.action_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.follow_up_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.follow_up_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.incident_created_v2": {
+            "$ref": "#/components/schemas/WebhookIncidentV2"
+          },
+          "public_incident.incident_status_updated_v2": {
+            "$ref": "#/components/schemas/IncidentWithStatusChangeV2"
+          },
+          "public_incident.incident_updated_v2": {
+            "$ref": "#/components/schemas/WebhookIncidentV2"
+          }
+        },
+        "required": [
+          "event_type"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentActionCreatedV1ResponseBody": {
+        "example": {
+          "event_type": "private_incident.action_created_v1",
+          "private_incident.action_created_v1": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.action_created_v1",
+            "type": "string"
+          },
+          "private_incident.action_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.action_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentActionUpdatedV1ResponseBody": {
+        "example": {
+          "event_type": "private_incident.action_updated_v1",
+          "private_incident.action_updated_v1": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.action_updated_v1",
+            "type": "string"
+          },
+          "private_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.action_updated_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentFollowUpCreatedV1ResponseBody": {
+        "example": {
+          "event_type": "private_incident.follow_up_created_v1",
+          "private_incident.follow_up_created_v1": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.follow_up_created_v1",
+            "type": "string"
+          },
+          "private_incident.follow_up_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.follow_up_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentFollowUpUpdatedV1ResponseBody": {
+        "example": {
+          "event_type": "private_incident.follow_up_updated_v1",
+          "private_incident.follow_up_updated_v1": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.follow_up_updated_v1",
+            "type": "string"
+          },
+          "private_incident.follow_up_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.follow_up_updated_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentIncidentCreatedV2ResponseBody": {
+        "example": {
+          "event_type": "private_incident.incident_created_v2",
+          "private_incident.incident_created_v2": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.incident_created_v2",
+            "type": "string"
+          },
+          "private_incident.incident_created_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.incident_created_v2"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentIncidentUpdatedV2ResponseBody": {
+        "example": {
+          "event_type": "private_incident.incident_updated_v2",
+          "private_incident.incident_updated_v2": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.incident_updated_v2",
+            "type": "string"
+          },
+          "private_incident.incident_updated_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.incident_updated_v2"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentMembershipGrantedV1ResponseBody": {
+        "example": {
+          "event_type": "private_incident.membership_granted_v1",
+          "private_incident.membership_granted_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.membership_granted_v1",
+            "type": "string"
+          },
+          "private_incident.membership_granted_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.membership_granted_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentMembershipRevokedV1ResponseBody": {
+        "example": {
+          "event_type": "private_incident.membership_revoked_v1",
+          "private_incident.membership_revoked_v1": {
+            "actor_user_id": "abc123",
+            "incident_id": "abc123",
+            "user_id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.membership_revoked_v1",
+            "type": "string"
+          },
+          "private_incident.membership_revoked_v1": {
+            "$ref": "#/components/schemas/WebhookIncidentUserV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.membership_revoked_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicIncidentActionCreatedV1ResponseBody": {
+        "example": {
+          "event_type": "public_incident.action_created_v1",
+          "public_incident.action_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.action_created_v1",
+            "type": "string"
+          },
+          "public_incident.action_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.action_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicIncidentActionUpdatedV1ResponseBody": {
+        "example": {
+          "event_type": "public_incident.action_updated_v1",
+          "public_incident.action_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.action_updated_v1",
+            "type": "string"
+          },
+          "public_incident.action_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.action_updated_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicIncidentFollowUpCreatedV1ResponseBody": {
+        "example": {
+          "event_type": "public_incident.follow_up_created_v1",
+          "public_incident.follow_up_created_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.follow_up_created_v1",
+            "type": "string"
+          },
+          "public_incident.follow_up_created_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.follow_up_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicIncidentFollowUpUpdatedV1ResponseBody": {
+        "example": {
+          "event_type": "public_incident.follow_up_updated_v1",
+          "public_incident.follow_up_updated_v1": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "follow_up": true,
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "status": "outstanding",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.follow_up_updated_v1",
+            "type": "string"
+          },
+          "public_incident.follow_up_updated_v1": {
+            "$ref": "#/components/schemas/ActionV1"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.follow_up_updated_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicIncidentIncidentCreatedV2ResponseBody": {
+        "example": {
+          "event_type": "public_incident.incident_created_v2",
+          "public_incident.incident_created_v2": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "has_debrief": false,
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "most_recent_update_message": "We're working on a fix, hoping to ship in the next 30 minutes",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.incident_created_v2",
+            "type": "string"
+          },
+          "public_incident.incident_created_v2": {
+            "$ref": "#/components/schemas/WebhookIncidentV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.incident_created_v2"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicIncidentIncidentStatusUpdatedV2ResponseBody": {
+        "example": {
+          "event_type": "public_incident.incident_status_updated_v2",
+          "public_incident.incident_status_updated_v2": {
+            "incident": {
+              "call_url": "https://zoom.us/foo",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              },
+              "custom_field_entries": [
+                {
+                  "custom_field": {
+                    "description": "Which team is impacted by this issue",
+                    "field_type": "single_select",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Affected Team",
+                    "options": [
+                      {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      }
+                    ]
+                  },
+                  "values": [
+                    {
+                      "value_catalog_entry": {
+                        "aliases": [
+                          "lawrence@incident.io",
+                          "lawrence"
+                        ],
+                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Primary On-call"
+                      },
+                      "value_link": "https://google.com/",
+                      "value_numeric": "123.456",
+                      "value_option": {
+                        "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "sort_key": 10,
+                        "value": "Product"
+                      },
+                      "value_text": "This is my text field, I hope you like it"
+                    }
+                  ]
+                }
+              ],
+              "duration_metrics": [
+                {
+                  "duration_metric": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Lasted"
+                  },
+                  "value_seconds": 1
+                }
+              ],
+              "external_issue_reference": {
+                "issue_name": "INC-123",
+                "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                "provider": "asana"
+              },
+              "has_debrief": false,
+              "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "incident_role_assignments": [
+                {
+                  "assignee": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "role": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "The person currently coordinating the incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                    "name": "Incident Lead",
+                    "required": false,
+                    "role_type": "lead",
+                    "shortform": "lead",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_status": {
+                "category": "triage",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+                "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                "name": "Closed",
+                "rank": 4,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "incident_timestamp_values": [
+                {
+                  "incident_timestamp": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                    "name": "Impact started",
+                    "rank": 1
+                  },
+                  "value": {
+                    "value": "2021-08-17T13:28:57.801578Z"
+                  }
+                }
+              ],
+              "incident_type": {
+                "create_in_triage": "always",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Customer facing production outages",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_default": false,
+                "name": "Production Outage",
+                "private_incidents_only": false,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "mode": "standard",
+              "name": "Our database is sad",
+              "permalink": "https://app.incident.io/incidents/123",
+              "postmortem_document_url": "https://docs.google.com/my_doc_id",
+              "reference": "INC-123",
+              "severity": {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Issues with **low impact**.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Minor",
+                "rank": 1,
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "slack_channel_id": "C02AW36C1M5",
+              "slack_channel_name": "inc-165-green-parrot",
+              "slack_team_id": "T02A1FSLE8J",
+              "summary": "Our database is really really sad, and we don't know why yet.",
+              "updated_at": "2021-08-17T13:28:57.801578Z",
+              "visibility": "public",
+              "workload_minutes_late": 40.7,
+              "workload_minutes_sleeping": 0,
+              "workload_minutes_total": 60.7,
+              "workload_minutes_working": 20
+            },
+            "message": "We're working on a fix, hoping to ship in the next 30 minutes",
+            "new_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "previous_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.incident_status_updated_v2",
+            "type": "string"
+          },
+          "public_incident.incident_status_updated_v2": {
+            "$ref": "#/components/schemas/IncidentWithStatusChangeV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.incident_status_updated_v2"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicIncidentIncidentUpdatedV2ResponseBody": {
+        "example": {
+          "event_type": "public_incident.incident_updated_v2",
+          "public_incident.incident_updated_v2": {
+            "call_url": "https://zoom.us/foo",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            },
+            "custom_field_entries": [
+              {
+                "custom_field": {
+                  "description": "Which team is impacted by this issue",
+                  "field_type": "single_select",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Affected Team",
+                  "options": [
+                    {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    }
+                  ]
+                },
+                "values": [
+                  {
+                    "value_catalog_entry": {
+                      "aliases": [
+                        "lawrence@incident.io",
+                        "lawrence"
+                      ],
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "value_link": "https://google.com/",
+                    "value_numeric": "123.456",
+                    "value_option": {
+                      "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "sort_key": 10,
+                      "value": "Product"
+                    },
+                    "value_text": "This is my text field, I hope you like it"
+                  }
+                ]
+              }
+            ],
+            "duration_metrics": [
+              {
+                "duration_metric": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Lasted"
+                },
+                "value_seconds": 1
+              }
+            ],
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "has_debrief": false,
+            "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "incident_role_assignments": [
+              {
+                "assignee": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "role": {
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "description": "The person currently coordinating the incident",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "instructions": "Take point on the incident; Make sure people are clear on responsibilities",
+                  "name": "Incident Lead",
+                  "required": false,
+                  "role_type": "lead",
+                  "shortform": "lead",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_status": {
+              "category": "triage",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Impact has been **fully mitigated**, and we're ready to learn from this incident.",
+              "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+              "name": "Closed",
+              "rank": 4,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "incident_timestamp_values": [
+              {
+                "incident_timestamp": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYD5H",
+                  "name": "Impact started",
+                  "rank": 1
+                },
+                "value": {
+                  "value": "2021-08-17T13:28:57.801578Z"
+                }
+              }
+            ],
+            "incident_type": {
+              "create_in_triage": "always",
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Customer facing production outages",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_default": false,
+              "name": "Production Outage",
+              "private_incidents_only": false,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "mode": "standard",
+            "most_recent_update_message": "We're working on a fix, hoping to ship in the next 30 minutes",
+            "name": "Our database is sad",
+            "permalink": "https://app.incident.io/incidents/123",
+            "postmortem_document_url": "https://docs.google.com/my_doc_id",
+            "reference": "INC-123",
+            "related_incidents": [
+              "INC-237"
+            ],
+            "severity": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Issues with **low impact**.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Minor",
+              "rank": 1,
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "slack_channel_id": "C02AW36C1M5",
+            "slack_channel_name": "inc-165-green-parrot",
+            "slack_team_id": "T02A1FSLE8J",
+            "summary": "Our database is really really sad, and we don't know why yet.",
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "visibility": "public",
+            "workload_minutes_late": 40.7,
+            "workload_minutes_sleeping": 0,
+            "workload_minutes_total": 60.7,
+            "workload_minutes_working": 20
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.incident_updated_v2",
+            "type": "string"
+          },
+          "public_incident.incident_updated_v2": {
+            "$ref": "#/components/schemas/WebhookIncidentV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.incident_updated_v2"
         ],
         "type": "object"
       },
@@ -39423,7 +40145,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody"
+                  "$ref": "#/components/schemas/IncidentAttachmentsListResultV1"
                 }
               }
             },
@@ -39433,7 +40155,8 @@
         "summary": "List Incident Attachments V1",
         "tags": [
           "Incident Attachments V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "post": {
         "description": "Attaches an external resource to an incident",
@@ -39449,7 +40172,7 @@
                 }
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody"
+                "$ref": "#/components/schemas/IncidentAttachmentsCreatePayloadV1"
               }
             }
           },
@@ -39472,7 +40195,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody"
+                  "$ref": "#/components/schemas/IncidentAttachmentsCreateResultV1"
                 }
               }
             },
@@ -39482,7 +40205,8 @@
         "summary": "Create Incident Attachments V1",
         "tags": [
           "Incident Attachments V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incident_attachments/{id}": {
@@ -39511,7 +40235,8 @@
         "summary": "Delete Incident Attachments V1",
         "tags": [
           "Incident Attachments V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incident_memberships": {
@@ -39526,7 +40251,7 @@
                 "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody2"
+                "$ref": "#/components/schemas/IncidentMembershipsCreatePayloadV1"
               }
             }
           },
@@ -39552,7 +40277,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateResponseBody2"
+                  "$ref": "#/components/schemas/IncidentMembershipsCreateResultV1"
                 }
               }
             },
@@ -39562,7 +40287,8 @@
         "summary": "Create Incident Memberships V1",
         "tags": [
           "Incident Memberships V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incident_memberships/actions/revoke": {
@@ -39577,7 +40303,7 @@
                 "user_id": "01FCQSP07Z74QMMYPDDGQB9FTG"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody2"
+                "$ref": "#/components/schemas/IncidentMembershipsRevokePayloadV1"
               }
             }
           },
@@ -39591,7 +40317,8 @@
         "summary": "Revoke Incident Memberships V1",
         "tags": [
           "Incident Memberships V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incident_roles": {
@@ -39619,7 +40346,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody2"
+                  "$ref": "#/components/schemas/IncidentRolesListResultV1"
                 }
               }
             },
@@ -39629,7 +40356,8 @@
         "summary": "List Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "post": {
         "deprecated": true,
@@ -39646,7 +40374,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody3"
+                "$ref": "#/components/schemas/IncidentRolesCreatePayloadV1"
               }
             }
           },
@@ -39670,7 +40398,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody"
+                  "$ref": "#/components/schemas/IncidentRolesCreateResultV1"
                 }
               }
             },
@@ -39680,7 +40408,8 @@
         "summary": "Create Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incident_roles/{id}": {
@@ -39710,7 +40439,8 @@
         "summary": "Delete Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "get": {
         "deprecated": true,
@@ -39748,7 +40478,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody"
+                  "$ref": "#/components/schemas/IncidentRolesShowResultV1"
                 }
               }
             },
@@ -39758,7 +40488,8 @@
         "summary": "Show Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "put": {
         "deprecated": true,
@@ -39789,7 +40520,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody"
+                "$ref": "#/components/schemas/IncidentRolesUpdatePayloadV1"
               }
             }
           },
@@ -39813,7 +40544,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody"
+                  "$ref": "#/components/schemas/IncidentRolesUpdateResultV1"
                 }
               }
             },
@@ -39823,7 +40554,8 @@
         "summary": "Update Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incident_statuses": {
@@ -39848,7 +40580,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody4"
+                  "$ref": "#/components/schemas/IncidentStatusesListResultV1"
                 }
               }
             },
@@ -39858,7 +40590,8 @@
         "summary": "List Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "post": {
         "description": "Create a new incident status",
@@ -39872,7 +40605,7 @@
                 "name": "Closed"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody5"
+                "$ref": "#/components/schemas/IncidentStatusesCreatePayloadV1"
               }
             }
           },
@@ -39894,7 +40627,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody3"
+                  "$ref": "#/components/schemas/IncidentStatusesCreateResultV1"
                 }
               }
             },
@@ -39904,7 +40637,8 @@
         "summary": "Create Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incident_statuses/{id}": {
@@ -39933,7 +40667,8 @@
         "summary": "Delete Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "get": {
         "description": "Get a single incident status.",
@@ -39968,7 +40703,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody3"
+                  "$ref": "#/components/schemas/IncidentStatusesShowResultV1"
                 }
               }
             },
@@ -39978,7 +40713,8 @@
         "summary": "Show Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       },
       "put": {
         "description": "Update an existing incident status",
@@ -40005,7 +40741,7 @@
                 "name": "Closed"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody3"
+                "$ref": "#/components/schemas/IncidentStatusesUpdatePayloadV1"
               }
             }
           },
@@ -40027,7 +40763,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody3"
+                  "$ref": "#/components/schemas/IncidentStatusesUpdateResultV1"
                 }
               }
             },
@@ -40037,7 +40773,8 @@
         "summary": "Update Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incident_types": {
@@ -40063,7 +40800,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody6"
+                  "$ref": "#/components/schemas/IncidentTypesListResultV1"
                 }
               }
             },
@@ -40073,7 +40810,8 @@
         "summary": "List Incident Types V1",
         "tags": [
           "Incident Types V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incident_types/{id}": {
@@ -40111,7 +40849,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody5"
+                  "$ref": "#/components/schemas/IncidentTypesShowResultV1"
                 }
               }
             },
@@ -40121,7 +40859,8 @@
         "summary": "Show Incident Types V1",
         "tags": [
           "Incident Types V1"
-        ]
+        ],
+        "x-public-api-version": "v1"
       }
     },
     "/v1/incidents": {
@@ -40313,7 +41052,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody8"
+                  "$ref": "#/components/schemas/IncidentsV1ListResponseBody"
                 }
               }
             },
@@ -40372,7 +41111,7 @@
                 "visibility": "public"
               },
               "schema": {
-                "$ref": "#/components/schemas/IncidentCreatePayloadV1"
+                "$ref": "#/components/schemas/IncidentsV1CreateRequestBody"
               }
             }
           },
@@ -40501,7 +41240,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody6"
+                  "$ref": "#/components/schemas/IncidentsV1CreateResponseBody"
                 }
               }
             },
@@ -40656,7 +41395,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody6"
+                  "$ref": "#/components/schemas/IncidentsV1ShowResponseBody"
                 }
               }
             },
@@ -41325,7 +42064,7 @@
                 "title": "*errors.withMessage: PG::Error failed to connect"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateHTTPRequestBody"
+                "$ref": "#/components/schemas/AlertEventsCreateHTTPPayloadV2"
               }
             }
           },
@@ -41341,7 +42080,7 @@
                   "status": "success"
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/AlertResult"
+                  "$ref": "#/components/schemas/AlertEventsCreateHTTPResultV2"
                 }
               }
             },
@@ -41351,7 +42090,8 @@
         "summary": "CreateHTTP Alert Events V2",
         "tags": [
           "Alert Events V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/alert_routes": {
@@ -45746,6 +46486,9 @@
                     "type": "if_else"
                   }
                 ],
+                "team_ids": [
+                  "01JPQA75EPNEES4479P16P4XAB"
+                ],
                 "working_hours": [
                   {
                     "id": "abc123",
@@ -45851,6 +46594,9 @@
                         },
                         "type": "if_else"
                       }
+                    ],
+                    "team_ids": [
+                      "01JPQA75EPNEES4479P16P4XAB"
                     ],
                     "working_hours": [
                       {
@@ -46013,6 +46759,9 @@
                         "type": "if_else"
                       }
                     ],
+                    "team_ids": [
+                      "01JPQA75EPNEES4479P16P4XAB"
+                    ],
                     "working_hours": [
                       {
                         "id": "abc123",
@@ -46133,6 +46882,9 @@
                     "type": "if_else"
                   }
                 ],
+                "team_ids": [
+                  "01JPQA75EPNEES4479P16P4XAB"
+                ],
                 "working_hours": [
                   {
                     "id": "abc123",
@@ -46238,6 +46990,9 @@
                         },
                         "type": "if_else"
                       }
+                    ],
+                    "team_ids": [
+                      "01JPQA75EPNEES4479P16P4XAB"
                     ],
                     "working_hours": [
                       {
@@ -46448,7 +47203,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody3"
+                  "$ref": "#/components/schemas/IncidentRolesListResultV2"
                 }
               }
             },
@@ -46458,7 +47213,8 @@
         "summary": "List Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "post": {
         "description": "Create a new incident role",
@@ -46473,7 +47229,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateRequestBody4"
+                "$ref": "#/components/schemas/IncidentRolesCreatePayloadV2"
               }
             }
           },
@@ -46496,7 +47252,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody2"
+                  "$ref": "#/components/schemas/IncidentRolesCreateResultV2"
                 }
               }
             },
@@ -46506,7 +47262,8 @@
         "summary": "Create Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/incident_roles/{id}": {
@@ -46535,7 +47292,8 @@
         "summary": "Delete Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "get": {
         "description": "Get a single incident role.",
@@ -46571,7 +47329,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody2"
+                  "$ref": "#/components/schemas/IncidentRolesShowResultV2"
                 }
               }
             },
@@ -46581,7 +47339,8 @@
         "summary": "Show Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       },
       "put": {
         "description": "Update an existing incident role",
@@ -46610,7 +47369,7 @@
                 "shortform": "lead"
               },
               "schema": {
-                "$ref": "#/components/schemas/UpdateRequestBody2"
+                "$ref": "#/components/schemas/IncidentRolesUpdatePayloadV2"
               }
             }
           },
@@ -46633,7 +47392,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody2"
+                  "$ref": "#/components/schemas/IncidentRolesUpdateResultV2"
                 }
               }
             },
@@ -46643,7 +47402,8 @@
         "summary": "Update Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/incident_timestamps": {
@@ -46664,7 +47424,7 @@
                   ]
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody5"
+                  "$ref": "#/components/schemas/IncidentTimestampsListResultV2"
                 }
               }
             },
@@ -46674,7 +47434,8 @@
         "summary": "List Incident Timestamps V2",
         "tags": [
           "Incident Timestamps V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/incident_timestamps/{id}": {
@@ -46707,7 +47468,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody4"
+                  "$ref": "#/components/schemas/IncidentTimestampsShowResultV2"
                 }
               }
             },
@@ -46717,7 +47478,8 @@
         "summary": "Show Incident Timestamps V2",
         "tags": [
           "Incident Timestamps V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/incident_updates": {
@@ -46748,7 +47510,6 @@
               "description": "Integer number of records to return",
               "example": 25,
               "format": "int64",
-              "maximum": 500,
               "type": "integer"
             }
           },
@@ -46775,7 +47536,7 @@
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "merged_into_incident_id": "abc123",
+                      "merged_into_incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "message": "We're working on a fix, hoping to ship in the next 30 minutes",
                       "new_incident_status": {
                         "category": "triage",
@@ -46815,7 +47576,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody7"
+                  "$ref": "#/components/schemas/IncidentUpdatesListResultV2"
                 }
               }
             },
@@ -46825,7 +47586,8 @@
         "summary": "List Incident Updates V2",
         "tags": [
           "Incident Updates V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/incidents": {
@@ -47321,7 +48083,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponseBody9"
+                  "$ref": "#/components/schemas/IncidentsV2ListResponseBody"
                 }
               }
             },
@@ -47551,7 +48313,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody7"
+                  "$ref": "#/components/schemas/IncidentsV2CreateResponseBody"
                 }
               }
             },
@@ -47738,7 +48500,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody7"
+                  "$ref": "#/components/schemas/IncidentsV2ShowResponseBody"
                 }
               }
             },
@@ -47816,7 +48578,7 @@
                 "notify_incident_channel": true
               },
               "schema": {
-                "$ref": "#/components/schemas/EditRequestBody"
+                "$ref": "#/components/schemas/IncidentsV2EditRequestBody"
               }
             }
           },
@@ -47978,7 +48740,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ShowResponseBody7"
+                  "$ref": "#/components/schemas/IncidentsV2EditResponseBody"
                 }
               }
             },
@@ -48006,7 +48768,7 @@
                 "resource_type": "schedule"
               },
               "schema": {
-                "$ref": "#/components/schemas/CreateManagedResourceRequestBody"
+                "$ref": "#/components/schemas/ManagedResourcesCreateManagedResourcePayloadV2"
               }
             }
           },
@@ -48028,7 +48790,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/CreateManagedResourceResponseBody"
+                  "$ref": "#/components/schemas/ManagedResourcesCreateManagedResourceResultV2"
                 }
               }
             },
@@ -48038,7 +48800,8 @@
         "summary": "CreateManagedResource Managed Resources V2",
         "tags": [
           "Managed Resources V2"
-        ]
+        ],
+        "x-public-api-version": "v2"
       }
     },
     "/v2/schedule_entries": {
@@ -48346,6 +49109,9 @@
                       },
                       "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                       "name": "Primary On-Call Schedule",
+                      "team_ids": [
+                        "01JPQA75EPNEES4479P16P4XAB"
+                      ],
                       "timezone": "Europe/London",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     }
@@ -48417,7 +49183,10 @@
                       "abc123"
                     ]
                   },
-                  "name": "My Schedule",
+                  "name": "Primary On-call Schedule",
+                  "team_ids": [
+                    "01JPQA75EPNEES4479P16P4XAB"
+                  ],
                   "timezone": "America/Los_Angeles"
                 }
               },
@@ -48508,6 +49277,9 @@
                     },
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "name": "Primary On-Call Schedule",
+                    "team_ids": [
+                      "01JPQA75EPNEES4479P16P4XAB"
+                    ],
                     "timezone": "Europe/London",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
@@ -48653,6 +49425,9 @@
                     },
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "name": "Primary On-Call Schedule",
+                    "team_ids": [
+                      "01JPQA75EPNEES4479P16P4XAB"
+                    ],
                     "timezone": "Europe/London",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
@@ -48737,7 +49512,10 @@
                       "abc123"
                     ]
                   },
-                  "name": "My Schedule",
+                  "name": "Primary On-call Schedule",
+                  "team_ids": [
+                    "01JPQA75EPNEES4479P16P4XAB"
+                  ],
                   "timezone": "America/Los_Angeles"
                 }
               },
@@ -48828,6 +49606,9 @@
                     },
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
                     "name": "Primary On-Call Schedule",
+                    "team_ids": [
+                      "01JPQA75EPNEES4479P16P4XAB"
+                    ],
                     "timezone": "Europe/London",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
@@ -56566,7 +57347,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PrivateIncidentActionCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentActionCreatedV1ResponseBody"
                 }
               }
             },
@@ -56593,7 +57374,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PrivateIncidentActionUpdatedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentActionUpdatedV1ResponseBody"
                 }
               }
             },
@@ -56620,7 +57401,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PrivateIncidentFollowUpCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentFollowUpCreatedV1ResponseBody"
                 }
               }
             },
@@ -56647,7 +57428,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PrivateIncidentFollowUpUpdatedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentFollowUpUpdatedV1ResponseBody"
                 }
               }
             },
@@ -56674,7 +57455,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PrivateIncidentIncidentCreatedV2ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentIncidentCreatedV2ResponseBody"
                 }
               }
             },
@@ -56701,7 +57482,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PrivateIncidentIncidentUpdatedV2ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentIncidentUpdatedV2ResponseBody"
                 }
               }
             },
@@ -56730,7 +57511,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PrivateIncidentMembershipGrantedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentMembershipGrantedV1ResponseBody"
                 }
               }
             },
@@ -56759,7 +57540,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PrivateIncidentMembershipRevokedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentMembershipRevokedV1ResponseBody"
                 }
               }
             },
@@ -56805,7 +57586,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PublicIncidentActionCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPublicIncidentActionCreatedV1ResponseBody"
                 }
               }
             },
@@ -56851,7 +57632,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PublicIncidentActionUpdatedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPublicIncidentActionUpdatedV1ResponseBody"
                 }
               }
             },
@@ -56897,7 +57678,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PublicIncidentFollowUpCreatedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPublicIncidentFollowUpCreatedV1ResponseBody"
                 }
               }
             },
@@ -56943,7 +57724,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PublicIncidentFollowUpUpdatedV1ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPublicIncidentFollowUpUpdatedV1ResponseBody"
                 }
               }
             },
@@ -57120,7 +57901,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PublicIncidentIncidentCreatedV2ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPublicIncidentIncidentCreatedV2ResponseBody"
                 }
               }
             },
@@ -57314,7 +58095,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PublicIncidentIncidentStatusUpdatedV2ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPublicIncidentIncidentStatusUpdatedV2ResponseBody"
                 }
               }
             },
@@ -57491,7 +58272,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/PublicIncidentIncidentUpdatedV2ResponseBody"
+                  "$ref": "#/components/schemas/WebhooksPublicIncidentIncidentUpdatedV2ResponseBody"
                 }
               }
             },

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -34,6 +34,12 @@ const (
 	ActionV2StatusOutstanding ActionV2Status = "outstanding"
 )
 
+// Defines values for AlertEventsCreateHTTPPayloadV2Status.
+const (
+	Firing   AlertEventsCreateHTTPPayloadV2Status = "firing"
+	Resolved AlertEventsCreateHTTPPayloadV2Status = "resolved"
+)
+
 // Defines values for AlertRouteIncidentTemplatePayloadV2PrioritySeverity.
 const (
 	AlertRouteIncidentTemplatePayloadV2PrioritySeveritySeverityFirstWins AlertRouteIncidentTemplatePayloadV2PrioritySeverity = "severity-first-wins"
@@ -517,44 +523,6 @@ const (
 	CatalogUpdateTypePayloadV3IconUsers          CatalogUpdateTypePayloadV3Icon = "users"
 )
 
-// Defines values for CreateHTTPRequestBodyStatus.
-const (
-	Firing   CreateHTTPRequestBodyStatus = "firing"
-	Resolved CreateHTTPRequestBodyStatus = "resolved"
-)
-
-// Defines values for CreateManagedResourceRequestBodyResourceType.
-const (
-	CreateManagedResourceRequestBodyResourceTypeEscalationPath CreateManagedResourceRequestBodyResourceType = "escalation_path"
-	CreateManagedResourceRequestBodyResourceTypeSchedule       CreateManagedResourceRequestBodyResourceType = "schedule"
-	CreateManagedResourceRequestBodyResourceTypeWorkflow       CreateManagedResourceRequestBodyResourceType = "workflow"
-)
-
-// Defines values for CreateRequestBodyResourceResourceType.
-const (
-	CreateRequestBodyResourceResourceTypeAtlassianStatuspageIncident CreateRequestBodyResourceResourceType = "atlassian_statuspage_incident"
-	CreateRequestBodyResourceResourceTypeDatadogMonitorAlert         CreateRequestBodyResourceResourceType = "datadog_monitor_alert"
-	CreateRequestBodyResourceResourceTypeGithubPullRequest           CreateRequestBodyResourceResourceType = "github_pull_request"
-	CreateRequestBodyResourceResourceTypeGitlabMergeRequest          CreateRequestBodyResourceResourceType = "gitlab_merge_request"
-	CreateRequestBodyResourceResourceTypeGoogleCalendarEvent         CreateRequestBodyResourceResourceType = "google_calendar_event"
-	CreateRequestBodyResourceResourceTypeJiraIssue                   CreateRequestBodyResourceResourceType = "jira_issue"
-	CreateRequestBodyResourceResourceTypeOpsgenieAlert               CreateRequestBodyResourceResourceType = "opsgenie_alert"
-	CreateRequestBodyResourceResourceTypeOutlookCalendarEvent        CreateRequestBodyResourceResourceType = "outlook_calendar_event"
-	CreateRequestBodyResourceResourceTypePagerDutyIncident           CreateRequestBodyResourceResourceType = "pager_duty_incident"
-	CreateRequestBodyResourceResourceTypeScrubbed                    CreateRequestBodyResourceResourceType = "scrubbed"
-	CreateRequestBodyResourceResourceTypeSentryIssue                 CreateRequestBodyResourceResourceType = "sentry_issue"
-	CreateRequestBodyResourceResourceTypeSlackFile                   CreateRequestBodyResourceResourceType = "slack_file"
-	CreateRequestBodyResourceResourceTypeStatuspageIncident          CreateRequestBodyResourceResourceType = "statuspage_incident"
-	CreateRequestBodyResourceResourceTypeZendeskTicket               CreateRequestBodyResourceResourceType = "zendesk_ticket"
-)
-
-// Defines values for CreateRequestBody5Category.
-const (
-	CreateRequestBody5CategoryClosed   CreateRequestBody5Category = "closed"
-	CreateRequestBody5CategoryLearning CreateRequestBody5Category = "learning"
-	CreateRequestBody5CategoryLive     CreateRequestBody5Category = "live"
-)
-
 // Defines values for CustomFieldTypeInfoV1FieldType.
 const (
 	CustomFieldTypeInfoV1FieldTypeLink         CustomFieldTypeInfoV1FieldType = "link"
@@ -818,26 +786,22 @@ const (
 	IdentityV1RolesWorkflowsEditor           IdentityV1Roles = "workflows_editor"
 )
 
-// Defines values for IncidentCreatePayloadV1Mode.
+// Defines values for IncidentAttachmentsCreatePayloadV1ResourceResourceType.
 const (
-	IncidentCreatePayloadV1ModeReal IncidentCreatePayloadV1Mode = "real"
-	IncidentCreatePayloadV1ModeTest IncidentCreatePayloadV1Mode = "test"
-)
-
-// Defines values for IncidentCreatePayloadV1Status.
-const (
-	IncidentCreatePayloadV1StatusClosed        IncidentCreatePayloadV1Status = "closed"
-	IncidentCreatePayloadV1StatusDeclined      IncidentCreatePayloadV1Status = "declined"
-	IncidentCreatePayloadV1StatusFixing        IncidentCreatePayloadV1Status = "fixing"
-	IncidentCreatePayloadV1StatusInvestigating IncidentCreatePayloadV1Status = "investigating"
-	IncidentCreatePayloadV1StatusMonitoring    IncidentCreatePayloadV1Status = "monitoring"
-	IncidentCreatePayloadV1StatusTriage        IncidentCreatePayloadV1Status = "triage"
-)
-
-// Defines values for IncidentCreatePayloadV1Visibility.
-const (
-	IncidentCreatePayloadV1VisibilityPrivate IncidentCreatePayloadV1Visibility = "private"
-	IncidentCreatePayloadV1VisibilityPublic  IncidentCreatePayloadV1Visibility = "public"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeAtlassianStatuspageIncident IncidentAttachmentsCreatePayloadV1ResourceResourceType = "atlassian_statuspage_incident"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeDatadogMonitorAlert         IncidentAttachmentsCreatePayloadV1ResourceResourceType = "datadog_monitor_alert"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeGithubPullRequest           IncidentAttachmentsCreatePayloadV1ResourceResourceType = "github_pull_request"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeGitlabMergeRequest          IncidentAttachmentsCreatePayloadV1ResourceResourceType = "gitlab_merge_request"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeGoogleCalendarEvent         IncidentAttachmentsCreatePayloadV1ResourceResourceType = "google_calendar_event"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeJiraIssue                   IncidentAttachmentsCreatePayloadV1ResourceResourceType = "jira_issue"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeOpsgenieAlert               IncidentAttachmentsCreatePayloadV1ResourceResourceType = "opsgenie_alert"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeOutlookCalendarEvent        IncidentAttachmentsCreatePayloadV1ResourceResourceType = "outlook_calendar_event"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypePagerDutyIncident           IncidentAttachmentsCreatePayloadV1ResourceResourceType = "pager_duty_incident"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeScrubbed                    IncidentAttachmentsCreatePayloadV1ResourceResourceType = "scrubbed"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeSentryIssue                 IncidentAttachmentsCreatePayloadV1ResourceResourceType = "sentry_issue"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeSlackFile                   IncidentAttachmentsCreatePayloadV1ResourceResourceType = "slack_file"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeStatuspageIncident          IncidentAttachmentsCreatePayloadV1ResourceResourceType = "statuspage_incident"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeZendeskTicket               IncidentAttachmentsCreatePayloadV1ResourceResourceType = "zendesk_ticket"
 )
 
 // Defines values for IncidentCreatePayloadV2Mode.
@@ -892,6 +856,13 @@ const (
 	IncidentStatusV2CategoryTriage   IncidentStatusV2Category = "triage"
 )
 
+// Defines values for IncidentStatusesCreatePayloadV1Category.
+const (
+	IncidentStatusesCreatePayloadV1CategoryClosed   IncidentStatusesCreatePayloadV1Category = "closed"
+	IncidentStatusesCreatePayloadV1CategoryLearning IncidentStatusesCreatePayloadV1Category = "learning"
+	IncidentStatusesCreatePayloadV1CategoryLive     IncidentStatusesCreatePayloadV1Category = "live"
+)
+
 // Defines values for IncidentTypeV1CreateInTriage.
 const (
 	IncidentTypeV1CreateInTriageAlways   IncidentTypeV1CreateInTriage = "always"
@@ -913,12 +884,12 @@ const (
 
 // Defines values for IncidentV1Status.
 const (
-	Closed        IncidentV1Status = "closed"
-	Declined      IncidentV1Status = "declined"
-	Fixing        IncidentV1Status = "fixing"
-	Investigating IncidentV1Status = "investigating"
-	Monitoring    IncidentV1Status = "monitoring"
-	Triage        IncidentV1Status = "triage"
+	IncidentV1StatusClosed        IncidentV1Status = "closed"
+	IncidentV1StatusDeclined      IncidentV1Status = "declined"
+	IncidentV1StatusFixing        IncidentV1Status = "fixing"
+	IncidentV1StatusInvestigating IncidentV1Status = "investigating"
+	IncidentV1StatusMonitoring    IncidentV1Status = "monitoring"
+	IncidentV1StatusTriage        IncidentV1Status = "triage"
 )
 
 // Defines values for IncidentV1Visibility.
@@ -941,6 +912,28 @@ const (
 	IncidentV2VisibilityPublic  IncidentV2Visibility = "public"
 )
 
+// Defines values for IncidentsV1CreateRequestBodyMode.
+const (
+	IncidentsV1CreateRequestBodyModeReal IncidentsV1CreateRequestBodyMode = "real"
+	IncidentsV1CreateRequestBodyModeTest IncidentsV1CreateRequestBodyMode = "test"
+)
+
+// Defines values for IncidentsV1CreateRequestBodyStatus.
+const (
+	Closed        IncidentsV1CreateRequestBodyStatus = "closed"
+	Declined      IncidentsV1CreateRequestBodyStatus = "declined"
+	Fixing        IncidentsV1CreateRequestBodyStatus = "fixing"
+	Investigating IncidentsV1CreateRequestBodyStatus = "investigating"
+	Monitoring    IncidentsV1CreateRequestBodyStatus = "monitoring"
+	Triage        IncidentsV1CreateRequestBodyStatus = "triage"
+)
+
+// Defines values for IncidentsV1CreateRequestBodyVisibility.
+const (
+	IncidentsV1CreateRequestBodyVisibilityPrivate IncidentsV1CreateRequestBodyVisibility = "private"
+	IncidentsV1CreateRequestBodyVisibilityPublic  IncidentsV1CreateRequestBodyVisibility = "public"
+)
+
 // Defines values for ManagedResourceV2ManagedBy.
 const (
 	ManagedResourceV2ManagedByDashboard ManagedResourceV2ManagedBy = "dashboard"
@@ -950,9 +943,16 @@ const (
 
 // Defines values for ManagedResourceV2ResourceType.
 const (
-	EscalationPath ManagedResourceV2ResourceType = "escalation_path"
-	Schedule       ManagedResourceV2ResourceType = "schedule"
-	Workflow       ManagedResourceV2ResourceType = "workflow"
+	ManagedResourceV2ResourceTypeEscalationPath ManagedResourceV2ResourceType = "escalation_path"
+	ManagedResourceV2ResourceTypeSchedule       ManagedResourceV2ResourceType = "schedule"
+	ManagedResourceV2ResourceTypeWorkflow       ManagedResourceV2ResourceType = "workflow"
+)
+
+// Defines values for ManagedResourcesCreateManagedResourcePayloadV2ResourceType.
+const (
+	EscalationPath ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "escalation_path"
+	Schedule       ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "schedule"
+	Workflow       ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "workflow"
 )
 
 // Defines values for ManagementMetaV2ManagedBy.
@@ -1347,8 +1347,32 @@ type AlertAttributesUpdateResultV2 struct {
 	AlertAttribute AlertAttributeV2 `json:"alert_attribute"`
 }
 
-// AlertResult defines model for AlertResult.
-type AlertResult struct {
+// AlertEventsCreateHTTPPayloadV2 defines model for AlertEventsCreateHTTPPayloadV2.
+type AlertEventsCreateHTTPPayloadV2 struct {
+	// DeduplicationKey A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.
+	DeduplicationKey *string `json:"deduplication_key,omitempty"`
+
+	// Description Description that optionally adds more detail to title. Supports markdown.
+	Description *string `json:"description,omitempty"`
+
+	// Metadata Any additional metadata that you've configured your alert source to parse
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
+	// SourceUrl If applicable, a link to the alert in the upstream system
+	SourceUrl *string `json:"source_url,omitempty"`
+
+	// Status Current status of this alert
+	Status AlertEventsCreateHTTPPayloadV2Status `json:"status"`
+
+	// Title Alert title which is used when summarising the alert
+	Title string `json:"title"`
+}
+
+// AlertEventsCreateHTTPPayloadV2Status Current status of this alert
+type AlertEventsCreateHTTPPayloadV2Status string
+
+// AlertEventsCreateHTTPResultV2 defines model for AlertEventsCreateHTTPResultV2.
+type AlertEventsCreateHTTPResultV2 struct {
 	// DeduplicationKey The deduplication key that the event has been processed with
 	DeduplicationKey string `json:"deduplication_key"`
 
@@ -2550,130 +2574,6 @@ type ConditionV2 struct {
 	Subject       ConditionSubjectV2     `json:"subject"`
 }
 
-// CreateHTTPRequestBody defines model for CreateHTTPRequestBody.
-type CreateHTTPRequestBody struct {
-	// DeduplicationKey A deduplication key can be provided to uniquely reference this alert from your alert source. If you send an event with the same deduplication_key multiple times, only one alert will be created in incident.io for this alert source config.
-	DeduplicationKey *string `json:"deduplication_key,omitempty"`
-
-	// Description Description that optionally adds more detail to title. Supports markdown.
-	Description *string `json:"description,omitempty"`
-
-	// Metadata Any additional metadata that you've configured your alert source to parse
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
-
-	// SourceUrl If applicable, a link to the alert in the upstream system
-	SourceUrl *string `json:"source_url,omitempty"`
-
-	// Status Current status of this alert
-	Status CreateHTTPRequestBodyStatus `json:"status"`
-
-	// Title Alert title which is used when summarising the alert
-	Title string `json:"title"`
-}
-
-// CreateHTTPRequestBodyStatus Current status of this alert
-type CreateHTTPRequestBodyStatus string
-
-// CreateManagedResourceRequestBody defines model for CreateManagedResourceRequestBody.
-type CreateManagedResourceRequestBody struct {
-	// Annotations Annotations that track metadata about this resource
-	Annotations map[string]string `json:"annotations"`
-
-	// ResourceId The ID of the related resource
-	ResourceId string `json:"resource_id"`
-
-	// ResourceType The type of the related resource
-	ResourceType CreateManagedResourceRequestBodyResourceType `json:"resource_type"`
-}
-
-// CreateManagedResourceRequestBodyResourceType The type of the related resource
-type CreateManagedResourceRequestBodyResourceType string
-
-// CreateManagedResourceResponseBody defines model for CreateManagedResourceResponseBody.
-type CreateManagedResourceResponseBody struct {
-	ManagedResource ManagedResourceV2 `json:"managed_resource"`
-}
-
-// CreateRequestBody defines model for CreateRequestBody.
-type CreateRequestBody struct {
-	// IncidentId ID of the incident to add an attachment to
-	IncidentId string `json:"incident_id"`
-	Resource   struct {
-		// ExternalId ID of the resource in the external system
-		ExternalId string `json:"external_id"`
-
-		// ResourceType E.g. PagerDuty: the external system that holds the resource
-		ResourceType CreateRequestBodyResourceResourceType `json:"resource_type"`
-	} `json:"resource"`
-}
-
-// CreateRequestBodyResourceResourceType E.g. PagerDuty: the external system that holds the resource
-type CreateRequestBodyResourceResourceType string
-
-// CreateRequestBody2 defines model for CreateRequestBody2.
-type CreateRequestBody2 struct {
-	IncidentId string `json:"incident_id"`
-	UserId     string `json:"user_id"`
-}
-
-// CreateRequestBody3 defines model for CreateRequestBody3.
-type CreateRequestBody3 struct {
-	// Description Describes the purpose of the role
-	Description string `json:"description"`
-
-	// Instructions Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
-	Instructions string `json:"instructions"`
-
-	// Name Human readable name of the incident role
-	Name string `json:"name"`
-
-	// Required DEPRECATED: this will always be false.
-	Required bool `json:"required"`
-
-	// Shortform Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
-	Shortform string `json:"shortform"`
-}
-
-// CreateRequestBody4 defines model for CreateRequestBody4.
-type CreateRequestBody4 struct {
-	// Description Describes the purpose of the role
-	Description string `json:"description"`
-
-	// Instructions Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
-	Instructions string `json:"instructions"`
-
-	// Name Human readable name of the incident role
-	Name string `json:"name"`
-
-	// Shortform Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
-	Shortform string `json:"shortform"`
-}
-
-// CreateRequestBody5 defines model for CreateRequestBody5.
-type CreateRequestBody5 struct {
-	// Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
-	Category CreateRequestBody5Category `json:"category"`
-
-	// Description Rich text description of the incident status
-	Description string `json:"description"`
-
-	// Name Unique name of this status
-	Name string `json:"name"`
-}
-
-// CreateRequestBody5Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
-type CreateRequestBody5Category string
-
-// CreateResponseBody defines model for CreateResponseBody.
-type CreateResponseBody struct {
-	IncidentAttachment IncidentAttachmentV1 `json:"incident_attachment"`
-}
-
-// CreateResponseBody2 defines model for CreateResponseBody2.
-type CreateResponseBody2 struct {
-	IncidentMembership IncidentMembership `json:"incident_membership"`
-}
-
 // CustomFieldEntryPayloadV1 defines model for CustomFieldEntryPayloadV1.
 type CustomFieldEntryPayloadV1 struct {
 	// CustomFieldId ID of the custom field this entry is linked against
@@ -3152,14 +3052,6 @@ type CustomFieldsUpdateResultV2 struct {
 	CustomField CustomFieldV2 `json:"custom_field"`
 }
 
-// EditRequestBody defines model for EditRequestBody.
-type EditRequestBody struct {
-	Incident IncidentEditPayloadV2 `json:"incident"`
-
-	// NotifyIncidentChannel Should we send Slack channel notifications to inform responders of this update? Note that this won't work if the Slack channel has already been archived.
-	NotifyIncidentChannel bool `json:"notify_incident_channel"`
-}
-
 // EmbeddedCatalogEntryV1 defines model for EmbeddedCatalogEntryV1.
 type EmbeddedCatalogEntryV1 struct {
 	// Aliases Optional aliases that can be used to reference this entry
@@ -3440,6 +3332,9 @@ type EscalationPathV2 struct {
 	// Path The nodes that form the levels and branches of this escalation path.
 	Path []EscalationPathNodeV2 `json:"path"`
 
+	// TeamIds IDs of teams that own this escalation path
+	TeamIds []string `json:"team_ids"`
+
 	// WorkingHours The working hours for this escalation path.
 	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
 }
@@ -3451,6 +3346,9 @@ type EscalationsCreatePathPayloadV2 struct {
 
 	// Path The nodes that form the levels and branches of this escalation path.
 	Path []EscalationPathNodePayloadV2 `json:"path"`
+
+	// TeamIds IDs of the teams that own this escalation path
+	TeamIds *[]string `json:"team_ids,omitempty"`
 
 	// WorkingHours The working hours for this escalation path.
 	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
@@ -3473,6 +3371,9 @@ type EscalationsUpdatePathPayloadV2 struct {
 
 	// Path The nodes that form the levels and branches of this escalation path.
 	Path []EscalationPathNodePayloadV2 `json:"path"`
+
+	// TeamIds IDs of the teams that own this escalation path
+	TeamIds *[]string `json:"team_ids,omitempty"`
 
 	// WorkingHours The working hours for this escalation path.
 	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
@@ -3777,56 +3678,31 @@ type IncidentAttachmentV1 struct {
 	Resource   ExternalResourceV1 `json:"resource"`
 }
 
-// IncidentCreatePayloadV1 defines model for IncidentCreatePayloadV1.
-type IncidentCreatePayloadV1 struct {
-	// CustomFieldEntries Set the incident's custom fields to these values
-	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
+// IncidentAttachmentsCreatePayloadV1 defines model for IncidentAttachmentsCreatePayloadV1.
+type IncidentAttachmentsCreatePayloadV1 struct {
+	// IncidentId ID of the incident to add an attachment to
+	IncidentId string `json:"incident_id"`
+	Resource   struct {
+		// ExternalId ID of the resource in the external system
+		ExternalId string `json:"external_id"`
 
-	// IdempotencyKey Unique string used to de-duplicate incident create requests
-	IdempotencyKey string `json:"idempotency_key"`
-
-	// IncidentRoleAssignments Assign incident roles to these people
-	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV1 `json:"incident_role_assignments,omitempty"`
-
-	// IncidentTypeId Incident type to create this incident as
-	IncidentTypeId *string `json:"incident_type_id,omitempty"`
-
-	// Mode Whether the incident is real or test
-	Mode *IncidentCreatePayloadV1Mode `json:"mode,omitempty"`
-
-	// Name Explanation of the incident
-	Name *string `json:"name,omitempty"`
-
-	// SeverityId Severity to create incident as
-	SeverityId *string `json:"severity_id,omitempty"`
-
-	// SlackTeamId ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
-	SlackTeamId *string `json:"slack_team_id,omitempty"`
-
-	// SourceMessageChannelId Channel ID of the source message, if this incident was created from one
-	SourceMessageChannelId *string `json:"source_message_channel_id,omitempty"`
-
-	// SourceMessageTimestamp Timestamp of the source message, if this incident was created from one
-	SourceMessageTimestamp *string `json:"source_message_timestamp,omitempty"`
-
-	// Status Current status of the incident
-	Status *IncidentCreatePayloadV1Status `json:"status,omitempty"`
-
-	// Summary Detailed description of the incident
-	Summary *string `json:"summary,omitempty"`
-
-	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/articles/5905558102-can-we-mark-incidents-as-sensitive-and-restrict-access).
-	Visibility IncidentCreatePayloadV1Visibility `json:"visibility"`
+		// ResourceType E.g. PagerDuty: the external system that holds the resource
+		ResourceType IncidentAttachmentsCreatePayloadV1ResourceResourceType `json:"resource_type"`
+	} `json:"resource"`
 }
 
-// IncidentCreatePayloadV1Mode Whether the incident is real or test
-type IncidentCreatePayloadV1Mode string
+// IncidentAttachmentsCreatePayloadV1ResourceResourceType E.g. PagerDuty: the external system that holds the resource
+type IncidentAttachmentsCreatePayloadV1ResourceResourceType string
 
-// IncidentCreatePayloadV1Status Current status of the incident
-type IncidentCreatePayloadV1Status string
+// IncidentAttachmentsCreateResultV1 defines model for IncidentAttachmentsCreateResultV1.
+type IncidentAttachmentsCreateResultV1 struct {
+	IncidentAttachment IncidentAttachmentV1 `json:"incident_attachment"`
+}
 
-// IncidentCreatePayloadV1Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/articles/5905558102-can-we-mark-incidents-as-sensitive-and-restrict-access).
-type IncidentCreatePayloadV1Visibility string
+// IncidentAttachmentsListResultV1 defines model for IncidentAttachmentsListResultV1.
+type IncidentAttachmentsListResultV1 struct {
+	IncidentAttachments []IncidentAttachmentV1 `json:"incident_attachments"`
+}
 
 // IncidentCreatePayloadV2 defines model for IncidentCreatePayloadV2.
 type IncidentCreatePayloadV2 struct {
@@ -3924,8 +3800,8 @@ type IncidentEditPayloadV2 struct {
 	Summary *string `json:"summary,omitempty"`
 }
 
-// IncidentMembership defines model for IncidentMembership.
-type IncidentMembership struct {
+// IncidentMembershipV1 defines model for IncidentMembershipV1.
+type IncidentMembershipV1 struct {
 	// CreatedAt When the membership was created
 	CreatedAt time.Time `json:"created_at"`
 
@@ -3937,7 +3813,25 @@ type IncidentMembership struct {
 
 	// UpdatedAt When the membership was last updated
 	UpdatedAt time.Time `json:"updated_at"`
-	User      UserV2    `json:"user"`
+	User      UserV1    `json:"user"`
+}
+
+// IncidentMembershipsCreatePayloadV1 defines model for IncidentMembershipsCreatePayloadV1.
+type IncidentMembershipsCreatePayloadV1 struct {
+	IncidentId string `json:"incident_id"`
+	UserId     string `json:"user_id"`
+}
+
+// IncidentMembershipsCreateResultV1 defines model for IncidentMembershipsCreateResultV1.
+type IncidentMembershipsCreateResultV1 struct {
+	IncidentMembership IncidentMembershipV1 `json:"incident_membership"`
+}
+
+// IncidentMembershipsRevokePayloadV1 defines model for IncidentMembershipsRevokePayloadV1.
+type IncidentMembershipsRevokePayloadV1 struct {
+	// IncidentId Revoke memberships to incident
+	IncidentId string `json:"incident_id"`
+	UserId     string `json:"user_id"`
 }
 
 // IncidentRoleAssignmentPayloadV1 defines model for IncidentRoleAssignmentPayloadV1.
@@ -4031,6 +3925,112 @@ type IncidentRoleV2 struct {
 // IncidentRoleV2RoleType Type of incident role
 type IncidentRoleV2RoleType string
 
+// IncidentRolesCreatePayloadV1 defines model for IncidentRolesCreatePayloadV1.
+type IncidentRolesCreatePayloadV1 struct {
+	// Description Describes the purpose of the role
+	Description string `json:"description"`
+
+	// Instructions Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
+	Instructions string `json:"instructions"`
+
+	// Name Human readable name of the incident role
+	Name string `json:"name"`
+
+	// Required DEPRECATED: this will always be false.
+	Required bool `json:"required"`
+
+	// Shortform Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
+	Shortform string `json:"shortform"`
+}
+
+// IncidentRolesCreatePayloadV2 defines model for IncidentRolesCreatePayloadV2.
+type IncidentRolesCreatePayloadV2 struct {
+	// Description Describes the purpose of the role
+	Description string `json:"description"`
+
+	// Instructions Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
+	Instructions string `json:"instructions"`
+
+	// Name Human readable name of the incident role
+	Name string `json:"name"`
+
+	// Shortform Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
+	Shortform string `json:"shortform"`
+}
+
+// IncidentRolesCreateResultV1 defines model for IncidentRolesCreateResultV1.
+type IncidentRolesCreateResultV1 struct {
+	IncidentRole IncidentRoleV1 `json:"incident_role"`
+}
+
+// IncidentRolesCreateResultV2 defines model for IncidentRolesCreateResultV2.
+type IncidentRolesCreateResultV2 struct {
+	IncidentRole IncidentRoleV2 `json:"incident_role"`
+}
+
+// IncidentRolesListResultV1 defines model for IncidentRolesListResultV1.
+type IncidentRolesListResultV1 struct {
+	IncidentRoles []IncidentRoleV1 `json:"incident_roles"`
+}
+
+// IncidentRolesListResultV2 defines model for IncidentRolesListResultV2.
+type IncidentRolesListResultV2 struct {
+	IncidentRoles []IncidentRoleV2 `json:"incident_roles"`
+}
+
+// IncidentRolesShowResultV1 defines model for IncidentRolesShowResultV1.
+type IncidentRolesShowResultV1 struct {
+	IncidentRole IncidentRoleV1 `json:"incident_role"`
+}
+
+// IncidentRolesShowResultV2 defines model for IncidentRolesShowResultV2.
+type IncidentRolesShowResultV2 struct {
+	IncidentRole IncidentRoleV2 `json:"incident_role"`
+}
+
+// IncidentRolesUpdatePayloadV1 defines model for IncidentRolesUpdatePayloadV1.
+type IncidentRolesUpdatePayloadV1 struct {
+	// Description Describes the purpose of the role
+	Description string `json:"description"`
+
+	// Instructions Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
+	Instructions string `json:"instructions"`
+
+	// Name Human readable name of the incident role
+	Name string `json:"name"`
+
+	// Required DEPRECATED: this will always be false.
+	Required *bool `json:"required,omitempty"`
+
+	// Shortform Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
+	Shortform string `json:"shortform"`
+}
+
+// IncidentRolesUpdatePayloadV2 defines model for IncidentRolesUpdatePayloadV2.
+type IncidentRolesUpdatePayloadV2 struct {
+	// Description Describes the purpose of the role
+	Description string `json:"description"`
+
+	// Instructions Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
+	Instructions string `json:"instructions"`
+
+	// Name Human readable name of the incident role
+	Name string `json:"name"`
+
+	// Shortform Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
+	Shortform string `json:"shortform"`
+}
+
+// IncidentRolesUpdateResultV1 defines model for IncidentRolesUpdateResultV1.
+type IncidentRolesUpdateResultV1 struct {
+	IncidentRole IncidentRoleV1 `json:"incident_role"`
+}
+
+// IncidentRolesUpdateResultV2 defines model for IncidentRolesUpdateResultV2.
+type IncidentRolesUpdateResultV2 struct {
+	IncidentRole IncidentRoleV2 `json:"incident_role"`
+}
+
 // IncidentStatusV1 defines model for IncidentStatusV1.
 type IncidentStatusV1 struct {
 	// Category What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured
@@ -4077,6 +4077,50 @@ type IncidentStatusV2 struct {
 // IncidentStatusV2Category What category of status it is. All statuses apart from live (renamed in the app to Active) and learning (renamed in the app to Post-incident) are managed by incident.io and cannot be configured
 type IncidentStatusV2Category string
 
+// IncidentStatusesCreatePayloadV1 defines model for IncidentStatusesCreatePayloadV1.
+type IncidentStatusesCreatePayloadV1 struct {
+	// Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
+	Category IncidentStatusesCreatePayloadV1Category `json:"category"`
+
+	// Description Rich text description of the incident status
+	Description string `json:"description"`
+
+	// Name Unique name of this status
+	Name string `json:"name"`
+}
+
+// IncidentStatusesCreatePayloadV1Category Whether the status should be considered 'live' (now renamed to active), 'learning' (now renamed to post-incident) or 'closed'. The triage and declined statuses cannot be created or modified.
+type IncidentStatusesCreatePayloadV1Category string
+
+// IncidentStatusesCreateResultV1 defines model for IncidentStatusesCreateResultV1.
+type IncidentStatusesCreateResultV1 struct {
+	IncidentStatus IncidentStatusV1 `json:"incident_status"`
+}
+
+// IncidentStatusesListResultV1 defines model for IncidentStatusesListResultV1.
+type IncidentStatusesListResultV1 struct {
+	IncidentStatuses []IncidentStatusV1 `json:"incident_statuses"`
+}
+
+// IncidentStatusesShowResultV1 defines model for IncidentStatusesShowResultV1.
+type IncidentStatusesShowResultV1 struct {
+	IncidentStatus IncidentStatusV1 `json:"incident_status"`
+}
+
+// IncidentStatusesUpdatePayloadV1 defines model for IncidentStatusesUpdatePayloadV1.
+type IncidentStatusesUpdatePayloadV1 struct {
+	// Description Rich text description of the incident status
+	Description string `json:"description"`
+
+	// Name Unique name of this status
+	Name string `json:"name"`
+}
+
+// IncidentStatusesUpdateResultV1 defines model for IncidentStatusesUpdateResultV1.
+type IncidentStatusesUpdateResultV1 struct {
+	IncidentStatus IncidentStatusV1 `json:"incident_status"`
+}
+
 // IncidentTimestampV1 defines model for IncidentTimestampV1.
 type IncidentTimestampV1 struct {
 	// LastOccurredAt When this last occurred, if it did
@@ -4117,6 +4161,16 @@ type IncidentTimestampValueV2 struct {
 type IncidentTimestampWithValueV2 struct {
 	IncidentTimestamp IncidentTimestampV2       `json:"incident_timestamp"`
 	Value             *IncidentTimestampValueV2 `json:"value,omitempty"`
+}
+
+// IncidentTimestampsListResultV2 defines model for IncidentTimestampsListResultV2.
+type IncidentTimestampsListResultV2 struct {
+	IncidentTimestamps []IncidentTimestampV2 `json:"incident_timestamps"`
+}
+
+// IncidentTimestampsShowResultV2 defines model for IncidentTimestampsShowResultV2.
+type IncidentTimestampsShowResultV2 struct {
+	IncidentTimestamp IncidentTimestampV2 `json:"incident_timestamp"`
 }
 
 // IncidentTypeV1 defines model for IncidentTypeV1.
@@ -4179,6 +4233,16 @@ type IncidentTypeV2 struct {
 // IncidentTypeV2CreateInTriage Whether incidents of this must always, or can optionally, be created in triage
 type IncidentTypeV2CreateInTriage string
 
+// IncidentTypesListResultV1 defines model for IncidentTypesListResultV1.
+type IncidentTypesListResultV1 struct {
+	IncidentTypes []IncidentTypeV1 `json:"incident_types"`
+}
+
+// IncidentTypesShowResultV1 defines model for IncidentTypesShowResultV1.
+type IncidentTypesShowResultV1 struct {
+	IncidentType IncidentTypeV1 `json:"incident_type"`
+}
+
 // IncidentUpdateV2 defines model for IncidentUpdateV2.
 type IncidentUpdateV2 struct {
 	// CreatedAt When the update was created
@@ -4190,7 +4254,7 @@ type IncidentUpdateV2 struct {
 	// IncidentId The incident this update relates to
 	IncidentId string `json:"incident_id"`
 
-	// MergedIntoIncidentId The ID of the incident that this incident was merged into, if it was merged in to another incident
+	// MergedIntoIncidentId The ID of the incident this incident was merged into, if the to state of this update is 'merged'.
 	MergedIntoIncidentId *string `json:"merged_into_incident_id,omitempty"`
 
 	// Message Message that explains the context behind the update
@@ -4198,6 +4262,12 @@ type IncidentUpdateV2 struct {
 	NewIncidentStatus IncidentStatusV2 `json:"new_incident_status"`
 	NewSeverity       *SeverityV2      `json:"new_severity,omitempty"`
 	Updater           ActorV2          `json:"updater"`
+}
+
+// IncidentUpdatesListResultV2 defines model for IncidentUpdatesListResultV2.
+type IncidentUpdatesListResultV2 struct {
+	IncidentUpdates []IncidentUpdateV2      `json:"incident_updates"`
+	PaginationMeta  *PaginationMetaResultV2 `json:"pagination_meta,omitempty"`
 }
 
 // IncidentV1 defines model for IncidentV1.
@@ -4352,52 +4422,100 @@ type IncidentV2Mode string
 // IncidentV2Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/articles/5905558102-can-we-mark-incidents-as-sensitive-and-restrict-access).
 type IncidentV2Visibility string
 
-// ListResponseBody defines model for ListResponseBody.
-type ListResponseBody struct {
-	IncidentAttachments []IncidentAttachmentV1 `json:"incident_attachments"`
+// IncidentsV1CreateRequestBody defines model for IncidentsV1CreateRequestBody.
+type IncidentsV1CreateRequestBody struct {
+	// CustomFieldEntries Set the incident's custom fields to these values
+	CustomFieldEntries *[]CustomFieldEntryPayloadV1 `json:"custom_field_entries,omitempty"`
+
+	// IdempotencyKey Unique string used to de-duplicate incident create requests
+	IdempotencyKey string `json:"idempotency_key"`
+
+	// IncidentRoleAssignments Assign incident roles to these people
+	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV1 `json:"incident_role_assignments,omitempty"`
+
+	// IncidentTypeId Incident type to create this incident as
+	IncidentTypeId *string `json:"incident_type_id,omitempty"`
+
+	// Mode Whether the incident is real or test
+	Mode *IncidentsV1CreateRequestBodyMode `json:"mode,omitempty"`
+
+	// Name Explanation of the incident
+	Name *string `json:"name,omitempty"`
+
+	// SeverityId Severity to create incident as
+	SeverityId *string `json:"severity_id,omitempty"`
+
+	// SlackTeamId ID of the Slack team / workspace. This is only required if you are using a Slack Enterprise Grid with multiple teams.
+	SlackTeamId *string `json:"slack_team_id,omitempty"`
+
+	// SourceMessageChannelId Channel ID of the source message, if this incident was created from one
+	SourceMessageChannelId *string `json:"source_message_channel_id,omitempty"`
+
+	// SourceMessageTimestamp Timestamp of the source message, if this incident was created from one
+	SourceMessageTimestamp *string `json:"source_message_timestamp,omitempty"`
+
+	// Status Current status of the incident
+	Status *IncidentsV1CreateRequestBodyStatus `json:"status,omitempty"`
+
+	// Summary Detailed description of the incident
+	Summary *string `json:"summary,omitempty"`
+
+	// Visibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/articles/5905558102-can-we-mark-incidents-as-sensitive-and-restrict-access).
+	Visibility IncidentsV1CreateRequestBodyVisibility `json:"visibility"`
 }
 
-// ListResponseBody2 defines model for ListResponseBody2.
-type ListResponseBody2 struct {
-	IncidentRoles []IncidentRoleV1 `json:"incident_roles"`
+// IncidentsV1CreateRequestBodyMode Whether the incident is real or test
+type IncidentsV1CreateRequestBodyMode string
+
+// IncidentsV1CreateRequestBodyStatus Current status of the incident
+type IncidentsV1CreateRequestBodyStatus string
+
+// IncidentsV1CreateRequestBodyVisibility Whether the incident should be open to anyone in your Slack workspace (public), or invite-only (private). For more information on Private Incidents see our [help centre](https://help.incident.io/articles/5905558102-can-we-mark-incidents-as-sensitive-and-restrict-access).
+type IncidentsV1CreateRequestBodyVisibility string
+
+// IncidentsV1CreateResponseBody defines model for IncidentsV1CreateResponseBody.
+type IncidentsV1CreateResponseBody struct {
+	Incident IncidentV1 `json:"incident"`
 }
 
-// ListResponseBody3 defines model for ListResponseBody3.
-type ListResponseBody3 struct {
-	IncidentRoles []IncidentRoleV2 `json:"incident_roles"`
-}
-
-// ListResponseBody4 defines model for ListResponseBody4.
-type ListResponseBody4 struct {
-	IncidentStatuses []IncidentStatusV1 `json:"incident_statuses"`
-}
-
-// ListResponseBody5 defines model for ListResponseBody5.
-type ListResponseBody5 struct {
-	IncidentTimestamps []IncidentTimestampV2 `json:"incident_timestamps"`
-}
-
-// ListResponseBody6 defines model for ListResponseBody6.
-type ListResponseBody6 struct {
-	IncidentTypes []IncidentTypeV1 `json:"incident_types"`
-}
-
-// ListResponseBody7 defines model for ListResponseBody7.
-type ListResponseBody7 struct {
-	IncidentUpdates []IncidentUpdateV2    `json:"incident_updates"`
-	PaginationMeta  *PaginationMetaResult `json:"pagination_meta,omitempty"`
-}
-
-// ListResponseBody8 defines model for ListResponseBody8.
-type ListResponseBody8 struct {
+// IncidentsV1ListResponseBody defines model for IncidentsV1ListResponseBody.
+type IncidentsV1ListResponseBody struct {
 	Incidents      []IncidentV1                   `json:"incidents"`
 	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
 }
 
-// ListResponseBody9 defines model for ListResponseBody9.
-type ListResponseBody9 struct {
+// IncidentsV1ShowResponseBody defines model for IncidentsV1ShowResponseBody.
+type IncidentsV1ShowResponseBody struct {
+	Incident IncidentV1 `json:"incident"`
+}
+
+// IncidentsV2CreateResponseBody defines model for IncidentsV2CreateResponseBody.
+type IncidentsV2CreateResponseBody struct {
+	Incident IncidentV2 `json:"incident"`
+}
+
+// IncidentsV2EditRequestBody defines model for IncidentsV2EditRequestBody.
+type IncidentsV2EditRequestBody struct {
+	Incident IncidentEditPayloadV2 `json:"incident"`
+
+	// NotifyIncidentChannel Should we send Slack channel notifications to inform responders of this update? Note that this won't work if the Slack channel has already been archived.
+	NotifyIncidentChannel bool `json:"notify_incident_channel"`
+}
+
+// IncidentsV2EditResponseBody defines model for IncidentsV2EditResponseBody.
+type IncidentsV2EditResponseBody struct {
+	Incident IncidentV2 `json:"incident"`
+}
+
+// IncidentsV2ListResponseBody defines model for IncidentsV2ListResponseBody.
+type IncidentsV2ListResponseBody struct {
 	Incidents      []IncidentV2                   `json:"incidents"`
 	PaginationMeta *PaginationMetaResultWithTotal `json:"pagination_meta,omitempty"`
+}
+
+// IncidentsV2ShowResponseBody defines model for IncidentsV2ShowResponseBody.
+type IncidentsV2ShowResponseBody struct {
+	Incident IncidentV2 `json:"incident"`
 }
 
 // ManagedResourceV2 defines model for ManagedResourceV2.
@@ -4408,7 +4526,7 @@ type ManagedResourceV2 struct {
 	// ManagedBy How is this resource managed
 	ManagedBy ManagedResourceV2ManagedBy `json:"managed_by"`
 
-	// ResourceId The ID of the related resource
+	// ResourceId The ID of the resource that this relates to
 	ResourceId   string                        `json:"resource_id"`
 	ResourceType ManagedResourceV2ResourceType `json:"resource_type"`
 
@@ -4421,6 +4539,26 @@ type ManagedResourceV2ManagedBy string
 
 // ManagedResourceV2ResourceType defines model for ManagedResourceV2.ResourceType.
 type ManagedResourceV2ResourceType string
+
+// ManagedResourcesCreateManagedResourcePayloadV2 defines model for ManagedResourcesCreateManagedResourcePayloadV2.
+type ManagedResourcesCreateManagedResourcePayloadV2 struct {
+	// Annotations Annotations that track metadata about this resource
+	Annotations map[string]string `json:"annotations"`
+
+	// ResourceId The ID of the resource that this relates to
+	ResourceId string `json:"resource_id"`
+
+	// ResourceType The type of the related resource
+	ResourceType ManagedResourcesCreateManagedResourcePayloadV2ResourceType `json:"resource_type"`
+}
+
+// ManagedResourcesCreateManagedResourcePayloadV2ResourceType The type of the related resource
+type ManagedResourcesCreateManagedResourcePayloadV2ResourceType string
+
+// ManagedResourcesCreateManagedResourceResultV2 defines model for ManagedResourcesCreateManagedResourceResultV2.
+type ManagedResourcesCreateManagedResourceResultV2 struct {
+	ManagedResource ManagedResourceV2 `json:"managed_resource"`
+}
 
 // ManagementMetaV2 defines model for ManagementMetaV2.
 type ManagementMetaV2 struct {
@@ -4436,15 +4574,6 @@ type ManagementMetaV2 struct {
 
 // ManagementMetaV2ManagedBy How is this resource managed
 type ManagementMetaV2ManagedBy string
-
-// PaginationMetaResult defines model for PaginationMetaResult.
-type PaginationMetaResult struct {
-	// After If provided, pass this as the 'after' param to load the next page
-	After *string `json:"after,omitempty"`
-
-	// PageSize What was the maximum number of results requested
-	PageSize int64 `json:"page_size"`
-}
 
 // PaginationMetaResultV1 defines model for PaginationMetaResultV1.
 type PaginationMetaResultV1 struct {
@@ -4558,6 +4687,9 @@ type ScheduleCreatePayloadV2 struct {
 
 	// Name Name of the schedule
 	Name *string `json:"name,omitempty"`
+
+	// TeamIds IDs of teams that own this schedule
+	TeamIds *[]string `json:"team_ids,omitempty"`
 
 	// Timezone Timezone of the schedule
 	Timezone *string `json:"timezone,omitempty"`
@@ -4781,6 +4913,9 @@ type ScheduleUpdatePayloadV2 struct {
 	// Name Name of the schedule
 	Name *string `json:"name,omitempty"`
 
+	// TeamIds IDs of teams that own this schedule
+	TeamIds *[]string `json:"team_ids,omitempty"`
+
 	// Timezone Timezone of the schedule
 	Timezone *string `json:"timezone,omitempty"`
 }
@@ -4801,6 +4936,9 @@ type ScheduleV2 struct {
 
 	// Name Human readable name synced from external provider
 	Name string `json:"name"`
+
+	// TeamIds IDs of teams that own this schedule
+	TeamIds []string `json:"team_ids"`
 
 	// Timezone Timezone of the schedule, as interpreted at the point of generating the report
 	Timezone  string    `json:"timezone"`
@@ -4954,41 +5092,6 @@ type SeverityV2 struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// ShowResponseBody defines model for ShowResponseBody.
-type ShowResponseBody struct {
-	IncidentRole IncidentRoleV1 `json:"incident_role"`
-}
-
-// ShowResponseBody2 defines model for ShowResponseBody2.
-type ShowResponseBody2 struct {
-	IncidentRole IncidentRoleV2 `json:"incident_role"`
-}
-
-// ShowResponseBody3 defines model for ShowResponseBody3.
-type ShowResponseBody3 struct {
-	IncidentStatus IncidentStatusV1 `json:"incident_status"`
-}
-
-// ShowResponseBody4 defines model for ShowResponseBody4.
-type ShowResponseBody4 struct {
-	IncidentTimestamp IncidentTimestampV2 `json:"incident_timestamp"`
-}
-
-// ShowResponseBody5 defines model for ShowResponseBody5.
-type ShowResponseBody5 struct {
-	IncidentType IncidentTypeV1 `json:"incident_type"`
-}
-
-// ShowResponseBody6 defines model for ShowResponseBody6.
-type ShowResponseBody6 struct {
-	Incident IncidentV1 `json:"incident"`
-}
-
-// ShowResponseBody7 defines model for ShowResponseBody7.
-type ShowResponseBody7 struct {
-	Incident IncidentV2 `json:"incident"`
-}
-
 // StepConfigPayloadV2 defines model for StepConfigPayloadV2.
 type StepConfigPayloadV2 struct {
 	// ForEach Reference to an expression that returns resources to run this step over
@@ -5037,48 +5140,6 @@ type TriggerSlimV2 struct {
 	Label string `json:"label"`
 
 	// Name Unique name of the trigger
-	Name string `json:"name"`
-}
-
-// UpdateRequestBody defines model for UpdateRequestBody.
-type UpdateRequestBody struct {
-	// Description Describes the purpose of the role
-	Description string `json:"description"`
-
-	// Instructions Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
-	Instructions string `json:"instructions"`
-
-	// Name Human readable name of the incident role
-	Name string `json:"name"`
-
-	// Required DEPRECATED: this will always be false.
-	Required *bool `json:"required,omitempty"`
-
-	// Shortform Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
-	Shortform string `json:"shortform"`
-}
-
-// UpdateRequestBody2 defines model for UpdateRequestBody2.
-type UpdateRequestBody2 struct {
-	// Description Describes the purpose of the role
-	Description string `json:"description"`
-
-	// Instructions Provided to whoever is nominated for the role. Note that this will be empty for the 'reporter' role.
-	Instructions string `json:"instructions"`
-
-	// Name Human readable name of the incident role
-	Name string `json:"name"`
-
-	// Shortform Short human readable name for Slack. Note that this will be empty for the 'reporter' role.
-	Shortform string `json:"shortform"`
-}
-
-// UpdateRequestBody3 defines model for UpdateRequestBody3.
-type UpdateRequestBody3 struct {
-	// Description Rich text description of the incident status
-	Description string `json:"description"`
-
-	// Name Unique name of this status
 	Name string `json:"name"`
 }
 
@@ -5683,28 +5744,28 @@ type CustomFieldsV1CreateJSONRequestBody = CustomFieldsCreatePayloadV1
 type CustomFieldsV1UpdateJSONRequestBody = CustomFieldsUpdatePayloadV1
 
 // IncidentAttachmentsV1CreateJSONRequestBody defines body for IncidentAttachmentsV1Create for application/json ContentType.
-type IncidentAttachmentsV1CreateJSONRequestBody = CreateRequestBody
+type IncidentAttachmentsV1CreateJSONRequestBody = IncidentAttachmentsCreatePayloadV1
 
 // IncidentMembershipsV1CreateJSONRequestBody defines body for IncidentMembershipsV1Create for application/json ContentType.
-type IncidentMembershipsV1CreateJSONRequestBody = CreateRequestBody2
+type IncidentMembershipsV1CreateJSONRequestBody = IncidentMembershipsCreatePayloadV1
 
 // IncidentMembershipsV1RevokeJSONRequestBody defines body for IncidentMembershipsV1Revoke for application/json ContentType.
-type IncidentMembershipsV1RevokeJSONRequestBody = CreateRequestBody2
+type IncidentMembershipsV1RevokeJSONRequestBody = IncidentMembershipsRevokePayloadV1
 
 // IncidentRolesV1CreateJSONRequestBody defines body for IncidentRolesV1Create for application/json ContentType.
-type IncidentRolesV1CreateJSONRequestBody = CreateRequestBody3
+type IncidentRolesV1CreateJSONRequestBody = IncidentRolesCreatePayloadV1
 
 // IncidentRolesV1UpdateJSONRequestBody defines body for IncidentRolesV1Update for application/json ContentType.
-type IncidentRolesV1UpdateJSONRequestBody = UpdateRequestBody
+type IncidentRolesV1UpdateJSONRequestBody = IncidentRolesUpdatePayloadV1
 
 // IncidentStatusesV1CreateJSONRequestBody defines body for IncidentStatusesV1Create for application/json ContentType.
-type IncidentStatusesV1CreateJSONRequestBody = CreateRequestBody5
+type IncidentStatusesV1CreateJSONRequestBody = IncidentStatusesCreatePayloadV1
 
 // IncidentStatusesV1UpdateJSONRequestBody defines body for IncidentStatusesV1Update for application/json ContentType.
-type IncidentStatusesV1UpdateJSONRequestBody = UpdateRequestBody3
+type IncidentStatusesV1UpdateJSONRequestBody = IncidentStatusesUpdatePayloadV1
 
 // IncidentsV1CreateJSONRequestBody defines body for IncidentsV1Create for application/json ContentType.
-type IncidentsV1CreateJSONRequestBody = IncidentCreatePayloadV1
+type IncidentsV1CreateJSONRequestBody = IncidentsV1CreateRequestBody
 
 // SeveritiesV1CreateJSONRequestBody defines body for SeveritiesV1Create for application/json ContentType.
 type SeveritiesV1CreateJSONRequestBody = SeveritiesCreatePayloadV1
@@ -5719,7 +5780,7 @@ type AlertAttributesV2CreateJSONRequestBody = AlertAttributesCreatePayloadV2
 type AlertAttributesV2UpdateJSONRequestBody = AlertAttributesUpdatePayloadV2
 
 // AlertEventsV2CreateHTTPJSONRequestBody defines body for AlertEventsV2CreateHTTP for application/json ContentType.
-type AlertEventsV2CreateHTTPJSONRequestBody = CreateHTTPRequestBody
+type AlertEventsV2CreateHTTPJSONRequestBody = AlertEventsCreateHTTPPayloadV2
 
 // AlertRoutesV2CreateJSONRequestBody defines body for AlertRoutesV2Create for application/json ContentType.
 type AlertRoutesV2CreateJSONRequestBody = AlertRoutesCreatePayloadV2
@@ -5761,19 +5822,19 @@ type EscalationsV2CreatePathJSONRequestBody = EscalationsCreatePathPayloadV2
 type EscalationsV2UpdatePathJSONRequestBody = EscalationsUpdatePathPayloadV2
 
 // IncidentRolesV2CreateJSONRequestBody defines body for IncidentRolesV2Create for application/json ContentType.
-type IncidentRolesV2CreateJSONRequestBody = CreateRequestBody4
+type IncidentRolesV2CreateJSONRequestBody = IncidentRolesCreatePayloadV2
 
 // IncidentRolesV2UpdateJSONRequestBody defines body for IncidentRolesV2Update for application/json ContentType.
-type IncidentRolesV2UpdateJSONRequestBody = UpdateRequestBody2
+type IncidentRolesV2UpdateJSONRequestBody = IncidentRolesUpdatePayloadV2
 
 // IncidentsV2CreateJSONRequestBody defines body for IncidentsV2Create for application/json ContentType.
 type IncidentsV2CreateJSONRequestBody = IncidentCreatePayloadV2
 
 // IncidentsV2EditJSONRequestBody defines body for IncidentsV2Edit for application/json ContentType.
-type IncidentsV2EditJSONRequestBody = EditRequestBody
+type IncidentsV2EditJSONRequestBody = IncidentsV2EditRequestBody
 
 // ManagedResourcesV2CreateManagedResourceJSONRequestBody defines body for ManagedResourcesV2CreateManagedResource for application/json ContentType.
-type ManagedResourcesV2CreateManagedResourceJSONRequestBody = CreateManagedResourceRequestBody
+type ManagedResourcesV2CreateManagedResourceJSONRequestBody = ManagedResourcesCreateManagedResourcePayloadV2
 
 // SchedulesV2CreateOverrideJSONRequestBody defines body for SchedulesV2CreateOverride for application/json ContentType.
 type SchedulesV2CreateOverrideJSONRequestBody = SchedulesCreateOverridePayloadV2
@@ -14134,7 +14195,7 @@ func (r UtilitiesV1IdentityResponse) StatusCode() int {
 type IncidentAttachmentsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody
+	JSON200      *IncidentAttachmentsListResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14156,7 +14217,7 @@ func (r IncidentAttachmentsV1ListResponse) StatusCode() int {
 type IncidentAttachmentsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *CreateResponseBody
+	JSON201      *IncidentAttachmentsCreateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14199,7 +14260,7 @@ func (r IncidentAttachmentsV1DeleteResponse) StatusCode() int {
 type IncidentMembershipsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *CreateResponseBody2
+	JSON201      *IncidentMembershipsCreateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14242,7 +14303,7 @@ func (r IncidentMembershipsV1RevokeResponse) StatusCode() int {
 type IncidentRolesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody2
+	JSON200      *IncidentRolesListResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14264,7 +14325,7 @@ func (r IncidentRolesV1ListResponse) StatusCode() int {
 type IncidentRolesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody
+	JSON201      *IncidentRolesCreateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14307,7 +14368,7 @@ func (r IncidentRolesV1DeleteResponse) StatusCode() int {
 type IncidentRolesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody
+	JSON200      *IncidentRolesShowResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14329,7 +14390,7 @@ func (r IncidentRolesV1ShowResponse) StatusCode() int {
 type IncidentRolesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody
+	JSON200      *IncidentRolesUpdateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14351,7 +14412,7 @@ func (r IncidentRolesV1UpdateResponse) StatusCode() int {
 type IncidentStatusesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody4
+	JSON200      *IncidentStatusesListResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14373,7 +14434,7 @@ func (r IncidentStatusesV1ListResponse) StatusCode() int {
 type IncidentStatusesV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody3
+	JSON201      *IncidentStatusesCreateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14416,7 +14477,7 @@ func (r IncidentStatusesV1DeleteResponse) StatusCode() int {
 type IncidentStatusesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody3
+	JSON200      *IncidentStatusesShowResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14438,7 +14499,7 @@ func (r IncidentStatusesV1ShowResponse) StatusCode() int {
 type IncidentStatusesV1UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody3
+	JSON200      *IncidentStatusesUpdateResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14460,7 +14521,7 @@ func (r IncidentStatusesV1UpdateResponse) StatusCode() int {
 type IncidentTypesV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody6
+	JSON200      *IncidentTypesListResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14482,7 +14543,7 @@ func (r IncidentTypesV1ListResponse) StatusCode() int {
 type IncidentTypesV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody5
+	JSON200      *IncidentTypesShowResultV1
 }
 
 // Status returns HTTPResponse.Status
@@ -14504,7 +14565,7 @@ func (r IncidentTypesV1ShowResponse) StatusCode() int {
 type IncidentsV1ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody8
+	JSON200      *IncidentsV1ListResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -14526,7 +14587,7 @@ func (r IncidentsV1ListResponse) StatusCode() int {
 type IncidentsV1CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody6
+	JSON200      *IncidentsV1CreateResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -14548,7 +14609,7 @@ func (r IncidentsV1CreateResponse) StatusCode() int {
 type IncidentsV1ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody6
+	JSON200      *IncidentsV1ShowResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -14876,7 +14937,7 @@ func (r AlertAttributesV2UpdateResponse) StatusCode() int {
 type AlertEventsV2CreateHTTPResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON202      *AlertResult
+	JSON202      *AlertEventsCreateHTTPResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15596,7 +15657,7 @@ func (r FollowUpsV2ShowResponse) StatusCode() int {
 type IncidentRolesV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody3
+	JSON200      *IncidentRolesListResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15618,7 +15679,7 @@ func (r IncidentRolesV2ListResponse) StatusCode() int {
 type IncidentRolesV2CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *ShowResponseBody2
+	JSON201      *IncidentRolesCreateResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15661,7 +15722,7 @@ func (r IncidentRolesV2DeleteResponse) StatusCode() int {
 type IncidentRolesV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody2
+	JSON200      *IncidentRolesShowResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15683,7 +15744,7 @@ func (r IncidentRolesV2ShowResponse) StatusCode() int {
 type IncidentRolesV2UpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody2
+	JSON200      *IncidentRolesUpdateResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15705,7 +15766,7 @@ func (r IncidentRolesV2UpdateResponse) StatusCode() int {
 type IncidentTimestampsV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody5
+	JSON200      *IncidentTimestampsListResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15727,7 +15788,7 @@ func (r IncidentTimestampsV2ListResponse) StatusCode() int {
 type IncidentTimestampsV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody4
+	JSON200      *IncidentTimestampsShowResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15749,7 +15810,7 @@ func (r IncidentTimestampsV2ShowResponse) StatusCode() int {
 type IncidentUpdatesV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody7
+	JSON200      *IncidentUpdatesListResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -15771,7 +15832,7 @@ func (r IncidentUpdatesV2ListResponse) StatusCode() int {
 type IncidentsV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ListResponseBody9
+	JSON200      *IncidentsV2ListResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -15793,7 +15854,7 @@ func (r IncidentsV2ListResponse) StatusCode() int {
 type IncidentsV2CreateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody7
+	JSON200      *IncidentsV2CreateResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -15815,7 +15876,7 @@ func (r IncidentsV2CreateResponse) StatusCode() int {
 type IncidentsV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody7
+	JSON200      *IncidentsV2ShowResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -15837,7 +15898,7 @@ func (r IncidentsV2ShowResponse) StatusCode() int {
 type IncidentsV2EditResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *ShowResponseBody7
+	JSON200      *IncidentsV2EditResponseBody
 }
 
 // Status returns HTTPResponse.Status
@@ -15859,7 +15920,7 @@ func (r IncidentsV2EditResponse) StatusCode() int {
 type ManagedResourcesV2CreateManagedResourceResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *CreateManagedResourceResponseBody
+	JSON200      *ManagedResourcesCreateManagedResourceResultV2
 }
 
 // Status returns HTTPResponse.Status
@@ -18210,7 +18271,7 @@ func ParseIncidentAttachmentsV1ListResponse(rsp *http.Response) (*IncidentAttach
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody
+		var dest IncidentAttachmentsListResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18236,7 +18297,7 @@ func ParseIncidentAttachmentsV1CreateResponse(rsp *http.Response) (*IncidentAtta
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest CreateResponseBody
+		var dest IncidentAttachmentsCreateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18278,7 +18339,7 @@ func ParseIncidentMembershipsV1CreateResponse(rsp *http.Response) (*IncidentMemb
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest CreateResponseBody2
+		var dest IncidentMembershipsCreateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18320,7 +18381,7 @@ func ParseIncidentRolesV1ListResponse(rsp *http.Response) (*IncidentRolesV1ListR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody2
+		var dest IncidentRolesListResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18346,7 +18407,7 @@ func ParseIncidentRolesV1CreateResponse(rsp *http.Response) (*IncidentRolesV1Cre
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody
+		var dest IncidentRolesCreateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18388,7 +18449,7 @@ func ParseIncidentRolesV1ShowResponse(rsp *http.Response) (*IncidentRolesV1ShowR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody
+		var dest IncidentRolesShowResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18414,7 +18475,7 @@ func ParseIncidentRolesV1UpdateResponse(rsp *http.Response) (*IncidentRolesV1Upd
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody
+		var dest IncidentRolesUpdateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18440,7 +18501,7 @@ func ParseIncidentStatusesV1ListResponse(rsp *http.Response) (*IncidentStatusesV
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody4
+		var dest IncidentStatusesListResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18466,7 +18527,7 @@ func ParseIncidentStatusesV1CreateResponse(rsp *http.Response) (*IncidentStatuse
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody3
+		var dest IncidentStatusesCreateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18508,7 +18569,7 @@ func ParseIncidentStatusesV1ShowResponse(rsp *http.Response) (*IncidentStatusesV
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody3
+		var dest IncidentStatusesShowResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18534,7 +18595,7 @@ func ParseIncidentStatusesV1UpdateResponse(rsp *http.Response) (*IncidentStatuse
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody3
+		var dest IncidentStatusesUpdateResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18560,7 +18621,7 @@ func ParseIncidentTypesV1ListResponse(rsp *http.Response) (*IncidentTypesV1ListR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody6
+		var dest IncidentTypesListResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18586,7 +18647,7 @@ func ParseIncidentTypesV1ShowResponse(rsp *http.Response) (*IncidentTypesV1ShowR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody5
+		var dest IncidentTypesShowResultV1
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18612,7 +18673,7 @@ func ParseIncidentsV1ListResponse(rsp *http.Response) (*IncidentsV1ListResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody8
+		var dest IncidentsV1ListResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18638,7 +18699,7 @@ func ParseIncidentsV1CreateResponse(rsp *http.Response) (*IncidentsV1CreateRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody6
+		var dest IncidentsV1CreateResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18664,7 +18725,7 @@ func ParseIncidentsV1ShowResponse(rsp *http.Response) (*IncidentsV1ShowResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody6
+		var dest IncidentsV1ShowResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19034,7 +19095,7 @@ func ParseAlertEventsV2CreateHTTPResponse(rsp *http.Response) (*AlertEventsV2Cre
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
-		var dest AlertResult
+		var dest AlertEventsCreateHTTPResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19832,7 +19893,7 @@ func ParseIncidentRolesV2ListResponse(rsp *http.Response) (*IncidentRolesV2ListR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody3
+		var dest IncidentRolesListResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19858,7 +19919,7 @@ func ParseIncidentRolesV2CreateResponse(rsp *http.Response) (*IncidentRolesV2Cre
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest ShowResponseBody2
+		var dest IncidentRolesCreateResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19900,7 +19961,7 @@ func ParseIncidentRolesV2ShowResponse(rsp *http.Response) (*IncidentRolesV2ShowR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody2
+		var dest IncidentRolesShowResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19926,7 +19987,7 @@ func ParseIncidentRolesV2UpdateResponse(rsp *http.Response) (*IncidentRolesV2Upd
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody2
+		var dest IncidentRolesUpdateResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19952,7 +20013,7 @@ func ParseIncidentTimestampsV2ListResponse(rsp *http.Response) (*IncidentTimesta
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody5
+		var dest IncidentTimestampsListResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19978,7 +20039,7 @@ func ParseIncidentTimestampsV2ShowResponse(rsp *http.Response) (*IncidentTimesta
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody4
+		var dest IncidentTimestampsShowResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -20004,7 +20065,7 @@ func ParseIncidentUpdatesV2ListResponse(rsp *http.Response) (*IncidentUpdatesV2L
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody7
+		var dest IncidentUpdatesListResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -20030,7 +20091,7 @@ func ParseIncidentsV2ListResponse(rsp *http.Response) (*IncidentsV2ListResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListResponseBody9
+		var dest IncidentsV2ListResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -20056,7 +20117,7 @@ func ParseIncidentsV2CreateResponse(rsp *http.Response) (*IncidentsV2CreateRespo
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody7
+		var dest IncidentsV2CreateResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -20082,7 +20143,7 @@ func ParseIncidentsV2ShowResponse(rsp *http.Response) (*IncidentsV2ShowResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody7
+		var dest IncidentsV2ShowResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -20108,7 +20169,7 @@ func ParseIncidentsV2EditResponse(rsp *http.Response) (*IncidentsV2EditResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ShowResponseBody7
+		var dest IncidentsV2EditResponseBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -20134,7 +20195,7 @@ func ParseManagedResourcesV2CreateManagedResourceResponse(rsp *http.Response) (*
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest CreateManagedResourceResponseBody
+		var dest ManagedResourcesCreateManagedResourceResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -37,6 +39,7 @@ type IncidentEscalationPathResourceModel struct {
 	Name         types.String                           `tfsdk:"name"`
 	Path         []IncidentEscalationPathNode           `tfsdk:"path"`
 	WorkingHours []models.IncidentWeekdayIntervalConfig `tfsdk:"working_hours"`
+	TeamIDs      []types.String                         `tfsdk:"team_ids"`
 }
 
 type IncidentEscalationPathNode struct {
@@ -120,6 +123,13 @@ func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resourc
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: models.IncidentWeekdayIntervalConfig{}.Attributes(),
 				},
+			},
+			"team_ids": schema.SetAttribute{
+				MarkdownDescription: apischema.Docstring("ScheduleV2", "team_ids"),
+				Optional:            true,
+				ElementType:         types.StringType,
+				Computed:            true,
+				Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 			},
 		},
 	}
@@ -319,10 +329,19 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 		}
 	}
 
+	var teamIDs *[]string
+	if len(data.TeamIDs) > 0 {
+		teamIDs = &[]string{}
+		for _, id := range data.TeamIDs {
+			*teamIDs = append(*teamIDs, id.ValueString())
+		}
+	}
+
 	result, err := r.client.EscalationsV2CreatePathWithResponse(ctx, client.EscalationsV2CreatePathJSONRequestBody{
 		Name:         data.Name.ValueString(),
 		Path:         r.toPathPayload(data.Path),
 		WorkingHours: workingHours,
+		TeamIds:      teamIDs,
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))
@@ -382,10 +401,19 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 		}
 	}
 
+	var teamIDs *[]string
+	if len(data.TeamIDs) > 0 {
+		teamIDs = &[]string{}
+		for _, id := range data.TeamIDs {
+			*teamIDs = append(*teamIDs, id.ValueString())
+		}
+	}
+
 	result, err := r.client.EscalationsV2UpdatePathWithResponse(ctx, data.ID.ValueString(), client.EscalationsV2UpdatePathJSONRequestBody{
 		Name:         data.Name.ValueString(),
 		Path:         r.toPathPayload(data.Path),
 		WorkingHours: workingHours,
+		TeamIds:      teamIDs,
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))
@@ -428,11 +456,19 @@ func (r *IncidentEscalationPathResource) buildModel(ep client.EscalationPathV2) 
 		})
 	}
 
+	var teamIDs []types.String
+	if ep.TeamIds != nil {
+		teamIDs = lo.Map(ep.TeamIds, func(id string, _ int) types.String {
+			return types.StringValue(id)
+		})
+	}
+
 	return &IncidentEscalationPathResourceModel{
 		ID:           types.StringValue(ep.Id),
 		Name:         types.StringValue(ep.Name),
 		Path:         r.toPathModel(ep.Path),
 		WorkingHours: workingHours,
+		TeamIDs:      teamIDs,
 	}
 }
 

--- a/internal/provider/incident_escalation_path_resource_test.go
+++ b/internal/provider/incident_escalation_path_resource_test.go
@@ -70,6 +70,8 @@ func TestAccIncidentEscalationPathResource(t *testing.T) {
 						"incident_escalation_path.example", "working_hours.0.weekday_intervals.0.start_time", "09:00"),
 					resource.TestCheckResourceAttr(
 						"incident_escalation_path.example", "working_hours.0.weekday_intervals.0.end_time", "17:00"),
+					resource.TestCheckResourceAttrPair(
+						"incident_escalation_path.example", "team_ids.0", "incident_catalog_entry.response", "id"),
 				),
 			},
 			// Import
@@ -83,6 +85,21 @@ func TestAccIncidentEscalationPathResource(t *testing.T) {
 }
 
 var escalationPathTemplate = template.Must(template.New("incident_escalation_path").Funcs(sprig.TxtFuncMap()).Parse(`
+# This is the team catalog type
+resource "incident_catalog_type" "team" {
+  name            = "Test Team"
+  type_name       = "Custom[\"TestTeam\"]"
+  description     = "This is the team catalog type"
+  source_repo_url = "http://example.com"
+}
+
+# This is a team catalog entry
+resource "incident_catalog_entry" "response" {
+  catalog_type_id = incident_catalog_type.team.id
+  name = "Response"
+  attribute_values = []
+}
+
 # This is the primary schedule that receives pages in working hours.
 resource "incident_schedule" "primary_on_call" {
   name = {{ quote .ScheduleName }}
@@ -110,6 +127,9 @@ resource "incident_schedule" "primary_on_call" {
       },
     ]
   }]
+
+  # Teams that use this schedule
+  team_ids = [incident_catalog_entry.response.id]
 }
 
 # If in working hours, send high-urgency alerts. Otherwise use low-urgency.
@@ -190,6 +210,9 @@ resource "incident_escalation_path" "example" {
       ]
     }
   ]
+
+  # Teams that use this escalation path
+  team_ids = [incident_catalog_entry.response.id]
 }
 `))
 

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -358,6 +358,7 @@ func generateScheduleTerraform(name string, schedule *client.ScheduleV2) string 
 	result += "resource \"incident_schedule\" \"example\" {\n"
 	result += "  name     = " + quote(name) + "\n"
 	result += "  timezone = " + quote(schedule.Timezone) + "\n"
+	result += "  team_ids = " + generateTeamIDsArray(schedule.TeamIds) + "\n"
 	result += "  " + generateRotationsArray(schedule.Config.Rotations)
 
 	if schedule.HolidaysPublicConfig != nil {
@@ -467,6 +468,22 @@ func generateCountryCodesArray(codes []string) string {
 			result += ", "
 		}
 		result += quote(code)
+	}
+	result += "]\n"
+	return result
+}
+
+func generateTeamIDsArray(teamIDs []string) string {
+	var result string
+	if teamIDs == nil {
+		return "[]"
+	}
+	result += "[\n"
+	for idx, teamID := range teamIDs {
+		if idx > 0 {
+			result += ", "
+		}
+		result += quote(teamID)
 	}
 	result += "]\n"
 	return result

--- a/internal/provider/incident_status_resource.go
+++ b/internal/provider/incident_status_resource.go
@@ -98,7 +98,7 @@ func (r *IncidentStatusResource) Create(ctx context.Context, req resource.Create
 	result, err := r.client.IncidentStatusesV1CreateWithResponse(ctx, client.IncidentStatusesV1CreateJSONRequestBody{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueString(),
-		Category:    client.CreateRequestBody5Category(data.Category.ValueString()),
+		Category:    client.IncidentStatusesCreatePayloadV1Category(data.Category.ValueString()),
 	})
 	if err == nil && result.StatusCode() >= 400 {
 		err = fmt.Errorf(string(result.Body))

--- a/internal/provider/managed_resources.go
+++ b/internal/provider/managed_resources.go
@@ -13,14 +13,14 @@ func claimResource(
 	apiClient *client.ClientWithResponses,
 	resourceID string,
 	diagnostics diag.Diagnostics,
-	resourceType client.ManagedResourceV2ResourceType,
+	resourceType client.ManagedResourcesCreateManagedResourcePayloadV2ResourceType,
 	terraformVersion string,
 ) {
-	payload := client.CreateManagedResourceRequestBody{
+	payload := client.ManagedResourcesV2CreateManagedResourceJSONRequestBody{
 		Annotations: map[string]string{
 			"incident.io/terraform/version": terraformVersion,
 		},
-		ResourceType: client.CreateManagedResourceRequestBodyResourceType(resourceType),
+		ResourceType: resourceType,
 		ResourceId:   resourceID,
 	}
 

--- a/internal/provider/models/schedule_v2_model.go
+++ b/internal/provider/models/schedule_v2_model.go
@@ -10,6 +10,7 @@ type IncidentScheduleResourceModelV2 struct {
 	Timezone             types.String            `tfsdk:"timezone"`
 	Rotations            []RotationV2            `tfsdk:"rotations"`
 	HolidaysPublicConfig *HolidaysPublicConfigV2 `tfsdk:"holidays_public_config"`
+	TeamIDs              []types.String          `tfsdk:"team_ids"`
 }
 
 type RotationV2 struct {


### PR DESCRIPTION
This is the same as #159 with the following changes:
- Using a set attribute for `team_ids` rather than a list attribute because we don't care about the order
- Setting a default for `team_ids` so we don't error when team IDs isn't already in the state