### PR TITLE
Add use_name_as_identifier field to catalog types

### DIFF
--- a/docs/data-sources/catalog_type.md
+++ b/docs/data-sources/catalog_type.md
@@ -49,5 +49,6 @@ resource "incident_catalog_entries" "services" {
 - `description` (String) Human readble description of this type
 - `id` (String) ID of this catalog type
 - `source_repo_url` (String) The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.
+- `use_name_as_identifier` (Boolean) If populated, the name of the entry will be added to the list of identifiers for this type
 
 

--- a/docs/data-sources/catalog_type.md
+++ b/docs/data-sources/catalog_type.md
@@ -49,6 +49,6 @@ resource "incident_catalog_entries" "services" {
 - `description` (String) Human readble description of this type
 - `id` (String) ID of this catalog type
 - `source_repo_url` (String) The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.
-- `use_name_as_identifier` (Boolean) If populated, the name of the entry will be added to the list of identifiers for this type
+- `use_name_as_identifier` (Boolean) If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.
 
 

--- a/docs/resources/catalog_type.md
+++ b/docs/resources/catalog_type.md
@@ -73,7 +73,7 @@ resource "incident_catalog_type" "service_tier" {
 
 - `categories` (List of String) The categories that this type belongs to, to be shown in the web dashboard. Possible values are: `customer`, `issue-tracker`, `product-feature`, `service`, `on-call`, `team`, `user`.
 - `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
-- `use_name_as_identifier` (Boolean) If populated, the name of the entry will be added to the list of identifiers for this type
+- `use_name_as_identifier` (Boolean) If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.
 
 ### Read-Only
 

--- a/docs/resources/catalog_type.md
+++ b/docs/resources/catalog_type.md
@@ -73,6 +73,7 @@ resource "incident_catalog_type" "service_tier" {
 
 - `categories` (List of String) The categories that this type belongs to, to be shown in the web dashboard. Possible values are: `customer`, `issue-tracker`, `product-feature`, `service`, `on-call`, `team`, `user`.
 - `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
+- `use_name_as_identifier` (Boolean) If populated, the name of the entry will be added to the list of identifiers for this type
 
 ### Read-Only
 

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -3,19 +3,13 @@
 page_title: "incident_escalation_path Resource - terraform-provider-incident"
 subcategory: ""
 description: |-
-  Create and manage escalation paths, and list and filter escalations.
-  With incident.io On-call you can create escalation paths that describe how a page should
-  be escalated to people and schedules.
+  Create and manage escalation paths.
   We'd generally recommend building escalation paths in our web dashboard https://app.incident.io/~/on-call/escalation-paths, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.
 ---
 
 # incident_escalation_path (Resource)
 
-Create and manage escalation paths, and list and filter escalations.
-
-With incident.io On-call you can create escalation paths that describe how a page should
-be escalated to people and schedules.
-
+Create and manage escalation paths.
 
 We'd generally recommend building escalation paths in our [web dashboard](https://app.incident.io/~/on-call/escalation-paths), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.
 

--- a/examples/resources/incident_catalog_type/resource.tf
+++ b/examples/resources/incident_catalog_type/resource.tf
@@ -1,11 +1,10 @@
 # Create a catalog type for a service tier, representing how important a service is.
 resource "incident_catalog_type" "service_tier" {
-  name                   = "ServiceTier"
-  type_name              = "Custom[\"ServiceTier\"]"
-  description            = <<EOF
+  name            = "ServiceTier"
+  type_name       = "Custom[\"ServiceTier\"]"
+  description     = <<EOF
   How critical is this service, with tier 1 being the highest and 3 the lowest.
   EOF
-  categories             = ["service"]
-  source_repo_url        = "https://github.com/mycompany/infrastructure"
-  use_name_as_identifier = true
+  categories      = ["service"]
+  source_repo_url = "https://github.com/mycompany/infrastructure"
 }

--- a/examples/resources/incident_catalog_type/resource.tf
+++ b/examples/resources/incident_catalog_type/resource.tf
@@ -1,10 +1,11 @@
 # Create a catalog type for a service tier, representing how important a service is.
 resource "incident_catalog_type" "service_tier" {
-  name            = "ServiceTier"
-  type_name       = "Custom[\"ServiceTier\"]"
-  description     = <<EOF
+  name                   = "ServiceTier"
+  type_name              = "Custom[\"ServiceTier\"]"
+  description            = <<EOF
   How critical is this service, with tier 1 being the highest and 3 the lowest.
   EOF
-  categories      = ["service"]
-  source_repo_url = "https://github.com/mycompany/infrastructure"
+  categories             = ["service"]
+  source_repo_url        = "https://github.com/mycompany/infrastructure"
+  use_name_as_identifier = true
 }

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -18671,7 +18671,7 @@
             "type": "string"
           },
           "use_name_as_identifier": {
-            "description": "If populated, the name of the entry will be added to the list of identifiers for this type",
+            "description": "If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.",
             "example": true,
             "type": "boolean"
           }
@@ -21367,7 +21367,7 @@
             "type": "string"
           },
           "use_name_as_identifier": {
-            "description": "If populated, the name of the entry will be added to the list of identifiers for this type",
+            "description": "If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.",
             "example": true,
             "type": "boolean"
           }
@@ -22011,7 +22011,7 @@
             "type": "string"
           },
           "use_name_as_identifier": {
-            "description": "If populated, the name of the entry will be added to the list of identifiers for this type",
+            "description": "If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.",
             "example": true,
             "type": "boolean"
           }

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -18562,7 +18562,8 @@
           "name": "Kubernetes Cluster",
           "ranked": true,
           "source_repo_url": "https://github.com/my-company/incident-io-catalog",
