### PR TITLE
feat: use bulk update API for catalog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Performance improvement: `incident_catalog_entries` now uses bulk update API to batch updates in groups of 100, significantly reducing API calls for large catalog syncs
+
 ## v5.19.0
 
 - Automatically remove resources from Terraform state if they're not found remotely (contribution from @maxtacu)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ See also CONTRIBUTING.md
 
 # Development guidelines
 
+## Available libraries
+
+- **`lo` (samber/lo)** - Generic utility library for Go. Use for common helpers like `lo.Chunk`, `lo.Map`, `lo.ToPtr`, `lo.Filter`, etc. Prefer this over writing custom helpers.
+
+## Resources
+
 If you're developing a new resource:
 - DEVELOPING.md has development guidelines about how to best write your resource schema
 - The repository follows a structure of:

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -458,7 +458,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -498,7 +498,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -558,7 +558,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -598,7 +598,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -639,7 +639,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -679,7 +679,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -809,7 +809,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -849,7 +849,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -909,7 +909,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -949,7 +949,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -990,7 +990,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1030,7 +1030,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1071,7 +1071,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1111,7 +1111,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1311,7 +1311,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1351,7 +1351,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1411,7 +1411,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1451,7 +1451,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1492,7 +1492,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1532,7 +1532,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1662,7 +1662,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1702,7 +1702,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1762,7 +1762,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1802,7 +1802,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1843,7 +1843,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1883,7 +1883,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1924,7 +1924,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -1964,7 +1964,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2005,7 +2005,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2045,7 +2045,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2315,7 +2315,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2355,7 +2355,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2415,7 +2415,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2455,7 +2455,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2496,7 +2496,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2536,7 +2536,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2666,7 +2666,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2706,7 +2706,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2766,7 +2766,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2806,7 +2806,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2847,7 +2847,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2887,7 +2887,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2928,7 +2928,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -2968,7 +2968,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3168,7 +3168,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3208,7 +3208,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3268,7 +3268,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3308,7 +3308,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3349,7 +3349,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3389,7 +3389,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3519,7 +3519,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3559,7 +3559,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3619,7 +3619,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3659,7 +3659,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3700,7 +3700,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3740,7 +3740,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3781,7 +3781,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3821,7 +3821,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3862,7 +3862,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3902,7 +3902,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3943,7 +3943,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:
@@ -3983,7 +3983,7 @@ Optional:
 Required:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`.
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
 - `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
 
 Optional:

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -152,6 +152,27 @@
           },
           "completed_at": "2021-08-17T13:28:57.801578Z",
           "created_at": "2021-08-17T13:28:57.801578Z",
+          "creator": {
+            "alert": {
+              "id": "01GW2G3V0S59R238FAHPDS1R66",
+              "title": "*errors.withMessage: PG::Error failed to connect"
+            },
+            "api_key": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My test API key"
+            },
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "workflow": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My little workflow"
+            }
+          },
           "description": "Call the fire brigade",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -173,6 +194,9 @@
             "example": "2021-08-17T13:28:57.801578Z",
             "format": "date-time",
             "type": "string"
+          },
+          "creator": {
+            "$ref": "#/components/schemas/ActorV2"
           },
           "description": {
             "description": "Description of the action",
@@ -210,6 +234,7 @@
         "required": [
           "id",
           "incident_id",
+          "creator",
           "description",
           "status",
           "created_at",
@@ -295,6 +320,27 @@
               },
               "completed_at": "2021-08-17T13:28:57.801578Z",
               "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "alert": {
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "title": "*errors.withMessage: PG::Error failed to connect"
+                },
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "workflow": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My little workflow"
+                }
+              },
               "description": "Call the fire brigade",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -316,6 +362,27 @@
                 },
                 "completed_at": "2021-08-17T13:28:57.801578Z",
                 "created_at": "2021-08-17T13:28:57.801578Z",
+                "creator": {
+                  "alert": {
+                    "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "title": "*errors.withMessage: PG::Error failed to connect"
+                  },
+                  "api_key": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My test API key"
+                  },
+                  "user": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "workflow": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My little workflow"
+                  }
+                },
                 "description": "Call the fire brigade",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -381,6 +448,27 @@
             },
             "completed_at": "2021-08-17T13:28:57.801578Z",
             "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
             "description": "Call the fire brigade",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -438,6 +526,10 @@
             "name": "Lisa Karlin Curtis",
             "role": "viewer",
             "slack_user_id": "U02AYNF2XJM"
+          },
+          "workflow": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "My little workflow"
           }
         },
         "properties": {
@@ -449,6 +541,9 @@
           },
           "user": {
             "$ref": "#/components/schemas/UserV2"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/WorkflowActorV2"
           }
         },
         "type": "object"
@@ -1454,7 +1549,7 @@
             }
           },
           "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "merge_strategy": "append"
+          "merge_strategy": "first-wins"
         },
         "properties": {
           "binding": {
@@ -1472,7 +1567,7 @@
               "last-wins",
               "append"
             ],
-            "example": "append",
+            "example": "first-wins",
             "type": "string"
           }
         },
@@ -1500,7 +1595,7 @@
             }
           },
           "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "merge_strategy": "append"
+          "merge_strategy": "first-wins"
         },
         "properties": {
           "binding": {
@@ -1518,7 +1613,7 @@
               "last-wins",
               "append"
             ],
-            "example": "append",
+            "example": "first-wins",
             "type": "string"
           }
         },
@@ -2034,7 +2129,7 @@
                 }
               },
               "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "merge_strategy": "append"
+              "merge_strategy": "first-wins"
             }
           ],
           "incident_mode": {
@@ -2093,7 +2188,7 @@
                 "reference": "incident.severity"
               }
             },
-            "merge_strategy": "append"
+            "merge_strategy": "first-wins"
           },
           "start_in_triage": {
             "binding": {
@@ -2157,7 +2252,7 @@
                   }
                 },
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "merge_strategy": "append"
+                "merge_strategy": "first-wins"
               }
             ],
             "items": {
@@ -2211,7 +2306,7 @@
                 }
               },
               "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "merge_strategy": "append"
+              "merge_strategy": "first-wins"
             }
           ],
           "incident_mode": {
@@ -2278,7 +2373,7 @@
                 "reference": "incident.severity"
               }
             },
-            "merge_strategy": "append"
+            "merge_strategy": "first-wins"
           },
           "start_in_triage": {
             "binding": {
@@ -2350,7 +2445,7 @@
                   }
                 },
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "merge_strategy": "append"
+                "merge_strategy": "first-wins"
               }
             ],
             "items": {
@@ -2399,7 +2494,7 @@
               "reference": "incident.severity"
             }
           },
-          "merge_strategy": "append"
+          "merge_strategy": "first-wins"
         },
         "properties": {
           "binding": {
@@ -2411,7 +2506,7 @@
               "first-wins",
               "max"
             ],
-            "example": "append",
+            "example": "first-wins",
             "type": "string"
           }
         },
@@ -2436,7 +2531,7 @@
               "reference": "incident.severity"
             }
           },
-          "merge_strategy": "append"
+          "merge_strategy": "first-wins"
         },
         "properties": {
           "binding": {
@@ -2448,7 +2543,7 @@
               "first-wins",
               "max"
             ],
-            "example": "append",
+            "example": "first-wins",
             "type": "string"
           }
         },
@@ -2910,7 +3005,7 @@
                   }
                 },
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "merge_strategy": "append"
+                "merge_strategy": "first-wins"
               }
             ],
             "incident_mode": {
@@ -2977,7 +3072,7 @@
                   "reference": "incident.severity"
                 }
               },
-              "merge_strategy": "append"
+              "merge_strategy": "first-wins"
             },
             "start_in_triage": {
               "binding": {
@@ -3711,7 +3806,7 @@
                   }
                 },
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "merge_strategy": "append"
+                "merge_strategy": "first-wins"
               }
             ],
             "incident_mode": {
@@ -3770,7 +3865,7 @@
                   "reference": "incident.severity"
                 }
               },
-              "merge_strategy": "append"
+              "merge_strategy": "first-wins"
             },
             "start_in_triage": {
               "binding": {
@@ -4508,7 +4603,7 @@
                     }
                   },
                   "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "merge_strategy": "append"
+                  "merge_strategy": "first-wins"
                 }
               ],
               "incident_mode": {
@@ -4575,7 +4670,7 @@
                     "reference": "incident.severity"
                   }
                 },
-                "merge_strategy": "append"
+                "merge_strategy": "first-wins"
               },
               "start_in_triage": {
                 "binding": {
@@ -5059,7 +5154,7 @@
                     }
                   },
                   "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "merge_strategy": "append"
+                  "merge_strategy": "first-wins"
                 }
               ],
               "incident_mode": {
@@ -5126,7 +5221,7 @@
                     "reference": "incident.severity"
                   }
                 },
-                "merge_strategy": "append"
+                "merge_strategy": "first-wins"
               },
               "start_in_triage": {
                 "binding": {
@@ -5502,7 +5597,7 @@
                   }
                 },
                 "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "merge_strategy": "append"
+                "merge_strategy": "first-wins"
               }
             ],
             "incident_mode": {
@@ -5561,7 +5656,7 @@
                   "reference": "incident.severity"
                 }
               },
-              "merge_strategy": "append"
+              "merge_strategy": "first-wins"
             },
             "start_in_triage": {
               "binding": {
@@ -6299,7 +6394,7 @@
                     }
                   },
                   "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                  "merge_strategy": "append"
+                  "merge_strategy": "first-wins"
                 }
               ],
               "incident_mode": {
@@ -6366,7 +6461,7 @@
                     "reference": "incident.severity"
                   }
                 },
-                "merge_strategy": "append"
+                "merge_strategy": "first-wins"
               },
               "start_in_triage": {
                 "binding": {
@@ -6824,6 +6919,7 @@
               "honeycomb",
               "incoming_calls",
               "jira",
+              "jsm",
               "monte_carlo",
               "nagios",
               "new_relic",
@@ -6880,7 +6976,7 @@
             ]
           },
           "name": "Production Web Dashboard Alerts",
