### PR TITLE
Use `Set` to model schedule rotations

### DIFF
--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -139,7 +139,7 @@ Required:
 
 - `id` (String) Unique internal ID of the rotation
 - `name` (String) Human readable name synced from external provider
-- `versions` (Attributes List) (see [below for nested schema](#nestedatt--rotations--versions))
+- `versions` (Attributes Set) (see [below for nested schema](#nestedatt--rotations--versions))
 
 <a id="nestedatt--rotations--versions"></a>
 ### Nested Schema for `rotations.versions`

--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -120,7 +120,7 @@ resource "incident_schedule" "primary_on_call" {
 ### Required
 
 - `name` (String) Human readable name synced from external provider
-- `rotations` (Attributes List) (see [below for nested schema](#nestedatt--rotations))
+- `rotations` (Attributes Set) (see [below for nested schema](#nestedatt--rotations))
 - `timezone` (String)
 
 ### Optional

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -76,7 +76,7 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 				},
 				Optional: true,
 			},
-			"rotations": schema.ListNestedAttribute{
+			"rotations": schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -87,7 +87,7 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 							Required:            true,
 							MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "name"),
 						},
-						"versions": schema.ListNestedAttribute{
+						"versions": schema.SetNestedAttribute{
 							Required: true,
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
The order isn't important, using a set will allow us to return them in a different order as they are defined without causing a large plan diff.

Fixes #202