### PR TITLE
Allow external_id to be set on the server

### DIFF
--- a/internal/provider/incident_catalog_entry_resource.go
+++ b/internal/provider/incident_catalog_entry_resource.go
@@ -129,6 +129,7 @@ If you're working with a large number of entries (>100) or want to be authoritat
 			"external_id": schema.StringAttribute{
 				MarkdownDescription: apischema.Docstring("CatalogEntryV2", "external_id"),
 				Optional:            true,
+				Computed:            true,
 			},
 			"aliases": schema.ListAttribute{
 				ElementType: types.StringType,


### PR DESCRIPTION
If you create a catalog entry without an external_id, then set it on the website, we should allow that computed external_id be used without throwing an error due to state mismatch.