-          "source_type": "app_optics",
+          "source_type": "alertmanager",
           "template": {
             "attributes": [
               {
@@ -7059,6 +7155,7 @@
               "honeycomb",
               "incoming_calls",
               "jira",
+              "jsm",
               "monte_carlo",
               "nagios",
               "new_relic",
@@ -7078,7 +7175,7 @@
               "uptime",
               "zendesk"
             ],
-            "example": "app_optics",
+            "example": "alertmanager",
             "type": "string"
           },
           "template": {
@@ -7120,7 +7217,7 @@
             },
             "name": "Production Web Dashboard Alerts",
             "secret_token": "some-secret-token",
-            "source_type": "app_optics",
+            "source_type": "alertmanager",
             "template": {
               "attributes": [
                 {
@@ -7321,7 +7418,7 @@
               },
               "name": "Production Web Dashboard Alerts",
               "secret_token": "some-secret-token",
-              "source_type": "app_optics",
+              "source_type": "alertmanager",
               "template": {
                 "attributes": [
                   {
@@ -7513,7 +7610,7 @@
                 },
                 "name": "Production Web Dashboard Alerts",
                 "secret_token": "some-secret-token",
-                "source_type": "app_optics",
+                "source_type": "alertmanager",
                 "template": {
                   "attributes": [
                     {
@@ -7714,7 +7811,7 @@
             },
             "name": "Production Web Dashboard Alerts",
             "secret_token": "some-secret-token",
-            "source_type": "app_optics",
+            "source_type": "alertmanager",
             "template": {
               "attributes": [
                 {
@@ -8097,7 +8194,7 @@
             },
             "name": "Production Web Dashboard Alerts",
             "secret_token": "some-secret-token",
-            "source_type": "app_optics",
+            "source_type": "alertmanager",
             "template": {
               "attributes": [
                 {
@@ -9152,7 +9249,8 @@
           "alert_source",
           "created_at",
           "updated_at",
-          "themes"
+          "themes",
+          "can_resolve"
         ],
         "type": "object"
       },
@@ -9484,6 +9582,49 @@
         ],
         "type": "object"
       },
+      "AuditLogCatalogAttributeUpdatedMetadataV2": {
+        "example": {
+          "after_values": [
+            "01FCNDV6P870EA6S7TK1DSYDG0",
+            "01FCNDV6P870EA6S7TK1DSYDG2"
+          ],
+          "before_values": [
+            "01FCNDV6P870EA6S7TK1DSYDG0",
+            "01FCNDV6P870EA6S7TK1DSYDG1"
+          ]
+        },
+        "properties": {
+          "after_values": {
+            "description": "The user IDs that are in the attribute after the change",
+            "example": [
+              "01FCNDV6P870EA6S7TK1DSYDG0",
+              "01FCNDV6P870EA6S7TK1DSYDG2"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "before_values": {
+            "description": "The user IDs that were in the attribute before the change",
+            "example": [
+              "01FCNDV6P870EA6S7TK1DSYDG0",
+              "01FCNDV6P870EA6S7TK1DSYDG1"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "before_values",
+          "after_values"
+        ],
+        "type": "object"
+      },
       "AuditLogEntryContextV2": {
         "example": {
           "location": "1.2.3.4",
@@ -9628,6 +9769,8 @@
               "alert_source",
               "announcement_rule",
               "catalog_type",
+              "catalog_entry",
+              "catalog_attribute",
               "custom_field",
               "debrief_invite_rule",
               "escalation_path",
@@ -9655,6 +9798,7 @@
               "rbac_role",
               "scim_group",
               "schedule",
+              "team_role",
               "severity",
               "status_page",
               "status_page_sub_page",
@@ -10638,6 +10782,115 @@
           "actor",
           "targets",
           "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsCatalogEntryAttributeUpdatedV1": {
+        "example": {
+          "action": "catalog_entry_attribute.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "after_values": [
+              "01FCNDV6P870EA6S7TK1DSYDG0",
+              "01FCNDV6P870EA6S7TK1DSYDG2"
+            ],
+            "before_values": [
+              "01FCNDV6P870EA6S7TK1DSYDG0",
+              "01FCNDV6P870EA6S7TK1DSYDG1"
+            ]
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Service",
+              "type": "catalog_type"
+            },
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Engineering Team",
+              "type": "catalog_entry"
+            },
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Members",
+              "type": "catalog_attribute"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "catalog_entry_attribute.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogCatalogAttributeUpdatedMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Service",
+                "type": "catalog_type"
+              },
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Engineering Team",
+                "type": "catalog_entry"
+              },
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Members",
+                "type": "catalog_attribute"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
         ],
         "type": "object"
       },
@@ -17455,6 +17708,231 @@
         ],
         "type": "object"
       },
+      "AuditLogsTeamRoleCreatedV1": {
+        "example": {
+          "action": "team_role.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Tech lead",
+              "type": "team_role"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "team_role.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Tech lead",
+                "type": "team_role"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsTeamRoleDeletedV1": {
+        "example": {
+          "action": "team_role.deleted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Tech lead",
+              "type": "team_role"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "team_role.deleted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Tech lead",
+                "type": "team_role"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsTeamRoleUpdatedV1": {
+        "example": {
+          "action": "team_role.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Tech lead",
+              "type": "team_role"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "team_role.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Tech lead",
+                "type": "team_role"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
       "AuditLogsTeamSettingsUpdatedV1": {
         "example": {
           "action": "team_settings.updated",
@@ -18140,6 +18618,136 @@
         ],
         "type": "object"
       },
+      "CatalogBulkUpdateEntriesPayloadV3": {
+        "example": {
+          "catalog_type_id": "01GW2G3V0S59R238FAHPDS1R66",
+          "entries": [
+            {
+              "aliases": [
+                "abc123"
+              ],
+              "attribute_values": {
+                "abc123": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123"
+                  }
+                }
+              },
+              "entry_id": "abc123",
+              "external_id": "abc123",
+              "name": "abc123",
+              "rank": 1
+            },
+            {
+              "aliases": [
+                "abc123"
+              ],
+              "attribute_values": {
+                "abc123": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123"
+                  }
+                }
+              },
+              "entry_id": "abc123",
+              "external_id": "abc123",
+              "name": "abc123",
+              "rank": 1
+            }
+          ],
+          "update_attributes": [
+            "01GW2G3V0S59R238FAHPDS1R66",
+            "01GW2G3V0S59R238FAHPDS1R67"
+          ]
+        },
+        "properties": {
+          "catalog_type_id": {
+            "description": "The unique identifier of the catalog type containing the entries",
+            "example": "01GW2G3V0S59R238FAHPDS1R66",
+            "type": "string"
+          },
+          "entries": {
+            "description": "A list of entries to update with their new values. Maximum 100 entries per request.",
+            "example": [
+              {
+                "aliases": [
+                  "abc123"
+                ],
+                "attribute_values": {
+                  "abc123": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123"
+                    }
+                  }
+                },
+                "entry_id": "abc123",
+                "external_id": "abc123",
+                "name": "abc123",
+                "rank": 1
+              },
+              {
+                "aliases": [
+                  "abc123"
+                ],
+                "attribute_values": {
+                  "abc123": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123"
+                    }
+                  }
+                },
+                "entry_id": "abc123",
+                "external_id": "abc123",
+                "name": "abc123",
+                "rank": 1
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/PartialEntryPayloadV3"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          },
+          "update_attributes": {
+            "description": "Optional list of specific attribute IDs to update across all entries. When provided, only these attributes will be updated and all other attributes will be preserved. When omitted, all attributes in each entry's attribute_values will be updated.",
+            "example": [
+              "01GW2G3V0S59R238FAHPDS1R66",
+              "01GW2G3V0S59R238FAHPDS1R67"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "catalog_type_id",
+          "entries"
+        ],
+        "type": "object"
+      },
       "CatalogCreateEntryPayloadV2": {
         "example": {
           "aliases": [
@@ -18426,7 +19034,7 @@
             "incident.io/catalog-importer/id": "id-of-config"
           },
           "categories": [
-            "issue-tracker"
+            "customer"
           ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -18451,7 +19059,7 @@
           "categories": {
             "description": "What categories is this type considered part of",
             "example": [
-              "issue-tracker"
+              "customer"
             ],
             "items": {
               "enum": [
@@ -18463,7 +19071,7 @@
                 "team",
                 "user"
               ],
-              "example": "issue-tracker",
+              "example": "customer",
               "type": "string"
             },
             "type": "array"
@@ -18554,7 +19162,7 @@
             "incident.io/catalog-importer/id": "id-of-config"
           },
           "categories": [
-            "issue-tracker"
+            "customer"
           ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -18580,7 +19188,7 @@
           "categories": {
             "description": "What categories is this type considered part of",
             "example": [
-              "issue-tracker"
+              "customer"
             ],
             "items": {
               "enum": [
@@ -18592,7 +19200,7 @@
                 "team",
                 "user"
               ],
-              "example": "issue-tracker",
+              "example": "customer",
               "type": "string"
             },
             "type": "array"
@@ -18689,7 +19297,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -18712,7 +19320,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -18725,7 +19333,7 @@
               ],
               "version": 1
             },
-            "semantic_type": "custom",
+            "semantic_type": "abc123",
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -18748,7 +19356,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -18771,7 +19379,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "api",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -19437,7 +20045,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -19460,7 +20068,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -19473,7 +20081,7 @@
               ],
               "version": 1
             },
-            "semantic_type": "custom",
+            "semantic_type": "abc123",
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -19597,7 +20205,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -19620,7 +20228,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "api",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -19770,7 +20378,7 @@
                 "incident.io/catalog-importer/id": "id-of-config"
               },
               "categories": [
-                "issue-tracker"
+                "customer"
               ],
               "color": "yellow",
               "created_at": "2021-08-17T13:28:57.801578Z",
@@ -19793,7 +20401,7 @@
                     "array": false,
                     "backlink_attribute": "abc123",
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
-                    "mode": "manual",
+                    "mode": "",
                     "name": "tier",
                     "path": [
                       {
@@ -19806,7 +20414,7 @@
                 ],
                 "version": 1
               },
-              "semantic_type": "custom",
+              "semantic_type": "abc123",
               "source_repo_url": "https://github.com/my-company/incident-io-catalog",
               "type_name": "Custom[\"BackstageGroup\"]",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -19821,7 +20429,7 @@
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
                 "categories": [
-                  "issue-tracker"
+                  "customer"
                 ],
                 "color": "yellow",
                 "created_at": "2021-08-17T13:28:57.801578Z",
@@ -19844,7 +20452,7 @@
                       "array": false,
                       "backlink_attribute": "abc123",
                       "id": "01GW2G3V0S59R238FAHPDS1R66",
-                      "mode": "manual",
+                      "mode": "",
                       "name": "tier",
                       "path": [
                         {
@@ -19857,7 +20465,7 @@
                   ],
                   "version": 1
                 },
-                "semantic_type": "custom",
+                "semantic_type": "abc123",
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                 "type_name": "Custom[\"BackstageGroup\"]",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -19882,7 +20490,7 @@
                 "incident.io/catalog-importer/id": "id-of-config"
               },
               "categories": [
-                "issue-tracker"
+                "customer"
               ],
               "color": "yellow",
               "created_at": "2021-08-17T13:28:57.801578Z",
@@ -19905,7 +20513,7 @@
                     "array": false,
                     "backlink_attribute": "abc123",
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
-                    "mode": "api",
+                    "mode": "",
                     "name": "tier",
                     "path": [
                       {
@@ -19933,7 +20541,7 @@
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
                 "categories": [
-                  "issue-tracker"
+                  "customer"
                 ],
                 "color": "yellow",
                 "created_at": "2021-08-17T13:28:57.801578Z",
@@ -19956,7 +20564,7 @@
                       "array": false,
                       "backlink_attribute": "abc123",
                       "id": "01GW2G3V0S59R238FAHPDS1R66",
-                      "mode": "api",
+                      "mode": "",
                       "name": "tier",
                       "path": [
                         {
@@ -20149,7 +20757,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -20172,7 +20780,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -20185,7 +20793,7 @@
               ],
               "version": 1
             },
-            "semantic_type": "custom",
+            "semantic_type": "abc123",
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -20240,7 +20848,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -20263,7 +20871,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "api",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -20303,7 +20911,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -20326,7 +20934,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -20339,7 +20947,7 @@
               ],
               "version": 1
             },
-            "semantic_type": "custom",
+            "semantic_type": "abc123",
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -20362,7 +20970,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -20385,7 +20993,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "api",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -21625,7 +22233,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -21648,7 +22256,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -21661,7 +22269,7 @@
               ],
               "version": 1
             },
-            "semantic_type": "custom",
+            "semantic_type": "abc123",
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -21716,7 +22324,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -21739,7 +22347,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "api",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -21778,7 +22386,7 @@
             "incident.io/catalog-importer/id": "id-of-config"
           },
           "categories": [
-            "issue-tracker"
+            "customer"
           ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -21802,7 +22410,7 @@
           "categories": {
             "description": "What categories is this type considered part of",
             "example": [
-              "issue-tracker"
+              "customer"
             ],
             "items": {
               "enum": [
@@ -21814,7 +22422,7 @@
                 "team",
                 "user"
               ],
-              "example": "issue-tracker",
+              "example": "customer",
               "type": "string"
             },
             "type": "array"
@@ -21900,7 +22508,7 @@
             "incident.io/catalog-importer/id": "id-of-config"
           },
           "categories": [
-            "issue-tracker"
+            "customer"
           ],
           "color": "yellow",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -21925,7 +22533,7 @@
           "categories": {
             "description": "What categories is this type considered part of",
             "example": [
-              "issue-tracker"
+              "customer"
             ],
             "items": {
               "enum": [
@@ -21937,7 +22545,7 @@
                 "team",
                 "user"
               ],
-              "example": "issue-tracker",
+              "example": "customer",
               "type": "string"
             },
             "type": "array"
@@ -22029,7 +22637,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -22052,7 +22660,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -22065,7 +22673,7 @@
               ],
               "version": 1
             },
-            "semantic_type": "custom",
+            "semantic_type": "abc123",
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -22088,7 +22696,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -22111,7 +22719,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "api",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -22147,7 +22755,7 @@
               "array": false,
               "backlink_attribute": "abc123",
               "id": "01GW2G3V0S59R238FAHPDS1R66",
-              "mode": "manual",
+              "mode": "",
               "name": "tier",
               "path": [
                 {
@@ -22166,7 +22774,7 @@
                 "array": false,
                 "backlink_attribute": "abc123",
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
-                "mode": "manual",
+                "mode": "",
                 "name": "tier",
                 "path": [
                   {
@@ -22216,7 +22824,7 @@
               "array": false,
               "backlink_attribute": "abc123",
               "id": "01GW2G3V0S59R238FAHPDS1R66",
-              "mode": "api",
+              "mode": "",
               "name": "tier",
               "path": [
                 {
@@ -22235,7 +22843,7 @@
                 "array": false,
                 "backlink_attribute": "abc123",
                 "id": "01GW2G3V0S59R238FAHPDS1R66",
-                "mode": "api",
+                "mode": "",
                 "name": "tier",
                 "path": [
                   {
@@ -22284,7 +22892,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -22307,7 +22915,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "manual",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -22320,7 +22928,7 @@
               ],
               "version": 1
             },
-            "semantic_type": "custom",
+            "semantic_type": "abc123",
             "source_repo_url": "https://github.com/my-company/incident-io-catalog",
             "type_name": "Custom[\"BackstageGroup\"]",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -22343,7 +22951,7 @@
               "incident.io/catalog-importer/id": "id-of-config"
             },
             "categories": [
-              "issue-tracker"
+              "customer"
             ],
             "color": "yellow",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -22366,7 +22974,7 @@
                   "array": false,
                   "backlink_attribute": "abc123",
                   "id": "01GW2G3V0S59R238FAHPDS1R66",
-                  "mode": "api",
+                  "mode": "",
                   "name": "tier",
                   "path": [
                     {
@@ -26030,7 +26638,8 @@
             "enum": [
               "schedule",
               "user",
-              "slack_channel"
+              "slack_channel",
+              "msteams_channel"
             ],
             "example": "schedule",
             "type": "string",
@@ -26567,7 +27176,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -26580,7 +27189,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -26607,7 +27216,7 @@
                 {
                   "end_time": "17:00",
                   "start_time": "09:00",
-                  "weekday": "tuesday"
+                  "weekday": "monday"
                 }
               ]
             }
@@ -26662,7 +27271,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -26675,7 +27284,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -26717,7 +27326,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -26788,7 +27397,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -26801,7 +27410,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -26828,7 +27437,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -26842,6 +27451,148 @@
         },
         "required": [
           "escalation_path"
+        ],
+        "type": "object"
+      },
+      "EscalationsCreatePayloadV2": {
+        "example": {
+          "description": "Database CPU has been above 90% for 5 minutes",
+          "escalation_path_id": "01H0J1EXE7AXZ2C93K61WBPYEH",
+          "idempotency_key": "2024-01-15-abc123",
+          "title": "Production database experiencing high CPU",
+          "user_ids": [
+            "01H0J1EXE7AXZ2C93K61WBPYEH",
+            "01H0J1EXE7AXZ2C93K61WBPYEI"
+          ]
+        },
+        "properties": {
+          "description": {
+            "description": "Additional details about the escalation",
+            "example": "Database CPU has been above 90% for 5 minutes",
+            "type": "string"
+          },
+          "escalation_path_id": {
+            "description": "ID of the escalation path to follow",
+            "example": "01H0J1EXE7AXZ2C93K61WBPYEH",
+            "type": "string"
+          },
+          "idempotency_key": {
+            "description": "Unique key to prevent duplicate escalations. If this key has already been used, the existing escalation will be returned.",
+            "example": "2024-01-15-abc123",
+            "type": "string"
+          },
+          "title": {
+            "description": "The title of the escalation. This message will be included in all notifications about this escalation.",
+            "example": "Production database experiencing high CPU",
+            "type": "string"
+          },
+          "user_ids": {
+            "description": "IDs of users to escalate directly to",
+            "example": [
+              "01H0J1EXE7AXZ2C93K61WBPYEH",
+              "01H0J1EXE7AXZ2C93K61WBPYEI"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "idempotency_key",
+          "title"
+        ],
+        "type": "object"
+      },
+      "EscalationsCreateResultV2": {
+        "example": {
+          "escalation": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "events": [
+              {
+                "channels": [
+                  {
+                    "microsoft_teams_channel_id": "abc123",
+                    "microsoft_teams_team_id": "abc123",
+                    "slack_channel_id": "abc123",
+                    "slack_team_id": "abc123"
+                  }
+                ],
+                "event": "entered_grace_period",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "occurred_at": "2021-08-17T13:28:57.801578Z",
+                "urgency": "high",
+                "users": [
+                  {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                ]
+              }
+            ],
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "priority": {
+              "name": "P1"
+            },
+            "related_alerts": [
+              {
+                "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "deduplication_key": "4293868629",
+                "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "resolved_at": "2021-08-17T14:28:57.801578Z",
+                "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                "status": "firing",
+                "title": "*errors.withMessage: PG::Error failed to connect",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "related_incidents": [
+              {
+                "external_id": 123,
+                "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                "name": "Our database is sad",
+                "reference": "INC-123",
+                "status_category": "triage",
+                "summary": "Our database is really really sad, and we don't know why yet.",
+                "visibility": "public"
+              }
+            ],
+            "status": "pending",
+            "title": "Database CPU is high",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "escalation": {
+            "$ref": "#/components/schemas/EscalationV2"
+          }
+        },
+        "required": [
+          "escalation"
         ],
         "type": "object"
       },
@@ -27083,7 +27834,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -27096,7 +27847,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -27123,7 +27874,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -27275,7 +28026,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -27288,7 +28039,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
-                    "type": "user",
+                    "type": "schedule",
                     "urgency": "high"
                   }
                 ],
@@ -27315,7 +28066,7 @@
                 {
                   "end_time": "17:00",
                   "start_time": "09:00",
-                  "weekday": "tuesday"
+                  "weekday": "monday"
                 }
               ]
             }
@@ -27370,7 +28121,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -27383,7 +28134,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -27425,7 +28176,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -27496,7 +28247,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -27509,7 +28260,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
-                      "type": "user",
+                      "type": "schedule",
                       "urgency": "high"
                     }
                   ],
@@ -27536,7 +28287,7 @@
                   {
                     "end_time": "17:00",
                     "start_time": "09:00",
-                    "weekday": "tuesday"
+                    "weekday": "monday"
                   }
                 ]
               }
@@ -29091,6 +29842,7 @@
               "jira_server",
               "github",
               "gitlab",
+              "service_now",
               "shortcut"
             ],
             "example": "asana",
@@ -29127,6 +29879,7 @@
               "jira_server",
               "github",
               "gitlab",
+              "service_now",
               "shortcut"
             ],
             "example": "asana",
@@ -29168,6 +29921,7 @@
               "gitlab_merge_request",
               "sentry_issue",
               "jira_issue",
+              "jsm_alert",
               "atlassian_statuspage_incident",
               "zendesk_ticket",
               "google_calendar_event",
@@ -29245,6 +29999,27 @@
           },
           "completed_at": "2021-08-17T13:28:57.801578Z",
           "created_at": "2021-08-17T13:28:57.801578Z",
+          "creator": {
+            "alert": {
+              "id": "01GW2G3V0S59R238FAHPDS1R66",
+              "title": "*errors.withMessage: PG::Error failed to connect"
+            },
+            "api_key": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My test API key"
+            },
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "workflow": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My little workflow"
+            }
+          },
           "description": "Call the fire brigade",
           "external_issue_reference": {
             "issue_name": "INC-123",
@@ -29253,6 +30028,10 @@
           },
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "labels": [
+            "bug",
+            "urgent"
+          ],
           "priority": {
             "description": "A follow-up that requires immediate attention.",
             "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
@@ -29279,6 +30058,9 @@
             "format": "date-time",
             "type": "string"
           },
