### PR TITLE
Default to API mode on a catalog type attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Add debug logging for outbound HTTP requests
-- Default catalog type attributes to being managed via Terraform, unless marked as schema-only.
+- Fixed a bug where catalog type attributes weren't defaulting to being marked as managed via Terraform, unless explicitly marked. You may see a change in the state of schema_only in your next plan if you hadn't set it previously.
 
 ## v5.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add debug logging for outbound HTTP requests
+- Default catalog type attributes to being managed via Terraform, unless marked as schema-only.
 
 ## v5.14.0
 

--- a/internal/provider/incident_catalog_type_attribute_resource.go
+++ b/internal/provider/incident_catalog_type_attribute_resource.go
@@ -61,7 +61,9 @@ func (m IncidentCatalogTypeAttributesResourceModel) buildAttribute(ctx context.C
 	}
 
 	var (
-		mode              *client.CatalogTypeAttributePayloadV3Mode
+		// We always default to API mode first, as we assume that the attribute is managed
+		// in Terraform unless told otherwise.
+		mode              = lo.ToPtr(client.CatalogTypeAttributePayloadV3ModeApi)
 		backlinkAttribute *string
 		path              *[]client.CatalogTypeAttributePathItemPayloadV3
 	)
@@ -467,7 +469,7 @@ func (r *IncidentCatalogTypeAttributeResource) ImportState(ctx context.Context, 
 
 func (*IncidentCatalogTypeAttributeResource) attributeToPayload(attribute client.CatalogTypeAttributeV3) client.CatalogTypeAttributePayloadV3 {
 	var (
-		mode *client.CatalogTypeAttributePayloadV3Mode
+		mode = lo.ToPtr(client.CatalogTypeAttributePayloadV3ModeApi)
 		path *[]client.CatalogTypeAttributePathItemPayloadV3
 	)
 

--- a/internal/provider/incident_catalog_type_attribute_resource_test.go
+++ b/internal/provider/incident_catalog_type_attribute_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
 
@@ -31,6 +32,9 @@ func TestAccIncidentCatalogTypeAttributeResource(t *testing.T) {
 						"incident_catalog_type_attribute.example", "type", "Text"),
 					resource.TestCheckResourceAttr(
 						"incident_catalog_type_attribute.example", "array", "false"),
+					// We haven't set mode, so should default to "api", meaning schema_only is false
+					resource.TestCheckResourceAttr(
+						"incident_catalog_type_attribute.example", "schema_only", "false"),
 				),
 			},
 			// Update and read
@@ -39,6 +43,7 @@ func TestAccIncidentCatalogTypeAttributeResource(t *testing.T) {
 					Name:  "Description",
 					Type:  "String",
 					Array: true,
+					Mode:  "api",
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -47,6 +52,8 @@ func TestAccIncidentCatalogTypeAttributeResource(t *testing.T) {
 						"incident_catalog_type_attribute.example", "type", "String"),
 					resource.TestCheckResourceAttr(
 						"incident_catalog_type_attribute.example", "array", "true"),
+					resource.TestCheckResourceAttr(
+						"incident_catalog_type_attribute.example", "schema_only", "false"),
 				),
 			},
 			// Schema-only


### PR DESCRIPTION
We should default to API, unless otherwise specified: https://registry.terraform.io/providers/incident-io/incident/latest/docs/resources/catalog_type_attribute#schema_only-1