### PR TITLE
Fix: 404 handling in alert attribute resource's Read function

### DIFF
--- a/internal/provider/incident_alert_attribute_resource.go
+++ b/internal/provider/incident_alert_attribute_resource.go
@@ -135,8 +135,8 @@ func (r *IncidentAlertAttributeResource) Read(ctx context.Context, req resource.
 	result, err := r.client.AlertAttributesV2ShowWithResponse(ctx, data.ID.ValueString())
 	if err != nil {
 		// Check if error message contains any indication of a 404 not found
-		errStr := err.Error()
-		if strings.Contains(errStr, "404") || strings.Contains(errStr, "not found") || strings.Contains(errStr, "resource_not_found") {
+		httpErr := client.HTTPError{}
+    if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
 			tflog.Warn(ctx, fmt.Sprintf("Alert attribute with ID %s not found (from error), removing from state. Error: %s", data.ID.ValueString(), errStr))
 			resp.State.RemoveResource(ctx)
 			return


### PR DESCRIPTION
If you create an alert attribute using terraform and then manually delete it, then provider will fail because it didn't find the object in the API and did not properly handle 404. 
Terraform should work in a way that **if there is 404 on a resource that is already in state, provider should either taint it or remove it from the state and show in the plan that this resource is missing and needs to be reapplied again.**

This PR addresses an issue with error handling in the alert attribute resource's Read function. Previously, the code attempted to check the status code using `result.StatusCode()` after an error occurred, but this was problematic because:
1. When an HTTP error occurs, the client returns an error and a nil result
2. This means that code checking `result.StatusCode()` after an error would never be reached

### Larger Issue
This PR addresses only one instance of a broader issue throughout the codebase. Many functions in all resources follow this pattern:
```
result, err := r.client.SomeMethodWithResponse(ctx, ...)
if err == nil && result.StatusCode() >= 400 {
    err = fmt.Errorf(string(result.Body))
}
```
This pattern is problematic because:
1. your HTTP client already converts any status code ≥ 300 into an error
2. This means `err` will never be nil when there's an HTTP error
3. The condition `err == nil && result.StatusCode() >= 400` will never be true
4. Additionally, when `err != nil`, `result` might be nil, making `result.StatusCode()` unsafe to call

### A more comprehensive fix would require updating error handling across all resources by incident-io team
**But this PR focuses narrowly on fixing the 404 handling in the alert attribute resource's Read function:**
Previously, the code attempted to check the status code using `result.StatusCode()` after an error occurred, but this was problematic because:
1. When an HTTP error occurs, the client returns an error and a nil result
2. This means that code checking `result.StatusCode()` after an error would never be reached