-          "type_name": "Custom[\"BackstageGroup\"]"
+          "type_name": "Custom[\"BackstageGroup\"]",
+          "use_name_as_identifier": true
         },
         "properties": {
           "annotations": {
@@ -18668,6 +18669,11 @@
             "description": "The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom[\"SomeName\"]",
             "example": "Custom[\"BackstageGroup\"]",
             "type": "string"
+          },
+          "use_name_as_identifier": {
+            "description": "If populated, the name of the entry will be added to the list of identifiers for this type",
+            "example": true,
+            "type": "boolean"
           }
         },
         "required": [
@@ -18780,7 +18786,8 @@
             },
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "use_name_as_identifier": true
           }
         },
         "properties": {
@@ -19628,7 +19635,8 @@
             },
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "use_name_as_identifier": true
           },
           "pagination_meta": {
             "after": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -19912,7 +19920,8 @@
               },
               "source_repo_url": "https://github.com/my-company/incident-io-catalog",
               "type_name": "Custom[\"BackstageGroup\"]",
-              "updated_at": "2021-08-17T13:28:57.801578Z"
+              "updated_at": "2021-08-17T13:28:57.801578Z",
+              "use_name_as_identifier": true
             }
           ]
         },
@@ -19962,7 +19971,8 @@
                 },
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                 "type_name": "Custom[\"BackstageGroup\"]",
-                "updated_at": "2021-08-17T13:28:57.801578Z"
+                "updated_at": "2021-08-17T13:28:57.801578Z",
+                "use_name_as_identifier": true
               }
             ],
             "items": {
@@ -20268,7 +20278,8 @@
             },
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "use_name_as_identifier": true
           }
         },
         "properties": {
@@ -20389,7 +20400,8 @@
             },
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "use_name_as_identifier": true
           }
         },
         "properties": {
@@ -21187,7 +21199,8 @@
           },
           "source_repo_url": "https://github.com/my-company/incident-io-catalog",
           "type_name": "Custom[\"BackstageGroup\"]",
-          "updated_at": "2021-08-17T13:28:57.801578Z"
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "use_name_as_identifier": true
         },
         "properties": {
           "annotations": {
@@ -21352,6 +21365,11 @@
             "example": "2021-08-17T13:28:57.801578Z",
             "format": "date-time",
             "type": "string"
+          },
+          "use_name_as_identifier": {
+            "description": "If populated, the name of the entry will be added to the list of identifiers for this type",
+            "example": true,
+            "type": "boolean"
           }
         },
         "required": [
@@ -21368,9 +21386,9 @@
           "annotations",
           "created_at",
           "updated_at",
+          "use_name_as_identifier",
           "engine_resource_type",
-          "mode",
-          "use_name_as_identifier"
+          "mode"
         ],
         "type": "object"
       },
