### PR TITLE
Add debug logging for HTTP requests and responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add debug logging for outbound HTTP requests
+
 ## v5.14.0
 
 - Fix issue with HTML-like characters (e.g. `>`) in JSON engine values being incorrectly encoded


### PR DESCRIPTION
This means that when running with `TF_LOG=debug`, you'll be able to see the responses coming back from the incident.io API, which makes it easier to debug things like slow Terraform runs.