### PR TITLE
Use ListNestedAttributes for engine conditions

### DIFF
--- a/docs/data-sources/alert_sources.md
+++ b/docs/data-sources/alert_sources.md
@@ -136,7 +136,7 @@ Read-Only:
 
 - `attributes` (Attributes Set) Attributes to set on alerts coming from this source, with a binding describing how to set them. (see [below for nested schema](#nestedatt--alert_sources--template--attributes))
 - `description` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--description))
-- `expressions` (Attributes Set) Expressions that make variables available in the scope (see [below for nested schema](#nestedatt--alert_sources--template--expressions))
+- `expressions` (Attributes List) Expressions that make variables available in the scope (see [below for nested schema](#nestedatt--alert_sources--template--expressions))
 - `title` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--title))
 
 <a id="nestedatt--alert_sources--template--attributes"></a>
@@ -152,7 +152,7 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes Set) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--attributes--binding--array_value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--attributes--binding--array_value))
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--attributes--binding--value))
 
 <a id="nestedatt--alert_sources--template--attributes--binding--array_value"></a>
@@ -207,7 +207,7 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes Set) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--else_branch--result--array_value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--else_branch--result--array_value))
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--else_branch--result--value))
 
 <a id="nestedatt--alert_sources--template--expressions--else_branch--result--array_value"></a>
@@ -254,7 +254,7 @@ Read-Only:
 
 Read-Only:
 
-- `condition_groups` (Attributes Set) The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass. (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups))
+- `condition_groups` (Attributes List) The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass. (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups))
 - `result` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--result))
 
 <a id="nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups"></a>
@@ -262,7 +262,7 @@ Read-Only:
 
 Read-Only:
 
-- `conditions` (Attributes Set) All conditions in this list must be satisfied for the group to be satisfied (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions))
+- `conditions` (Attributes List) All conditions in this list must be satisfied for the group to be satisfied (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions))
 
 <a id="nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions"></a>
 ### Nested Schema for `alert_sources.template.expressions.operations.branches.branches.condition_groups.conditions`
@@ -278,7 +278,7 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes Set) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--alert_sources--template--expressions--operations--branches--branches--condition_groups--conditions--param_bindings--array_value"></a>
@@ -307,7 +307,7 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes Set) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--result--array_value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--result--array_value))
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--branches--branches--result--value))
 
 <a id="nestedatt--alert_sources--template--expressions--operations--branches--branches--result--array_value"></a>
@@ -345,14 +345,14 @@ Read-Only:
 
 Read-Only:
 
-- `condition_groups` (Attributes Set) The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass. (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups))
+- `condition_groups` (Attributes List) The condition groups to apply in this filter. Only one group needs to be satisfied for the filter to pass. (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups))
 
 <a id="nestedatt--alert_sources--template--expressions--operations--filter--condition_groups"></a>
 ### Nested Schema for `alert_sources.template.expressions.operations.filter.condition_groups`
 
 Read-Only:
 
-- `conditions` (Attributes Set) All conditions in this list must be satisfied for the group to be satisfied (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions))
+- `conditions` (Attributes List) All conditions in this list must be satisfied for the group to be satisfied (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions))
 
 <a id="nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions"></a>
 ### Nested Schema for `alert_sources.template.expressions.operations.filter.condition_groups.conditions`
@@ -368,7 +368,7 @@ Read-Only:
 
 Read-Only:
 
-- `array_value` (Attributes Set) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
+- `array_value` (Attributes List) If array_value is set, this helps render the values (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value))
 - `value` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions--param_bindings--value))
 
 <a id="nestedatt--alert_sources--template--expressions--operations--filter--condition_groups--conditions--param_bindings--array_value"></a>

--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -234,10 +234,10 @@ resource "incident_alert_route" "service_alerts" {
 ### Required
 
 - `alert_sources` (Attributes Set) Which alert sources should this alert route match? (see [below for nested schema](#nestedatt--alert_sources))
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
 - `enabled` (Boolean) Whether this alert route is enabled or not
 - `escalation_config` (Attributes) (see [below for nested schema](#nestedatt--escalation_config))
-- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
+- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `incident_config` (Attributes) (see [below for nested schema](#nestedatt--incident_config))
 - `incident_template` (Attributes) (see [below for nested schema](#nestedatt--incident_template))
 - `is_private` (Boolean) Whether this alert route is private. Private alert routes will only create private incidents from alerts.
@@ -257,14 +257,14 @@ resource "incident_alert_route" "service_alerts" {
 Required:
 
 - `alert_source_id` (String) The alert source ID that will match for the route
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--alert_sources--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--alert_sources--condition_groups))
 
 <a id="nestedatt--alert_sources--condition_groups"></a>
 ### Nested Schema for `alert_sources.condition_groups`
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--alert_sources--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--alert_sources--condition_groups--conditions))
 
 <a id="nestedatt--alert_sources--condition_groups--conditions"></a>
 ### Nested Schema for `alert_sources.condition_groups.conditions`
@@ -310,7 +310,7 @@ Optional:
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--condition_groups--conditions))
 
 <a id="nestedatt--condition_groups--conditions"></a>
 ### Nested Schema for `condition_groups.conditions`
@@ -463,7 +463,7 @@ Required:
 
 Required:
 
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups))
 - `result` (Attributes) The result assumed if the condition groups are satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result))
 
 <a id="nestedatt--expressions--operations--branches--branches--condition_groups"></a>
