### PR TITLE
Use sets for expressions

### DIFF
--- a/docs/data-sources/alert_sources.md
+++ b/docs/data-sources/alert_sources.md
@@ -136,7 +136,7 @@ Read-Only:
 
 - `attributes` (Attributes Set) Attributes to set on alerts coming from this source, with a binding describing how to set them. (see [below for nested schema](#nestedatt--alert_sources--template--attributes))
 - `description` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--description))
-- `expressions` (Attributes List) Expressions that make variables available in the scope (see [below for nested schema](#nestedatt--alert_sources--template--expressions))
+- `expressions` (Attributes Set) Expressions that make variables available in the scope (see [below for nested schema](#nestedatt--alert_sources--template--expressions))
 - `title` (Attributes) (see [below for nested schema](#nestedatt--alert_sources--template--title))
 
 <a id="nestedatt--alert_sources--template--attributes"></a>

--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -237,7 +237,7 @@ resource "incident_alert_route" "service_alerts" {
 - `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
 - `enabled` (Boolean) Whether this alert route is enabled or not
 - `escalation_config` (Attributes) (see [below for nested schema](#nestedatt--escalation_config))
-- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
+- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `incident_config` (Attributes) (see [below for nested schema](#nestedatt--incident_config))
 - `incident_template` (Attributes) (see [below for nested schema](#nestedatt--incident_template))
 - `is_private` (Boolean) Whether this alert route is private. Private alert routes will only create private incidents from alerts.

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -152,7 +152,7 @@ Required:
 
 - `attributes` (Attributes Set) Attributes to set on alerts coming from this source, with a binding describing how to set them. (see [below for nested schema](#nestedatt--template--attributes))
 - `description` (Attributes) (see [below for nested schema](#nestedatt--template--description))
-- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--template--expressions))
+- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--template--expressions))
 - `title` (Attributes) (see [below for nested schema](#nestedatt--template--title))
 
 <a id="nestedatt--template--attributes"></a>

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -83,7 +83,7 @@ resource "incident_workflow" "autoassign_incident_lead" {
 
 - `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
 - `continue_on_step_error` (Boolean) Whether to continue executing the workflow if a step fails
-- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
+- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `include_private_incidents` (Boolean) Whether to include private incidents
 - `name` (String) Name provided by the user when creating the workflow
 - `once_for` (List of String) This workflow will run 'once for' a list of references

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -367,8 +367,8 @@ func ReturnsAttribute() schema.SingleNestedAttribute {
 	}
 }
 
-func ExpressionsAttribute() schema.ListNestedAttribute {
-	return schema.ListNestedAttribute{
+func ExpressionsAttribute() schema.SetNestedAttribute {
+	return schema.SetNestedAttribute{
 		MarkdownDescription: "The expressions to be prepared for use by steps and conditions",
 		Required:            true,
 		NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/models/engine_datasource.go
+++ b/internal/provider/models/engine_datasource.go
@@ -97,8 +97,8 @@ func ReturnsDataSourceAttribute() schema.SingleNestedAttribute {
 	}
 }
 
-func ExpressionsDataSourceAttribute() schema.ListNestedAttribute {
-	return schema.ListNestedAttribute{
+func ExpressionsDataSourceAttribute() schema.SetNestedAttribute {
+	return schema.SetNestedAttribute{
 		MarkdownDescription: apischema.Docstring("WorkflowV2", "expressions"),
 		Computed:            true,
 		NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
For some types these are stored in the database without a defined order, so returning them in a defined order is going to be hard. Use sets for the moment, which will make plans slower, but reliable.

This fixes the provider for Semrush who it's currently broken