+          "creator": {
+            "$ref": "#/components/schemas/ActorV2"
+          },
           "description": {
             "description": "Description of the follow-up",
             "example": "Call the fire brigade",
@@ -29296,6 +30078,18 @@
             "description": "Unique identifier of the incident the follow-up belongs to",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
             "type": "string"
+          },
+          "labels": {
+            "description": "Labels associated with this follow-up",
+            "example": [
+              "bug",
+              "urgent"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
           },
           "priority": {
             "$ref": "#/components/schemas/FollowUpPriorityV2"
@@ -29326,8 +30120,10 @@
         "required": [
           "id",
           "incident_id",
+          "creator",
           "title",
           "status",
+          "labels",
           "created_at",
           "updated_at"
         ],
@@ -29346,6 +30142,27 @@
               },
               "completed_at": "2021-08-17T13:28:57.801578Z",
               "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "alert": {
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "title": "*errors.withMessage: PG::Error failed to connect"
+                },
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "viewer",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "workflow": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My little workflow"
+                }
+              },
               "description": "Call the fire brigade",
               "external_issue_reference": {
                 "issue_name": "INC-123",
@@ -29354,6 +30171,10 @@
               },
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "labels": [
+                "bug",
+                "urgent"
+              ],
               "priority": {
                 "description": "A follow-up that requires immediate attention.",
                 "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
@@ -29379,6 +30200,27 @@
                 },
                 "completed_at": "2021-08-17T13:28:57.801578Z",
                 "created_at": "2021-08-17T13:28:57.801578Z",
+                "creator": {
+                  "alert": {
+                    "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "title": "*errors.withMessage: PG::Error failed to connect"
+                  },
+                  "api_key": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My test API key"
+                  },
+                  "user": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "viewer",
+                    "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "workflow": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My little workflow"
+                  }
+                },
                 "description": "Call the fire brigade",
                 "external_issue_reference": {
                   "issue_name": "INC-123",
@@ -29387,6 +30229,10 @@
                 },
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "labels": [
+                  "bug",
+                  "urgent"
+                ],
                 "priority": {
                   "description": "A follow-up that requires immediate attention.",
                   "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
@@ -29421,6 +30267,27 @@
             },
             "completed_at": "2021-08-17T13:28:57.801578Z",
             "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
             "description": "Call the fire brigade",
             "external_issue_reference": {
               "issue_name": "INC-123",
@@ -29429,6 +30296,10 @@
             },
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "labels": [
+              "bug",
+              "urgent"
+            ],
             "priority": {
               "description": "A follow-up that requires immediate attention.",
               "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
@@ -29672,8 +30543,11 @@
                 "workflows_editor",
                 "private_workflows_editor",
                 "on_call_editor",
+                "escalation_creator",
                 "post_incident_flow_opt_out",
-                "security_settings_editor"
+                "security_settings_editor",
+                "investigation_download",
+                "team_memberships_manage"
               ],
               "example": "viewer",
               "type": "string",
@@ -29811,6 +30685,7 @@
                   "gitlab_merge_request",
                   "sentry_issue",
                   "jira_issue",
+                  "jsm_alert",
                   "atlassian_statuspage_incident",
                   "zendesk_ticket",
                   "google_calendar_event",
@@ -31822,6 +32697,10 @@
               "name": "Lisa Karlin Curtis",
               "role": "viewer",
               "slack_user_id": "U02AYNF2XJM"
+            },
+            "workflow": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My little workflow"
             }
           }
         },
@@ -31913,6 +32792,10 @@
                   "name": "Lisa Karlin Curtis",
                   "role": "viewer",
                   "slack_user_id": "U02AYNF2XJM"
+                },
+                "workflow": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My little workflow"
                 }
               }
             }
@@ -31963,6 +32846,10 @@
                     "name": "Lisa Karlin Curtis",
                     "role": "viewer",
                     "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "workflow": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My little workflow"
                   }
                 }
               }
@@ -32336,6 +33223,10 @@
               "name": "Lisa Karlin Curtis",
               "role": "viewer",
               "slack_user_id": "U02AYNF2XJM"
+            },
+            "workflow": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My little workflow"
             }
           },
           "custom_field_entries": [
@@ -32754,6 +33645,10 @@
                 "name": "Lisa Karlin Curtis",
                 "role": "viewer",
                 "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
               }
             },
             "custom_field_entries": [
@@ -33414,6 +34309,10 @@
                 "name": "Lisa Karlin Curtis",
                 "role": "viewer",
                 "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
               }
             },
             "custom_field_entries": [
@@ -33640,6 +34539,10 @@
                 "name": "Lisa Karlin Curtis",
                 "role": "viewer",
                 "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
               }
             },
             "custom_field_entries": [
@@ -34067,6 +34970,10 @@
                   "name": "Lisa Karlin Curtis",
                   "role": "viewer",
                   "slack_user_id": "U02AYNF2XJM"
+                },
+                "workflow": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My little workflow"
                 }
               },
               "custom_field_entries": [
@@ -34230,6 +35137,10 @@
                     "name": "Lisa Karlin Curtis",
                     "role": "viewer",
                     "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "workflow": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My little workflow"
                   }
                 },
                 "custom_field_entries": [
@@ -34529,6 +35440,10 @@
                 "name": "Lisa Karlin Curtis",
                 "role": "viewer",
                 "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
               }
             },
             "custom_field_entries": [
@@ -34744,7 +35659,7 @@
             "incident.io/terraform/version": "3.0.0"
           },
           "resource_id": "abc123",
-          "resource_type": "alert_source"
+          "resource_type": "alert_route"
         },
         "properties": {
           "annotations": {
@@ -34772,7 +35687,7 @@
               "schedule",
               "workflow"
             ],
-            "example": "alert_source",
+            "example": "alert_route",
             "type": "string"
           }
         },
@@ -34792,7 +35707,7 @@
             },
             "managed_by": "dashboard",
             "resource_id": "abc123",
-            "resource_type": "alert_source",
+            "resource_type": "alert_route",
             "source_url": "https://github.com/my-company/infrastructure"
           }
         },
@@ -34987,6 +35902,88 @@
         ],
         "type": "object"
       },
+      "PartialEntryPayloadV3": {
+        "description": "Represents a partial entry update, allowing selective field updates",
+        "example": {
+          "aliases": [
+            "abc123"
+          ],
+          "attribute_values": {
+            "abc123": {
+              "array_value": [
+                {
+                  "literal": "SEV123"
+                }
+              ],
+              "value": {
+                "literal": "SEV123"
+              }
+            }
+          },
+          "entry_id": "abc123",
+          "external_id": "abc123",
+          "name": "abc123",
+          "rank": 1
+        },
+        "properties": {
+          "aliases": {
+            "description": "If specified, will update the aliases of the entry. When omitted, preserves the existing aliases.",
+            "example": [
+              "abc123"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "attribute_values": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CatalogEngineParamBindingPayloadV3"
+            },
+            "description": "The attribute values to apply to this entry",
+            "example": {
+              "abc123": {
+                "array_value": [
+                  {
+                    "literal": "SEV123"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123"
+                }
+              }
+            },
+            "type": "object"
+          },
+          "entry_id": {
+            "description": "ID of the relevant catalog entry",
+            "example": "abc123",
+            "type": "string"
+          },
+          "external_id": {
+            "description": "If specified, will update the external ID of the entry. When omitted, preserves the existing external ID.",
+            "example": "abc123",
+            "type": "string"
+          },
+          "name": {
+            "description": "If specified, will update the name of the entry. When omitted, preserves the existing name.",
+            "example": "abc123",
+            "type": "string"
+          },
+          "rank": {
+            "description": "If specified, will update the rank of the entry. When omitted, rank will be set to null (allowing rank removal).",
+            "example": 1,
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "entry_id",
+          "attribute_values"
+        ],
+        "type": "object"
+      },
       "RBACRoleV2": {
         "example": {
           "description": "Elevated permissions for the customer success team.",
@@ -35098,6 +36095,7 @@
                 }
               ],
               "name": "My Rotation",
+              "scheduling_mode": "fair",
               "users": [
                 {
                   "email": "bob@example.com",
@@ -35135,6 +36133,7 @@
                   }
                 ],
                 "name": "My Rotation",
+                "scheduling_mode": "fair",
                 "users": [
                   {
                     "email": "bob@example.com",
@@ -35179,6 +36178,7 @@
                 }
               ],
               "name": "My Rotation",
+              "scheduling_mode": "fair",
               "users": [
                 {
                   "email": "bob@example.com",
@@ -35216,6 +36216,7 @@
                   }
                 ],
                 "name": "My Rotation",
+                "scheduling_mode": "fair",
                 "users": [
                   {
                     "email": "bob@example.com",
@@ -35260,6 +36261,7 @@
                 }
               ],
               "name": "Primary On-Call Schedule",
+              "scheduling_mode": "fair",
               "users": [
                 {
                   "email": "lisa@incident.io",
@@ -35307,6 +36309,7 @@
                   }
                 ],
                 "name": "Primary On-Call Schedule",
+                "scheduling_mode": "fair",
                 "users": [
                   {
                     "email": "lisa@incident.io",
@@ -35368,6 +36371,7 @@
                   }
                 ],
                 "name": "My Rotation",
+                "scheduling_mode": "fair",
                 "users": [
                   {
                     "email": "bob@example.com",
@@ -35835,6 +36839,7 @@
             }
           ],
           "name": "My Rotation",
+          "scheduling_mode": "fair",
           "users": [
             {
               "email": "bob@example.com",
@@ -35893,6 +36898,15 @@
           "name": {
             "description": "Name of the rotation",
             "example": "My Rotation",
+            "type": "string"
+          },
+          "scheduling_mode": {
+            "description": "Scheduling algorithm to use for this rotation. 'fair' balances workload by considering handover duration, while 'sequential' uses simple round-robin rotation through users. Only applies when you have asymmetric handovers (e.g., 2 days then 5 days).",
+            "enum": [
+              "fair",
+              "sequential"
+            ],
+            "example": "fair",
             "type": "string"
           },
           "users": {
@@ -35970,6 +36984,7 @@
             }
           ],
           "name": "My Rotation",
+          "scheduling_mode": "fair",
           "users": [
             {
               "email": "bob@example.com",
@@ -36030,6 +37045,15 @@
             "example": "My Rotation",
             "type": "string"
           },
+          "scheduling_mode": {
+            "description": "Scheduling algorithm to use for this rotation. 'fair' balances workload by considering handover duration, while 'sequential' uses simple round-robin rotation through users. Only applies when you have asymmetric handovers (e.g., 2 days then 5 days).",
+            "enum": [
+              "fair",
+              "sequential"
+            ],
+            "example": "fair",
+            "type": "string"
+          },
           "users": {
             "example": [
               {
@@ -36077,6 +37101,7 @@
             }
           ],
           "name": "Primary On-Call Schedule",
+          "scheduling_mode": "fair",
           "users": [
             {
               "email": "lisa@incident.io",
@@ -36148,6 +37173,15 @@
           "name": {
             "description": "Human readable name synced from external provider",
             "example": "Primary On-Call Schedule",
+            "type": "string"
+          },
+          "scheduling_mode": {
+            "description": "Scheduling algorithm to use for this rotation. 'fair' balances workload by considering handover duration, while 'sequential' uses simple round-robin rotation through users. Only applies when you have asymmetric handovers (e.g., 2 days then 5 days).",
+            "enum": [
+              "fair",
+              "sequential"
+            ],
+            "example": "fair",
             "type": "string"
           },
           "users": {
@@ -36311,6 +37345,7 @@
                   }
                 ],
                 "name": "My Rotation",
+                "scheduling_mode": "fair",
                 "users": [
                   {
                     "email": "bob@example.com",
@@ -36405,6 +37440,7 @@
                   }
                 ],
                 "name": "Primary On-Call Schedule",
+                "scheduling_mode": "fair",
                 "users": [
                   {
                     "email": "lisa@incident.io",
@@ -36655,7 +37691,7 @@
                   "handovers": [
                     {
                       "interval": 1,
-                      "interval_type": "daily"
+                      "interval_type": "hourly"
                     }
                   ],
                   "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -36666,6 +37702,7 @@
                     }
                   ],
                   "name": "My Rotation",
+                  "scheduling_mode": "fair",
                   "users": [
                     {
                       "email": "bob@example.com",
@@ -36677,7 +37714,7 @@
                     {
                       "end_time": "17:00",
                       "start_time": "09:00",
-                      "weekday": "tuesday"
+                      "weekday": "monday"
                     }
                   ]
                 }
@@ -36719,7 +37756,7 @@
                   "handovers": [
                     {
                       "interval": 1,
-                      "interval_type": "daily"
+                      "interval_type": "hourly"
                     }
                   ],
                   "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -36730,6 +37767,7 @@
                     }
                   ],
                   "name": "Primary On-Call Schedule",
+                  "scheduling_mode": "fair",
                   "users": [
                     {
                       "email": "lisa@incident.io",
@@ -36743,14 +37781,14 @@
                     {
                       "end_time": "17:00",
                       "start_time": "09:00",
-                      "weekday": "tuesday"
+                      "weekday": "monday"
                     }
                   ],
                   "working_intervals": [
                     {
                       "end_time": "17:00",
                       "start_time": "09:00",
-                      "weekday": "tuesday"
+                      "weekday": "monday"
                     }
                   ]
                 }
@@ -36819,7 +37857,7 @@
                     "handovers": [
                       {
                         "interval": 1,
-                        "interval_type": "daily"
+                        "interval_type": "hourly"
                       }
                     ],
                     "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -36830,6 +37868,7 @@
                       }
                     ],
                     "name": "Primary On-Call Schedule",
+                    "scheduling_mode": "fair",
                     "users": [
                       {
                         "email": "lisa@incident.io",
@@ -36843,14 +37882,14 @@
                       {
                         "end_time": "17:00",
                         "start_time": "09:00",
-                        "weekday": "tuesday"
+                        "weekday": "monday"
                       }
                     ],
                     "working_intervals": [
                       {
                         "end_time": "17:00",
                         "start_time": "09:00",
-                        "weekday": "tuesday"
+                        "weekday": "monday"
                       }
                     ]
                   }
@@ -36908,7 +37947,7 @@
                       "handovers": [
                         {
                           "interval": 1,
-                          "interval_type": "daily"
+                          "interval_type": "hourly"
                         }
                       ],
                       "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -36919,6 +37958,7 @@
                         }
                       ],
                       "name": "Primary On-Call Schedule",
