### PR TITLE
Add validation for RFC3339 timestamp format in timestamp fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add validation for RFC3339 timestamp format in `handover_start_at` and `effective_from` fields to prevent invalid dates
+
 ## v5.4.1
 
 - Allow `terraform import` for `incident_catalog_type_attribute`

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.49.1
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.11.0
 )
 
@@ -70,6 +71,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -101,10 +101,12 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 									},
 									"effective_from": schema.StringAttribute{
 										Optional:            true,
+										Validators:          []validator.String{RFC3339TimestampValidator{}},
 										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "effective_from"),
 									},
 									"handover_start_at": schema.StringAttribute{
 										Required:            true,
+										Validators:          []validator.String{RFC3339TimestampValidator{}},
 										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "handover_start_at"),
 									},
 									"working_intervals": schema.ListNestedAttribute{

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
@@ -24,4 +25,29 @@ func (n NonEmptyListValidator) Description(ctx context.Context) string {
 
 func (n NonEmptyListValidator) MarkdownDescription(ctx context.Context) string {
 	return "List cannot be empty"
+}
+
+// RFC3339TimestampValidator validates that a string value is a valid RFC3339 timestamp.
+type RFC3339TimestampValidator struct{}
+
+func (v RFC3339TimestampValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := req.ConfigValue.ValueString()
+	if _, err := time.Parse(time.RFC3339, value); err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Timestamp Format",
+			fmt.Sprintf("The timestamp value %q is not a valid RFC3339 format (YYYY-MM-DDThh:mm:ssZ): %s", value, err),
+		)
+	}
+}
+
+func (v RFC3339TimestampValidator) Description(ctx context.Context) string {
+	return "Value must be a valid RFC3339 timestamp (YYYY-MM-DDThh:mm:ssZ)"
+}
+
+func (v RFC3339TimestampValidator) MarkdownDescription(ctx context.Context) string {
+	return "Value must be a valid RFC3339 timestamp (YYYY-MM-DDThh:mm:ssZ)"
 }

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRFC3339TimestampValidator(t *testing.T) {
+	testCases := []struct {
+		name          string
+		value         string
+		expectedError bool
+	}{
+		{
+			name:          "valid RFC3339 timestamp",
+			value:         "2023-04-20T15:30:45Z",
+			expectedError: false,
+		},
+		{
+			name:          "another valid RFC3339 timestamp with timezone offset",
+			value:         "2023-04-20T15:30:45+01:00",
+			expectedError: false,
+		},
+		{
+			name:          "invalid month",
+			value:         "2023-13-20T15:30:45Z",
+			expectedError: true,
+		},
+		{
+			name:          "invalid day",
+			value:         "2023-04-32T15:30:45Z",
+			expectedError: true,
+		},
+		{
+			name:          "invalid hours",
+			value:         "2023-04-20T25:30:45Z",
+			expectedError: true,
+		},
+		{
+			name:          "invalid minutes",
+			value:         "2023-04-20T15:70:45Z",
+			expectedError: true,
+		},
+		{
+			name:          "invalid seconds",
+			value:         "2023-04-20T15:30:65Z",
+			expectedError: true,
+		},
+		{
+			name:          "incorrect format",
+			value:         "2023-04-20 15:30:45",
+			expectedError: true,
+		},
+		{
+			name:          "missing time part",
+			value:         "2023-04-20",
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := validator.StringRequest{
+				ConfigValue: types.StringValue(tc.value),
+			}
+			response := validator.StringResponse{}
+
+			v := RFC3339TimestampValidator{}
+			v.ValidateString(context.Background(), request, &response)
+
+			if tc.expectedError {
+				assert.True(t, response.Diagnostics.HasError(), "expected validation to fail")
+			} else {
+				assert.False(t, response.Diagnostics.HasError(), "expected validation to succeed")
+			}
+		})
+	}
+}
+
+func TestTimestampValidatorWithNullAndUnknown(t *testing.T) {
+	v := RFC3339TimestampValidator{}
+
+	// Test with null value
+	nullRequest := validator.StringRequest{
+		ConfigValue: types.StringNull(),
+	}
+	nullResponse := validator.StringResponse{}
+	v.ValidateString(context.Background(), nullRequest, &nullResponse)
+	assert.False(t, nullResponse.Diagnostics.HasError(), "null values should not cause validation errors")
+
+	// Test with unknown value
+	unknownRequest := validator.StringRequest{
+		ConfigValue: types.StringUnknown(),
+	}
+	unknownResponse := validator.StringResponse{}
+	v.ValidateString(context.Background(), unknownRequest, &unknownResponse)
+	assert.False(t, unknownResponse.Diagnostics.HasError(), "unknown values should not cause validation errors")
+}


### PR DESCRIPTION
This prevents errors during plan that previously could only be caught at apply time.
Implemented a validator that checks the timestamp format is valid RFC3339.

Closes #170