### PR TITLE
Use ListNestetedAttribute for array_value values

### DIFF
--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -280,7 +280,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--alert_sources--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--alert_sources--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--alert_sources--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--alert_sources--condition_groups--conditions--param_bindings--array_value"></a>
@@ -326,7 +326,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--condition_groups--conditions--param_bindings--array_value"></a>
@@ -371,7 +371,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--escalation_paths--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--escalation_paths--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--escalation_paths--value))
 
 <a id="nestedatt--escalation_config--escalation_targets--escalation_paths--array_value"></a>
@@ -398,7 +398,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--users--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--users--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--escalation_config--escalation_targets--users--value))
 
 <a id="nestedatt--escalation_config--escalation_targets--users--array_value"></a>
@@ -487,7 +487,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value"></a>
@@ -516,7 +516,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--value))
 
 <a id="nestedatt--expressions--operations--branches--branches--result--array_value"></a>
@@ -577,7 +577,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value"></a>
@@ -641,7 +641,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--else_branch--result--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--else_branch--result--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--else_branch--result--value))
 
 <a id="nestedatt--expressions--else_branch--result--array_value"></a>
@@ -698,7 +698,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_config--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_config--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_config--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--incident_config--condition_groups--conditions--param_bindings--array_value"></a>
@@ -818,7 +818,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--custom_fields--binding--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--custom_fields--binding--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--custom_fields--binding--value))
 
 <a id="nestedatt--incident_template--custom_fields--binding--array_value"></a>
@@ -846,7 +846,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--incident_mode--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--incident_mode--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--incident_mode--value))
 
 <a id="nestedatt--incident_template--incident_mode--array_value"></a>
@@ -873,7 +873,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--incident_type--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--incident_type--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--incident_type--value))
 
 <a id="nestedatt--incident_template--incident_type--array_value"></a>
@@ -911,7 +911,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--severity--binding--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--severity--binding--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--severity--binding--value))
 
 <a id="nestedatt--incident_template--severity--binding--array_value"></a>
@@ -939,7 +939,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--start_in_triage--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--start_in_triage--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--start_in_triage--value))
 
 <a id="nestedatt--incident_template--start_in_triage--array_value"></a>
@@ -966,7 +966,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--workspace--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--incident_template--workspace--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--incident_template--workspace--value))
 
 <a id="nestedatt--incident_template--workspace--array_value"></a>
@@ -1022,7 +1022,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--channel_config--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--channel_config--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--channel_config--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--channel_config--condition_groups--conditions--param_bindings--array_value"></a>
@@ -1059,7 +1059,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--channel_config--ms_teams_targets--binding--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--channel_config--ms_teams_targets--binding--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--channel_config--ms_teams_targets--binding--value))
 
 <a id="nestedatt--channel_config--ms_teams_targets--binding--array_value"></a>
@@ -1095,7 +1095,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--channel_config--slack_targets--binding--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--channel_config--slack_targets--binding--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--channel_config--slack_targets--binding--value))
 
 <a id="nestedatt--channel_config--slack_targets--binding--array_value"></a>

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -168,7 +168,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--attributes--binding--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--attributes--binding--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--attributes--binding--value))
 
 <a id="nestedatt--template--attributes--binding--array_value"></a>
@@ -265,7 +265,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value"></a>
@@ -294,7 +294,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--result--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--result--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--result--value))
 
 <a id="nestedatt--template--expressions--operations--branches--branches--result--array_value"></a>
@@ -355,7 +355,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value"></a>
@@ -419,7 +419,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--else_branch--result--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--template--expressions--else_branch--result--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--template--expressions--else_branch--result--value))
 
 <a id="nestedatt--template--expressions--else_branch--result--array_value"></a>

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -184,7 +184,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--conditions--param_bindings--array_value"></a>
@@ -254,7 +254,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
@@ -324,7 +324,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
@@ -394,7 +394,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
@@ -745,7 +745,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
@@ -1177,7 +1177,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
@@ -1247,7 +1247,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
@@ -1598,7 +1598,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
@@ -2111,7 +2111,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
@@ -2181,7 +2181,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
@@ -2251,7 +2251,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
@@ -2602,7 +2602,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
@@ -3034,7 +3034,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
@@ -3104,7 +3104,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
@@ -3455,7 +3455,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -124,7 +124,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--condition_groups--conditions--param_bindings--array_value"></a>
@@ -213,7 +213,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value"></a>
@@ -242,7 +242,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result--value))
 
 <a id="nestedatt--expressions--operations--branches--branches--result--array_value"></a>
@@ -303,7 +303,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value"></a>
@@ -367,7 +367,7 @@ Required:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--else_branch--result--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--expressions--else_branch--result--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--expressions--else_branch--result--value))
 
 <a id="nestedatt--expressions--else_branch--result--array_value"></a>
@@ -409,7 +409,7 @@ Optional:
 
 Optional:
 
-- `array_value` (Attributes Set) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--steps--param_bindings--array_value))
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--steps--param_bindings--array_value))
 - `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--steps--param_bindings--value))
 
 <a id="nestedatt--steps--param_bindings--array_value"></a>

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -293,7 +293,7 @@ func ParamBindingValueAttributes() map[string]schema.Attribute {
 
 func ParamBindingAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
-		"array_value": schema.SetNestedAttribute{
+		"array_value": schema.ListNestedAttribute{
 			MarkdownDescription: "The array of literal or reference parameter values",
 			Optional:            true,
 			NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
We always pass them around as JSON arrays, or slices, they are stored with order, so we should be able to reliably treat them like lists. This fixes a performance bug where the complexity (and therefore planning time) can get real bad real quick with what look like small numbers of values.

This will hopefully fix #277