### PR TITLE
Update alert route and source docs to point to new Export flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Update the documentation for `incident_alert_source` and `incident_alert_route` to reference the new 'Export' flow
+  in the dashboard, which allows you to generate Terraform from configuration
+
 ## v5.8.0
 
 - `incident_schedule_resource` now uses sets for rotations as the ordering of them does not matter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
-- Update the documentation for `incident_alert_source` and `incident_alert_route` to reference the new 'Export' flow
-  in the dashboard, which allows you to generate Terraform from configuration
+- Update the documentation for `incident_alert_source`, `incident_alert_route`, `incident_escalation_path` and `incident_schedule` to reference the 'Export' flow
+  in the dashboard
 
 ## v5.8.0
 

--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   Configure your alert routes in incident.io.
   Alert routes define how alerts from different sources are processed, grouped, and routed to the right teams and people.
+  We'd generally recommend building alert routes in our web dashboard https://app.incident.io/alerts/configuration, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.
 ---
 
 # incident_alert_route (Resource)
@@ -12,6 +13,8 @@ description: |-
 Configure your alert routes in incident.io.
 
 Alert routes define how alerts from different sources are processed, grouped, and routed to the right teams and people.
+
+We'd generally recommend building alert routes in our [web dashboard](https://app.incident.io/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.
 
 ## Example Usage
 

--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Configure your alert routes in incident.io.
   Alert routes define how alerts from different sources are processed, grouped, and routed to the right teams and people.
-  We'd generally recommend building alert routes in our web dashboard https://app.incident.io/alerts/configuration, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.
+  We'd generally recommend building alert routes in our web dashboard https://app.incident.io/~/alerts/configuration, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.
 ---
 
 # incident_alert_route (Resource)
@@ -14,7 +14,7 @@ Configure your alert routes in incident.io.
 
 Alert routes define how alerts from different sources are processed, grouped, and routed to the right teams and people.
 
-We'd generally recommend building alert routes in our [web dashboard](https://app.incident.io/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.
+We'd generally recommend building alert routes in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.
 
 ## Example Usage
 

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Configure your alert sources in incident.io.
   Alert sources are the systems that send alerts to incident.io, which can then be routed to the right people and teams.
-  We'd generally recommend building alert sources in our web dashboard https://app.incident.io/alerts/configuration, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.
+  We'd generally recommend building alert sources in our web dashboard https://app.incident.io/~/alerts/configuration, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.
 ---
 
 # incident_alert_source (Resource)
@@ -14,7 +14,7 @@ Configure your alert sources in incident.io.
 
 Alert sources are the systems that send alerts to incident.io, which can then be routed to the right people and teams.
 
-We'd generally recommend building alert sources in our [web dashboard](https://app.incident.io/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.
+We'd generally recommend building alert sources in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.
 
 ## Example Usage
 

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   Configure your alert sources in incident.io.
   Alert sources are the systems that send alerts to incident.io, which can then be routed to the right people and teams.
+  We'd generally recommend building alert sources in our web dashboard https://app.incident.io/alerts/configuration, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.
 ---
 
 # incident_alert_source (Resource)
@@ -13,10 +14,12 @@ Configure your alert sources in incident.io.
 
 Alert sources are the systems that send alerts to incident.io, which can then be routed to the right people and teams.
 
