### PR TITLE
Update catalog_type categories to be computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix `incident_catalog_type` to be able to better handle undefined or empty category lists
+
 ## v5.11.0
 
 - Add `incident_catalog_entries` data source to get catalog entries for a specific catalog type. This is useful for


### PR DESCRIPTION
With the V3 API we always return an empty array for catalog type categories. This can cause problem if it's empty as we weren't creating the stuct from the server response.

This caused a `.categories: was cty.ListValEmpty(cty.String), but now null.` error. This swaps us out to use a `types.List` type which can much better handle missing attributes that are computed.

Fixes #231 