### PR TITLE
Add incident_catalog_entries data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Add `incident_catalog_entries` data source to get catalog entries for a specific catalog type. This is useful for
+  building up a list of catalog entries which you might be managing via catalog-importer.
+
 ## v5.10.0
 
 - Enforce consistent ordering of keys in engine literal values which are JSON objects.

--- a/examples/data-sources/incident_catalog_entries/data-source.tf
+++ b/examples/data-sources/incident_catalog_entries/data-source.tf
@@ -1,0 +1,29 @@
+# List catalog entries for a specific catalog type
+data "incident_catalog_entries" "services" {
+  catalog_type_id = "01FCNDV6P870EA6S7TK1DSYDG0"
+}
+
+# Example usage: output all entry names
+output "service_names" {
+  value = [for entry in data.incident_catalog_entries.services.catalog_entries : entry.name]
+}
+
+# Example usage: find entries with specific attributes
+output "services_with_external_id" {
+  value = [
+    for entry in data.incident_catalog_entries.services.catalog_entries : {
+      name        = entry.name
+      external_id = entry.external_id
+    }
+    if entry.external_id != ""
+  ]
+}
+
+# Example usage: get all aliases for entries
+output "service_aliases" {
+  value = {
+    for entry in data.incident_catalog_entries.services.catalog_entries :
+    entry.name => entry.aliases
+    if length(entry.aliases) > 0
+  }
+}

