### PR TITLE
Add a script to help read terraform output errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.3
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
+	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/getkin/kin-openapi v0.127.0
 	github.com/google/uuid v1.6.0
@@ -31,6 +32,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
@@ -86,6 +88,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
+	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	github.com/zclconf/go-cty v1.16.2 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,10 @@ github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQA
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
+github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -286,6 +290,8 @@ github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9N
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.16.2 h1:LAJSwc3v81IRBZyUVQDUdZ7hs3SYs9jv0eZJDWHD/70=

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,30 @@
+## parse_tf_error.go
+
+A simple tool for best-effort cleaning Terraform cty error messages to make them more readable and easier to debug.
+In all likelihood this won't produce valid JSON, but it will make the error message more readable.
+
+### Usage
+
+```bash
+# Parse an error from a file
+go run scripts/parse_tf_error.go error_file.txt
+
+# Preserve newlines in the output
+go run scripts/parse_tf_error.go -n error_file.txt
+
+# Write output to a file
+go run scripts/parse_tf_error.go -o cleaned.txt error_file.txt
+```
+
+### What it does
+
+- Removes pipe characters (│) and normalizes whitespace
+- Cleans up cty syntax:
+  - Converts `cty.StringVal("abc")` to `"abc"`
+  - Converts `cty.BoolVal(true)` to `true`
+  - Converts `cty.NullVal()` to `null`
+  - Replaces bare `cty.String` and similar types with `null`
+- Removes parentheses that break JSON format
+- Produces a cleaner, more readable error message
+
+This is particularly useful for parsing "Provider produced inconsistent result after apply" errors that contain complex cty structures.

--- a/scripts/parse_tf_error.go
+++ b/scripts/parse_tf_error.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+func main() {
+	app := kingpin.New("parse-tf-error", "Tries to parse Terraform cty error messages").
+		Author("terraform-provider-incident")
+
+	inputFile := app.Arg("file", "Error file to parse)").String()
+	outputFile := app.Flag("output", "Write output to file instead of stdout").Short('o').String()
+	preserveNewlines := app.Flag("preserve-newlines", "Preserve newlines in the output").Short('n').Bool()
+
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	// Read from stdin or file
+	var input string
+	if *inputFile != "" {
+		fmt.Println(inputFile)
+		data, err := os.ReadFile(*inputFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading file: %v\n", err)
+			os.Exit(1)
+		}
+		input = string(data)
+	} else {
+		fmt.Fprintln(os.Stderr, "No input provided. Please provide a file")
+		return
+	}
+
+	// Clean up pipe characters and extra spaces
+	lines := strings.Split(input, "\n")
+	var cleanedLines []string
+	for _, line := range lines {
+		// Remove pipe character and leading/trailing spaces
+		line = strings.TrimSpace(strings.TrimPrefix(line, "│"))
+		if line != "" {
+			cleanedLines = append(cleanedLines, line)
+		}
+	}
+
+	// Join lines with appropriate separator
+	var cleaned string
+	if *preserveNewlines {
+		cleaned = strings.Join(cleanedLines, "\n")
+	} else {
+		cleaned = strings.Join(cleanedLines, " ")
+	}
+
+	// Apply cleanups to simplify the cty syntax
+	cleaned = simplify(cleaned)
+
+	// Output the result
+	if *outputFile != "" {
+		err := os.WriteFile(*outputFile, []byte(cleaned), 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing to file: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Println(cleaned)
+	}
+}
+
+func simplify(input string) string {
+	// First, normalize whitespace
+	input = regexp.MustCompile(`\s+`).ReplaceAllString(input, " ")
+
+	// Step 1: Remove cty. prefixes and simple expressions
+	replacements := []struct {
+		pattern string
+		replace string
+	}{
+		// Remove map[string] patterns
+		{`map\[string\]cty\.(Value|Type)\{`, "{"},
+		// Remove cty prefixes for common types
+		{`cty\.ObjectVal\(`, ""},
+		{`cty\.ListVal\(`, ""},
+		{`cty\.SetVal\(`, ""},
+		{`cty\.StringVal\("([^"]*)"\)`, `"$1"`},
+		{`cty\.BoolVal\((true|false)\)`, "$1"},
+		{`cty\.True`, "true"},
+		{`cty\.False`, "false"},
+		{`cty\.NullVal\([^)]*\)`, "null"},
+		// Remove array declarations
+		{`\[\]cty\.Value\{`, "["},
+		// Handle bare cty.String and cty.Val (replace with null)
+		{`cty\.(String|Val|Bool|Number)(\s|,|})`, "null$2"},
+		// Remove type references
+		{`cty\.(String|Bool|Number|List|Set|Map|Object)`, ""},
+		// Remove Val pattern which is still present
+		{`Val\("([^"]*)"\)`, `"$1"`},
+		{`Val\(`, ""},
+	}
+
+	for _, r := range replacements {
+		re := regexp.MustCompile(r.pattern)
+		input = re.ReplaceAllString(input, r.replace)
+	}
+
+	// Step 2: Clean up parentheses - remove trailing parentheses that break JSON
+	// This is the key step to fix the output
+	parentheses := []struct {
+		pattern string
+		replace string
+	}{
+		{`\)\)`, ")"},
+		{`\)\}`, "}"},
+		{`\}\)`, "}"},
+		{`\]\)`, "]"},
+		// Fix broken patterns with parentheses
+		{`\(([^():]*)\)`, "$1"},       // Remove simple parentheses around content without colons
+		{`\(([^()]*:[^()]*)\)`, "$1"}, // Remove parentheses around key-value pairs
+	}
+
+	for _, p := range parentheses {
+		re := regexp.MustCompile(p.pattern)
+		for re.MatchString(input) { // Keep replacing until no more matches
+			input = re.ReplaceAllString(input, p.replace)
+		}
+	}
+
+	// Step 3: best-effort - remove any remaining unmatched parentheses
+	input = strings.ReplaceAll(input, "(", "")
+	input = strings.ReplaceAll(input, ")", "")
+
+	return input
+}


### PR DESCRIPTION
Our nested objects can get pretty complicated to read when they look like the following, so I got Claude to help with a best-effort script to make it easier.

```
 cty.ObjectVal(map[string]cty.Value{"alert_attribute_id":cty.StringVal("01JKB2YX8CBENYVX3XCYQFT776"),
│ "binding":cty.ObjectVal(map[string]cty.Value{"array_value":cty.NullVal(cty.Set(cty.Object(map[string]cty.Type{"literal":cty.String,
│ "reference":cty.String}))),
│ "value":cty.ObjectVal(map[string]cty.Value{"literal":cty.StringVal("01HZ00RA86E5PKYBHSD1SMZ0GS"),
│ "reference":cty.NullVal(cty.String)})})})
```