### PR TITLE
ONC-7504 Fix normaliseJSON for HTML-ish characters

### DIFF
--- a/internal/provider/incident_alert_route_resource_test.go
+++ b/internal/provider/incident_alert_route_resource_test.go
@@ -1149,7 +1149,8 @@ resource "incident_alert_route" "test" {
               content = [
                 {
                   attrs = {
-                    label   = "Alert → Title"
+                    # Note that this uses '->' not '→' to test escaping if you dislike the fancy character
+                    label   = "Alert -> Title"
                     missing = false
                     name    = "alert.title"
                   }
@@ -1173,6 +1174,7 @@ resource "incident_alert_route" "test" {
 						content = [
 							{
 								attrs = {
+                  # Note that this uses '→' not '->' to test if you use a fancy character
 									label   = "Alert → Description"
 									missing = false
 									name    = "alert.description"

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -138,7 +138,6 @@ func normaliseJSON(jsonString string) (string, error) {
 	// Use encoder with HTML escaping disabled to preserve special characters like >
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
-	encoder.SetEscapeHTML(false)
 	err = encoder.Encode(data)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Setting `SetEscapeHTML(false)` means using HTML characters like `>` somehow ends up getting screwed up: I think this is because Terraform's `jsonencode` _does_ escape the HTML, although I've had a dig through the implementation inside `cty` and can't figure out _why_ that happens.

Anyway, removing that has fixed this test case