### PR TITLE
incident_catalog_type.source_repo_url is not required

### DIFF
--- a/docs/resources/catalog_type.md
+++ b/docs/resources/catalog_type.md
@@ -67,11 +67,11 @@ resource "incident_catalog_type" "service_tier" {
 
 - `description` (String) Human readble description of this type
 - `name` (String) Name is the human readable name of this type
-- `source_repo_url` (String) The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.
 
 ### Optional
 
 - `categories` (List of String) The categories that this type belongs to, to be shown in the web dashboard. Possible values are: `customer`, `issue-tracker`, `product-feature`, `service`, `on-call`, `team`, `user`.
+- `source_repo_url` (String) The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.
 - `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
 
 ### Read-Only

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -90,7 +90,7 @@ func (r *IncidentCatalogTypeResource) Schema(ctx context.Context, req resource.S
 			},
 			"source_repo_url": schema.StringAttribute{
 				MarkdownDescription: "The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.",
-				Required:            true,
+				Optional:            true,
 			},
 		},
 	}


### PR DESCRIPTION
The docs for [CatalogTypeV3](https://api-docs.incident.io/tag/Catalog-V3#operation/Catalog%20V3_CreateType) say that `source_repo_url` is not required, which matches implication in the [Provider docs](https://registry.terraform.io/providers/incident-io/incident/latest/docs/resources/catalog_type#source_repo_url-1), and the code appears to [support it being null](https://github.com/incident-io/terraform-provider-incident/blob/master/internal/provider/incident_catalog_type_resource.go#L135)

In which case, mark it as optional in the Provider schema and update the docs to match.

Closes #184.