+We'd generally recommend building alert sources in our [web dashboard](https://app.incident.io/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.
+
 ## Example Usage
 
 ```terraform
-## Create a basic Alert Source that recieves from an SNS Topic in AWS
+## Create a basic Alert Source that receives from an SNS Topic in AWS
 
 resource "incident_alert_source" "cloudwatch" {
   name        = "CloudWatch Alerts"

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -7,7 +7,7 @@ description: |-
   With incident.io On-call you can create escalation paths that describe how a page should
   be escalated to people and schedules, and create escalations that will execute those
   paths.
-  We'd generally recommend building escalation paths in our web dashboard https://app.incident.io/on-call/escalation-paths, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.
+  We'd generally recommend building escalation paths in our web dashboard https://app.incident.io/~/on-call/escalation-paths, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.
 ---
 
 # incident_escalation_path (Resource)
@@ -19,7 +19,7 @@ be escalated to people and schedules, and create escalations that will execute t
 paths.
 
 
-We'd generally recommend building escalation paths in our [web dashboard](https://app.incident.io/on-call/escalation-paths), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.
+We'd generally recommend building escalation paths in our [web dashboard](https://app.incident.io/~/on-call/escalation-paths), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.
 
 ## Example Usage
 

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -7,6 +7,7 @@ description: |-
   With incident.io On-call you can create escalation paths that describe how a page should
   be escalated to people and schedules, and create escalations that will execute those
   paths.
+  We'd generally recommend building escalation paths in our web dashboard https://app.incident.io/on-call/escalation-paths, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.
 ---
 
 # incident_escalation_path (Resource)
@@ -16,6 +17,9 @@ Create and manage escalations.
 With incident.io On-call you can create escalation paths that describe how a page should
 be escalated to people and schedules, and create escalations that will execute those
 paths.
+
+
+We'd generally recommend building escalation paths in our [web dashboard](https://app.incident.io/on-call/escalation-paths), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.
 
 ## Example Usage
 

--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -5,12 +5,16 @@ subcategory: ""
 description: |-
   View and manage schedules.
   Manage your full schedule of on-call rotations, including the users and rotation configuration.
+  We'd generally recommend building schedules in our web dashboard https://app.incident.io/on-call/schedules, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing schedule and copy the resulting Terraform without persisting it.
 ---
 
 # incident_schedule (Resource)
 
 View and manage schedules.
 Manage your full schedule of on-call rotations, including the users and rotation configuration.
+
+
+We'd generally recommend building schedules in our [web dashboard](https://app.incident.io/on-call/schedules), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing schedule and copy the resulting Terraform without persisting it.
 
 ## Example Usage
 

--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   View and manage schedules.
   Manage your full schedule of on-call rotations, including the users and rotation configuration.
-  We'd generally recommend building schedules in our web dashboard https://app.incident.io/on-call/schedules, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing schedule and copy the resulting Terraform without persisting it.
+  We'd generally recommend building schedules in our web dashboard https://app.incident.io/~/on-call/schedules, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing schedule and copy the resulting Terraform without persisting it.
 ---
 
 # incident_schedule (Resource)
@@ -14,7 +14,7 @@ View and manage schedules.
 Manage your full schedule of on-call rotations, including the users and rotation configuration.
 
 
-We'd generally recommend building schedules in our [web dashboard](https://app.incident.io/on-call/schedules), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing schedule and copy the resulting Terraform without persisting it.
+We'd generally recommend building schedules in our [web dashboard](https://app.incident.io/~/on-call/schedules), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing schedule and copy the resulting Terraform without persisting it.
 
 ## Example Usage
 

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -4,14 +4,14 @@ page_title: "incident_workflow Resource - terraform-provider-incident"
 subcategory: ""
 description: |-
   This resource is used to manage Workflows.
-  We'd generally recommend building workflows in our web dashboard https://app.incident.io/workflows, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this Loom https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448.
+  We'd generally recommend building workflows in our web dashboard https://app.incident.io/~/workflows, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this Loom https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448.
 ---
 
 # incident_workflow (Resource)
 
 This resource is used to manage Workflows.
 
-We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this [Loom](https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448).
+We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/~/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this [Loom](https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448).
 
 ## Example Usage
 

--- a/examples/resources/incident_alert_source/resource.tf
+++ b/examples/resources/incident_alert_source/resource.tf
@@ -1,4 +1,4 @@
-## Create a basic Alert Source that recieves from an SNS Topic in AWS
+## Create a basic Alert Source that receives from an SNS Topic in AWS
 
 resource "incident_alert_source" "cloudwatch" {
   name        = "CloudWatch Alerts"

--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -36,7 +36,7 @@ func (r *IncidentAlertRouteResource) Metadata(ctx context.Context, req resource.
 
 func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Routes V2"), `We'd generally recommend building alert routes in our [web dashboard](https://app.incident.io/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.`),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Routes V2"), `We'd generally recommend building alert routes in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -36,7 +36,7 @@ func (r *IncidentAlertRouteResource) Metadata(ctx context.Context, req resource.
 
 func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: apischema.TagDocstring("Alert Routes V2"),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Routes V2"), `We'd generally recommend building alert routes in our [web dashboard](https://app.incident.io/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -71,7 +71,7 @@ func (r *IncidentAlertSourceResource) Metadata(ctx context.Context, req resource
 
 func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: apischema.TagDocstring("Alert Sources V2"),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Sources V2"), `We'd generally recommend building alert sources in our [web dashboard](https://app.incident.io/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -71,7 +71,7 @@ func (r *IncidentAlertSourceResource) Metadata(ctx context.Context, req resource
 
 func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Sources V2"), `We'd generally recommend building alert sources in our [web dashboard](https://app.incident.io/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.`),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Sources V2"), `We'd generally recommend building alert sources in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert source and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -98,7 +98,7 @@ func (r *IncidentEscalationPathResource) Metadata(ctx context.Context, req resou
 
 func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Escalations V2"), `We'd generally recommend building escalation paths in our [web dashboard](https://app.incident.io/on-call/escalation-paths), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.`),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Escalations V2"), `We'd generally recommend building escalation paths in our [web dashboard](https://app.incident.io/~/on-call/escalation-paths), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -98,7 +98,7 @@ func (r *IncidentEscalationPathResource) Metadata(ctx context.Context, req resou
 
 func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: apischema.TagDocstring("Escalations V2"),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Escalations V2"), `We'd generally recommend building escalation paths in our [web dashboard](https://app.incident.io/on-call/escalation-paths), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -42,7 +42,7 @@ func (r *IncidentScheduleResource) Metadata(ctx context.Context, req resource.Me
 
 func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: apischema.TagDocstring("Schedules V2"),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Schedules V2"), `We'd generally recommend building schedules in our [web dashboard](https://app.incident.io/on-call/schedules), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing schedule and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -42,7 +42,7 @@ func (r *IncidentScheduleResource) Metadata(ctx context.Context, req resource.Me
 
 func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Schedules V2"), `We'd generally recommend building schedules in our [web dashboard](https://app.incident.io/on-call/schedules), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing schedule and copy the resulting Terraform without persisting it.`),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Schedules V2"), `We'd generally recommend building schedules in our [web dashboard](https://app.incident.io/~/on-call/schedules), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing schedule and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -70,7 +70,7 @@ func (r *IncidentWorkflowResource) Schema(ctx context.Context, req resource.Sche
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `This resource is used to manage Workflows.
 
-We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this [Loom](https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448).`,
+We'd generally recommend building workflows in our [web dashboard](https://app.incident.io/~/workflows), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing workflow and copy the resulting Terraform without persisting it. You can learn more in this [Loom](https://www.loom.com/share/b833d7d0fd114d6ba3f24d8c72e5208f?sid=c6d3cc3f-aa93-44ba-b12d-a0a4cbe09448).`,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: apischema.Docstring("WorkflowV2", "id"),


### PR DESCRIPTION
Points users to use the new 'Export' flow in the dashboard, to generate and copy Terraform rather than hand-write it.