+                      "scheduling_mode": "fair",
                       "users": [
                         {
                           "email": "lisa@incident.io",
@@ -36932,14 +37972,14 @@
                         {
                           "end_time": "17:00",
                           "start_time": "09:00",
-                          "weekday": "tuesday"
+                          "weekday": "monday"
                         }
                       ],
                       "working_intervals": [
                         {
                           "end_time": "17:00",
                           "start_time": "09:00",
-                          "weekday": "tuesday"
+                          "weekday": "monday"
                         }
                       ]
                     }
@@ -37076,7 +38116,7 @@
                   "handovers": [
                     {
                       "interval": 1,
-                      "interval_type": "daily"
+                      "interval_type": "hourly"
                     }
                   ],
                   "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -37087,6 +38127,7 @@
                     }
                   ],
                   "name": "Primary On-Call Schedule",
+                  "scheduling_mode": "fair",
                   "users": [
                     {
                       "email": "lisa@incident.io",
@@ -37100,14 +38141,14 @@
                     {
                       "end_time": "17:00",
                       "start_time": "09:00",
-                      "weekday": "tuesday"
+                      "weekday": "monday"
                     }
                   ],
                   "working_intervals": [
                     {
                       "end_time": "17:00",
                       "start_time": "09:00",
-                      "weekday": "tuesday"
+                      "weekday": "monday"
                     }
                   ]
                 }
@@ -37170,7 +38211,7 @@
                   "handovers": [
                     {
                       "interval": 1,
-                      "interval_type": "daily"
+                      "interval_type": "hourly"
                     }
                   ],
                   "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -37181,6 +38222,7 @@
                     }
                   ],
                   "name": "My Rotation",
+                  "scheduling_mode": "fair",
                   "users": [
                     {
                       "email": "bob@example.com",
@@ -37192,7 +38234,7 @@
                     {
                       "end_time": "17:00",
                       "start_time": "09:00",
-                      "weekday": "tuesday"
+                      "weekday": "monday"
                     }
                   ]
                 }
@@ -37243,7 +38285,7 @@
                   "handovers": [
                     {
                       "interval": 1,
-                      "interval_type": "daily"
+                      "interval_type": "hourly"
                     }
                   ],
                   "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -37254,6 +38296,7 @@
                     }
                   ],
                   "name": "Primary On-Call Schedule",
+                  "scheduling_mode": "fair",
                   "users": [
                     {
                       "email": "lisa@incident.io",
@@ -37267,14 +38310,14 @@
                     {
                       "end_time": "17:00",
                       "start_time": "09:00",
-                      "weekday": "tuesday"
+                      "weekday": "monday"
                     }
                   ],
                   "working_intervals": [
                     {
                       "end_time": "17:00",
                       "start_time": "09:00",
-                      "weekday": "tuesday"
+                      "weekday": "monday"
                     }
                   ]
                 }
@@ -38205,7 +39248,7 @@
             "dashboard_url": "https://app.incident.io/my-org",
             "name": "Alertmanager token",
             "roles": [
-              "incident_creator"
+              "viewer"
             ]
           }
         },
@@ -38267,6 +39310,10 @@
               "name": "Lisa Karlin Curtis",
               "role": "viewer",
               "slack_user_id": "U02AYNF2XJM"
+            },
+            "workflow": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My little workflow"
             }
           },
           "custom_field_entries": [
@@ -38713,7 +39760,13 @@
           "private_incident.follow_up_created_v1": {
             "id": "abc123"
           },
+          "private_incident.follow_up_created_v2": {
+            "id": "abc123"
+          },
           "private_incident.follow_up_updated_v1": {
+            "id": "abc123"
+          },
+          "private_incident.follow_up_updated_v2": {
             "id": "abc123"
           },
           "private_incident.incident_created_v2": {
@@ -38798,6 +39851,59 @@
             "status": "outstanding",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           },
+          "public_incident.follow_up_created_v2": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "labels": [
+              "bug",
+              "urgent"
+            ],
+            "priority": {
+              "description": "A follow-up that requires immediate attention.",
+              "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+              "name": "Urgent",
+              "rank": 10
+            },
+            "status": "outstanding",
+            "title": "Cat is stuck in the tree",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
           "public_incident.follow_up_updated_v1": {
             "assignee": {
               "email": "lisa@incident.io",
@@ -38820,6 +39926,59 @@
             "status": "outstanding",
             "updated_at": "2021-08-17T13:28:57.801578Z"
           },
+          "public_incident.follow_up_updated_v2": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "labels": [
+              "bug",
+              "urgent"
+            ],
+            "priority": {
+              "description": "A follow-up that requires immediate attention.",
+              "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+              "name": "Urgent",
+              "rank": 10
+            },
+            "status": "outstanding",
+            "title": "Cat is stuck in the tree",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
           "public_incident.incident_created_v2": {
             "call_url": "https://zoom.us/foo",
             "created_at": "2021-08-17T13:28:57.801578Z",
@@ -38838,6 +39997,10 @@
                 "name": "Lisa Karlin Curtis",
                 "role": "viewer",
                 "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
               }
             },
             "custom_field_entries": [
@@ -38996,6 +40159,10 @@
                   "name": "Lisa Karlin Curtis",
                   "role": "viewer",
                   "slack_user_id": "U02AYNF2XJM"
+                },
+                "workflow": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My little workflow"
                 }
               },
               "custom_field_entries": [
@@ -39169,6 +40336,10 @@
                 "name": "Lisa Karlin Curtis",
                 "role": "viewer",
                 "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
               }
             },
             "custom_field_entries": [
@@ -39322,6 +40493,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39341,7 +40516,13 @@
           "private_incident.follow_up_created_v1": {
             "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
+          "private_incident.follow_up_created_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
           "private_incident.follow_up_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_incident.follow_up_updated_v2": {
             "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.incident_created_v2": {
@@ -39365,8 +40546,14 @@
           "public_incident.follow_up_created_v1": {
             "$ref": "#/components/schemas/ActionV1"
           },
+          "public_incident.follow_up_created_v2": {
+            "$ref": "#/components/schemas/FollowUpV2"
+          },
           "public_incident.follow_up_updated_v1": {
             "$ref": "#/components/schemas/ActionV1"
+          },
+          "public_incident.follow_up_updated_v2": {
+            "$ref": "#/components/schemas/FollowUpV2"
           },
           "public_incident.incident_created_v2": {
             "$ref": "#/components/schemas/WebhookIncidentV2"
@@ -39403,6 +40590,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39443,6 +40634,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39483,6 +40678,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39500,6 +40699,50 @@
         "required": [
           "event_type",
           "private_incident.follow_up_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentFollowUpCreatedV2ResponseBody": {
+        "example": {
+          "event_type": "private_incident.follow_up_created_v2",
+          "private_incident.follow_up_created_v2": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.follow_up_created_v2",
+            "type": "string"
+          },
+          "private_incident.follow_up_created_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.follow_up_created_v2"
         ],
         "type": "object"
       },
@@ -39523,6 +40766,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39540,6 +40787,50 @@
         "required": [
           "event_type",
           "private_incident.follow_up_updated_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateIncidentFollowUpUpdatedV2ResponseBody": {
+        "example": {
+          "event_type": "private_incident.follow_up_updated_v2",
+          "private_incident.follow_up_updated_v2": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "private_incident.follow_up_updated_v2",
+            "type": "string"
+          },
+          "private_incident.follow_up_updated_v2": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_incident.follow_up_updated_v2"
         ],
         "type": "object"
       },
@@ -39563,6 +40854,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39603,6 +40898,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39645,6 +40944,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39687,6 +40990,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39746,6 +41053,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39805,6 +41116,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39864,6 +41179,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39881,6 +41200,100 @@
         "required": [
           "event_type",
           "public_incident.follow_up_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicIncidentFollowUpCreatedV2ResponseBody": {
+        "example": {
+          "event_type": "public_incident.follow_up_created_v2",
+          "public_incident.follow_up_created_v2": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "labels": [
+              "bug",
+              "urgent"
+            ],
+            "priority": {
+              "description": "A follow-up that requires immediate attention.",
+              "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+              "name": "Urgent",
+              "rank": 10
+            },
+            "status": "outstanding",
+            "title": "Cat is stuck in the tree",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.follow_up_created_v2",
+            "type": "string"
+          },
+          "public_incident.follow_up_created_v2": {
+            "$ref": "#/components/schemas/FollowUpV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.follow_up_created_v2"
         ],
         "type": "object"
       },
@@ -39923,6 +41336,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -39940,6 +41357,100 @@
         "required": [
           "event_type",
           "public_incident.follow_up_updated_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicIncidentFollowUpUpdatedV2ResponseBody": {
+        "example": {
+          "event_type": "public_incident.follow_up_updated_v2",
+          "public_incident.follow_up_updated_v2": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "labels": [
+              "bug",
+              "urgent"
+            ],
+            "priority": {
+              "description": "A follow-up that requires immediate attention.",
+              "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+              "name": "Urgent",
+              "rank": 10
+            },
+            "status": "outstanding",
+            "title": "Cat is stuck in the tree",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1"
+            ],
+            "example": "public_incident.follow_up_updated_v2",
+            "type": "string"
+          },
+          "public_incident.follow_up_updated_v2": {
+            "$ref": "#/components/schemas/FollowUpV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_incident.follow_up_updated_v2"
         ],
         "type": "object"
       },
@@ -39964,6 +41475,10 @@
                 "name": "Lisa Karlin Curtis",
                 "role": "viewer",
                 "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
               }
             },
             "custom_field_entries": [
@@ -40117,6 +41632,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -40159,6 +41678,10 @@
                   "name": "Lisa Karlin Curtis",
                   "role": "viewer",
                   "slack_user_id": "U02AYNF2XJM"
+                },
+                "workflow": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My little workflow"
                 }
               },
               "custom_field_entries": [
@@ -40328,6 +41851,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -40369,6 +41896,10 @@
                 "name": "Lisa Karlin Curtis",
                 "role": "viewer",
                 "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
               }
             },
             "custom_field_entries": [
@@ -40522,6 +42053,10 @@
               "private_incident.follow_up_created_v1",
               "public_incident.follow_up_updated_v1",
               "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
               "public_incident.action_created_v1",
               "private_incident.action_created_v1",
               "public_incident.action_updated_v1",
@@ -42176,7 +43711,7 @@
                 "test",
                 "retrospective"
               ],
-              "example": "test",
+              "example": "standard",
               "type": "string"
             },
             "type": "array"
@@ -43579,7 +45114,7 @@
                 "test",
                 "retrospective"
               ],
-              "example": "test",
+              "example": "standard",
               "type": "string"
             },
             "type": "array"
@@ -44621,7 +46156,7 @@
                     "dashboard_url": "https://app.incident.io/my-org",
                     "name": "Alertmanager token",
                     "roles": [
-                      "incident_creator"
+                      "viewer"
                     ]
                   }
                 },
@@ -44689,6 +46224,7 @@
                 "gitlab_merge_request",
                 "sentry_issue",
                 "jira_issue",
+                "jsm_alert",
                 "atlassian_statuspage_incident",
                 "zendesk_ticket",
                 "google_calendar_event",
@@ -46507,6 +48043,27 @@
                       },
                       "completed_at": "2021-08-17T13:28:57.801578Z",
                       "created_at": "2021-08-17T13:28:57.801578Z",
+                      "creator": {
+                        "alert": {
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "title": "*errors.withMessage: PG::Error failed to connect"
+                        },
+                        "api_key": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My test API key"
+                        },
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        },
+                        "workflow": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My little workflow"
+                        }
+                      },
                       "description": "Call the fire brigade",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -46562,6 +48119,27 @@
                     },
                     "completed_at": "2021-08-17T13:28:57.801578Z",
                     "created_at": "2021-08-17T13:28:57.801578Z",
+                    "creator": {
+                      "alert": {
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "title": "*errors.withMessage: PG::Error failed to connect"
+                      },
+                      "api_key": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My test API key"
+                      },
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
+                      }
+                    },
                     "description": "Call the fire brigade",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -47256,7 +48834,7 @@
                         }
                       },
                       "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "merge_strategy": "append"
+                      "merge_strategy": "first-wins"
                     }
                   ],
                   "incident_mode": {
@@ -47315,7 +48893,7 @@
                         "reference": "incident.severity"
                       }
                     },
-                    "merge_strategy": "append"
+                    "merge_strategy": "first-wins"
                   },
                   "start_in_triage": {
                     "binding": {
@@ -47754,7 +49332,7 @@
                             }
                           },
                           "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "merge_strategy": "append"
+                          "merge_strategy": "first-wins"
                         }
                       ],
                       "incident_mode": {
@@ -47821,7 +49399,7 @@
                             "reference": "incident.severity"
                           }
                         },
-                        "merge_strategy": "append"
+                        "merge_strategy": "first-wins"
                       },
                       "start_in_triage": {
                         "binding": {
@@ -48319,7 +49897,7 @@
                             }
                           },
                           "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "merge_strategy": "append"
+                          "merge_strategy": "first-wins"
                         }
                       ],
                       "incident_mode": {
@@ -48386,7 +49964,7 @@
                             "reference": "incident.severity"
                           }
                         },
-                        "merge_strategy": "append"
+                        "merge_strategy": "first-wins"
                       },
                       "start_in_triage": {
                         "binding": {
@@ -48789,7 +50367,7 @@
                         }
                       },
                       "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "merge_strategy": "append"
+                      "merge_strategy": "first-wins"
                     }
                   ],
                   "incident_mode": {
@@ -48848,7 +50426,7 @@
                         "reference": "incident.severity"
                       }
                     },
-                    "merge_strategy": "append"
+                    "merge_strategy": "first-wins"
                   },
                   "start_in_triage": {
                     "binding": {
@@ -49287,7 +50865,7 @@
                             }
                           },
                           "custom_field_id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                          "merge_strategy": "append"
+                          "merge_strategy": "first-wins"
                         }
                       ],
                       "incident_mode": {
@@ -49354,7 +50932,7 @@
                             "reference": "incident.severity"
                           }
                         },
