### PR TITLE
Pass `skip_step_upgrades=true` when updating a workflow in incident

### DIFF
--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -270,6 +270,7 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		Annotations: &map[string]string{
 			"incident.io/terraform/version": r.terraformVersion,
 		},
+		SkipStepUpgrades: lo.ToPtr(true),
 	}
 
 	if !data.IncludePrivateEscalations.IsNull() {


### PR DESCRIPTION
The Terraform provider can currently break when the backend upgrades a workflow step and changes the `param_bindings` that it contains in the response.

To correct for this, we've added an additional `step_step_upgrades` option to the update endpoint which prevents the fields from changing in the response. This was already implemented (and used) when getting workflows (the Terraform provider sends `skip_step_upgrades` to that endpoint already) but was not available in the update endpoint.

This PR hard codes requests made by this provider to send the `skip_step_upgrades` option with every workflow update request.