### PR TITLE
Severity on incident_alert_route is not computed

### DIFF
--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -215,7 +215,6 @@ func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.Sc
 					},
 					"severity": schema.SingleNestedAttribute{
 						Optional:            true,
-						Computed:            true,
 						MarkdownDescription: apischema.Docstring("AlertRouteIncidentTemplateV2", "severity"),
 						Attributes: map[string]schema.Attribute{
 							"binding": schema.SingleNestedAttribute{


### PR DESCRIPTION
Severity is optional, but this was failing locally for me without setting a severity:
```
│ Error: Value Conversion Error
│
│   with incident_alert_route.tf_alert_route,
│   on main.tf line 877, in resource "incident_alert_route" "tf_alert_route":
│  877: resource "incident_alert_route" "tf_alert_route" {
│
│ An unexpected error was encountered trying to build a value. This is always an error in
│ the provider. Please report the following to the provider developer:
│
│ Received unknown value, however the target type cannot handle unknown values. Use the
│ corresponding `types` package type or a custom type that handles unknown values.
│
│ Path: incident_template.severity
│ Target Type: *models.AlertRouteSeverityModel
│ Suggested Type: basetypes.ObjectValue
```

I don't think we want this to be computed, as we don't default it to anything.