@@ -21736,7 +21754,8 @@
             },
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "use_name_as_identifier": true
           }
         },
         "properties": {
@@ -21888,7 +21907,8 @@
           "icon": "alert",
           "name": "Kubernetes Cluster",
           "ranked": true,
-          "source_repo_url": "https://github.com/my-company/incident-io-catalog"
+          "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+          "use_name_as_identifier": true
         },
         "properties": {
           "annotations": {
@@ -21989,6 +22009,11 @@
             "description": "The url of the external repository where this type is managed",
             "example": "https://github.com/my-company/incident-io-catalog",
             "type": "string"
+          },
+          "use_name_as_identifier": {
+            "description": "If populated, the name of the entry will be added to the list of identifiers for this type",
+            "example": true,
+            "type": "boolean"
           }
         },
         "required": [
@@ -22101,7 +22126,8 @@
             },
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "use_name_as_identifier": true
           }
         },
         "properties": {
@@ -22245,9 +22271,9 @@
           "annotations",
           "created_at",
           "updated_at",
+          "use_name_as_identifier",
           "engine_resource_type",
-          "mode",
-          "use_name_as_identifier"
+          "mode"
         ],
         "type": "object"
       },
@@ -22355,7 +22381,8 @@
             },
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
-            "updated_at": "2021-08-17T13:28:57.801578Z"
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "use_name_as_identifier": true
           }
         },
         "properties": {
@@ -57813,7 +57840,8 @@
                     },
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "use_name_as_identifier": true
                   },
                   "pagination_meta": {
                     "after": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -58037,7 +58065,8 @@
                     },
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "use_name_as_identifier": true
                   }
                 },
                 "schema": {
@@ -58180,7 +58209,8 @@
                     },
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "use_name_as_identifier": true
                   }
                 },
                 "schema": {
@@ -58283,7 +58313,8 @@
                       },
                       "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                       "type_name": "Custom[\"BackstageGroup\"]",
-                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                      "updated_at": "2021-08-17T13:28:57.801578Z",
+                      "use_name_as_identifier": true
                     }
                   ]
                 },
