### PR TITLE
Add units to 10s backoff

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -90,7 +90,7 @@ func attentiveBackoff(minDuration, maxDuration time.Duration, attemptNum int, re
 			retryAfterDate, err := time.Parse(time.RFC1123, retryAfter)
 			if err != nil {
 				// If we can't parse the Retry-After, lets just wait for 10 seconds
-				return 10
+				return 10 * time.Second
 			}
 
 			timeToWait := time.Until(retryAfterDate)


### PR DESCRIPTION
This was causing our back-off to not be very effective, as it was 10ns rather than 10s, resulting in unnecessary rate limiting 