-                        "merge_strategy": "append"
+                        "merge_strategy": "first-wins"
                       },
                       "start_in_triage": {
                         "binding": {
@@ -49453,7 +51031,7 @@
                       },
                       "name": "Production Web Dashboard Alerts",
                       "secret_token": "some-secret-token",
-                      "source_type": "app_optics",
+                      "source_type": "alertmanager",
                       "template": {
                         "attributes": [
                           {
@@ -49656,7 +51234,7 @@
                   ]
                 },
                 "name": "Production Web Dashboard Alerts",
-                "source_type": "app_optics",
+                "source_type": "alertmanager",
                 "template": {
                   "attributes": [
                     {
@@ -49825,7 +51403,7 @@
                     },
                     "name": "Production Web Dashboard Alerts",
                     "secret_token": "some-secret-token",
-                    "source_type": "app_optics",
+                    "source_type": "alertmanager",
                     "template": {
                       "attributes": [
                         {
@@ -50077,7 +51655,7 @@
                     },
                     "name": "Production Web Dashboard Alerts",
                     "secret_token": "some-secret-token",
-                    "source_type": "app_optics",
+                    "source_type": "alertmanager",
                     "template": {
                       "attributes": [
                         {
@@ -50461,7 +52039,7 @@
                     },
                     "name": "Production Web Dashboard Alerts",
                     "secret_token": "some-secret-token",
-                    "source_type": "app_optics",
+                    "source_type": "alertmanager",
                     "template": {
                       "attributes": [
                         {
@@ -51034,7 +52612,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -51057,7 +52635,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "manual",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -51070,7 +52648,7 @@
                       ],
                       "version": 1
                     },
-                    "semantic_type": "custom",
+                    "semantic_type": "abc123",
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -51316,7 +52894,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -51339,7 +52917,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "manual",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -51352,7 +52930,7 @@
                       ],
                       "version": 1
                     },
-                    "semantic_type": "custom",
+                    "semantic_type": "abc123",
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -51486,7 +53064,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -51509,7 +53087,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "manual",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -51522,7 +53100,7 @@
                       ],
                       "version": 1
                     },
-                    "semantic_type": "custom",
+                    "semantic_type": "abc123",
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -51592,7 +53170,7 @@
                         "incident.io/catalog-importer/id": "id-of-config"
                       },
                       "categories": [
-                        "issue-tracker"
+                        "customer"
                       ],
                       "color": "yellow",
                       "created_at": "2021-08-17T13:28:57.801578Z",
@@ -51615,7 +53193,7 @@
                             "array": false,
                             "backlink_attribute": "abc123",
                             "id": "01GW2G3V0S59R238FAHPDS1R66",
-                            "mode": "manual",
+                            "mode": "",
                             "name": "tier",
                             "path": [
                               {
@@ -51628,7 +53206,7 @@
                         ],
                         "version": 1
                       },
-                      "semantic_type": "custom",
+                      "semantic_type": "abc123",
                       "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                       "type_name": "Custom[\"BackstageGroup\"]",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -51660,7 +53238,7 @@
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
                 "categories": [
-                  "issue-tracker"
+                  "customer"
                 ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -51687,7 +53265,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -51710,7 +53288,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "manual",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -51723,7 +53301,7 @@
                       ],
                       "version": 1
                     },
-                    "semantic_type": "custom",
+                    "semantic_type": "abc123",
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -51800,7 +53378,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -51823,7 +53401,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "manual",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -51836,7 +53414,7 @@
                       ],
                       "version": 1
                     },
-                    "semantic_type": "custom",
+                    "semantic_type": "abc123",
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -51881,7 +53459,7 @@
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
                 "categories": [
-                  "issue-tracker"
+                  "customer"
                 ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -51907,7 +53485,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -51930,7 +53508,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "manual",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -51943,7 +53521,7 @@
                       ],
                       "version": 1
                     },
-                    "semantic_type": "custom",
+                    "semantic_type": "abc123",
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -51991,7 +53569,7 @@
                     "array": false,
                     "backlink_attribute": "abc123",
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
-                    "mode": "manual",
+                    "mode": "",
                     "name": "tier",
                     "path": [
                       {
@@ -52020,7 +53598,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -52043,7 +53621,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "manual",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -52056,7 +53634,7 @@
                       ],
                       "version": 1
                     },
-                    "semantic_type": "custom",
+                    "semantic_type": "abc123",
                     "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                     "type_name": "Custom[\"BackstageGroup\"]",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -52377,7 +53955,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
-                          "type": "user",
+                          "type": "schedule",
                           "urgency": "high"
                         }
                       ],
@@ -52390,7 +53968,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
-                          "type": "user",
+                          "type": "schedule",
                           "urgency": "high"
                         }
                       ],
@@ -52417,7 +53995,7 @@
                       {
                         "end_time": "17:00",
                         "start_time": "09:00",
-                        "weekday": "tuesday"
+                        "weekday": "monday"
                       }
                     ]
                   }
@@ -52487,7 +54065,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
-                              "type": "user",
+                              "type": "schedule",
                               "urgency": "high"
                             }
                           ],
@@ -52500,7 +54078,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
-                              "type": "user",
+                              "type": "schedule",
                               "urgency": "high"
                             }
                           ],
@@ -52527,7 +54105,7 @@
                           {
                             "end_time": "17:00",
                             "start_time": "09:00",
-                            "weekday": "tuesday"
+                            "weekday": "monday"
                           }
                         ]
                       }
@@ -52650,7 +54228,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
-                              "type": "user",
+                              "type": "schedule",
                               "urgency": "high"
                             }
                           ],
@@ -52663,7 +54241,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
-                              "type": "user",
+                              "type": "schedule",
                               "urgency": "high"
                             }
                           ],
@@ -52690,7 +54268,7 @@
                           {
                             "end_time": "17:00",
                             "start_time": "09:00",
-                            "weekday": "tuesday"
+                            "weekday": "monday"
                           }
                         ]
                       }
@@ -52773,7 +54351,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
-                          "type": "user",
+                          "type": "schedule",
                           "urgency": "high"
                         }
                       ],
@@ -52786,7 +54364,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
-                          "type": "user",
+                          "type": "schedule",
                           "urgency": "high"
                         }
                       ],
@@ -52813,7 +54391,7 @@
                       {
                         "end_time": "17:00",
                         "start_time": "09:00",
-                        "weekday": "tuesday"
+                        "weekday": "monday"
                       }
                     ]
                   }
@@ -52883,7 +54461,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
-                              "type": "user",
+                              "type": "schedule",
                               "urgency": "high"
                             }
                           ],
@@ -52896,7 +54474,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
-                              "type": "user",
+                              "type": "schedule",
                               "urgency": "high"
                             }
                           ],
@@ -52923,7 +54501,7 @@
                           {
                             "end_time": "17:00",
                             "start_time": "09:00",
-                            "weekday": "tuesday"
+                            "weekday": "monday"
                           }
                         ]
                       }
@@ -52946,7 +54524,7 @@
     },
     "/v2/escalations": {
       "get": {
-        "description": "List all escalations for your account.\n\nThis endpoint supports a number of filters, which can help find escalations matching certain\ncriteria.\n\nNote that:\n- Filters may be used together, and the result will be escalations that match all filters.\n- All query parameters must be URI encoded.\n\nTo use this API, you will need an API key with the \"View data\" or \"Create and manage on-call resources\" permission.\n\n### By escalation_path\n\nFind all escalations that escalated to escalation path with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'escalation_path[one_of]=ABC'\n\n### By status\n\nFind all escalations with a current status of \"triggered\":\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'status[one_of]=triggered'\n\nPossible values are \"pending\", \"triggered\", \"acked\", \"resolved\", \"expired\" and \"cancelled\".\nEscalations are in \"pending\" when they are in a grace period when the related alert has \nbeen grouped in an incident.\n\n### By alert\n\nFind all escalations that were created by alert with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'alert[one_of]=ABC'\n\n### By created_at and updated_at\nFind all escalations that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and \n\"date_range\" (between two dates).\nFor example, to find all escalations updated after 2025-01-01:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'updated_at[gte]=2025-01-01'\n\nTo find all escalations created between 2025-01-01 and 2025-01-31:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\ \n            --data 'created_at[date_range]=2025-01-01~2025-01-31'\n",
+        "description": "List all escalations for your account.\n\nThis endpoint supports a number of filters, which can help find escalations matching certain\ncriteria.\n\nNote that:\n- Filters may be used together, and the result will be escalations that match all filters.\n- All query parameters must be URI encoded.\n\nTo use this API, you will need an API key with the \"View data\" or \"Create and manage on-call resources\" permission.\n\n### By escalation_path\n\nFind all escalations that escalated to escalation path with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'escalation_path[one_of]=ABC'\n\n### By status\n\nFind all escalations with a current status of \"triggered\":\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'status[one_of]=triggered'\n\nPossible values are \"pending\", \"triggered\", \"acked\", \"resolved\", \"expired\" and \"cancelled\".\nEscalations are in \"pending\" when they are in a grace period when the related alert has\nbeen grouped in an incident.\n\n### By alert\n\nFind all escalations that were created by alert with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'alert[one_of]=ABC'\n\n### By created_at and updated_at\nFind all escalations that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and\n\"date_range\" (between two dates).\nFor example, to find all escalations updated after 2025-01-01:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n\t\t\t--data 'updated_at[gte]=2025-01-01'\n\nTo find all escalations created between 2025-01-01 and 2025-01-31:\n\n\t\tcurl --get 'https://api.incident.io/v2/escalations' \\\n            --data 'created_at[date_range]=2025-01-01~2025-01-31'\n",
         "operationId": "Escalations V2#List",
         "parameters": [
           {
@@ -53230,6 +54808,126 @@
         "tags": [
           "Escalations V2"
         ]
+      },
+      "post": {
+        "description": "Create an escalation.\n\nAn escalation pages people, either according to an escalation path, or directly to\nspecific users. You must provide either an escalation_path_id OR user_ids, but not both.\n\nWhen escalating via an escalation path, the escalation will follow the configured path\nwith its levels and timeouts, using your default [alert\npriority](https://app.incident.io/~/settings/alerts/configuration/priorities).\n\nWhen escalating directly to users, they will receive a high-urgency\nnotification, based on their notification rules.\n\nThis endpoint is rate-limited to 60 requests per minute, since it is intended for\ninteractive use cases (for example someone clicking a \"escalate to team\" button\nin your internal developer platform). To escalate based on automated alerts, we\nrecommend sending events to an alert source instead.\n",
+        "operationId": "Escalations V2#Create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "description": "Database CPU has been above 90% for 5 minutes",
+                "escalation_path_id": "01H0J1EXE7AXZ2C93K61WBPYEH",
+                "idempotency_key": "2024-01-15-abc123",
+                "title": "Production database experiencing high CPU",
+                "user_ids": [
+                  "01H0J1EXE7AXZ2C93K61WBPYEH",
+                  "01H0J1EXE7AXZ2C93K61WBPYEI"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/EscalationsCreatePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "escalation": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "creator": {
+                      "alert": {
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "title": "*errors.withMessage: PG::Error failed to connect"
+                      },
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
+                      }
+                    },
+                    "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "events": [
+                      {
+                        "channels": [
+                          {
+                            "microsoft_teams_channel_id": "abc123",
+                            "microsoft_teams_team_id": "abc123",
+                            "slack_channel_id": "abc123",
+                            "slack_team_id": "abc123"
+                          }
+                        ],
+                        "event": "entered_grace_period",
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "occurred_at": "2021-08-17T13:28:57.801578Z",
+                        "urgency": "high",
+                        "users": [
+                          {
+                            "email": "lisa@incident.io",
+                            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "name": "Lisa Karlin Curtis",
+                            "role": "viewer",
+                            "slack_user_id": "U02AYNF2XJM"
+                          }
+                        ]
+                      }
+                    ],
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "priority": {
+                      "name": "P1"
+                    },
+                    "related_alerts": [
+                      {
+                        "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "created_at": "2021-08-17T13:28:57.801578Z",
+                        "deduplication_key": "4293868629",
+                        "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "resolved_at": "2021-08-17T14:28:57.801578Z",
+                        "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                        "status": "firing",
+                        "title": "*errors.withMessage: PG::Error failed to connect",
+                        "updated_at": "2021-08-17T13:28:57.801578Z"
+                      }
+                    ],
+                    "related_incidents": [
+                      {
+                        "external_id": 123,
+                        "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                        "name": "Our database is sad",
+                        "reference": "INC-123",
+                        "status_category": "triage",
+                        "summary": "Our database is really really sad, and we don't know why yet.",
+                        "visibility": "public"
+                      }
+                    ],
+                    "status": "pending",
+                    "title": "Database CPU is high",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/EscalationsCreateResultV2"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "Create Escalations V2",
+        "tags": [
+          "Escalations V2"
+        ]
       }
     },
     "/v2/escalations/{id}": {
@@ -53401,6 +55099,27 @@
                       },
                       "completed_at": "2021-08-17T13:28:57.801578Z",
                       "created_at": "2021-08-17T13:28:57.801578Z",
+                      "creator": {
+                        "alert": {
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "title": "*errors.withMessage: PG::Error failed to connect"
+                        },
+                        "api_key": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My test API key"
+                        },
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "viewer",
+                          "slack_user_id": "U02AYNF2XJM"
+                        },
+                        "workflow": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My little workflow"
+                        }
+                      },
                       "description": "Call the fire brigade",
                       "external_issue_reference": {
                         "issue_name": "INC-123",
@@ -53409,6 +55128,10 @@
                       },
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "labels": [
+                        "bug",
+                        "urgent"
+                      ],
                       "priority": {
                         "description": "A follow-up that requires immediate attention.",
                         "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
@@ -53468,6 +55191,27 @@
                     },
                     "completed_at": "2021-08-17T13:28:57.801578Z",
                     "created_at": "2021-08-17T13:28:57.801578Z",
+                    "creator": {
+                      "alert": {
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "title": "*errors.withMessage: PG::Error failed to connect"
+                      },
+                      "api_key": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My test API key"
+                      },
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
+                      }
+                    },
                     "description": "Call the fire brigade",
                     "external_issue_reference": {
                       "issue_name": "INC-123",
@@ -53476,6 +55220,10 @@
                     },
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "labels": [
+                      "bug",
+                      "urgent"
+                    ],
                     "priority": {
                       "description": "A follow-up that requires immediate attention.",
                       "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
@@ -53995,6 +55743,10 @@
                           "name": "Lisa Karlin Curtis",
                           "role": "viewer",
                           "slack_user_id": "U02AYNF2XJM"
+                        },
+                        "workflow": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My little workflow"
                         }
                       }
                     }
@@ -54378,6 +56130,10 @@
                           "name": "Lisa Karlin Curtis",
                           "role": "viewer",
                           "slack_user_id": "U02AYNF2XJM"
+                        },
+                        "workflow": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My little workflow"
                         }
                       },
                       "custom_field_entries": [
@@ -54618,6 +56374,10 @@
                         "name": "Lisa Karlin Curtis",
                         "role": "viewer",
                         "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
                       }
                     },
                     "custom_field_entries": [
@@ -54809,6 +56569,10 @@
                         "name": "Lisa Karlin Curtis",
                         "role": "viewer",
                         "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
                       }
                     },
                     "custom_field_entries": [
@@ -55053,6 +56817,10 @@
                         "name": "Lisa Karlin Curtis",
                         "role": "viewer",
                         "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
                       }
                     },
                     "custom_field_entries": [
@@ -55215,7 +56983,7 @@
                   "incident.io/terraform/version": "3.0.0"
                 },
                 "resource_id": "abc123",
-                "resource_type": "alert_source"
+                "resource_type": "alert_route"
               },
               "schema": {
                 "$ref": "#/components/schemas/ManagedResourcesCreateManagedResourcePayloadV2"
@@ -55235,7 +57003,7 @@
                     },
                     "managed_by": "dashboard",
                     "resource_id": "abc123",
-                    "resource_type": "alert_source",
+                    "resource_type": "alert_route",
                     "source_url": "https://github.com/my-company/infrastructure"
                   }
                 },
