### PR TITLE
Explicitly only support 3 levels of nesting on escalation_path

### DIFF
--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -128,7 +128,9 @@ resource "incident_escalation_path" "urgent_support" {
 ### Required
 
 - `name` (String) The name of this escalation path, for the user's reference.
-- `path` (Attributes List) The nodes that form the levels and branches of this escalation path. (see [below for nested schema](#nestedatt--path))
+- `path` (Attributes List) The nodes that form the levels and branches of this escalation path.
+
+-->**Note** Although the `if_else` block is recursive, currently a maximum of 3 levels are supported. Attempting to configure more than 3 levels of nesting will result in a schema error. (see [below for nested schema](#nestedatt--path))
 
 ### Optional
 
@@ -365,9 +367,258 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat`
+
+Required:
+
+- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.conditions.subject`
+
+Optional:
+
+- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--value))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--array_value"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--value"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
 
 <a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--level"></a>
 ### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat`
@@ -464,9 +715,258 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat`
+
+Required:
+
+- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.conditions.subject`
+
+Optional:
+
+- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--value))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--array_value"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--value"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
 
 <a id="nestedatt--path--if_else--then_path--repeat--then_path--repeat--else_path--level"></a>
 ### Nested Schema for `path.if_else.then_path.repeat.then_path.repeat.else_path.repeat`
@@ -713,9 +1213,258 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.conditions.subject`
+
+Optional:
+
+- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--value))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--array_value"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--value"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
 
 <a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--level"></a>
 ### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat`
@@ -812,9 +1561,258 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.conditions.subject`
+
+Optional:
+
+- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--value))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--array_value"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--value"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
 
 <a id="nestedatt--path--if_else--then_path--repeat--else_path--repeat--else_path--level"></a>
 ### Nested Schema for `path.if_else.then_path.repeat.else_path.repeat.else_path.repeat`
@@ -1211,9 +2209,258 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat`
+
+Required:
+
+- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.conditions.subject`
+
+Optional:
+
+- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--value))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--array_value"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--value"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
 
 <a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--level"></a>
 ### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat`
@@ -1310,9 +2557,258 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat`
+
+Required:
+
+- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.conditions.subject`
+
+Optional:
+
+- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--value))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--array_value"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--conditions--subject--value"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--repeat--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
 
 <a id="nestedatt--path--if_else--else_path--repeat--then_path--repeat--else_path--level"></a>
 ### Nested Schema for `path.if_else.else_path.repeat.then_path.repeat.else_path.repeat`
@@ -1559,9 +3055,258 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.conditions.subject`
+
+Optional:
+
+- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--value))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--array_value"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--value"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
 
 <a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--level"></a>
 ### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat`
@@ -1658,9 +3403,258 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.conditions.subject`
+
+Optional:
+
+- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--value))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--array_value"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--conditions--subject--value"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.conditions.subject.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+
+Optional:
+
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat--targets"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat.time_to_ack_weekday_interval_config_id`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--repeat--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
 
 <a id="nestedatt--path--if_else--else_path--repeat--else_path--repeat--else_path--level"></a>
 ### Nested Schema for `path.if_else.else_path.repeat.else_path.repeat.else_path.repeat`

--- a/internal/provider/models/alert_source_v1_model.go
+++ b/internal/provider/models/alert_source_v1_model.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
 
@@ -27,10 +28,10 @@ func (AlertSourceResourceModel) FromAPI(source client.AlertSourceV2) AlertSource
 		SourceType:  types.StringValue(string(source.SourceType)),
 		SecretToken: types.StringPointerValue(source.SecretToken),
 		Template: &AlertTemplateModel{
-			Title:        IncidentEngineParamBindingValue{}.FromAPI(source.Template.Title),
-			Description:  IncidentEngineParamBindingValue{}.FromAPI(source.Template.Description),
-			Attributes:   AlertTemplateAttributesModel{}.FromAPI(source.Template.Attributes),
-			Expresssions: IncidentEngineExpressions{}.FromAPI(source.Template.Expressions),
+			Title:       IncidentEngineParamBindingValue{}.FromAPI(source.Template.Title),
+			Description: IncidentEngineParamBindingValue{}.FromAPI(source.Template.Description),
+			Attributes:  AlertTemplateAttributesModel{}.FromAPI(source.Template.Attributes),
+			Expressions: IncidentEngineExpressions{}.FromAPI(source.Template.Expressions),
 		},
 		JiraOptions:  AlertSourceJiraOptionsModel{}.FromAPI(source.JiraOptions),
 		EmailAddress: types.StringPointerValue(emailAddress),
@@ -38,15 +39,15 @@ func (AlertSourceResourceModel) FromAPI(source client.AlertSourceV2) AlertSource
 }
 
 type AlertTemplateModel struct {
-	Expresssions IncidentEngineExpressions       `tfsdk:"expressions"`
-	Title        IncidentEngineParamBindingValue `tfsdk:"title"`
-	Description  IncidentEngineParamBindingValue `tfsdk:"description"`
-	Attributes   AlertTemplateAttributesModel    `tfsdk:"attributes"`
+	Expressions IncidentEngineExpressions       `tfsdk:"expressions"`
+	Title       IncidentEngineParamBindingValue `tfsdk:"title"`
+	Description IncidentEngineParamBindingValue `tfsdk:"description"`
+	Attributes  AlertTemplateAttributesModel    `tfsdk:"attributes"`
 }
 
 func (template AlertTemplateModel) ToPayload() client.AlertTemplatePayloadV2 {
 	return client.AlertTemplatePayloadV2{
-		Expressions: template.Expresssions.ToPayload(),
+		Expressions: template.Expressions.ToPayload(),
 		Title:       template.Title.ToPayload(),
 		Description: template.Description.ToPayload(),
 		Attributes:  template.Attributes.ToPayload(),


### PR DESCRIPTION
Our escalation path resources are recursive, however terraform doesn't support recursive resources - as such we have to explicitly unpack the resource into a flat structure that terraform can use. 

We're now explicitly handling 3 levels of depth - the code made it seem like this was already the case but we were actually at 2. I've added a test to validate we're where we're expected.

AWS does something similar, and we should look into how they make their docs nicer: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_rule_group#complex