@@ -58319,7 +58350,8 @@
                 "name": "Kubernetes Cluster",
                 "ranked": true,
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog",
-                "type_name": "Custom[\"BackstageGroup\"]"
+                "type_name": "Custom[\"BackstageGroup\"]",
+                "use_name_as_identifier": true
               },
               "schema": {
                 "$ref": "#/components/schemas/CatalogCreateTypePayloadV3"
@@ -58376,7 +58408,8 @@
                     },
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "use_name_as_identifier": true
                   }
                 },
                 "schema": {
@@ -58486,7 +58519,8 @@
                     },
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "use_name_as_identifier": true
                   }
                 },
                 "schema": {
@@ -58534,7 +58568,8 @@
                 "icon": "alert",
                 "name": "Kubernetes Cluster",
                 "ranked": true,
-                "source_repo_url": "https://github.com/my-company/incident-io-catalog"
+                "source_repo_url": "https://github.com/my-company/incident-io-catalog",
+                "use_name_as_identifier": true
               },
               "schema": {
                 "$ref": "#/components/schemas/CatalogUpdateTypePayloadV3"
@@ -58591,7 +58626,8 @@
                     },
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "use_name_as_identifier": true
                   }
                 },
                 "schema": {
@@ -58702,7 +58738,8 @@
                     },
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
-                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "use_name_as_identifier": true
                   }
                 },
                 "schema": {

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -2204,7 +2204,7 @@ type CatalogCreateTypePayloadV3 struct {
 	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
 	TypeName *string `json:"type_name,omitempty"`
 
-	// UseNameAsIdentifier If populated, the name of the entry will be added to the list of identifiers for this type
+	// UseNameAsIdentifier If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.
 	UseNameAsIdentifier *bool `json:"use_name_as_identifier,omitempty"`
 }
 
@@ -2759,7 +2759,7 @@ type CatalogTypeV3 struct {
 	// UpdatedAt When this type was last updated
 	UpdatedAt time.Time `json:"updated_at"`
 
-	// UseNameAsIdentifier If populated, the name of the entry will be added to the list of identifiers for this type
+	// UseNameAsIdentifier If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.
 	UseNameAsIdentifier bool `json:"use_name_as_identifier"`
 }
 
@@ -2886,7 +2886,7 @@ type CatalogUpdateTypePayloadV3 struct {
 	// SourceRepoUrl The url of the external repository where this type is managed
 	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
 
-	// UseNameAsIdentifier If populated, the name of the entry will be added to the list of identifiers for this type
+	// UseNameAsIdentifier If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.
 	UseNameAsIdentifier *bool `json:"use_name_as_identifier,omitempty"`
 }
 

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -2203,6 +2203,9 @@ type CatalogCreateTypePayloadV3 struct {
 
 	// TypeName The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
 	TypeName *string `json:"type_name,omitempty"`
+
+	// UseNameAsIdentifier If populated, the name of the entry will be added to the list of identifiers for this type
+	UseNameAsIdentifier *bool `json:"use_name_as_identifier,omitempty"`
 }
 
 // CatalogCreateTypePayloadV3Categories defines model for CatalogCreateTypePayloadV3.Categories.
@@ -2755,6 +2758,9 @@ type CatalogTypeV3 struct {
 
 	// UpdatedAt When this type was last updated
 	UpdatedAt time.Time `json:"updated_at"`
+
+	// UseNameAsIdentifier If populated, the name of the entry will be added to the list of identifiers for this type
+	UseNameAsIdentifier bool `json:"use_name_as_identifier"`
 }
 
 // CatalogTypeV3Categories defines model for CatalogTypeV3.Categories.
@@ -2879,6 +2885,9 @@ type CatalogUpdateTypePayloadV3 struct {
 
 	// SourceRepoUrl The url of the external repository where this type is managed
 	SourceRepoUrl *string `json:"source_repo_url,omitempty"`
+
+	// UseNameAsIdentifier If populated, the name of the entry will be added to the list of identifiers for this type
+	UseNameAsIdentifier *bool `json:"use_name_as_identifier,omitempty"`
 }
 
 // CatalogUpdateTypePayloadV3Categories defines model for CatalogUpdateTypePayloadV3.Categories.

--- a/internal/provider/incident_alert_route_resource_test.go
+++ b/internal/provider/incident_alert_route_resource_test.go
@@ -220,7 +220,7 @@ func TestAccIncidentCustomFieldsAlphabeticalOrder(t *testing.T) {
 		Steps: []resource.TestStep{
 			// First step - create alert route with custom fields in reverse alphabetical order
 			{
-				Config: testAccIncidentAlertRouteWithAlphabeticalCustomFields("custom-fields-alpha-test"),
+				Config: testAccIncidentAlertRouteWithAlphabeticalCustomFields(StableSuffix("custom-fields-alpha-test")),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("incident_alert_route.custom_fields_alpha_test", "id", regexp.MustCompile("^[a-zA-Z0-9]+$")),
 

--- a/internal/provider/incident_alert_route_resource_test.go
+++ b/internal/provider/incident_alert_route_resource_test.go
@@ -413,7 +413,7 @@ func testAccIncidentAlertRouteWithAlphabeticalCustomFields(name string) string {
       }
     }
   }
-  `, testRunID, testRunID, testRunID, name)
+  `, testRunID[:8], testRunID[:8], testRunID[:8], name)
 }
 
 func testAccIncidentAlertRouteResourceConfig(name string) string {

--- a/internal/provider/incident_alert_route_resource_test.go
+++ b/internal/provider/incident_alert_route_resource_test.go
@@ -251,15 +251,15 @@ func TestAccIncidentCustomFieldsAlphabeticalOrder(t *testing.T) {
 }
 
 func testAccIncidentAlertRouteWithAlphabeticalCustomFields(name string) string {
-	return `
+	return fmt.Sprintf(`
   resource "incident_custom_field" "alpha_field1" {
-    name        = "Alpha Test Field 1"
+    name        = "Alpha Test Field 1 (%s)"
     description = "First alphabetical custom field"
     field_type  = "text"
   }
 
   resource "incident_custom_field" "alpha_field2" {
-    name        = "Alpha Test Field 2"
+    name        = "Alpha Test Field 2 (%s)"
     description = "Second alphabetical custom field"
     field_type  = "text"
     depends_on = [incident_custom_field.alpha_field1]
@@ -267,7 +267,7 @@ func testAccIncidentAlertRouteWithAlphabeticalCustomFields(name string) string {
   }
 
   resource "incident_alert_source" "alpha_test" {
-    name        = "Alpha Test Alert Source"
+    name        = "Alpha Test Alert Source (%s)"
     source_type = "http"
     template = {
       title = {
@@ -316,7 +316,7 @@ func testAccIncidentAlertRouteWithAlphabeticalCustomFields(name string) string {
   }
 
   resource "incident_alert_route" "custom_fields_alpha_test" {
-    name       = "` + name + `"
+    name       = "%s"
     enabled    = true
     is_private = false
 
@@ -413,7 +413,7 @@ func testAccIncidentAlertRouteWithAlphabeticalCustomFields(name string) string {
       }
     }
   }
-  `
+  `, testRunID, testRunID, testRunID, name)
 }
 
 func testAccIncidentAlertRouteResourceConfig(name string) string {

--- a/internal/provider/incident_catalog_type_data_source.go
+++ b/internal/provider/incident_catalog_type_data_source.go
@@ -57,6 +57,10 @@ func (i *IncidentCatalogTypeDataSource) Schema(ctx context.Context, req datasour
 				MarkdownDescription: "The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.",
 				Computed:            true,
 			},
+			"use_name_as_identifier": schema.BoolAttribute{
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "use_name_as_identifier"),
+				Computed:            true,
+			},
 		},
 	}
 }

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -31,13 +31,13 @@ type IncidentCatalogTypeResource struct {
 }
 
 type IncidentCatalogTypeResourceModel struct {
-	ID                   types.String `tfsdk:"id"`
-	Name                 types.String `tfsdk:"name"`
-	TypeName             types.String `tfsdk:"type_name"`
-	Description          types.String `tfsdk:"description"`
-	SourceRepoURL        types.String `tfsdk:"source_repo_url"`
-	Categories           types.List   `tfsdk:"categories"`
-	UseNameAsIdentifier  types.Bool   `tfsdk:"use_name_as_identifier"`
+	ID                  types.String `tfsdk:"id"`
+	Name                types.String `tfsdk:"name"`
+	TypeName            types.String `tfsdk:"type_name"`
+	Description         types.String `tfsdk:"description"`
+	SourceRepoURL       types.String `tfsdk:"source_repo_url"`
+	Categories          types.List   `tfsdk:"categories"`
+	UseNameAsIdentifier types.Bool   `tfsdk:"use_name_as_identifier"`
 }
 
 func NewIncidentCatalogTypeResource() resource.Resource {

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -31,12 +31,13 @@ type IncidentCatalogTypeResource struct {
 }
 
 type IncidentCatalogTypeResourceModel struct {
-	ID            types.String `tfsdk:"id"`
-	Name          types.String `tfsdk:"name"`
-	TypeName      types.String `tfsdk:"type_name"`
-	Description   types.String `tfsdk:"description"`
-	SourceRepoURL types.String `tfsdk:"source_repo_url"`
-	Categories    types.List   `tfsdk:"categories"`
+	ID                   types.String `tfsdk:"id"`
+	Name                 types.String `tfsdk:"name"`
+	TypeName             types.String `tfsdk:"type_name"`
+	Description          types.String `tfsdk:"description"`
+	SourceRepoURL        types.String `tfsdk:"source_repo_url"`
+	Categories           types.List   `tfsdk:"categories"`
+	UseNameAsIdentifier  types.Bool   `tfsdk:"use_name_as_identifier"`
 }
 
 func NewIncidentCatalogTypeResource() resource.Resource {
@@ -98,6 +99,11 @@ func (r *IncidentCatalogTypeResource) Schema(ctx context.Context, req resource.S
 				MarkdownDescription: "The url of the external repository where this type is managed. When set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.",
 				Required:            true,
 			},
+			"use_name_as_identifier": schema.BoolAttribute{
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "use_name_as_identifier"),
+				Optional:            true,
+				Computed:            true,
+			},
 		},
 	}
 }