@@ -55499,7 +57267,7 @@
                             "handovers": [
                               {
                                 "interval": 1,
-                                "interval_type": "daily"
+                                "interval_type": "hourly"
                               }
                             ],
                             "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -55510,6 +57278,7 @@
                               }
                             ],
                             "name": "Primary On-Call Schedule",
+                            "scheduling_mode": "fair",
                             "users": [
                               {
                                 "email": "lisa@incident.io",
@@ -55523,14 +57292,14 @@
                               {
                                 "end_time": "17:00",
                                 "start_time": "09:00",
-                                "weekday": "tuesday"
+                                "weekday": "monday"
                               }
                             ],
                             "working_intervals": [
                               {
                                 "end_time": "17:00",
                                 "start_time": "09:00",
-                                "weekday": "tuesday"
+                                "weekday": "monday"
                               }
                             ]
                           }
@@ -55602,7 +57371,7 @@
                         "handovers": [
                           {
                             "interval": 1,
-                            "interval_type": "daily"
+                            "interval_type": "hourly"
                           }
                         ],
                         "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -55613,6 +57382,7 @@
                           }
                         ],
                         "name": "My Rotation",
+                        "scheduling_mode": "fair",
                         "users": [
                           {
                             "email": "bob@example.com",
@@ -55624,7 +57394,7 @@
                           {
                             "end_time": "17:00",
                             "start_time": "09:00",
-                            "weekday": "tuesday"
+                            "weekday": "monday"
                           }
                         ]
                       }
@@ -55666,7 +57436,7 @@
                           "handovers": [
                             {
                               "interval": 1,
-                              "interval_type": "daily"
+                              "interval_type": "hourly"
                             }
                           ],
                           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -55677,6 +57447,7 @@
                             }
                           ],
                           "name": "Primary On-Call Schedule",
+                          "scheduling_mode": "fair",
                           "users": [
                             {
                               "email": "lisa@incident.io",
@@ -55690,14 +57461,14 @@
                             {
                               "end_time": "17:00",
                               "start_time": "09:00",
-                              "weekday": "tuesday"
+                              "weekday": "monday"
                             }
                           ],
                           "working_intervals": [
                             {
                               "end_time": "17:00",
                               "start_time": "09:00",
-                              "weekday": "tuesday"
+                              "weekday": "monday"
                             }
                           ]
                         }
@@ -55812,7 +57583,7 @@
                           "handovers": [
                             {
                               "interval": 1,
-                              "interval_type": "daily"
+                              "interval_type": "hourly"
                             }
                           ],
                           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -55823,6 +57594,7 @@
                             }
                           ],
                           "name": "Primary On-Call Schedule",
+                          "scheduling_mode": "fair",
                           "users": [
                             {
                               "email": "lisa@incident.io",
@@ -55836,14 +57608,14 @@
                             {
                               "end_time": "17:00",
                               "start_time": "09:00",
-                              "weekday": "tuesday"
+                              "weekday": "monday"
                             }
                           ],
                           "working_intervals": [
                             {
                               "end_time": "17:00",
                               "start_time": "09:00",
-                              "weekday": "tuesday"
+                              "weekday": "monday"
                             }
                           ]
                         }
@@ -55928,7 +57700,7 @@
                         "handovers": [
                           {
                             "interval": 1,
-                            "interval_type": "daily"
+                            "interval_type": "hourly"
                           }
                         ],
                         "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -55939,6 +57711,7 @@
                           }
                         ],
                         "name": "My Rotation",
+                        "scheduling_mode": "fair",
                         "users": [
                           {
                             "email": "bob@example.com",
@@ -55950,7 +57723,7 @@
                           {
                             "end_time": "17:00",
                             "start_time": "09:00",
-                            "weekday": "tuesday"
+                            "weekday": "monday"
                           }
                         ]
                       }
@@ -55992,7 +57765,7 @@
                           "handovers": [
                             {
                               "interval": 1,
-                              "interval_type": "daily"
+                              "interval_type": "hourly"
                             }
                           ],
                           "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -56003,6 +57776,7 @@
                             }
                           ],
                           "name": "Primary On-Call Schedule",
+                          "scheduling_mode": "fair",
                           "users": [
                             {
                               "email": "lisa@incident.io",
@@ -56016,14 +57790,14 @@
                             {
                               "end_time": "17:00",
                               "start_time": "09:00",
-                              "weekday": "tuesday"
+                              "weekday": "monday"
                             }
                           ],
                           "working_intervals": [
                             {
                               "end_time": "17:00",
                               "start_time": "09:00",
-                              "weekday": "tuesday"
+                              "weekday": "monday"
                             }
                           ]
                         }
@@ -57802,7 +59576,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -57825,7 +59599,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "api",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -57944,6 +59718,82 @@
         ]
       }
     },
+    "/v3/catalog_entries/actions/bulk_update": {
+      "post": {
+        "description": "Update multiple catalog entries in a single operation. You can update up to 100 entries at once. This operation is atomic - either all entries are updated successfully, or none are updated.",
+        "operationId": "Catalog V3#BulkUpdateEntries",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "catalog_type_id": "01GW2G3V0S59R238FAHPDS1R66",
+                "entries": [
+                  {
+                    "aliases": [
+                      "abc123"
+                    ],
+                    "attribute_values": {
+                      "abc123": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123"
+                        }
+                      }
+                    },
+                    "entry_id": "abc123",
+                    "external_id": "abc123",
+                    "name": "abc123",
+                    "rank": 1
+                  },
+                  {
+                    "aliases": [
+                      "abc123"
+                    ],
+                    "attribute_values": {
+                      "abc123": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123"
+                        }
+                      }
+                    },
+                    "entry_id": "abc123",
+                    "external_id": "abc123",
+                    "name": "abc123",
+                    "rank": 1
+                  }
+                ],
+                "update_attributes": [
+                  "01GW2G3V0S59R238FAHPDS1R66",
+                  "01GW2G3V0S59R238FAHPDS1R67"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CatalogBulkUpdateEntriesPayloadV3"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        },
+        "summary": "BulkUpdateEntries Catalog V3",
+        "tags": [
+          "Catalog V3"
+        ]
+      }
+    },
     "/v3/catalog_entries/{id}": {
       "delete": {
         "description": "Archives a catalog entry.",
@@ -58027,7 +59877,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -58050,7 +59900,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "api",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -58171,7 +60021,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -58194,7 +60044,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "api",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -58275,7 +60125,7 @@
                         "incident.io/catalog-importer/id": "id-of-config"
                       },
                       "categories": [
-                        "issue-tracker"
+                        "customer"
                       ],
                       "color": "yellow",
                       "created_at": "2021-08-17T13:28:57.801578Z",
@@ -58298,7 +60148,7 @@
                             "array": false,
                             "backlink_attribute": "abc123",
                             "id": "01GW2G3V0S59R238FAHPDS1R66",
-                            "mode": "api",
+                            "mode": "",
                             "name": "tier",
                             "path": [
                               {
@@ -58342,7 +60192,7 @@
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
                 "categories": [
-                  "issue-tracker"
+                  "customer"
                 ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -58370,7 +60220,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -58393,7 +60243,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "api",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -58481,7 +60331,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -58504,7 +60354,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "api",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -58561,7 +60411,7 @@
                   "incident.io/catalog-importer/id": "id-of-config"
                 },
                 "categories": [
-                  "issue-tracker"
+                  "customer"
                 ],
                 "color": "yellow",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
@@ -58588,7 +60438,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -58611,7 +60461,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "api",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -58671,7 +60521,7 @@
                     "array": false,
                     "backlink_attribute": "abc123",
                     "id": "01GW2G3V0S59R238FAHPDS1R66",
-                    "mode": "api",
+                    "mode": "",
                     "name": "tier",
                     "path": [
                       {
@@ -58700,7 +60550,7 @@
                       "incident.io/catalog-importer/id": "id-of-config"
                     },
                     "categories": [
-                      "issue-tracker"
+                      "customer"
                     ],
                     "color": "yellow",
                     "created_at": "2021-08-17T13:28:57.801578Z",
@@ -58723,7 +60573,7 @@
                           "array": false,
                           "backlink_attribute": "abc123",
                           "id": "01GW2G3V0S59R238FAHPDS1R66",
-                          "mode": "api",
+                          "mode": "",
                           "name": "tier",
                           "path": [
                             {
@@ -58812,7 +60662,7 @@
       "name": "Custom Fields V2"
     },
     {
-      "description": "Create and manage escalation paths, and list and filter escalations.\n\nWith incident.io On-call you can create escalation paths that describe how a page should\nbe escalated to people and schedules.\n",
+      "description": "Create and manage escalation paths, and create, list and filter escalations.\n\nWith incident.io On-call you can create escalation paths that describe how a page should\nbe escalated to people and schedules.\n",
       "name": "Escalations V2"
     },
     {
@@ -59446,6 +61296,72 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsAPIKeyDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/catalog_entry_attribute.updated.1": {
+      "get": {
+        "description": "This entry is created whenever a restricted catalog entry attribute is updated",
+        "operationId": "CatalogEntryAttributeUpdatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "catalog_entry_attribute.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "after_values": [
+                      "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "01FCNDV6P870EA6S7TK1DSYDG2"
+                    ],
+                    "before_values": [
+                      "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "01FCNDV6P870EA6S7TK1DSYDG1"
+                    ]
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Service",
+                      "type": "catalog_type"
+                    },
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Engineering Team",
+                      "type": "catalog_entry"
+                    },
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Members",
+                      "type": "catalog_attribute"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsCatalogEntryAttributeUpdatedV1"
                 }
               }
             },
@@ -63631,6 +65547,144 @@
         ]
       }
     },
