### PR TITLE
Fix RELEASE.MD instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,8 @@ When you want to cut a new release, you can:
 2. Ensure that Terraform acceptance tests have passed.
 3. Create a new commit on master that adjusts the CHANGELOG so all unreleased
    changes appear under the new version.
-4. Tag that commit with whatever your release version should be, and push everything.
+4. Push this commit to master
+5. Tag that commit with whatever your release version should be, and push with the tags flag set.
 
 That will trigger the CI pipeline that will publish your provider version to the
 Terraform registry.
@@ -15,6 +16,7 @@ That ends up looking like this:
 
 ```
 git commit -m "Changelog for v1.2.3"
+git push
 git tag v1.2.3
 git push --tags
 ```


### PR DESCRIPTION
The instructions now include a step to first push the changelog commit to master before tagging it.

<!-- !review #reviews-on-call @isaacseymour --!>