--- a/internal/provider/incident_catalog_entries_data_source.go
+++ b/internal/provider/incident_catalog_entries_data_source.go
@@ -1,0 +1,187 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/incident-io/terraform-provider-incident/internal/apischema"
+	"github.com/incident-io/terraform-provider-incident/internal/client"
+)
+
+var (
+	_ datasource.DataSource              = &IncidentCatalogEntriesDataSource{}
+	_ datasource.DataSourceWithConfigure = &IncidentCatalogEntriesDataSource{}
+)
+
+func NewIncidentCatalogEntriesDataSource() datasource.DataSource {
+	return &IncidentCatalogEntriesDataSource{}
+}
+
+type IncidentCatalogEntriesDataSource struct {
+	client *client.ClientWithResponses
+}
+
+type IncidentCatalogEntriesDataSourceModel struct {
+	CatalogTypeID  types.String                          `tfsdk:"catalog_type_id"`
+	CatalogEntries []IncidentCatalogEntryDataSourceModel `tfsdk:"catalog_entries"`
+}
+
+func (d *IncidentCatalogEntriesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*IncidentProviderData)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *IncidentProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client.Client
+}
+
+func (d *IncidentCatalogEntriesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_catalog_entries"
+}
+
+func (d *IncidentCatalogEntriesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data IncidentCatalogEntriesDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var allEntries []client.CatalogEntryV3
+
+	// Fetch entries for the specified catalog type
+	catalogTypeID := data.CatalogTypeID.ValueString()
+	params := &client.CatalogV3ListEntriesParams{
+		CatalogTypeId: catalogTypeID,
+	}
+
+	// Paginate through all entries
+	params.PageSize = 100
+
+	for {
+		result, err := d.client.CatalogV3ListEntriesWithResponse(ctx, params)
+		if err == nil && result.StatusCode() >= 400 {
+			err = fmt.Errorf("%s", string(result.Body))
+		}
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list catalog entries, got error: %s", err))
+			return
+		}
+
+		allEntries = append(allEntries, result.JSON200.CatalogEntries...)
+
+		// Check if there are more pages
+		if result.JSON200.PaginationMeta.After == nil {
+			break
+		}
+		params.After = result.JSON200.PaginationMeta.After
+	}
+
+	// Convert catalog entries to the model
+	var catalogEntries []IncidentCatalogEntryDataSourceModel
+	for _, entry := range allEntries {
+		catalogEntries = append(catalogEntries, *d.buildItemModel(entry))
+	}
+
+	modelResp := IncidentCatalogEntriesDataSourceModel{
+		CatalogTypeID:  data.CatalogTypeID,
+		CatalogEntries: catalogEntries,
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &modelResp)...)
+}
+
+func (d *IncidentCatalogEntriesDataSource) buildItemModel(entry client.CatalogEntryV3) *IncidentCatalogEntryDataSourceModel {
+	attributeValues := buildCatalogEntryAttributeValuesFromV3(entry.AttributeValues)
+
+	aliases := []attr.Value{}
+	for _, alias := range entry.Aliases {
+		aliases = append(aliases, types.StringValue(alias))
+	}
+
+	return &IncidentCatalogEntryDataSourceModel{
+		ID:              types.StringValue(entry.Id),
+		Name:            types.StringValue(entry.Name),
+		CatalogTypeID:   types.StringValue(entry.CatalogTypeId),
+		ExternalID:      types.StringPointerValue(entry.ExternalId),
+		Aliases:         types.ListValueMust(types.StringType, aliases),
+		Rank:            types.Int64Value(int64(entry.Rank)),
+		AttributeValues: attributeValues,
+	}
+}
+
+func (d *IncidentCatalogEntriesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "This data source provides a list of catalog entries for a specific catalog type.",
+		Attributes: map[string]schema.Attribute{
+			"catalog_type_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The catalog type ID to list entries for.",
+			},
+			"catalog_entries": schema.ListNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "List of catalog entries for the specified catalog type.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "id"),
+						},
+						"name": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "name"),
+						},
+						"catalog_type_id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "catalog_type_id"),
+						},
+						"external_id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "external_id"),
+						},
+						"aliases": schema.ListAttribute{
+							ElementType:         types.StringType,
+							Computed:            true,
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "aliases"),
+						},
+						"rank": schema.Int64Attribute{
+							Computed:            true,
+							MarkdownDescription: apischema.Docstring("CatalogEntryV2", "rank"),
+						},
+						"attribute_values": schema.SetNestedAttribute{
+							Computed: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"attribute": schema.StringAttribute{
+										Description: `The ID of this attribute.`,
+										Computed:    true,
+									},
+									"value": schema.StringAttribute{
+										Description: `The value of this attribute, in a format suitable for this attribute type.`,
+										Computed:    true,
+									},
+									"array_value": schema.ListAttribute{
+										ElementType: types.StringType,
+										Description: `The value of this element of the array, in a format suitable for this attribute type.`,
+										Computed:    true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/provider/incident_catalog_entries_data_source_test.go
+++ b/internal/provider/incident_catalog_entries_data_source_test.go
@@ -1,0 +1,203 @@
+package provider
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"text/template"
+
+	"github.com/Masterminds/sprig"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccIncidentCatalogEntriesDataSource(t *testing.T) {
+	typeName := generateTypeName()
+
+	// Test basic listing
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentCatalogEntriesDataSourceConfig(catalogEntriesDataSourceFixture{
+					TypeName: typeName,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check that we have exactly 3 catalog entries
+					resource.TestCheckResourceAttr("data.incident_catalog_entries.test", "catalog_entries.#", "3"),
+					// Check the catalog type ID is set
+					resource.TestCheckResourceAttrSet("data.incident_catalog_entries.test", "catalog_type_id"),
+					// Check that our test entries exist in the results
+					resource.TestCheckTypeSetElemNestedAttrs("data.incident_catalog_entries.test", "catalog_entries.*", map[string]string{
+						"name":        "Test Entry 1",
+						"external_id": "test-entry-1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("data.incident_catalog_entries.test", "catalog_entries.*", map[string]string{
+						"name":        "Test Entry 2",
+						"external_id": "test-entry-2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("data.incident_catalog_entries.test", "catalog_entries.*", map[string]string{
+						"name":        "Test Entry 3",
+						"external_id": "test-entry-3",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIncidentCatalogEntriesDataSource_WithAliases(t *testing.T) {
+	typeName := generateTypeName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentCatalogEntriesDataSourceConfigWithAliases(catalogEntriesDataSourceFixture{
+					TypeName: typeName,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check that we have the entry with aliases
+					resource.TestCheckResourceAttr("data.incident_catalog_entries.test", "catalog_entries.#", "1"),
+					// Check aliases are present
+					resource.TestCheckTypeSetElemAttr("data.incident_catalog_entries.test", "catalog_entries.0.aliases.*", "alias-1"),
+					resource.TestCheckTypeSetElemAttr("data.incident_catalog_entries.test", "catalog_entries.0.aliases.*", "alias-2"),
+					resource.TestCheckTypeSetElemAttr("data.incident_catalog_entries.test", "catalog_entries.0.aliases.*", "alias-3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIncidentCatalogEntriesDataSource_Empty(t *testing.T) {
+	typeName := generateTypeName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentCatalogEntriesDataSourceConfigEmpty(catalogEntriesDataSourceFixture{
+					TypeName: typeName,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check that we have no catalog entries
+					resource.TestCheckResourceAttr("data.incident_catalog_entries.test", "catalog_entries.#", "0"),
+					// Check the catalog type ID is set
+					resource.TestCheckResourceAttrSet("data.incident_catalog_entries.test", "catalog_type_id"),
+				),
+			},
+		},
+	})
+}
+
+var catalogEntriesDataSourceTemplate = template.Must(template.New("incident_catalog_entries_data_source").Funcs(sprig.TxtFuncMap()).Parse(`
+resource "incident_catalog_type" "test" {
+  name        = "Test Catalog Type"
+  type_name   = {{ quote .TypeName }}
+  description = "Used in terraform acceptance tests"
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
+}
+
+resource "incident_catalog_entry" "test1" {
+  catalog_type_id = incident_catalog_type.test.id
+  name            = "Test Entry 1"
+  external_id     = "test-entry-1"
+  aliases         = []
+  attribute_values = []
+}
+
+resource "incident_catalog_entry" "test2" {
+  catalog_type_id = incident_catalog_type.test.id
+  name            = "Test Entry 2"
+  external_id     = "test-entry-2"
+  aliases         = []
+  attribute_values = []
+}
+
+resource "incident_catalog_entry" "test3" {
+  catalog_type_id = incident_catalog_type.test.id
+  name            = "Test Entry 3"
+  external_id     = "test-entry-3"
+  aliases         = []
+  attribute_values = []
+}
+
+data "incident_catalog_entries" "test" {
+  catalog_type_id = incident_catalog_type.test.id
+  
+  depends_on = [
+    incident_catalog_entry.test1,
+    incident_catalog_entry.test2,
+    incident_catalog_entry.test3
+  ]
+}
+`))
+
+var catalogEntriesDataSourceTemplateWithAliases = template.Must(template.New("incident_catalog_entries_data_source_aliases").Funcs(sprig.TxtFuncMap()).Parse(`
+resource "incident_catalog_type" "test" {
+  name        = "Test Catalog Type With Aliases"
+  type_name   = {{ quote .TypeName }}
+  description = "Used in terraform acceptance tests"
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
+}
+
+resource "incident_catalog_entry" "test_with_aliases" {
+  catalog_type_id = incident_catalog_type.test.id
+  name            = "Test Entry With Aliases"
+  external_id     = "test-entry-aliases"
+  aliases         = ["alias-1", "alias-2", "alias-3"]
+  attribute_values = []
+}
+
+data "incident_catalog_entries" "test" {
+  catalog_type_id = incident_catalog_type.test.id
+  
+  depends_on = [incident_catalog_entry.test_with_aliases]
+}
+`))
+
+var catalogEntriesDataSourceTemplateEmpty = template.Must(template.New("incident_catalog_entries_data_source_empty").Funcs(sprig.TxtFuncMap()).Parse(`
+resource "incident_catalog_type" "test" {
+  name        = "Empty Catalog Type"
+  type_name   = {{ quote .TypeName }}
+  description = "Used in terraform acceptance tests"
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
+}
+
+data "incident_catalog_entries" "test" {
+  catalog_type_id = incident_catalog_type.test.id
+}
+`))
+
+type catalogEntriesDataSourceFixture struct {
+	TypeName string
+}
+
+func testAccIncidentCatalogEntriesDataSourceConfig(payload catalogEntriesDataSourceFixture) string {
+	var buf bytes.Buffer
+	if err := catalogEntriesDataSourceTemplate.Execute(&buf, payload); err != nil {
+		panic(fmt.Errorf("failed to execute template: %w", err))
+	}
+	return buf.String()
+}
+
+func testAccIncidentCatalogEntriesDataSourceConfigWithAliases(payload catalogEntriesDataSourceFixture) string {
+	var buf bytes.Buffer
+	if err := catalogEntriesDataSourceTemplateWithAliases.Execute(&buf, payload); err != nil {
+		panic(fmt.Errorf("failed to execute template: %w", err))
+	}
+	return buf.String()
+}
+
+func testAccIncidentCatalogEntriesDataSourceConfigEmpty(payload catalogEntriesDataSourceFixture) string {
+	var buf bytes.Buffer
+	if err := catalogEntriesDataSourceTemplateEmpty.Execute(&buf, payload); err != nil {
+		panic(fmt.Errorf("failed to execute template: %w", err))
+	}
+	return buf.String()
+}

--- a/internal/provider/incident_catalog_entry_data_source.go
+++ b/internal/provider/incident_catalog_entry_data_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -165,33 +164,7 @@ func (i *IncidentCatalogEntryDataSource) Read(ctx context.Context, req datasourc
 	}
 
 	// Build the data model from the matched entry
-	values := []CatalogEntryAttributeValue{}
-	for attributeID, binding := range matchedEntry.AttributeValues {
-		value := CatalogEntryAttributeValue{
-			Attribute:  types.StringValue(attributeID),
-			ArrayValue: types.ListNull(types.StringType),
-		}
-
-		if binding.Value != nil {
-			value.Value = types.StringValue(*binding.Value.Literal)
-		}
-
-		if binding.ArrayValue != nil {
-			elements := []attr.Value{}
-			for _, value := range *binding.ArrayValue {
-				elements = append(elements, types.StringValue(*value.Literal))
-			}
-
-			value.ArrayValue = types.ListValueMust(types.StringType, elements)
-		}
-
-		values = append(values, value)
-	}
-
-	// Ensure consistent ordering
-	sort.Slice(values, func(i, j int) bool {
-		return values[i].Attribute.ValueString() < values[j].Attribute.ValueString()
-	})
+	values := buildCatalogEntryAttributeValuesFromV3(matchedEntry.AttributeValues)
 
 	aliases := []attr.Value{}
 	for _, alias := range matchedEntry.Aliases {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -135,6 +135,7 @@ func (p *IncidentProvider) DataSources(ctx context.Context) []func() datasource.
 		NewIncidentCatalogTypeDataSource,
 		NewIncidentCatalogTypeAttributeDataSource,
 		NewIncidentCatalogEntryDataSource,
+		NewIncidentCatalogEntriesDataSource,
 		NewIncidentCustomFieldDataSource,
 		NewIncidentCustomFieldOptionDataSource,
 		NewIncidentUserDataSource,


### PR DESCRIPTION
This adds an incident_catalog_entries data source, which means you can manage your catalog via catalog-importer but then refer to them via terraform, if you want. 