### PR TITLE
ONC-7057: Stop escaping HTML chars in JSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
 - Fix `incident_catalog_type` to be able to better handle undefined or empty category lists
-- Expose `incident_catalog_entries` in the documentation 
+- Expose `incident_catalog_entries` in the documentation
+- No longer escape HTML characters in engine JSON strings
 
 ## v5.11.0
 

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -1,7 +1,9 @@
 package models
 
 import (
+	"bytes"
 	"encoding/json"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -133,13 +135,19 @@ func normaliseJSON(jsonString string) (string, error) {
 		return "", err
 	}
 
-	// json.Marshal will return alphabetically sorted keys
-	normalisedJSON, err := json.Marshal(data)
+	// Use encoder with HTML escaping disabled to preserve special characters like >
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	err = encoder.Encode(data)
 	if err != nil {
 		return "", err
 	}
 
-	return string(normalisedJSON), nil
+	// Remove the trailing newline that Encode adds
+	normalisedJSON := strings.TrimSuffix(buf.String(), "\n")
+
+	return normalisedJSON, nil
 }
 
 type IncidentEngineExpressions []IncidentEngineExpression


### PR DESCRIPTION
We normalise JSON responses in order to guarantee key ordering etc.

The default behaviour for the JSON unmarhsalling is to escape HTML chars, which we don't want, as that causes differences between what the user submits and the API response we get back, leading to sadness in state.

---

Example sad:

```
"Alert -> Title"
```

Get's escaped as 

```
"Alert -\\u003e Title"
```
