### PR TITLE
NonEmptyListValidator can allow unknown values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- We will now allow you to use dynamic variables for `working_intervals` in `incident_schedule`.
+
 ## v5.17.1
 
 - Handle 404s when an alert attribute has been deleted outside of Terraform (contribution from @maxtacu)

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -107,7 +107,7 @@ func (r *IncidentScheduleResource) Schema(ctx context.Context, req resource.Sche
 										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "handover_start_at"),
 									},
 									"working_intervals": schema.ListNestedAttribute{
-										Validators:          []validator.List{NonEmptyListValidator{}},
+										Validators:          []validator.List{NonEmptyListValidator{AllowUnknownValues: true}},
 										Optional:            true,
 										MarkdownDescription: apischema.Docstring("ScheduleRotationV2", "working_intervals"),
 										NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -8,10 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-type NonEmptyListValidator struct{}
+type NonEmptyListValidator struct {
+	AllowUnknownValues bool
+}
 
 func (n NonEmptyListValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
-	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+	if req.ConfigValue.IsNull() || (n.AllowUnknownValues && req.ConfigValue.IsUnknown()) {
 		return
 	} else if len(req.ConfigValue.Elements()) == 0 {
 		resp.Diagnostics.AddError("List cannot be empty", fmt.Sprintf("%s cannot be empty", req.Path.String()))

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -148,7 +148,9 @@ func TestNonEmptyListValidator(t *testing.T) {
 			}
 			response := validator.ListResponse{}
 
-			v := NonEmptyListValidator{}
+			v := NonEmptyListValidator{
+				AllowUnknownValues: true,
+			}
 			v.ValidateList(context.Background(), request, &response)
 
 			if tc.expectedError {
@@ -162,7 +164,9 @@ func TestNonEmptyListValidator(t *testing.T) {
 }
 
 func TestNonEmptyListValidatorWithNullAndUnknown(t *testing.T) {
-	v := NonEmptyListValidator{}
+	v := NonEmptyListValidator{
+		AllowUnknownValues: true,
+	}
 
 	// Test with null value
 	nullRequest := validator.ListRequest{


### PR DESCRIPTION
The NonEmptyListValidator was incorrectly rejecting unknown values.

In practise, this was effectively making it impossible to switch `working_intervals` based on any derived/data based values.

This change adds the standard "IsUnknown" check alongside "IsNull" and also adds tests

Previous error:

```
│ Error: List cannot be empty
│ 
│   with module.teams.module.incident_on_call.incident_schedule.team,
│   on incident-on-call/schedule.tf line 1, in resource "incident_schedule" "team":
│    1: resource "incident_schedule" "team" {
│ 
│ rotations[Value({"id":<unknown>,"name":<unknown>,"versions":[{"effective_from":<null>,"handover_start_at":<unknown>,"handovers":[{"interval":<unknown>,"interval_type":<unknown>}],"layers":[{"id":"primary","name":"Primary"}],"users":<unknown>,"working_intervals":<unknown>}]})].versions[Value({"effective_from":<null>,"handover_start_at":<unknown>,"handovers":[{"interval":<unknown>,"interval_type":<unknown>}],"layers":[{"id":"primary","name":"Primary"}],"users":<unknown>,"working_intervals":<unknown>})].working_intervals
│ cannot be empty
```