### PR TITLE
Make schedule handovers required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Made `handovers` on `incident_schedule.config.rotations.*` required, as it
+  was always required by the API, but was not marked as such in the provider.
+
 ## v5.9.0
 
 - Update the documentation for `incident_alert_source`, `incident_alert_route`, `incident_escalation_path` and `incident_schedule` to reference the 'Export' flow

--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -151,23 +151,14 @@ Required:
 Required:
 
 - `handover_start_at` (String) Defines the next moment we'll trigger a handover
+- `handovers` (Attributes List) Defines the handover intervals for this rota, in order they should apply (see [below for nested schema](#nestedatt--rotations--versions--handovers))
 - `layers` (Attributes List) Controls how many people are on-call concurrently (see [below for nested schema](#nestedatt--rotations--versions--layers))
 - `users` (List of String) The incident.io ID of a user
 
 Optional:
 
 - `effective_from` (String) When this rotation config will be effective from
-- `handovers` (Attributes List) Defines the handover intervals for this rota, in order they should apply (see [below for nested schema](#nestedatt--rotations--versions--handovers))
 - `working_intervals` (Attributes List) Optional restrictions that define when to schedule people for this rota (see [below for nested schema](#nestedatt--rotations--versions--working_intervals))
-
-<a id="nestedatt--rotations--versions--layers"></a>
-### Nested Schema for `rotations.versions.layers`
-
-Required:
-
-- `id` (String)
-- `name` (String)
-
 
 <a id="nestedatt--rotations--versions--handovers"></a>
 ### Nested Schema for `rotations.versions.handovers`
@@ -176,6 +167,15 @@ Required:
 
 - `interval` (Number)
 - `interval_type` (String)
+
+
+<a id="nestedatt--rotations--versions--layers"></a>
+### Nested Schema for `rotations.versions.layers`
+
+Required:
+
+- `id` (String)
+- `name` (String)
 
 
 <a id="nestedatt--rotations--versions--working_intervals"></a>

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -139,7 +139,7 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 										},
 									},
 									"handovers": schema.ListNestedAttribute{
-										Optional:            true,
+										Required:            true,
 										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "handovers"),
 										NestedObject: schema.NestedAttributeObject{
 											Attributes: map[string]schema.Attribute{

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -366,6 +366,12 @@ resource "incident_schedule" "invalid_timestamp" {
       versions = [
         {
           handover_start_at = "2024-15-11T15:00:00Z" # Invalid month (15)
+					handovers = [
+						{
+							interval = 1,
+							interval_type = "daily"
+						}
+					]
           users = []
           layers = [
             {
@@ -393,6 +399,12 @@ resource "incident_schedule" "invalid_timestamp" {
       versions = [
         {
           handover_start_at = "2024-05-11T15:00:00Z"
+					handovers = [
+						{
+							interval = 1,
+							interval_type = "daily"
+						}
+					]
           effective_from   = "2024-05-32T15:00:00Z" # Invalid day (32)
           users = []
           layers = [


### PR DESCRIPTION
Our API requires these already, so the previous terraform schema was incorrect, leading to plans saying this would succeed, for it then to get a 422 error response back.