@@ -471,7 +471,7 @@ Required:
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions))
 
 <a id="nestedatt--expressions--operations--branches--branches--condition_groups--conditions"></a>
 ### Nested Schema for `expressions.operations.branches.branches.condition_groups.conditions`
@@ -554,14 +554,14 @@ Required:
 
 Required:
 
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups))
 
 <a id="nestedatt--expressions--operations--filter--condition_groups"></a>
 ### Nested Schema for `expressions.operations.filter.condition_groups`
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions))
 
 <a id="nestedatt--expressions--operations--filter--condition_groups--conditions"></a>
 ### Nested Schema for `expressions.operations.filter.condition_groups.conditions`
@@ -671,7 +671,7 @@ Optional:
 Required:
 
 - `auto_decline_enabled` (Boolean) Should triage incidents be declined when alerts are resolved?
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--incident_config--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--incident_config--condition_groups))
 - `defer_time_seconds` (Number) How long should the escalation defer time be?
 - `enabled` (Boolean) Whether incident creation is enabled for this alert route
 - `grouping_keys` (Attributes Set) Which attributes should this alert route use to group alerts? (see [below for nested schema](#nestedatt--incident_config--grouping_keys))
@@ -686,7 +686,7 @@ Optional:
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--incident_config--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--incident_config--condition_groups--conditions))
 
 <a id="nestedatt--incident_config--condition_groups--conditions"></a>
 ### Nested Schema for `incident_config.condition_groups.conditions`
@@ -998,7 +998,7 @@ Optional:
 
 Required:
 
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--channel_config--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--channel_config--condition_groups))
 
 Optional:
 
@@ -1010,7 +1010,7 @@ Optional:
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--channel_config--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--channel_config--condition_groups--conditions))
 
 <a id="nestedatt--channel_config--condition_groups--conditions"></a>
 ### Nested Schema for `channel_config.condition_groups.conditions`

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -152,7 +152,7 @@ Required:
 
 - `attributes` (Attributes Set) Attributes to set on alerts coming from this source, with a binding describing how to set them. (see [below for nested schema](#nestedatt--template--attributes))
 - `description` (Attributes) (see [below for nested schema](#nestedatt--template--description))
-- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--template--expressions))
+- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--template--expressions))
 - `title` (Attributes) (see [below for nested schema](#nestedatt--template--title))
 
 <a id="nestedatt--template--attributes"></a>
@@ -241,7 +241,7 @@ Required:
 
 Required:
 
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups))
 - `result` (Attributes) The result assumed if the condition groups are satisfied (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--result))
 
 <a id="nestedatt--template--expressions--operations--branches--branches--condition_groups"></a>
@@ -249,7 +249,7 @@ Required:
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions))
 
 <a id="nestedatt--template--expressions--operations--branches--branches--condition_groups--conditions"></a>
 ### Nested Schema for `template.expressions.operations.branches.branches.condition_groups.conditions`
@@ -332,14 +332,14 @@ Required:
 
 Required:
 
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups))
 
 <a id="nestedatt--template--expressions--operations--filter--condition_groups"></a>
 ### Nested Schema for `template.expressions.operations.filter.condition_groups`
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--template--expressions--operations--filter--condition_groups--conditions))
 
 <a id="nestedatt--template--expressions--operations--filter--condition_groups--conditions"></a>
 ### Nested Schema for `template.expressions.operations.filter.condition_groups.conditions`

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -163,7 +163,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path))
 
 Optional:
@@ -233,7 +233,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path))
 
 Optional:
@@ -303,7 +303,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path))
 
 Optional:
@@ -373,7 +373,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path))
 
 Optional:
@@ -724,7 +724,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path))
 
 Optional:
@@ -1156,7 +1156,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path))
 
 Optional:
@@ -1226,7 +1226,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path))
 
 Optional:
@@ -1577,7 +1577,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path))
 
 Optional:
@@ -2090,7 +2090,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path))
 
 Optional:
@@ -2160,7 +2160,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path))
 
 Optional:
@@ -2230,7 +2230,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path))
 
 Optional:
@@ -2581,7 +2581,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path))
 
 Optional:
@@ -3013,7 +3013,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path))
 
 Optional:
@@ -3083,7 +3083,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path))
 
 Optional:
