### PR TITLE
Skip validation of catalog entry resource in ValidateConfig

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,38 +5,38 @@ before:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
-    # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
-    # they are unable to install libraries.
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-  goos:
-    - freebsd
-    - windows
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - '386'
-    - arm
-    - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}"
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+    binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 signs:
   - artifacts: checksum
@@ -52,9 +52,5 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
-changelog:
-  skip: true
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- In the catalog entry resource, we now guard against cases where the type of
+  `attribute_values` is inferred to be unknown during the validation of managed
+  attributes.
+
 ## v5.3.1
 
 When loading workflows, ensure that any additional parameter bindings are

--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -336,7 +336,8 @@ func (r *IncidentCatalogEntryResource) ValidateConfig(ctx context.Context, req r
 	diag := req.Config.GetAttribute(ctx, path.Root("attribute_values"), &attributeValues)
 	if diag.HasError() || attributeValues.IsUnknown() {
 		// If attribute_values is unknown, don't attempt to validate the managed
-		// attributes.
+		// attributes. We have to return early here because the call to req.Config.Get
+		// fails to marshal into the []CatalogEntryAttributeValue in this case.
 		return
 	}
 

--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -331,6 +331,15 @@ func (r *IncidentCatalogEntryResource) ImportState(ctx context.Context, req reso
 
 func (r *IncidentCatalogEntryResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var data IncidentCatalogEntryResourceModel
+
+	var attributeValues types.Set
+	diag := req.Config.GetAttribute(ctx, path.Root("attribute_values"), &attributeValues)
+	if diag.HasError() || attributeValues.IsUnknown() {
+		// If attribute_values is unknown, don't attempt to validate the managed
+		// attributes.
+		return
+	}
+
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/incident_catalog_entry_resource_test.go
+++ b/internal/provider/incident_catalog_entry_resource_test.go
@@ -248,7 +248,7 @@ func TestIncidentCatalogEntryResource_ValidateConfigConditionalArray(t *testing.
 		Steps: []resource.TestStep{
 			// Test validation error when attribute isn't in managed_attributes
 			{
-				Config: fmt.Sprintf(`
+				Config: `
 resource "incident_catalog_entry" "test" {
   for_each = {
     for name, value in [
@@ -273,7 +273,7 @@ resource "incident_catalog_entry" "test" {
     },
   ]
 }
-`),
+`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/provider/incident_catalog_entry_resource_test.go
+++ b/internal/provider/incident_catalog_entry_resource_test.go
@@ -241,6 +241,46 @@ resource "incident_catalog_entry" "test" {
 	})
 }
 
+func TestIncidentCatalogEntryResource_ValidateConfigConditionalArray(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Test validation error when attribute isn't in managed_attributes
+			{
+				Config: fmt.Sprintf(`
+resource "incident_catalog_entry" "test" {
+  for_each = {
+    for name, value in [
+      {
+        name       = "foo"
+        test_value = "ABC"
+      },
+      {
+        name       = "bar"
+        test_value = null
+      },
+    ] : value.name => value
+  }
+
+  catalog_type_id = "catalog-type-id-123"
+  name = "Test Entry"
+
+  attribute_values = each.value.test_value == null ? [] : [
+    {
+      attribute = "test",
+      value     = each.value.test_value
+    },
+  ]
+}
+`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 var catalogEntryTemplate = template.Must(template.New("incident_catalog_entry").Funcs(sprig.TxtFuncMap()).Parse(`
 resource "incident_catalog_type" "example" {
   name        = "Catalog Entry Acceptance Test ({{ .ID }})"


### PR DESCRIPTION
This seems to cause issues when you have conditions in your Terraform that look like this:

```
attribute_values = each.value.escalation_path == null ? [] : [
  {
    attribute = incident_catalog_type_attribute.team_escalation_path.id,
    value     = each.value.escalation_path
  },
]
```

This gives you an error along these lines:

```
  | An unexpected error was encountered trying to build a value. This is always an error in the provider. Please report the following to the provider developer:
  | 
  | Received unknown value, however the target type cannot handle unknown values. Use the corresponding types package type or a custom type that handles unknown values.
  | 
  | Path: attribute_values
  | Target Type: []provider.CatalogEntryAttributeValue
  | Suggested Type: basetypes.SetValue
```

We think this happens because Terraform can't tell if the value is a set or a list: it infers it to be `unknown`. We need to guard against this in `ValidateConfig` to prevent this error: this change does that.