### PR TITLE
fix: error handling when retrieving resources from incident.io

### DIFF
--- a/internal/provider/incident_alert_attribute_data_source.go
+++ b/internal/provider/incident_alert_attribute_data_source.go
@@ -84,9 +84,6 @@ func (i *IncidentAlertAttributeDataSource) Read(ctx context.Context, req datasou
 	}
 
 	result, err := i.client.AlertAttributesV2ListWithResponse(ctx)
-	if err == nil && result.StatusCode() >= 400 {
-		err = fmt.Errorf(string(result.Body))
-	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read alert attributes, got error: %s", err))
 		return

--- a/internal/provider/incident_alert_sources_data_source.go
+++ b/internal/provider/incident_alert_sources_data_source.go
@@ -71,9 +71,6 @@ func (d *IncidentAlertSourcesDataSource) Read(ctx context.Context, req datasourc
 
 	// Get all alert sources
 	result, err := d.client.AlertSourcesV2ListWithResponse(ctx)
-	if err == nil && result.StatusCode() >= 400 {
-		err = fmt.Errorf("%s", string(result.Body))
-	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list alert sources, got error: %s", err))
 		return

--- a/internal/provider/incident_catalog_entries_data_source.go
+++ b/internal/provider/incident_catalog_entries_data_source.go
@@ -82,9 +82,6 @@ func (d *IncidentCatalogEntriesDataSource) Read(ctx context.Context, req datasou
 
 	for {
 		result, err := d.client.CatalogV3ListEntriesWithResponse(ctx, params)
-		if err == nil && result.StatusCode() >= 400 {
-			err = fmt.Errorf("%s", string(result.Body))
-		}
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list catalog entries, got error: %s", err))
 			return

--- a/internal/provider/incident_catalog_entries_resource.go
+++ b/internal/provider/incident_catalog_entries_resource.go
@@ -427,9 +427,6 @@ func (r *IncidentCatalogEntriesResource) getEntries(ctx context.Context, catalog
 			PageSize:      250,
 			After:         after,
 		})
-		if err == nil && result.StatusCode() >= 400 {
-			err = fmt.Errorf(string(result.Body))
-		}
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "listing entries")
 		}
@@ -489,10 +486,7 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 				entry = entry // avoid shadow loop variable
 			)
 			g.Go(func() error {
-				result, err := r.client.CatalogV3DestroyEntryWithResponse(ctx, entry.Id)
-				if err == nil && result.StatusCode() >= 400 {
-					err = fmt.Errorf(string(result.Body))
-				}
+				_, err := r.client.CatalogV3DestroyEntryWithResponse(ctx, entry.Id)
 				if err != nil {
 					return errors.Wrap(err, "unable to destroy catalog entry, got error")
 				}
@@ -577,7 +571,7 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 
 			g.Go(func() error {
 				if shouldUpdate {
-					result, err := r.client.CatalogV3UpdateEntryWithResponse(ctx, entry.Id, client.CatalogUpdateEntryPayloadV3{
+					_, err := r.client.CatalogV3UpdateEntryWithResponse(ctx, entry.Id, client.CatalogUpdateEntryPayloadV3{
 						Name:             payload.Payload.Name,
 						ExternalId:       payload.Payload.ExternalId,
 						Rank:             payload.Payload.Rank,
@@ -585,9 +579,6 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 						AttributeValues:  payload.Payload.AttributeValues,
 						UpdateAttributes: data.buildUpdateAttributes(ctx),
 					})
-					if err == nil && result.StatusCode() >= 400 {
-						err = fmt.Errorf(string(result.Body))
-					}
 					if err != nil {
 						return errors.Wrap(err, fmt.Sprintf("unable to update catalog entry with id=%s, got error", entry.Id))
 					}
@@ -602,9 +593,6 @@ func (r *IncidentCatalogEntriesResource) reconcile(ctx context.Context, data *In
 						Aliases:         payload.Payload.Aliases,
 						AttributeValues: payload.Payload.AttributeValues,
 					})
-					if err == nil && result.StatusCode() >= 400 {
-						err = fmt.Errorf(string(result.Body))
-					}
 					if err != nil {
 						return errors.Wrap(err, fmt.Sprintf("unable to create catalog entry with external_id=%s, got error", *payload.Payload.ExternalId))
 					}

--- a/internal/provider/incident_catalog_entry_data_source.go
+++ b/internal/provider/incident_catalog_entry_data_source.go
@@ -142,11 +142,6 @@ func (i *IncidentCatalogEntryDataSource) Read(ctx context.Context, req datasourc
 		return
 	}
 
-	if result.StatusCode() >= 400 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to find catalog entry, got status code: %d", result.StatusCode()))
-		return
-	}
-
 	// Check if we got any matching entries
 	var matchedEntry *client.CatalogEntryV3
 	if len(result.JSON200.CatalogEntries) > 0 {

--- a/internal/provider/incident_catalog_type_attribute_data_source.go
+++ b/internal/provider/incident_catalog_type_attribute_data_source.go
@@ -111,9 +111,6 @@ func (i *IncidentCatalogTypeAttributeDataSource) Read(ctx context.Context, req d
 	tflog.Trace(ctx, fmt.Sprintf("Reading catalog type attribute with name=%s for catalog type id=%s", data.Name.ValueString(), data.CatalogTypeID.ValueString()))
 
 	result, err := i.client.CatalogV3ShowTypeWithResponse(ctx, data.CatalogTypeID.ValueString())
-	if err == nil && result.StatusCode() >= 400 {
-		err = fmt.Errorf(string(result.Body))
-	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read catalog type, got error: %s", err))
 		return

--- a/internal/provider/incident_catalog_type_data_source.go
+++ b/internal/provider/incident_catalog_type_data_source.go
@@ -95,9 +95,6 @@ func (i *IncidentCatalogTypeDataSource) Read(ctx context.Context, req datasource
 	}
 
 	result, err := i.client.CatalogV3ListTypesWithResponse(ctx)
-	if err == nil && result.StatusCode() >= 400 {
-		err = fmt.Errorf(string(result.Body))
-	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read catalog types, got error: %s", err))
 		return

--- a/internal/provider/incident_custom_field_data_source.go
+++ b/internal/provider/incident_custom_field_data_source.go
@@ -105,9 +105,6 @@ func (i *IncidentCustomFieldDataSource) Read(ctx context.Context, req datasource
 	}
 
 	result, err := i.client.CustomFieldsV2ListWithResponse(ctx)
-	if err == nil && result.StatusCode() >= 400 {
-		err = fmt.Errorf(string(result.Body))
-	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read custom fields, got error: %s", err))
 		return

--- a/internal/provider/incident_custom_field_option_data_source.go
+++ b/internal/provider/incident_custom_field_option_data_source.go
@@ -90,9 +90,6 @@ func (i *IncidentCustomFieldOptionDataSource) Read(ctx context.Context, req data
 	result, err := i.client.CustomFieldOptionsV1ListWithResponse(ctx, &client.CustomFieldOptionsV1ListParams{
 		CustomFieldId: data.CustomFieldID.ValueString(),
 	})
-	if err == nil && result.StatusCode() >= 400 {
-		err = fmt.Errorf(string(result.Body))
-	}
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read custom field options, got error: %s", err))
 		return

--- a/internal/provider/incident_role_data_source.go
+++ b/internal/provider/incident_role_data_source.go
@@ -93,9 +93,6 @@ func (i *IncidentRoleDataSource) Read(ctx context.Context, req datasource.ReadRe
 			return
 		}
 		result, err := i.client.IncidentRolesV2ShowWithResponse(ctx, data.ID.ValueString())
-		if err == nil && result.StatusCode() >= 400 {
-			err = fmt.Errorf(string(result.Body))
-		}
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read role, got error: %s", err))
 			return

--- a/internal/provider/incident_schedule_data_source.go
+++ b/internal/provider/incident_schedule_data_source.go
@@ -96,9 +96,6 @@ func (d *IncidentScheduleDataSource) Read(ctx context.Context, req datasource.Re
 	if !data.ID.IsNull() {
 		// Lookup by ID
 		result, err := d.client.SchedulesV2ShowWithResponse(ctx, data.ID.ValueString())
-		if err == nil && result.StatusCode() >= 400 {
-			err = fmt.Errorf(string(result.Body))
-		}
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read schedule, got error: %s", err))
 			return
@@ -143,9 +140,6 @@ func (d *IncidentScheduleDataSource) Read(ctx context.Context, req datasource.Re
 		// Step 3: Fetch schedule by ID using the external ID from catalog entry
 		scheduleID := *catalogEntry.ExternalId
 		result, err := d.client.SchedulesV2ShowWithResponse(ctx, scheduleID)
-		if err == nil && result.StatusCode() >= 400 {
-			err = fmt.Errorf(string(result.Body))
-		}
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read schedule with ID %s, got error: %s", scheduleID, err))
 			return

--- a/internal/provider/incident_user_data_source.go
+++ b/internal/provider/incident_user_data_source.go
@@ -67,9 +67,6 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 			return
 		}
 		result, err := i.client.UsersV2ShowWithResponse(ctx, data.ID.ValueString())
-		if err == nil && result.StatusCode() >= 400 {
-			err = fmt.Errorf(string(result.Body))
-		}
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
 			return
@@ -79,9 +76,6 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 		result, err := i.client.UsersV2ListWithResponse(ctx, &client.UsersV2ListParams{
 			Email: data.Email.ValueStringPointer(),
 		})
-		if err == nil && result.StatusCode() >= 400 {
-			err = fmt.Errorf(string(result.Body))
-		}
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
 			return
@@ -98,9 +92,6 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 		result, err := i.client.UsersV2ListWithResponse(ctx, &client.UsersV2ListParams{
 			SlackUserId: data.SlackUserID.ValueStringPointer(),
 		})
-		if err == nil && result.StatusCode() >= 400 {
-			err = fmt.Errorf(string(result.Body))
-		}
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
 			return

--- a/internal/provider/managed_resources.go
+++ b/internal/provider/managed_resources.go
@@ -24,10 +24,7 @@ func claimResource(
 		ResourceId:   resourceID,
 	}
 
-	result, err := apiClient.ManagedResourcesV2CreateManagedResourceWithResponse(ctx, payload)
-	if err == nil && result.StatusCode() >= 400 {
-		err = fmt.Errorf(string(result.Body))
-	}
+	_, err := apiClient.ManagedResourcesV2CreateManagedResourceWithResponse(ctx, payload)
 	if err != nil {
 		diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create managed resource, got error: %s", err))
 		return


### PR DESCRIPTION
this is a continuation MR from https://github.com/incident-io/terraform-provider-incident/pull/257 to cover all remaining resources in incident-io provider

This PR fixes a critical error handling issue where `result.StatusCode()` was being called on API responses that don't actually return a `StatusCode()` method, causing runtime panics and incorrect error handling throughout the provider.