@@ -140,6 +146,9 @@ func (r *IncidentCatalogTypeResource) Create(ctx context.Context, req resource.C
 	}
 	if sourceRepoURL := data.SourceRepoURL.ValueString(); sourceRepoURL != "" {
 		requestBody.SourceRepoUrl = &sourceRepoURL
+	}
+	if !data.UseNameAsIdentifier.IsNull() {
+		requestBody.UseNameAsIdentifier = lo.ToPtr(data.UseNameAsIdentifier.ValueBool())
 	}
 
 	categories := []client.CatalogCreateTypePayloadV3Categories{}
@@ -208,6 +217,9 @@ func (r *IncidentCatalogTypeResource) Update(ctx context.Context, req resource.U
 	if sourceRepoURL := data.SourceRepoURL.ValueString(); sourceRepoURL != "" {
 		requestBody.SourceRepoUrl = &sourceRepoURL
 	}
+	if !data.UseNameAsIdentifier.IsNull() {
+		requestBody.UseNameAsIdentifier = lo.ToPtr(data.UseNameAsIdentifier.ValueBool())
+	}
 
 	categories := []client.CatalogUpdateTypePayloadV3Categories{}
 	if !data.Categories.IsNull() {
@@ -255,10 +267,11 @@ func (r *IncidentCatalogTypeResource) ImportState(ctx context.Context, req resou
 
 func (r *IncidentCatalogTypeResource) buildModel(catalogType client.CatalogTypeV3) *IncidentCatalogTypeResourceModel {
 	model := &IncidentCatalogTypeResourceModel{
-		ID:          types.StringValue(catalogType.Id),
-		Name:        types.StringValue(catalogType.Name),
-		TypeName:    types.StringValue(catalogType.TypeName),
-		Description: types.StringValue(catalogType.Description),
+		ID:                  types.StringValue(catalogType.Id),
+		Name:                types.StringValue(catalogType.Name),
+		TypeName:            types.StringValue(catalogType.TypeName),
+		Description:         types.StringValue(catalogType.Description),
+		UseNameAsIdentifier: types.BoolValue(catalogType.UseNameAsIdentifier),
 	}
 	if catalogType.SourceRepoUrl != nil {
 		model.SourceRepoURL = types.StringValue(*catalogType.SourceRepoUrl)

--- a/internal/provider/incident_catalog_type_resource_test.go
+++ b/internal/provider/incident_catalog_type_resource_test.go
@@ -193,13 +193,13 @@ func testAccIncidentCatalogTypeResourceConfig(override *client.CatalogTypeV2) st
 
 func testAccIncidentCatalogTypeResourceConfigWithUseNameAsIdentifier(useNameAsIdentifier bool) string {
 	model := struct {
-		Name                 string
-		Description          string
-		UseNameAsIdentifier  bool
+		Name                string
+		Description         string
+		UseNameAsIdentifier bool
 	}{
-		Name:                 StableSuffix("Service"),
-		Description:          "Catalog Type Acceptance tests",
-		UseNameAsIdentifier:  useNameAsIdentifier,
+		Name:                StableSuffix("Service"),
+		Description:         "Catalog Type Acceptance tests",
+		UseNameAsIdentifier: useNameAsIdentifier,
 	}
 
 	var buf bytes.Buffer

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -101,7 +101,7 @@ func (r *IncidentEscalationPathResource) Metadata(ctx context.Context, req resou
 
 func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Escalations V2"), `We'd generally recommend building escalation paths in our [web dashboard](https://app.incident.io/~/on-call/escalation-paths), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.`),
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", "Create and manage escalation paths.", `We'd generally recommend building escalation paths in our [web dashboard](https://app.incident.io/~/on-call/escalation-paths), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing escalation path and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,


### PR DESCRIPTION
Adds the missing `use_name_as_identifier` field to the `incident_catalog_type` resource.

This field was available in the API but missing from the Terraform provider. Now users can set it to automatically include the catalog entry name in the list of identifiers.

- Added `use_name_as_identifier` field (optional, defaults to false)
- Updated API schema and regenerated client
- Added tests for create/update scenarios
- Updated example docs

Also fixes some issues where custom field and alert route acceptance tests were failing due to naming collisions with existing resources.