+    "/x-audit-logs/team_role.created.1": {
+      "get": {
+        "description": "This entry is created whenever a team role is created",
+        "operationId": "TeamRoleCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "team_role.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Tech lead",
+                      "type": "team_role"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTeamRoleCreatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/team_role.deleted.1": {
+      "get": {
+        "description": "This entry is created whenever a team role is deleted",
+        "operationId": "TeamRoleDeletedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "team_role.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Tech lead",
+                      "type": "team_role"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTeamRoleDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/team_role.updated.1": {
+      "get": {
+        "description": "This entry is created whenever a team role is updated",
+        "operationId": "TeamRoleUpdatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "team_role.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Tech lead",
+                      "type": "team_role"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTeamRoleUpdatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
     "/x-audit-logs/team_settings.updated.1": {
       "get": {
         "description": "This entry is created whenever team settings are updated",
@@ -64132,6 +66186,33 @@
         ]
       }
     },
+    "/x-webhooks/private_incident.follow_up_created_v2": {
+      "get": {
+        "description": "This webhook is emitted whenever a follow-up for a private incident is created.",
+        "operationId": "PrivateIncidentFollowUpCreatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "private_incident.follow_up_created_v2",
+                  "private_incident.follow_up_created_v2": {
+                    "id": "abc123"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentFollowUpCreatedV2ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
     "/x-webhooks/private_incident.follow_up_updated_v1": {
       "get": {
         "description": "This webhook is emitted whenever a follow-up for a private incident is updated.",
@@ -64148,6 +66229,33 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/WebhooksPrivateIncidentFollowUpUpdatedV1ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
+    "/x-webhooks/private_incident.follow_up_updated_v2": {
+      "get": {
+        "description": "This webhook is emitted whenever a follow-up for a private incident is updated.",
+        "operationId": "PrivateIncidentFollowUpUpdatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "private_incident.follow_up_updated_v2",
+                  "private_incident.follow_up_updated_v2": {
+                    "id": "abc123"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPrivateIncidentFollowUpUpdatedV2ResponseBody"
                 }
               }
             },
@@ -64409,6 +66517,83 @@
         ]
       }
     },
+    "/x-webhooks/public_incident.follow_up_created_v2": {
+      "get": {
+        "description": "This webhook is emitted whenever a follow-up is created.",
+        "operationId": "PublicIncidentFollowUpCreatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "public_incident.follow_up_created_v2",
+                  "public_incident.follow_up_created_v2": {
+                    "assignee": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    },
+                    "completed_at": "2021-08-17T13:28:57.801578Z",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "creator": {
+                      "alert": {
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "title": "*errors.withMessage: PG::Error failed to connect"
+                      },
+                      "api_key": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My test API key"
+                      },
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
+                      }
+                    },
+                    "description": "Call the fire brigade",
+                    "external_issue_reference": {
+                      "issue_name": "INC-123",
+                      "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                      "provider": "asana"
+                    },
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "labels": [
+                      "bug",
+                      "urgent"
+                    ],
+                    "priority": {
+                      "description": "A follow-up that requires immediate attention.",
+                      "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+                      "name": "Urgent",
+                      "rank": 10
+                    },
+                    "status": "outstanding",
+                    "title": "Cat is stuck in the tree",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPublicIncidentFollowUpCreatedV2ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
     "/x-webhooks/public_incident.follow_up_updated_v1": {
       "get": {
         "description": "This webhook is emitted whenever a follow-up is updated.",
@@ -64455,6 +66640,83 @@
         ]
       }
     },
+    "/x-webhooks/public_incident.follow_up_updated_v2": {
+      "get": {
+        "description": "This webhook is emitted whenever a follow-up is updated.",
+        "operationId": "PublicIncidentFollowUpUpdatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "public_incident.follow_up_updated_v2",
+                  "public_incident.follow_up_updated_v2": {
+                    "assignee": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "viewer",
+                      "slack_user_id": "U02AYNF2XJM"
+                    },
+                    "completed_at": "2021-08-17T13:28:57.801578Z",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "creator": {
+                      "alert": {
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "title": "*errors.withMessage: PG::Error failed to connect"
+                      },
+                      "api_key": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My test API key"
+                      },
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
+                      }
+                    },
+                    "description": "Call the fire brigade",
+                    "external_issue_reference": {
+                      "issue_name": "INC-123",
+                      "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                      "provider": "asana"
+                    },
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "labels": [
+                      "bug",
+                      "urgent"
+                    ],
+                    "priority": {
+                      "description": "A follow-up that requires immediate attention.",
+                      "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+                      "name": "Urgent",
+                      "rank": 10
+                    },
+                    "status": "outstanding",
+                    "title": "Cat is stuck in the tree",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPublicIncidentFollowUpUpdatedV2ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
     "/x-webhooks/public_incident.incident_created_v2": {
       "get": {
         "description": "This webhook is emitted whenever a new incident is created.",
@@ -64483,6 +66745,10 @@
                         "name": "Lisa Karlin Curtis",
                         "role": "viewer",
                         "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
                       }
                     },
                     "custom_field_entries": [
@@ -64665,6 +66931,10 @@
                           "name": "Lisa Karlin Curtis",
                           "role": "viewer",
                           "slack_user_id": "U02AYNF2XJM"
+                        },
+                        "workflow": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My little workflow"
                         }
                       },
                       "custom_field_entries": [
@@ -64862,6 +67132,10 @@
                         "name": "Lisa Karlin Curtis",
                         "role": "viewer",
                         "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
                       }
                     },
                     "custom_field_entries": [

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -98,6 +98,7 @@ const (
 	AlertSourceV2SourceTypeHttpCustom        AlertSourceV2SourceType = "http_custom"
 	AlertSourceV2SourceTypeIncomingCalls     AlertSourceV2SourceType = "incoming_calls"
 	AlertSourceV2SourceTypeJira              AlertSourceV2SourceType = "jira"
+	AlertSourceV2SourceTypeJsm               AlertSourceV2SourceType = "jsm"
 	AlertSourceV2SourceTypeMonteCarlo        AlertSourceV2SourceType = "monte_carlo"
 	AlertSourceV2SourceTypeNagios            AlertSourceV2SourceType = "nagios"
 	AlertSourceV2SourceTypeNewRelic          AlertSourceV2SourceType = "new_relic"
@@ -144,6 +145,7 @@ const (
 	AlertSourcesCreatePayloadV2SourceTypeHttpCustom        AlertSourcesCreatePayloadV2SourceType = "http_custom"
 	AlertSourcesCreatePayloadV2SourceTypeIncomingCalls     AlertSourcesCreatePayloadV2SourceType = "incoming_calls"
 	AlertSourcesCreatePayloadV2SourceTypeJira              AlertSourcesCreatePayloadV2SourceType = "jira"
+	AlertSourcesCreatePayloadV2SourceTypeJsm               AlertSourcesCreatePayloadV2SourceType = "jsm"
 	AlertSourcesCreatePayloadV2SourceTypeMonteCarlo        AlertSourcesCreatePayloadV2SourceType = "monte_carlo"
 	AlertSourcesCreatePayloadV2SourceTypeNagios            AlertSourcesCreatePayloadV2SourceType = "nagios"
 	AlertSourcesCreatePayloadV2SourceTypeNewRelic          AlertSourcesCreatePayloadV2SourceType = "new_relic"
@@ -713,9 +715,10 @@ const (
 
 // Defines values for EscalationPathTargetV2Type.
 const (
-	EscalationPathTargetV2TypeSchedule     EscalationPathTargetV2Type = "schedule"
-	EscalationPathTargetV2TypeSlackChannel EscalationPathTargetV2Type = "slack_channel"
-	EscalationPathTargetV2TypeUser         EscalationPathTargetV2Type = "user"
+	EscalationPathTargetV2TypeMsteamsChannel EscalationPathTargetV2Type = "msteams_channel"
+	EscalationPathTargetV2TypeSchedule       EscalationPathTargetV2Type = "schedule"
+	EscalationPathTargetV2TypeSlackChannel   EscalationPathTargetV2Type = "slack_channel"
+	EscalationPathTargetV2TypeUser           EscalationPathTargetV2Type = "user"
 )
 
 // Defines values for EscalationPathTargetV2Urgency.
@@ -774,6 +777,7 @@ const (
 	ExternalIssueReferenceV1ProviderJira        ExternalIssueReferenceV1Provider = "jira"
 	ExternalIssueReferenceV1ProviderJiraServer  ExternalIssueReferenceV1Provider = "jira_server"
 	ExternalIssueReferenceV1ProviderLinear      ExternalIssueReferenceV1Provider = "linear"
+	ExternalIssueReferenceV1ProviderServiceNow  ExternalIssueReferenceV1Provider = "service_now"
 	ExternalIssueReferenceV1ProviderShortcut    ExternalIssueReferenceV1Provider = "shortcut"
 )
 
@@ -787,6 +791,7 @@ const (
 	ExternalIssueReferenceV2ProviderJira        ExternalIssueReferenceV2Provider = "jira"
 	ExternalIssueReferenceV2ProviderJiraServer  ExternalIssueReferenceV2Provider = "jira_server"
 	ExternalIssueReferenceV2ProviderLinear      ExternalIssueReferenceV2Provider = "linear"
+	ExternalIssueReferenceV2ProviderServiceNow  ExternalIssueReferenceV2Provider = "service_now"
 	ExternalIssueReferenceV2ProviderShortcut    ExternalIssueReferenceV2Provider = "shortcut"
 )
 
@@ -798,6 +803,7 @@ const (
 	ExternalResourceV1ResourceTypeGitlabMergeRequest          ExternalResourceV1ResourceType = "gitlab_merge_request"
 	ExternalResourceV1ResourceTypeGoogleCalendarEvent         ExternalResourceV1ResourceType = "google_calendar_event"
 	ExternalResourceV1ResourceTypeJiraIssue                   ExternalResourceV1ResourceType = "jira_issue"
+	ExternalResourceV1ResourceTypeJsmAlert                    ExternalResourceV1ResourceType = "jsm_alert"
 	ExternalResourceV1ResourceTypeOpsgenieAlert               ExternalResourceV1ResourceType = "opsgenie_alert"
 	ExternalResourceV1ResourceTypeOutlookCalendarEvent        ExternalResourceV1ResourceType = "outlook_calendar_event"
 	ExternalResourceV1ResourceTypePagerDutyIncident           ExternalResourceV1ResourceType = "pager_duty_incident"
@@ -820,10 +826,12 @@ const (
 const (
 	IdentityV1RolesCatalogEditor             IdentityV1Roles = "catalog_editor"
 	IdentityV1RolesCatalogViewer             IdentityV1Roles = "catalog_viewer"
+	IdentityV1RolesEscalationCreator         IdentityV1Roles = "escalation_creator"
 	IdentityV1RolesGlobalAccess              IdentityV1Roles = "global_access"
 	IdentityV1RolesIncidentCreator           IdentityV1Roles = "incident_creator"
 	IdentityV1RolesIncidentEditor            IdentityV1Roles = "incident_editor"
 	IdentityV1RolesIncidentMembershipsEditor IdentityV1Roles = "incident_memberships_editor"
+	IdentityV1RolesInvestigationDownload     IdentityV1Roles = "investigation_download"
 	IdentityV1RolesManageSettings            IdentityV1Roles = "manage_settings"
 	IdentityV1RolesOnCallEditor              IdentityV1Roles = "on_call_editor"
 	IdentityV1RolesPostIncidentFlowOptOut    IdentityV1Roles = "post_incident_flow_opt_out"
@@ -832,6 +840,7 @@ const (
 	IdentityV1RolesSchedulesEditor           IdentityV1Roles = "schedules_editor"
 	IdentityV1RolesSchedulesReader           IdentityV1Roles = "schedules_reader"
 	IdentityV1RolesSecuritySettingsEditor    IdentityV1Roles = "security_settings_editor"
+	IdentityV1RolesTeamMembershipsManage     IdentityV1Roles = "team_memberships_manage"
 	IdentityV1RolesViewer                    IdentityV1Roles = "viewer"
 	IdentityV1RolesWorkflowsEditor           IdentityV1Roles = "workflows_editor"
 )
@@ -844,6 +853,7 @@ const (
 	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeGitlabMergeRequest          IncidentAttachmentsCreatePayloadV1ResourceResourceType = "gitlab_merge_request"
 	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeGoogleCalendarEvent         IncidentAttachmentsCreatePayloadV1ResourceResourceType = "google_calendar_event"
 	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeJiraIssue                   IncidentAttachmentsCreatePayloadV1ResourceResourceType = "jira_issue"
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeJsmAlert                    IncidentAttachmentsCreatePayloadV1ResourceResourceType = "jsm_alert"
 	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeOpsgenieAlert               IncidentAttachmentsCreatePayloadV1ResourceResourceType = "opsgenie_alert"
 	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeOutlookCalendarEvent        IncidentAttachmentsCreatePayloadV1ResourceResourceType = "outlook_calendar_event"
 	IncidentAttachmentsCreatePayloadV1ResourceResourceTypePagerDutyIncident           IncidentAttachmentsCreatePayloadV1ResourceResourceType = "pager_duty_incident"
@@ -1034,11 +1044,29 @@ const (
 	ManagementMetaV2ManagedByTerraform ManagementMetaV2ManagedBy = "terraform"
 )
 
+// Defines values for ScheduleRotationCreatePayloadV2SchedulingMode.
+const (
+	ScheduleRotationCreatePayloadV2SchedulingModeFair       ScheduleRotationCreatePayloadV2SchedulingMode = "fair"
+	ScheduleRotationCreatePayloadV2SchedulingModeSequential ScheduleRotationCreatePayloadV2SchedulingMode = "sequential"
+)
+
 // Defines values for ScheduleRotationHandoverV2IntervalType.
 const (
 	Daily  ScheduleRotationHandoverV2IntervalType = "daily"
 	Hourly ScheduleRotationHandoverV2IntervalType = "hourly"
 	Weekly ScheduleRotationHandoverV2IntervalType = "weekly"
+)
+
+// Defines values for ScheduleRotationUpdatePayloadV2SchedulingMode.
+const (
+	ScheduleRotationUpdatePayloadV2SchedulingModeFair       ScheduleRotationUpdatePayloadV2SchedulingMode = "fair"
+	ScheduleRotationUpdatePayloadV2SchedulingModeSequential ScheduleRotationUpdatePayloadV2SchedulingMode = "sequential"
+)
+
+// Defines values for ScheduleRotationV2SchedulingMode.
+const (
+	Fair       ScheduleRotationV2SchedulingMode = "fair"
+	Sequential ScheduleRotationV2SchedulingMode = "sequential"
 )
 
 // Defines values for ScheduleRotationWorkingIntervalCreatePayloadV2Weekday.
@@ -1200,6 +1228,7 @@ const (
 	GitlabMergeRequest          IncidentAttachmentsV1ListParamsResourceType = "gitlab_merge_request"
 	GoogleCalendarEvent         IncidentAttachmentsV1ListParamsResourceType = "google_calendar_event"
 	JiraIssue                   IncidentAttachmentsV1ListParamsResourceType = "jira_issue"
+	JsmAlert                    IncidentAttachmentsV1ListParamsResourceType = "jsm_alert"
 	OpsgenieAlert               IncidentAttachmentsV1ListParamsResourceType = "opsgenie_alert"
 	OutlookCalendarEvent        IncidentAttachmentsV1ListParamsResourceType = "outlook_calendar_event"
 	PagerDutyIncident           IncidentAttachmentsV1ListParamsResourceType = "pager_duty_incident"
@@ -1288,6 +1317,7 @@ type ActionV2 struct {
 
 	// CreatedAt When the action was created
 	CreatedAt time.Time `json:"created_at"`
+	Creator   ActorV2   `json:"creator"`
 
 	// Description Description of the action
 	Description string `json:"description"`
@@ -1336,9 +1366,10 @@ type ActorV1 struct {
 
 // ActorV2 defines model for ActorV2.
 type ActorV2 struct {
-	Alert  *AlertActorV2 `json:"alert,omitempty"`
-	ApiKey *APIKeyV2     `json:"api_key,omitempty"`
-	User   *UserV2       `json:"user,omitempty"`
+	Alert    *AlertActorV2    `json:"alert,omitempty"`
+	ApiKey   *APIKeyV2        `json:"api_key,omitempty"`
+	User     *UserV2          `json:"user,omitempty"`
+	Workflow *WorkflowActorV2 `json:"workflow,omitempty"`
 }
 
 // AfterPaginationMetaResultV2 defines model for AfterPaginationMetaResultV2.
@@ -2082,6 +2113,18 @@ type AlertsListResultV2 struct {
 // AlertsShowResultV2 defines model for AlertsShowResultV2.
 type AlertsShowResultV2 struct {
 	Alert AlertV2 `json:"alert"`
+}
+
+// CatalogBulkUpdateEntriesPayloadV3 defines model for CatalogBulkUpdateEntriesPayloadV3.
+type CatalogBulkUpdateEntriesPayloadV3 struct {
+	// CatalogTypeId The unique identifier of the catalog type containing the entries
+	CatalogTypeId string `json:"catalog_type_id"`
+
+	// Entries A list of entries to update with their new values. Maximum 100 entries per request.
+	Entries []PartialEntryPayloadV3 `json:"entries"`
+
+	// UpdateAttributes Optional list of specific attribute IDs to update across all entries. When provided, only these attributes will be updated and all other attributes will be preserved. When omitted, all attributes in each entry's attribute_values will be updated.
+	UpdateAttributes *[]string `json:"update_attributes,omitempty"`
 }
 
 // CatalogCreateEntryPayloadV2 defines model for CatalogCreateEntryPayloadV2.
@@ -3866,6 +3909,29 @@ type EscalationsCreatePathResultV2 struct {
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
 }
 
+// EscalationsCreatePayloadV2 defines model for EscalationsCreatePayloadV2.
+type EscalationsCreatePayloadV2 struct {
+	// Description Additional details about the escalation
+	Description *string `json:"description,omitempty"`
+
+	// EscalationPathId ID of the escalation path to follow
+	EscalationPathId *string `json:"escalation_path_id,omitempty"`
+
+	// IdempotencyKey Unique key to prevent duplicate escalations. If this key has already been used, the existing escalation will be returned.
+	IdempotencyKey string `json:"idempotency_key"`
+
+	// Title The title of the escalation. This message will be included in all notifications about this escalation.
+	Title string `json:"title"`
+
+	// UserIds IDs of users to escalate directly to
+	UserIds *[]string `json:"user_ids,omitempty"`
+}
+
+// EscalationsCreateResultV2 defines model for EscalationsCreateResultV2.
+type EscalationsCreateResultV2 struct {
+	Escalation EscalationV2 `json:"escalation"`
+}
+
 // EscalationsListResultV2 defines model for EscalationsListResultV2.
 type EscalationsListResultV2 struct {
 	Escalations    []EscalationV2         `json:"escalations"`
@@ -4122,6 +4188,7 @@ type FollowUpV2 struct {
 
 	// CreatedAt When the follow-up was created
 	CreatedAt time.Time `json:"created_at"`
+	Creator   ActorV2   `json:"creator"`
 
 	// Description Description of the follow-up
 	Description            *string                   `json:"description,omitempty"`
@@ -4131,8 +4198,11 @@ type FollowUpV2 struct {
 	Id string `json:"id"`
 
 	// IncidentId Unique identifier of the incident the follow-up belongs to
-	IncidentId string              `json:"incident_id"`
-	Priority   *FollowUpPriorityV2 `json:"priority,omitempty"`
+	IncidentId string `json:"incident_id"`
+
+	// Labels Labels associated with this follow-up
+	Labels   []string            `json:"labels"`
+	Priority *FollowUpPriorityV2 `json:"priority,omitempty"`
 
 	// Status Status of the follow-up
 	Status FollowUpV2Status `json:"status"`
@@ -5251,6 +5321,27 @@ type PaginationMetaResultWithTotalV2 struct {
 	TotalRecordCount *int64 `json:"total_record_count,omitempty"`
 }
 
+// PartialEntryPayloadV3 Represents a partial entry update, allowing selective field updates
+type PartialEntryPayloadV3 struct {
+	// Aliases If specified, will update the aliases of the entry. When omitted, preserves the existing aliases.
+	Aliases *[]string `json:"aliases,omitempty"`
+
+	// AttributeValues The attribute values to apply to this entry
+	AttributeValues map[string]CatalogEngineParamBindingPayloadV3 `json:"attribute_values"`
+
+	// EntryId ID of the relevant catalog entry
+	EntryId string `json:"entry_id"`
+
+	// ExternalId If specified, will update the external ID of the entry. When omitted, preserves the existing external ID.
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Name If specified, will update the name of the entry. When omitted, preserves the existing name.
+	Name *string `json:"name,omitempty"`
+
+	// Rank If specified, will update the rank of the entry. When omitted, rank will be set to null (allowing rank removal).
+	Rank *int32 `json:"rank,omitempty"`
+}
+
 // RBACRoleV2 defines model for RBACRoleV2.
 type RBACRoleV2 struct {
 	// Description Description of the purpose for the RBAC role
@@ -5421,10 +5512,16 @@ type ScheduleRotationCreatePayloadV2 struct {
 	Layers *[]ScheduleLayerCreatePayloadV2 `json:"layers,omitempty"`
 
 	// Name Name of the rotation
-	Name            string                                            `json:"name"`
+	Name string `json:"name"`
+
+	// SchedulingMode Scheduling algorithm to use for this rotation. 'fair' balances workload by considering handover duration, while 'sequential' uses simple round-robin rotation through users. Only applies when you have asymmetric handovers (e.g., 2 days then 5 days).
+	SchedulingMode  *ScheduleRotationCreatePayloadV2SchedulingMode    `json:"scheduling_mode,omitempty"`
 	Users           *[]UserReferencePayloadV2                         `json:"users,omitempty"`
 	WorkingInterval *[]ScheduleRotationWorkingIntervalCreatePayloadV2 `json:"working_interval,omitempty"`
 }
+
+// ScheduleRotationCreatePayloadV2SchedulingMode Scheduling algorithm to use for this rotation. 'fair' balances workload by considering handover duration, while 'sequential' uses simple round-robin rotation through users. Only applies when you have asymmetric handovers (e.g., 2 days then 5 days).
+type ScheduleRotationCreatePayloadV2SchedulingMode string
 
 // ScheduleRotationHandoverV2 defines model for ScheduleRotationHandoverV2.
 type ScheduleRotationHandoverV2 struct {
@@ -5448,10 +5545,16 @@ type ScheduleRotationUpdatePayloadV2 struct {
 	Layers *[]ScheduleLayerUpdatePayloadV2 `json:"layers,omitempty"`
 
 	// Name Name of the rotation
-	Name            *string                              `json:"name,omitempty"`
-	Users           *[]UserReferencePayloadV2            `json:"users,omitempty"`
-	WorkingInterval *[]ScheduleRotationWorkingIntervalV2 `json:"working_interval,omitempty"`
+	Name *string `json:"name,omitempty"`
+
+	// SchedulingMode Scheduling algorithm to use for this rotation. 'fair' balances workload by considering handover duration, while 'sequential' uses simple round-robin rotation through users. Only applies when you have asymmetric handovers (e.g., 2 days then 5 days).
+	SchedulingMode  *ScheduleRotationUpdatePayloadV2SchedulingMode `json:"scheduling_mode,omitempty"`
+	Users           *[]UserReferencePayloadV2                      `json:"users,omitempty"`
+	WorkingInterval *[]ScheduleRotationWorkingIntervalV2           `json:"working_interval,omitempty"`
 }
+
+// ScheduleRotationUpdatePayloadV2SchedulingMode Scheduling algorithm to use for this rotation. 'fair' balances workload by considering handover duration, while 'sequential' uses simple round-robin rotation through users. Only applies when you have asymmetric handovers (e.g., 2 days then 5 days).
+type ScheduleRotationUpdatePayloadV2SchedulingMode string
 
 // ScheduleRotationV2 defines model for ScheduleRotationV2.
 type ScheduleRotationV2 struct {
@@ -5473,6 +5576,9 @@ type ScheduleRotationV2 struct {
 	// Name Human readable name synced from external provider
 	Name string `json:"name"`
 
+	// SchedulingMode Scheduling algorithm to use for this rotation. 'fair' balances workload by considering handover duration, while 'sequential' uses simple round-robin rotation through users. Only applies when you have asymmetric handovers (e.g., 2 days then 5 days).
+	SchedulingMode *ScheduleRotationV2SchedulingMode `json:"scheduling_mode,omitempty"`
+
 	// Users Users who are available to be scheduled on this rota
 	Users []UserV2 `json:"users"`
 
@@ -5482,6 +5588,9 @@ type ScheduleRotationV2 struct {
 	// WorkingIntervals Optional restrictions that define when to schedule people for this rota
 	WorkingIntervals []ScheduleRotationWorkingIntervalV2 `json:"working_intervals"`
 }
+
+// ScheduleRotationV2SchedulingMode Scheduling algorithm to use for this rotation. 'fair' balances workload by considering handover duration, while 'sequential' uses simple round-robin rotation through users. Only applies when you have asymmetric handovers (e.g., 2 days then 5 days).
+type ScheduleRotationV2SchedulingMode string
 
 // ScheduleRotationWorkingIntervalCreatePayloadV2 defines model for ScheduleRotationWorkingIntervalCreatePayloadV2.
 type ScheduleRotationWorkingIntervalCreatePayloadV2 struct {
@@ -6541,6 +6650,9 @@ type EscalationsV2CreatePathJSONRequestBody = EscalationsCreatePathPayloadV2
 // EscalationsV2UpdatePathJSONRequestBody defines body for EscalationsV2UpdatePath for application/json ContentType.
 type EscalationsV2UpdatePathJSONRequestBody = EscalationsUpdatePathPayloadV2
 
+// EscalationsV2CreateJSONRequestBody defines body for EscalationsV2Create for application/json ContentType.
+type EscalationsV2CreateJSONRequestBody = EscalationsCreatePayloadV2
+
 // IncidentRolesV2CreateJSONRequestBody defines body for IncidentRolesV2Create for application/json ContentType.
 type IncidentRolesV2CreateJSONRequestBody = IncidentRolesCreatePayloadV2
 
@@ -6573,6 +6685,9 @@ type WorkflowsV2UpdateWorkflowJSONRequestBody = WorkflowsUpdateWorkflowPayloadV2
 
 // CatalogV3CreateEntryJSONRequestBody defines body for CatalogV3CreateEntry for application/json ContentType.
 type CatalogV3CreateEntryJSONRequestBody = CatalogCreateEntryPayloadV3
+
+// CatalogV3BulkUpdateEntriesJSONRequestBody defines body for CatalogV3BulkUpdateEntries for application/json ContentType.
+type CatalogV3BulkUpdateEntriesJSONRequestBody = CatalogBulkUpdateEntriesPayloadV3
 
 // CatalogV3UpdateEntryJSONRequestBody defines body for CatalogV3UpdateEntry for application/json ContentType.
 type CatalogV3UpdateEntryJSONRequestBody = CatalogUpdateEntryPayloadV3
@@ -6979,6 +7094,11 @@ type ClientInterface interface {
 	// EscalationsV2List request
 	EscalationsV2List(ctx context.Context, params *EscalationsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EscalationsV2CreateWithBody request with any body
+	EscalationsV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EscalationsV2Create(ctx context.Context, body EscalationsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EscalationsV2Show request
 	EscalationsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -7099,6 +7219,11 @@ type ClientInterface interface {
 	CatalogV3CreateEntryWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CatalogV3CreateEntry(ctx context.Context, body CatalogV3CreateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CatalogV3BulkUpdateEntriesWithBody request with any body
+	CatalogV3BulkUpdateEntriesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CatalogV3BulkUpdateEntries(ctx context.Context, body CatalogV3BulkUpdateEntriesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CatalogV3DestroyEntry request
 	CatalogV3DestroyEntry(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8543,6 +8668,30 @@ func (c *Client) EscalationsV2List(ctx context.Context, params *EscalationsV2Lis
 	return c.Client.Do(req)
 }
 
+func (c *Client) EscalationsV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2CreateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EscalationsV2Create(ctx context.Context, body EscalationsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2CreateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) EscalationsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEscalationsV2ShowRequest(c.Server, id)
 	if err != nil {
@@ -9061,6 +9210,30 @@ func (c *Client) CatalogV3CreateEntryWithBody(ctx context.Context, contentType s
 
 func (c *Client) CatalogV3CreateEntry(ctx context.Context, body CatalogV3CreateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCatalogV3CreateEntryRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3BulkUpdateEntriesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3BulkUpdateEntriesRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CatalogV3BulkUpdateEntries(ctx context.Context, body CatalogV3BulkUpdateEntriesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCatalogV3BulkUpdateEntriesRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -12892,6 +13065,46 @@ func NewEscalationsV2ListRequest(server string, params *EscalationsV2ListParams)
 	return req, nil
 }
 
+// NewEscalationsV2CreateRequest calls the generic EscalationsV2Create builder with application/json body
+func NewEscalationsV2CreateRequest(server string, body EscalationsV2CreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEscalationsV2CreateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewEscalationsV2CreateRequestWithBody generates requests for EscalationsV2Create with any type of body
+func NewEscalationsV2CreateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/escalations")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewEscalationsV2ShowRequest generates requests for EscalationsV2Show
 func NewEscalationsV2ShowRequest(server string, id string) (*http.Request, error) {
 	var err error
@@ -14613,6 +14826,46 @@ func NewCatalogV3CreateEntryRequestWithBody(server string, contentType string, b
 	return req, nil
 }
 
+// NewCatalogV3BulkUpdateEntriesRequest calls the generic CatalogV3BulkUpdateEntries builder with application/json body
+func NewCatalogV3BulkUpdateEntriesRequest(server string, body CatalogV3BulkUpdateEntriesJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCatalogV3BulkUpdateEntriesRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCatalogV3BulkUpdateEntriesRequestWithBody generates requests for CatalogV3BulkUpdateEntries with any type of body
+func NewCatalogV3BulkUpdateEntriesRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v3/catalog_entries/actions/bulk_update")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewCatalogV3DestroyEntryRequest generates requests for CatalogV3DestroyEntry
 func NewCatalogV3DestroyEntryRequest(server string, id string) (*http.Request, error) {
 	var err error
@@ -15347,6 +15600,11 @@ type ClientWithResponsesInterface interface {
 	// EscalationsV2ListWithResponse request
 	EscalationsV2ListWithResponse(ctx context.Context, params *EscalationsV2ListParams, reqEditors ...RequestEditorFn) (*EscalationsV2ListResponse, error)
 
+	// EscalationsV2CreateWithBodyWithResponse request with any body
+	EscalationsV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EscalationsV2CreateResponse, error)
+
+	EscalationsV2CreateWithResponse(ctx context.Context, body EscalationsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*EscalationsV2CreateResponse, error)
+
 	// EscalationsV2ShowWithResponse request
 	EscalationsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EscalationsV2ShowResponse, error)
 
@@ -15467,6 +15725,11 @@ type ClientWithResponsesInterface interface {
 	CatalogV3CreateEntryWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3CreateEntryResponse, error)
 
 	CatalogV3CreateEntryWithResponse(ctx context.Context, body CatalogV3CreateEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3CreateEntryResponse, error)
+
+	// CatalogV3BulkUpdateEntriesWithBodyWithResponse request with any body
+	CatalogV3BulkUpdateEntriesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3BulkUpdateEntriesResponse, error)
+
+	CatalogV3BulkUpdateEntriesWithResponse(ctx context.Context, body CatalogV3BulkUpdateEntriesJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3BulkUpdateEntriesResponse, error)
 
 	// CatalogV3DestroyEntryWithResponse request
 	CatalogV3DestroyEntryWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*CatalogV3DestroyEntryResponse, error)
@@ -17385,6 +17648,28 @@ func (r EscalationsV2ListResponse) StatusCode() int {
 	return 0
 }
 
+type EscalationsV2CreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *EscalationsCreateResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r EscalationsV2CreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EscalationsV2CreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type EscalationsV2ShowResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -18102,6 +18387,27 @@ func (r CatalogV3CreateEntryResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r CatalogV3CreateEntryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CatalogV3BulkUpdateEntriesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r CatalogV3BulkUpdateEntriesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CatalogV3BulkUpdateEntriesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -19348,6 +19654,23 @@ func (c *ClientWithResponses) EscalationsV2ListWithResponse(ctx context.Context,
 	return ParseEscalationsV2ListResponse(rsp)
 }
 
+// EscalationsV2CreateWithBodyWithResponse request with arbitrary body returning *EscalationsV2CreateResponse
+func (c *ClientWithResponses) EscalationsV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EscalationsV2CreateResponse, error) {
+	rsp, err := c.EscalationsV2CreateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2CreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) EscalationsV2CreateWithResponse(ctx context.Context, body EscalationsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*EscalationsV2CreateResponse, error) {
+	rsp, err := c.EscalationsV2Create(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2CreateResponse(rsp)
+}
+
 // EscalationsV2ShowWithResponse request returning *EscalationsV2ShowResponse
 func (c *ClientWithResponses) EscalationsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EscalationsV2ShowResponse, error) {
 	rsp, err := c.EscalationsV2Show(ctx, id, reqEditors...)
@@ -19731,6 +20054,23 @@ func (c *ClientWithResponses) CatalogV3CreateEntryWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseCatalogV3CreateEntryResponse(rsp)
+}
+
+// CatalogV3BulkUpdateEntriesWithBodyWithResponse request with arbitrary body returning *CatalogV3BulkUpdateEntriesResponse
+func (c *ClientWithResponses) CatalogV3BulkUpdateEntriesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CatalogV3BulkUpdateEntriesResponse, error) {
+	rsp, err := c.CatalogV3BulkUpdateEntriesWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3BulkUpdateEntriesResponse(rsp)
+}
+
+func (c *ClientWithResponses) CatalogV3BulkUpdateEntriesWithResponse(ctx context.Context, body CatalogV3BulkUpdateEntriesJSONRequestBody, reqEditors ...RequestEditorFn) (*CatalogV3BulkUpdateEntriesResponse, error) {
+	rsp, err := c.CatalogV3BulkUpdateEntries(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCatalogV3BulkUpdateEntriesResponse(rsp)
 }
 
 // CatalogV3DestroyEntryWithResponse request returning *CatalogV3DestroyEntryResponse
@@ -21951,6 +22291,32 @@ func ParseEscalationsV2ListResponse(rsp *http.Response) (*EscalationsV2ListRespo
 	return response, nil
 }
 
+// ParseEscalationsV2CreateResponse parses an HTTP response from a EscalationsV2CreateWithResponse call
+func ParseEscalationsV2CreateResponse(rsp *http.Response) (*EscalationsV2CreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EscalationsV2CreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest EscalationsCreateResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseEscalationsV2ShowResponse parses an HTTP response from a EscalationsV2ShowWithResponse call
 func ParseEscalationsV2ShowResponse(rsp *http.Response) (*EscalationsV2ShowResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -22774,6 +23140,22 @@ func ParseCatalogV3CreateEntryResponse(rsp *http.Response) (*CatalogV3CreateEntr
 		}
 		response.JSON201 = &dest
 
+	}
+
+	return response, nil
+}
+
+// ParseCatalogV3BulkUpdateEntriesResponse parses an HTTP response from a CatalogV3BulkUpdateEntriesWithResponse call
+func ParseCatalogV3BulkUpdateEntriesResponse(rsp *http.Response) (*CatalogV3BulkUpdateEntriesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CatalogV3BulkUpdateEntriesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
 	}
 
 	return response, nil


### PR DESCRIPTION
## Summary

- Updates the API client with the latest schema from core (adds `CatalogV3BulkUpdateEntries` endpoint)
- Optimizes `incident_catalog_entries` resource to batch updates in groups of 100 using the new bulk update endpoint
- Adds documentation about `lo` library availability in CLAUDE.md

This significantly reduces API calls for large catalog syncs from N individual updates to ceil(N/100) batch requests.

## Test plan

- [x] Ran `TestAccIncidentCatalogEntriesResource` - passes
- [x] Ran `TestAccIncidentCatalogEntriesResourceWithManagedAttributes` - passes
- [x] Verified bulk update endpoint is being called in test logs (`POST .../catalog_entries/actions/bulk_update`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)