@@ -3434,7 +3434,7 @@ This allows you to reference the node in other nodes, such as when configuring a
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions))
 - `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path))
 
 Optional:

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -81,9 +81,9 @@ resource "incident_workflow" "autoassign_incident_lead" {
 
 ### Required
 
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
 - `continue_on_step_error` (Boolean) Whether to continue executing the workflow if a step fails
-- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
+- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `include_private_incidents` (Boolean) Whether to include private incidents
 - `name` (String) Name provided by the user when creating the workflow
 - `once_for` (List of String) This workflow will run 'once for' a list of references
@@ -108,7 +108,7 @@ resource "incident_workflow" "autoassign_incident_lead" {
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--condition_groups--conditions))
 
 <a id="nestedatt--condition_groups--conditions"></a>
 ### Nested Schema for `condition_groups.conditions`
@@ -189,7 +189,7 @@ Required:
 
 Required:
 
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups))
 - `result` (Attributes) The result assumed if the condition groups are satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--result))
 
 <a id="nestedatt--expressions--operations--branches--branches--condition_groups"></a>
@@ -197,7 +197,7 @@ Required:
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--expressions--operations--branches--branches--condition_groups--conditions))
 
 <a id="nestedatt--expressions--operations--branches--branches--condition_groups--conditions"></a>
 ### Nested Schema for `expressions.operations.branches.branches.condition_groups.conditions`
@@ -280,14 +280,14 @@ Required:
 
 Required:
 
-- `condition_groups` (Attributes Set) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups))
+- `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups))
 
 <a id="nestedatt--expressions--operations--filter--condition_groups"></a>
 ### Nested Schema for `expressions.operations.filter.condition_groups`
 
 Required:
 
-- `conditions` (Attributes Set) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions))
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--expressions--operations--filter--condition_groups--conditions))
 
 <a id="nestedatt--expressions--operations--filter--condition_groups--conditions"></a>
 ### Nested Schema for `expressions.operations.filter.condition_groups.conditions`

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -318,8 +318,8 @@ func ParamBindingsAttribute() schema.ListNestedAttribute {
 	}
 }
 
-func ConditionsAttribute() schema.SetNestedAttribute {
-	return schema.SetNestedAttribute{
+func ConditionsAttribute() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
 		MarkdownDescription: "The prerequisite conditions that must all be satisfied",
 		Required:            true,
 		NestedObject: schema.NestedAttributeObject{
@@ -338,8 +338,8 @@ func ConditionsAttribute() schema.SetNestedAttribute {
 	}
 }
 
-func ConditionGroupsAttribute() schema.SetNestedAttribute {
-	return schema.SetNestedAttribute{
+func ConditionGroupsAttribute() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
 		MarkdownDescription: "Groups of prerequisite conditions. All conditions in at least one group must be satisfied",
 		Required:            true,
 		NestedObject: schema.NestedAttributeObject{
@@ -367,8 +367,8 @@ func ReturnsAttribute() schema.SingleNestedAttribute {
 	}
 }
 
-func ExpressionsAttribute() schema.SetNestedAttribute {
-	return schema.SetNestedAttribute{
+func ExpressionsAttribute() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
 		MarkdownDescription: "The expressions to be prepared for use by steps and conditions",
 		Required:            true,
 		NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/models/engine_datasource.go
+++ b/internal/provider/models/engine_datasource.go
@@ -23,7 +23,7 @@ func ParamBindingValueDataSourceAttributes() map[string]schema.Attribute {
 
 func ParamBindingDataSourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
-		"array_value": schema.SetNestedAttribute{
+		"array_value": schema.ListNestedAttribute{
 			MarkdownDescription: apischema.Docstring("EngineParamBindingV2", "array_value"),
 			Computed:            true,
 			NestedObject: schema.NestedAttributeObject{
@@ -48,8 +48,8 @@ func ParamBindingsDataSourceAttribute() schema.ListNestedAttribute {
 	}
 }
 
-func ConditionsDataSourceAttribute() schema.SetNestedAttribute {
-	return schema.SetNestedAttribute{
+func ConditionsDataSourceAttribute() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
 		MarkdownDescription: apischema.Docstring("ConditionGroupV2", "conditions"),
 		Computed:            true,
 		NestedObject: schema.NestedAttributeObject{
@@ -68,8 +68,8 @@ func ConditionsDataSourceAttribute() schema.SetNestedAttribute {
 	}
 }
 
-func ConditionGroupsDataSourceAttribute() schema.SetNestedAttribute {
-	return schema.SetNestedAttribute{
+func ConditionGroupsDataSourceAttribute() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
 		MarkdownDescription: apischema.Docstring("ExpressionFilterOptsV2", "condition_groups"),
 		Computed:            true,
 		NestedObject: schema.NestedAttributeObject{
@@ -97,8 +97,8 @@ func ReturnsDataSourceAttribute() schema.SingleNestedAttribute {
 	}
 }
 
-func ExpressionsDataSourceAttribute() schema.SetNestedAttribute {
-	return schema.SetNestedAttribute{
+func ExpressionsDataSourceAttribute() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
 		MarkdownDescription: apischema.Docstring("WorkflowV2", "expressions"),
 		Computed:            true,
 		NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
Engine conditions are always stored in the same order that they are sent to the server, so this should be safe to use list types for them. This might cause some churn in state files on the first run when the server is updated to the code order, but after that it should be stable.