### PR TITLE
Update to latest public API schema

### DIFF
--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -246,7 +246,7 @@ resource "incident_alert_route" "service_alerts" {
 ### Optional
 
 - `channel_config` (Attributes Set) The channel configuration for this alert route (see [below for nested schema](#nestedatt--channel_config))
-- `owning_team_ids` (Set of String) Optional array of team IDs that are the owners of this alert route
+- `owning_team_ids` (Set of String) IDs of teams that own this alert route
 
 ### Read-Only
 

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -139,7 +139,7 @@ resource "aws_sns_topic_subscription" "incidentio_alert_source" {
 - `email_address` (String) Email address this alert source receives alerts to
 - `http_custom_options` (Attributes) (see [below for nested schema](#nestedatt--http_custom_options))
 - `jira_options` (Attributes) (see [below for nested schema](#nestedatt--jira_options))
-- `owning_team_ids` (Set of String) Optional array of team IDs that are the owners of this alert source
+- `owning_team_ids` (Set of String) IDs of teams that own this alert source
 
 ### Read-Only
 

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -1936,7 +1936,7 @@
           "defer_time_seconds": {
             "description": "How long should the escalation defer time be?",
             "example": 1,
-            "format": "int64",
+            "format": "int32",
             "type": "integer"
           },
           "enabled": {
@@ -1959,7 +1959,7 @@
           "grouping_window_seconds": {
             "description": "How large should the grouping window be?",
             "example": 1,
-            "format": "int64",
+            "format": "int32",
             "type": "integer"
           }
         },
@@ -2071,7 +2071,7 @@
           "defer_time_seconds": {
             "description": "How long should the escalation defer time be?",
             "example": 1,
-            "format": "int64",
+            "format": "int32",
             "type": "integer"
           },
           "enabled": {
@@ -2094,7 +2094,7 @@
           "grouping_window_seconds": {
             "description": "How large should the grouping window be?",
             "example": 1,
-            "format": "int64",
+            "format": "int32",
             "type": "integer"
           }
         },
@@ -3124,6 +3124,9 @@
           },
           "is_private": false,
           "name": "Production incidents",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "updated_at": "2021-08-17T13:28:57.801578Z",
           "version": 1
         },
@@ -3467,6 +3470,17 @@
             "example": "Production incidents",
             "type": "string"
           },
+          "owning_team_ids": {
+            "description": "IDs of teams that own this alert route",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "updated_at": {
             "description": "The time of last update of this alert route",
             "example": "2021-08-17T13:28:57.801578Z",
@@ -3478,17 +3492,6 @@
             "example": 1,
             "format": "int64",
             "type": "integer"
-          },
-          "owning_team_ids": {
-            "description": "Optional array of team IDs that are the owners of this alert route",
-            "example": [
-              "01KD5HNBYQ9HVX6EEZAJSE7FJ0"
-            ],
-            "items": {
-              "example": "01KD5HNBYQ9HVX6EEZAJSE7FJ0",
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "required": [
@@ -3923,6 +3926,9 @@
           },
           "is_private": false,
           "name": "Production incidents",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "updated_at": "2021-08-17T13:28:57.801578Z",
           "version": 1
         },
@@ -4207,6 +4213,17 @@
             "example": "Production incidents",
             "type": "string"
           },
+          "owning_team_ids": {
+            "description": "IDs of teams that own this alert route",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "updated_at": {
             "description": "The time of last update of this alert route",
             "example": "2021-08-17T13:28:57.801578Z",
@@ -4218,17 +4235,6 @@
             "example": 1,
             "format": "int64",
             "type": "integer"
-          },
-          "owning_team_ids": {
-            "description": "Optional array of team IDs that are the owners of this alert route",
-            "example": [
-              "01KD5HNBYQ9HVX6EEZAJSE7FJ0"
-            ],
-            "items": {
-              "example": "01KD5HNBYQ9HVX6EEZAJSE7FJ0",
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "required": [
@@ -4746,6 +4752,9 @@
             },
             "is_private": false,
             "name": "Production incidents",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "updated_at": "2021-08-17T13:28:57.801578Z",
             "version": 1
           }
@@ -5298,6 +5307,9 @@
             },
             "is_private": false,
             "name": "Production incidents",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "updated_at": "2021-08-17T13:28:57.801578Z",
             "version": 1
           }
@@ -5728,6 +5740,9 @@
           },
           "is_private": false,
           "name": "Production incidents",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "updated_at": "2021-08-17T13:28:57.801578Z",
           "version": 1
         },
@@ -6012,6 +6027,17 @@
             "example": "Production incidents",
             "type": "string"
           },
+          "owning_team_ids": {
+            "description": "IDs of teams that own this alert route",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "updated_at": {
             "description": "The time of last update of this alert route",
             "example": "2021-08-17T13:28:57.801578Z",
@@ -6023,17 +6049,6 @@
             "example": 1,
             "format": "int64",
             "type": "integer"
-          },
-          "owning_team_ids": {
-            "description": "Optional array of team IDs that are the owners of this alert route",
-            "example": [
-              "01KD5HNBYQ9HVX6EEZAJSE7FJ0"
-            ],
-            "items": {
-              "example": "01KD5HNBYQ9HVX6EEZAJSE7FJ0",
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "required": [
@@ -6551,6 +6566,9 @@
             },
             "is_private": false,
             "name": "Production incidents",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "updated_at": "2021-08-17T13:28:57.801578Z",
             "version": 1
           }
@@ -6731,6 +6749,9 @@
             ]
           },
           "name": "Production Web Dashboard Alerts",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "secret_token": "some-secret-token",
           "source_type": "alertmanager",
           "template": {
@@ -6937,6 +6958,17 @@
             "example": "Production Web Dashboard Alerts",
             "type": "string"
           },
+          "owning_team_ids": {
+            "description": "IDs of teams that own this alert source",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "secret_token": {
             "description": "Secret token used to authenticate this source, if applicable. If applicable, this is the token that must be included in either the query string or the 'Authorization' header when sending events to this alert source.",
             "example": "some-secret-token",
@@ -6995,17 +7027,6 @@
           },
           "template": {
             "$ref": "#/components/schemas/AlertTemplateV2"
-          },
-          "owning_team_ids": {
-            "description": "Optional array of team IDs that are the owners of this alert source",
-            "example": [
-              "01KD5HNBYQ9HVX6EEZAJSE7FJ0"
-            ],
-            "items": {
-              "example": "01KD5HNBYQ9HVX6EEZAJSE7FJ0",
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "required": [
@@ -7029,6 +7050,9 @@
             ]
           },
           "name": "Production Web Dashboard Alerts",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "source_type": "alertmanager",
           "template": {
             "attributes": [
@@ -7194,6 +7218,17 @@
             "example": "Production Web Dashboard Alerts",
             "type": "string"
           },
+          "owning_team_ids": {
+            "description": "IDs of teams that own this alert source",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "source_type": {
             "description": "Type of alert source",
             "enum": [
@@ -7246,17 +7281,6 @@
           },
           "template": {
             "$ref": "#/components/schemas/AlertTemplatePayloadV2"
-          },
-          "owning_team_ids": {
-            "description": "Optional array of team IDs that are the owners of this alert source",
-            "example": [
-              "01KD5HNBYQ9HVX6EEZAJSE7FJ0"
-            ],
-            "items": {
-              "example": "01KD5HNBYQ9HVX6EEZAJSE7FJ0",
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "required": [
@@ -7284,6 +7308,9 @@
               ]
             },
             "name": "Production Web Dashboard Alerts",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "secret_token": "some-secret-token",
             "source_type": "alertmanager",
             "template": {
@@ -7500,6 +7527,9 @@
                 ]
               },
               "name": "Production Web Dashboard Alerts",
+              "owning_team_ids": [
+                "01G0J1EXE7AXZ2C93K61WBPYEH"
+              ],
               "secret_token": "some-secret-token",
               "source_type": "alertmanager",
               "template": {
@@ -7707,6 +7737,9 @@
                   ]
                 },
                 "name": "Production Web Dashboard Alerts",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "secret_token": "some-secret-token",
                 "source_type": "alertmanager",
                 "template": {
@@ -7923,6 +7956,9 @@
               ]
             },
             "name": "Production Web Dashboard Alerts",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "secret_token": "some-secret-token",
             "source_type": "alertmanager",
             "template": {
@@ -8133,6 +8169,9 @@
             ]
           },
           "name": "Production Web Dashboard Alerts",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "template": {
             "attributes": [
               {
@@ -8297,19 +8336,19 @@
             "example": "Production Web Dashboard Alerts",
             "type": "string"
           },
-          "template": {
-            "$ref": "#/components/schemas/AlertTemplatePayloadV2"
-          },
           "owning_team_ids": {
-            "description": "Optional array of team IDs that are the owners of this alert source",
+            "description": "IDs of teams that own this alert source",
             "example": [
-              "01KD5HNBYQ9HVX6EEZAJSE7FJ0"
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
             ],
             "items": {
-              "example": "01KD5HNBYQ9HVX6EEZAJSE7FJ0",
+              "example": "abc123",
               "type": "string"
             },
             "type": "array"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertTemplatePayloadV2"
           }
         },
         "required": [
@@ -8336,6 +8375,9 @@
               ]
             },
             "name": "Production Web Dashboard Alerts",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "secret_token": "some-secret-token",
             "source_type": "alertmanager",
             "template": {
@@ -9939,6 +9981,23 @@
         },
         "type": "object"
       },
+      "AuditLogPrivateEscalationAccessAttemptedMetadataV2": {
+        "example": {
+          "outcome": "granted"
+        },
+        "properties": {
+          "outcome": {
+            "description": "Whether or not the user was able to access the private escalation",
+            "enum": [
+              "granted",
+              "denied"
+            ],
+            "example": "granted",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "AuditLogPrivateIncidentAccessAttemptedMetadataV2": {
         "example": {
           "outcome": "granted"
@@ -10004,12 +10063,15 @@
               "alert_route",
               "alert_schema",
               "alert_source",
+              "alert_priority",
               "announcement_rule",
               "catalog_type",
               "catalog_entry",
               "catalog_attribute",
+              "connector_config",
               "custom_field",
               "debrief_invite_rule",
+              "escalation",
               "escalation_path",
               "follow_up_priority",
               "holiday_user_feed",
@@ -10025,6 +10087,7 @@
               "internal_status_page",
               "ip_allowlist",
               "nudge",
+              "on_call_notification_method",
               "organisation_settings",
               "schedule_override",
               "policy",
@@ -10041,6 +10104,7 @@
               "status_page_sub_page",
               "status_page_template",
               "team_settings",
+              "telemetry_data_source",
               "user",
               "workflow"
             ],
@@ -10248,6 +10312,306 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "name": "Development API Key",
                 "type": "api_key"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAlertPriorityCreatedV1": {
+        "example": {
+          "action": "alert_priority.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Urgent",
+              "type": "alert_priority"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "alert_priority.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Urgent",
+                "type": "alert_priority"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAlertPriorityDeletedV1": {
+        "example": {
+          "action": "alert_priority.deleted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Urgent",
+              "type": "alert_priority"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "alert_priority.deleted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Urgent",
+                "type": "alert_priority"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAlertPrioritySetAsDefaultV1": {
+        "example": {
+          "action": "alert_priority.set_as_default",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Urgent",
+              "type": "alert_priority"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "alert_priority.set_as_default",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Urgent",
+                "type": "alert_priority"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAlertPriorityUpdatedV1": {
+        "example": {
+          "action": "alert_priority.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Urgent",
+              "type": "alert_priority"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "alert_priority.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Urgent",
+                "type": "alert_priority"
               }
             ],
             "items": {
@@ -11435,6 +11799,231 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "name": "Service",
                 "type": "catalog_type"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsConnectorConfigCreatedV1": {
+        "example": {
+          "action": "connector_config.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My Connector",
+              "type": "connector_config"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "connector_config.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My Connector",
+                "type": "connector_config"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsConnectorConfigTokenGeneratedV1": {
+        "example": {
+          "action": "connector_config.token_generated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My Connector",
+              "type": "connector_config"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "connector_config.token_generated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My Connector",
+                "type": "connector_config"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsConnectorConfigUpdatedV1": {
+        "example": {
+          "action": "connector_config.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My Connector",
+              "type": "connector_config"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "connector_config.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My Connector",
+                "type": "connector_config"
               }
             ],
             "items": {
@@ -14546,6 +15135,176 @@
         ],
         "type": "object"
       },
+      "AuditLogsOnCallNotificationMethodCreatedV1": {
+        "example": {
+          "action": "on_call_notification_method.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Phone notification method",
+              "type": "on_call_notification_method"
+            },
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Bob the builder",
+              "type": "user"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "on_call_notification_method.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Phone notification method",
+                "type": "on_call_notification_method"
+              },
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Bob the builder",
+                "type": "user"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsOnCallNotificationMethodDestroyedV1": {
+        "example": {
+          "action": "on_call_notification_method.destroyed",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Phone notification method",
+              "type": "on_call_notification_method"
+            },
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Bob the builder",
+              "type": "user"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "on_call_notification_method.destroyed",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Phone notification method",
+                "type": "on_call_notification_method"
+              },
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Bob the builder",
+                "type": "user"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
       "AuditLogsOrganisationSettingsUpdatedV1": {
         "example": {
           "action": "organisation_settings.updated",
@@ -16060,6 +16819,88 @@
         ],
         "type": "object"
       },
+      "AuditLogsPrivateEscalationAccessAttemptedV1": {
+        "example": {
+          "action": "private_escalation.access_attempted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "outcome": "granted"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Escalation (01KB0083ASNF7EPT8NHQNRDXFC)",
+              "type": "escalation"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "private_escalation.access_attempted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogPrivateEscalationAccessAttemptedMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Escalation (01KB0083ASNF7EPT8NHQNRDXFC)",
+                "type": "escalation"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
       "AuditLogsPrivateIncidentAccessAttemptedV1": {
         "example": {
           "action": "private_incident.access_attempted",
@@ -16172,6 +17013,81 @@
           "action": {
             "description": "The type of log entry that this is",
             "example": "private_incident.access_requested",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "#INC-123 The website is slow",
+                "type": "incident"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsPrivateIncidentAccessedViaBotV1": {
+        "example": {
+          "action": "private_incident.accessed_via_bot",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "#INC-123 The website is slow",
+              "type": "incident"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "private_incident.accessed_via_bot",
             "type": "string"
           },
           "actor": {
@@ -18430,6 +19346,156 @@
         ],
         "type": "object"
       },
+      "AuditLogsTelemetryDataSourceInstalledV1": {
+        "example": {
+          "action": "telemetry_data_source.installed",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Grafana Cloud",
+              "type": "telemetry_data_source"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "telemetry_data_source.installed",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Grafana Cloud",
+                "type": "telemetry_data_source"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsTelemetryDataSourceUninstalledV1": {
+        "example": {
+          "action": "telemetry_data_source.uninstalled",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Grafana Cloud",
+              "type": "telemetry_data_source"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "telemetry_data_source.uninstalled",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Grafana Cloud",
+                "type": "telemetry_data_source"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
       "AuditLogsUserCreatedV1": {
         "example": {
           "action": "user.created",
@@ -19099,7 +20165,7 @@
             "type": "string"
           },
           "entries": {
-            "description": "A list of entries to update with their new values. Maximum 100 entries per request.",
+            "description": "A list of entries to update with their new values. Maximum 250 entries per request.",
             "example": [
               {
                 "aliases": [
@@ -19147,7 +20213,7 @@
             "items": {
               "$ref": "#/components/schemas/PartialEntryPayloadV3"
             },
-            "maxItems": 100,
+            "maxItems": 250,
             "minItems": 1,
             "type": "array"
           },
@@ -20669,7 +21735,8 @@
           },
           "pagination_meta": {
             "after": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "page_size": 25
+            "page_size": 25,
+            "total_record_count": 238
           }
         },
         "properties": {
@@ -20713,7 +21780,7 @@
             "$ref": "#/components/schemas/CatalogTypeV3"
           },
           "pagination_meta": {
-            "$ref": "#/components/schemas/PaginationMetaResultV3"
+            "$ref": "#/components/schemas/PaginationMetaResultWithTotalV3"
           }
         },
         "required": [
@@ -26994,6 +28061,15 @@
       },
       "EscalationPathV2": {
         "example": {
+          "current_responders": [
+            {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "viewer",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          ],
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Urgent Support",
           "path": [
@@ -27092,6 +28168,22 @@
           ]
         },
         "properties": {
+          "current_responders": {
+            "description": "Users who are currently on-call for this escalation path",
+            "example": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/UserV2"
+            },
+            "type": "array"
+          },
           "id": {
             "description": "Unique identifier for this escalation path.",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -27670,6 +28762,15 @@
       "EscalationsCreatePathResultV2": {
         "example": {
           "escalation_path": {
+            "current_responders": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Urgent Support",
             "path": [
@@ -28107,6 +29208,15 @@
       "EscalationsShowPathResultV2": {
         "example": {
           "escalation_path": {
+            "current_responders": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Urgent Support",
             "path": [
@@ -28520,6 +29630,15 @@
       "EscalationsUpdatePathResultV2": {
         "example": {
           "escalation_path": {
+            "current_responders": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "viewer",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Urgent Support",
             "path": [
@@ -30865,7 +31984,8 @@
                 "post_incident_flow_opt_out",
                 "security_settings_editor",
                 "investigation_download",
-                "team_memberships_manage"
+                "team_memberships_manage",
+                "status_page_publisher"
               ],
               "example": "viewer",
               "type": "string",
@@ -31230,7 +32350,7 @@
             "type": "array"
           },
           "incident_status_id": {
-            "description": "Incident status to change incident to (you can only change an incident from one active status to another, any other lifecycle changes must be taken via the app.)",
+            "description": "Incident status to change incident to. You can only change an incident from one active status to another, or close an incident from a post-incident status. Any other lifecycle changes must be taken via the app.",
             "example": "abc123",
             "type": "string"
           },
@@ -33339,7 +34459,7 @@
             "type": "string"
           },
           "postmortem_document_url": {
-            "description": "Description of the incident",
+            "description": "The URL of the incident post-mortem document",
             "example": "https://docs.google.com/my_doc_id",
             "type": "string"
           },
@@ -33755,7 +34875,7 @@
             "type": "string"
           },
           "postmortem_document_url": {
-            "description": "Description of the incident",
+            "description": "The URL of the incident post-mortem document",
             "example": "https://docs.google.com/my_doc_id",
             "type": "string"
           },
@@ -36031,31 +37151,6 @@
         ],
         "type": "object"
       },
-      "PaginationMetaResultV3": {
-        "example": {
-          "after": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "page_size": 25
-        },
-        "properties": {
-          "after": {
-            "description": "If provided, pass this as the 'after' param to load the next page",
-            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "type": "string"
-          },
-          "page_size": {
-            "default": 25,
-            "description": "What was the maximum number of results requested",
-            "example": 25,
-            "format": "int64",
-            "maximum": 250,
-            "type": "integer"
-          }
-        },
-        "required": [
-          "page_size"
-        ],
-        "type": "object"
-      },
       "PaginationMetaResultWithTotalV1": {
         "example": {
           "after": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -36089,6 +37184,38 @@
         "type": "object"
       },
       "PaginationMetaResultWithTotalV2": {
+        "example": {
+          "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "page_size": 25,
+          "total_record_count": 238
+        },
+        "properties": {
+          "after": {
+            "description": "If provided, pass this as the 'after' param to load the next page",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "page_size": {
+            "default": 25,
+            "description": "What was the maximum number of results requested",
+            "example": 25,
+            "format": "int64",
+            "maximum": 250,
+            "type": "integer"
+          },
+          "total_record_count": {
+            "description": "How many matching records were there in total, if known",
+            "example": 238,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "page_size"
+        ],
+        "type": "object"
+      },
+      "PaginationMetaResultWithTotalV3": {
         "example": {
           "after": "01FCNDV6P870EA6S7TK1DSYDG0",
           "page_size": 25,
@@ -38832,6 +39959,336 @@
         ],
         "type": "object"
       },
+      "StatusPageIncidentAffectedComponentSlimV2": {
+        "example": {
+          "component_id": "abc123",
+          "current_status": "operational"
+        },
+        "properties": {
+          "component_id": {
+            "description": "The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.",
+            "example": "abc123",
+            "type": "string"
+          },
+          "current_status": {
+            "description": "The status of the relevant component in a status page incident",
+            "enum": [
+              "operational",
+              "degraded_performance",
+              "partial_outage",
+              "full_outage"
+            ],
+            "example": "operational",
+            "type": "string",
+            "x-public-api-version": "v2"
+          }
+        },
+        "required": [
+          "component_id",
+          "current_status"
+        ],
+        "type": "object"
+      },
+      "StatusPageIncidentAffectedComponentV2": {
+        "example": {
+          "component_id": "abc123",
+          "current_status": "operational",
+          "status": "operational"
+        },
+        "properties": {
+          "component_id": {
+            "description": "The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.",
+            "example": "abc123",
+            "type": "string"
+          },
+          "current_status": {
+            "description": "The status of the relevant component in a status page incident",
+            "enum": [
+              "operational",
+              "degraded_performance",
+              "partial_outage",
+              "full_outage"
+            ],
+            "example": "operational",
+            "type": "string",
+            "x-public-api-version": "v2"
+          },
+          "status": {
+            "description": "The status of the relevant component in a status page incident",
+            "enum": [
+              "operational",
+              "degraded_performance",
+              "partial_outage",
+              "full_outage"
+            ],
+            "example": "operational",
+            "type": "string",
+            "x-public-api-version": "v2"
+          }
+        },
+        "required": [
+          "component_id",
+          "status",
+          "current_status"
+        ],
+        "type": "object"
+      },
+      "StatusPageIncidentComponentImpactV2": {
+        "example": {
+          "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+          "end_at": "2021-08-17T13:28:57.801578Z",
+          "start_at": "2021-08-17T13:28:57.801578Z",
+          "status": "degraded_performance"
+        },
+        "properties": {
+          "component_id": {
+            "description": "The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.",
+            "example": "01GW7P4ES31Q6V1ZQH321T0GJN",
+            "type": "string"
+          },
+          "end_at": {
+            "description": "When the component left this status. If this is null, the impact is ongoing.",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "start_at": {
+            "description": "When the component entered this status",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the relevant component impact in a status page incident - this excludes the operational status.",
+            "enum": [
+              "degraded_performance",
+              "partial_outage",
+              "full_outage"
+            ],
+            "example": "degraded_performance",
+            "type": "string",
+            "x-public-api-version": "v2"
+          }
+        },
+        "required": [
+          "component_id",
+          "status",
+          "start_at"
+        ],
+        "type": "object"
+      },
+      "StatusPageIncidentUpdateV2": {
+        "example": {
+          "component_statuses": [
+            {
+              "component_id": "abc123",
+              "current_status": "operational",
+              "status": "operational"
+            }
+          ],
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "message": "abc123",
+          "published_at": "2021-08-17T13:28:57.801578Z",
+          "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+          "to_status": "investigating"
+        },
+        "properties": {
+          "component_statuses": {
+            "description": "The updated statuses of affected components",
+            "example": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational",
+                "status": "operational"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageIncidentAffectedComponentV2"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "A unique ID for this status page incident update",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "message": {
+            "description": "Markdown update on what's changed about this status page incident",
+            "example": "abc123",
+            "type": "string"
+          },
+          "published_at": {
+            "description": "When this status page incident update was published to the status page",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status_page_incident_id": {
+            "description": "The ID of the corresponding status page incident",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "type": "string"
+          },
+          "to_status": {
+            "description": "Current status for this incident",
+            "enum": [
+              "investigating",
+              "identified",
+              "monitoring",
+              "resolved"
+            ],
+            "example": "investigating",
+            "type": "string",
+            "x-public-api-version": "v2"
+          }
+        },
+        "required": [
+          "id",
+          "status_page_incident_id",
+          "published_at",
+          "message",
+          "to_status",
+          "component_statuses"
+        ],
+        "type": "object"
+      },
+      "StatusPageIncidentV2": {
+        "example": {
+          "affected_components": [
+            {
+              "component_id": "abc123",
+              "current_status": "operational",
+              "status": "operational"
+            }
+          ],
+          "component_impacts": [
+            {
+              "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "status": "degraded_performance"
+            }
+          ],
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Elevated API latency",
+          "published_at": "2021-08-17T13:28:57.801578Z",
+          "status": "investigating",
+          "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "updates": [
+            {
+              "component_statuses": [
+                {
+                  "component_id": "abc123",
+                  "current_status": "operational",
+                  "status": "operational"
+                }
+              ],
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "message": "abc123",
+              "published_at": "2021-08-17T13:28:57.801578Z",
+              "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+              "to_status": "investigating"
+            }
+          ]
+        },
+        "properties": {
+          "affected_components": {
+            "description": "A summary of the affected components",
+            "example": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational",
+                "status": "operational"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageIncidentAffectedComponentV2"
+            },
+            "type": "array"
+          },
+          "component_impacts": {
+            "description": "A list of time periods that this status page incident had an impact on a component",
+            "example": [
+              {
+                "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "status": "degraded_performance"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageIncidentComponentImpactV2"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "A unique ID for this status page incident",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "name": {
+            "description": "A title for the incident",
+            "example": "Elevated API latency",
+            "type": "string"
+          },
+          "published_at": {
+            "description": "When this status page incident was published to the status page",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current status for this incident",
+            "enum": [
+              "investigating",
+              "identified",
+              "monitoring",
+              "resolved"
+            ],
+            "example": "investigating",
+            "type": "string",
+            "x-public-api-version": "v2"
+          },
+          "status_page_id": {
+            "description": "The ID of the corresponding status page",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "updates": {
+            "description": "A list of updates posted to this status page incident",
+            "example": [
+              {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational",
+                    "status": "operational"
+                  }
+                ],
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "message": "abc123",
+                "published_at": "2021-08-17T13:28:57.801578Z",
+                "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "to_status": "investigating"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageIncidentUpdateV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "status_page_id",
+          "name",
+          "published_at",
+          "status",
+          "updates",
+          "affected_components",
+          "component_impacts"
+        ],
+        "type": "object"
+      },
       "StatusPageLinkedResponseIncidentV1": {
         "example": {
           "id": "01FDAG4SAH3GYPT98WGR2N7W91",
@@ -38854,6 +40311,832 @@
           "id",
           "linked_at"
         ],
+        "type": "object"
+      },
+      "StatusPageMaintenanceAffectedComponentV2": {
+        "example": {
+          "component_id": "abc123",
+          "current_status": "operational"
+        },
+        "properties": {
+          "component_id": {
+            "description": "The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.",
+            "example": "abc123",
+            "type": "string"
+          },
+          "current_status": {
+            "description": "The status of the relevant component in a status page maintenance window",
+            "enum": [
+              "operational",
+              "under_maintenance"
+            ],
+            "example": "operational",
+            "type": "string",
+            "x-public-api-version": "v2"
+          }
+        },
+        "required": [
+          "component_id",
+          "current_status"
+        ],
+        "type": "object"
+      },
+      "StatusPageMaintenanceComponentImpactV2": {
+        "example": {
+          "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+          "end_at": "2021-08-17T13:28:57.801578Z",
+          "start_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "properties": {
+          "component_id": {
+            "description": "The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.",
+            "example": "01GW7P4ES31Q6V1ZQH321T0GJN",
+            "type": "string"
+          },
+          "end_at": {
+            "description": "When the component stopped being under maintenance. If this is null, the impact is ongoing.",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "start_at": {
+            "description": "When the component started being under maintenance",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "component_id",
+          "start_at"
+        ],
+        "type": "object"
+      },
+      "StatusPageMaintenanceUpdateV2": {
+        "example": {
+          "component_statuses": [
+            {
+              "component_id": "abc123",
+              "current_status": "operational"
+            }
+          ],
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "message": "abc123",
+          "published_at": "2021-08-17T13:28:57.801578Z",
+          "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+          "to_status": "maintenance_scheduled"
+        },
+        "properties": {
+          "component_statuses": {
+            "description": "The updated statuses of affected components",
+            "example": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageMaintenanceAffectedComponentV2"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "A unique ID for this status page maintenance update",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "message": {
+            "description": "Markdown update on what's changed about this status page maintenance window",
+            "example": "abc123",
+            "type": "string"
+          },
+          "published_at": {
+            "description": "When this status page maintenance update was published to the status page",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status_page_maintenance_id": {
+            "description": "The ID of the corresponding status page maintenance window",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "type": "string"
+          },
+          "to_status": {
+            "description": "Current status for this maintenance window",
+            "enum": [
+              "maintenance_scheduled",
+              "maintenance_in_progress",
+              "maintenance_complete"
+            ],
+            "example": "maintenance_scheduled",
+            "type": "string",
+            "x-public-api-version": "v2"
+          }
+        },
+        "required": [
+          "id",
+          "status_page_maintenance_id",
+          "published_at",
+          "message",
+          "to_status",
+          "component_statuses"
+        ],
+        "type": "object"
+      },
+      "StatusPageMaintenanceV2": {
+        "example": {
+          "component_impacts": [
+            {
+              "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "start_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ],
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Routine infrastructure upgrade",
+          "published_at": "2021-08-17T13:28:57.801578Z",
+          "status": "maintenance_scheduled",
+          "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "updates": [
+            {
+              "component_statuses": [
+                {
+                  "component_id": "abc123",
+                  "current_status": "operational"
+                }
+              ],
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "message": "abc123",
+              "published_at": "2021-08-17T13:28:57.801578Z",
+              "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+              "to_status": "maintenance_scheduled"
+            }
+          ]
+        },
+        "properties": {
+          "component_impacts": {
+            "description": "A list of time periods that this status page maintenance window had an impact on components",
+            "example": [
+              {
+                "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "start_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageMaintenanceComponentImpactV2"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "A unique ID for this status page maintenance window",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "name": {
+            "description": "A title for the maintenance window",
+            "example": "Routine infrastructure upgrade",
+            "type": "string"
+          },
+          "published_at": {
+            "description": "When this status page maintenance window was published to the status page",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current status for this maintenance window",
+            "enum": [
+              "maintenance_scheduled",
+              "maintenance_in_progress",
+              "maintenance_complete"
+            ],
+            "example": "maintenance_scheduled",
+            "type": "string",
+            "x-public-api-version": "v2"
+          },
+          "status_page_id": {
+            "description": "The ID of the corresponding status page",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "updates": {
+            "description": "A list of updates posted to this status page maintenance window",
+            "example": [
+              {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational"
+                  }
+                ],
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "message": "abc123",
+                "published_at": "2021-08-17T13:28:57.801578Z",
+                "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "to_status": "maintenance_scheduled"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageMaintenanceUpdateV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "status_page_id",
+          "name",
+          "published_at",
+          "status",
+          "updates",
+          "component_impacts"
+        ],
+        "type": "object"
+      },
+      "StatusPageStructureComponentV2": {
+        "example": {
+          "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+          "name": "App"
+        },
+        "properties": {
+          "component_id": {
+            "description": "The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of this component",
+            "example": "App",
+            "type": "string"
+          }
+        },
+        "required": [
+          "component_id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "StatusPageStructureGroupV2": {
+        "example": {
+          "components": [
+            {
+              "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+              "name": "App"
+            }
+          ],
+          "id": "01FCNDV6P870EA6S7TK1DSYDG1",
+          "name": "EU Data center"
+        },
+        "properties": {
+          "components": {
+            "description": "Array of components belonging to this group",
+            "example": [
+              {
+                "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "name": "App"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageStructureComponentV2"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "Unique ID of this component group",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of this component group",
+            "example": "EU Data center",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "components"
+        ],
+        "type": "object"
+      },
+      "StatusPageStructureItemV2": {
+        "example": {
+          "component": {
+            "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "name": "App"
+          },
+          "group": {
+            "components": [
+              {
+                "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "name": "App"
+              }
+            ],
+            "id": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "name": "EU Data center"
+          }
+        },
+        "properties": {
+          "component": {
+            "$ref": "#/components/schemas/StatusPageStructureComponentV2"
+          },
+          "group": {
+            "$ref": "#/components/schemas/StatusPageStructureGroupV2"
+          }
+        },
+        "type": "object"
+      },
+      "StatusPageStructureV2": {
+        "example": {
+          "items": [
+            {
+              "component": {
+                "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "name": "App"
+              },
+              "group": {
+                "components": [
+                  {
+                    "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                    "name": "App"
+                  }
+                ],
+                "id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "name": "EU Data center"
+              }
+            }
+          ]
+        },
+        "properties": {
+          "items": {
+            "description": "Array of components and groups to display in the status page",
+            "example": [
+              {
+                "component": {
+                  "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                  "name": "App"
+                },
+                "group": {
+                  "components": [
+                    {
+                      "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                      "name": "App"
+                    }
+                  ],
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                  "name": "EU Data center"
+                }
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageStructureItemV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "StatusPageV2": {
+        "example": {
+          "description": "This status page is our public status page.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "name": "Our public status page",
+          "public_url": "https://statuspage.incident.io/our-public-status-page"
+        },
+        "properties": {
+          "description": {
+            "description": "The description of this status page",
+            "example": "This status page is our public status page.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique ID of this status page",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "name": {
+            "description": "The title of this status page",
+            "example": "Our public status page",
+            "type": "string"
+          },
+          "public_url": {
+            "description": "The public URL of this status page",
+            "example": "https://statuspage.incident.io/our-public-status-page",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageIncidentPayloadV2": {
+        "example": {
+          "component_statuses": [
+            {
+              "component_id": "abc123",
+              "current_status": "operational"
+            }
+          ],
+          "idempotency_key": "abc123",
+          "message": "abc123",
+          "name": "Elevated API latency",
+          "notify_subscribers": false,
+          "status": "investigating",
+          "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "properties": {
+          "component_statuses": {
+            "description": "An array of mappings from component ID to current status",
+            "example": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageIncidentAffectedComponentSlimV2"
+            },
+            "type": "array"
+          },
+          "idempotency_key": {
+            "description": "A unique key to de-duplicate incidents",
+            "example": "abc123",
+            "type": "string"
+          },
+          "message": {
+            "description": "Markdown initial update on this status page incident",
+            "example": "abc123",
+            "type": "string"
+          },
+          "name": {
+            "description": "A title for the incident",
+            "example": "Elevated API latency",
+            "type": "string"
+          },
+          "notify_subscribers": {
+            "description": "Whether to notify subscribers about this status page incident.",
+            "example": false,
+            "type": "boolean"
+          },
+          "status": {
+            "description": "Current status for this status page incident",
+            "enum": [
+              "investigating",
+              "identified",
+              "monitoring",
+              "resolved"
+            ],
+            "example": "investigating",
+            "type": "string"
+          },
+          "status_page_id": {
+            "description": "ID of the status page",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status_page_id",
+          "name",
+          "status",
+          "idempotency_key",
+          "message",
+          "notify_subscribers"
+        ],
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageIncidentResultV2": {
+        "example": {
+          "status_page_incident": {
+            "affected_components": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational",
+                "status": "operational"
+              }
+            ],
+            "component_impacts": [
+              {
+                "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "status": "degraded_performance"
+              }
+            ],
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Elevated API latency",
+            "published_at": "2021-08-17T13:28:57.801578Z",
+            "status": "investigating",
+            "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "updates": [
+              {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational",
+                    "status": "operational"
+                  }
+                ],
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "message": "abc123",
+                "published_at": "2021-08-17T13:28:57.801578Z",
+                "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "to_status": "investigating"
+              }
+            ]
+          }
+        },
+        "properties": {
+          "status_page_incident": {
+            "$ref": "#/components/schemas/StatusPageIncidentV2"
+          }
+        },
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageIncidentUpdatePayloadV2": {
+        "example": {
+          "component_statuses": [
+            {
+              "component_id": "abc123",
+              "current_status": "operational"
+            }
+          ],
+          "message": "abc123",
+          "notify_subscribers": false,
+          "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+          "to_status": "investigating"
+        },
+        "properties": {
+          "component_statuses": {
+            "description": "An array of mappings from component ID to component status. This must not be set if the status page incident status is being set to \"resolved\", as all components statuses will update to \"operational\".",
+            "example": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageIncidentAffectedComponentSlimV2"
+            },
+            "type": "array"
+          },
+          "message": {
+            "description": "Markdown update on what's changed about this status page incident",
+            "example": "abc123",
+            "type": "string"
+          },
+          "notify_subscribers": {
+            "description": "Whether to notify subscribers about this incident update",
+            "example": false,
+            "type": "boolean"
+          },
+          "status_page_incident_id": {
+            "description": "ID of the status page incident",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "type": "string"
+          },
+          "to_status": {
+            "description": "New status for this status page incident. Setting to \"resolved\" will end the status page incident.",
+            "enum": [
+              "investigating",
+              "identified",
+              "monitoring",
+              "resolved"
+            ],
+            "example": "investigating",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status_page_incident_id",
+          "message",
+          "notify_subscribers"
+        ],
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageIncidentUpdateResultV2": {
+        "example": {
+          "status_page_incident_update": {
+            "component_statuses": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational",
+                "status": "operational"
+              }
+            ],
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "message": "abc123",
+            "published_at": "2021-08-17T13:28:57.801578Z",
+            "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "to_status": "investigating"
+          }
+        },
+        "properties": {
+          "status_page_incident_update": {
+            "$ref": "#/components/schemas/StatusPageIncidentUpdateV2"
+          }
+        },
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageMaintenancePayloadV2": {
+        "example": {
+          "affected_component_ids": [
+            "abc123"
+          ],
+          "end_at": "1970-01-01T00:00:01Z",
+          "idempotency_key": "abc123",
+          "message": "abc123",
+          "name": "Routine infrastructure upgrade",
+          "start_at": "1970-01-01T00:00:01Z",
+          "status": "maintenance_scheduled",
+          "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+        },
+        "properties": {
+          "affected_component_ids": {
+            "description": "An array of IDs of component affected by the maintenance window",
+            "example": [
+              "abc123"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "end_at": {
+            "description": "The time the maintenance window ends",
+            "example": "1970-01-01T00:00:01Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "idempotency_key": {
+            "description": "A unique key to de-duplicate maintenances",
+            "example": "abc123",
+            "type": "string"
+          },
+          "message": {
+            "description": "Markdown initial update on this status page maintenance window",
+            "example": "abc123",
+            "type": "string"
+          },
+          "name": {
+            "description": "A title for the maintenance window",
+            "example": "Routine infrastructure upgrade",
+            "type": "string"
+          },
+          "start_at": {
+            "description": "The time the maintenance window starts",
+            "example": "1970-01-01T00:00:01Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current status for this status page maintenance window",
+            "enum": [
+              "maintenance_scheduled",
+              "maintenance_in_progress",
+              "maintenance_complete"
+            ],
+            "example": "maintenance_scheduled",
+            "type": "string"
+          },
+          "status_page_id": {
+            "description": "ID of the status page",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status_page_id",
+          "name",
+          "status",
+          "idempotency_key",
+          "affected_component_ids",
+          "start_at",
+          "end_at",
+          "message"
+        ],
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageMaintenanceResultV2": {
+        "example": {
+          "status_page_maintenance": {
+            "component_impacts": [
+              {
+                "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "start_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Routine infrastructure upgrade",
+            "published_at": "2021-08-17T13:28:57.801578Z",
+            "status": "maintenance_scheduled",
+            "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "updates": [
+              {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational"
+                  }
+                ],
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "message": "abc123",
+                "published_at": "2021-08-17T13:28:57.801578Z",
+                "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "to_status": "maintenance_scheduled"
+              }
+            ]
+          }
+        },
+        "properties": {
+          "status_page_maintenance": {
+            "$ref": "#/components/schemas/StatusPageMaintenanceV2"
+          }
+        },
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2": {
+        "example": {
+          "component_statuses": [
+            {
+              "component_id": "abc123",
+              "current_status": "operational"
+            }
+          ],
+          "message": "abc123",
+          "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+          "to_status": "maintenance_scheduled"
+        },
+        "properties": {
+          "component_statuses": {
+            "description": "An array of mappings from component ID to component status. This must not be set if the status page maintenance window status is being set to \"maintenance_complete\", as all components statuses will update to \"operational\".",
+            "example": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageMaintenanceAffectedComponentV2"
+            },
+            "type": "array"
+          },
+          "message": {
+            "description": "Markdown update on what's changed about this status page maintenance window",
+            "example": "abc123",
+            "type": "string"
+          },
+          "status_page_maintenance_id": {
+            "description": "ID of the status page maintenance window",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "type": "string"
+          },
+          "to_status": {
+            "description": "Current status for this status page maintenance window",
+            "enum": [
+              "maintenance_scheduled",
+              "maintenance_in_progress",
+              "maintenance_complete"
+            ],
+            "example": "maintenance_scheduled",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status_page_maintenance_id",
+          "message"
+        ],
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageMaintenanceUpdateResultV2": {
+        "example": {
+          "status_page_maintenance_update": {
+            "component_statuses": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational"
+              }
+            ],
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "message": "abc123",
+            "published_at": "2021-08-17T13:28:57.801578Z",
+            "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "to_status": "maintenance_scheduled"
+          }
+        },
+        "properties": {
+          "status_page_maintenance_update": {
+            "$ref": "#/components/schemas/StatusPageMaintenanceUpdateV2"
+          }
+        },
         "type": "object"
       },
       "StatusPagesListResponseIncidentsResultV1": {
@@ -38882,6 +41165,252 @@
         "required": [
           "incidents"
         ],
+        "type": "object"
+      },
+      "StatusPagesListStatusPagesPayloadV2": {
+        "example": {
+          "after": "01FDAG4SAP5TYPT98WGR2N7W91",
+          "page_size": 25
+        },
+        "properties": {
+          "after": {
+            "description": "An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "type": "string"
+          },
+          "page_size": {
+            "default": 25,
+            "description": "Integer number of records to return",
+            "example": 25,
+            "format": "int64",
+            "maximum": 250,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "StatusPagesListStatusPagesResultV2": {
+        "example": {
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          },
+          "status_pages": [
+            {
+              "description": "This status page is our public status page.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Our public status page",
+              "public_url": "https://statuspage.incident.io/our-public-status-page"
+            }
+          ]
+        },
+        "properties": {
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          },
+          "status_pages": {
+            "example": [
+              {
+                "description": "This status page is our public status page.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Our public status page",
+                "public_url": "https://statuspage.incident.io/our-public-status-page"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "status_pages",
+          "pagination_meta"
+        ],
+        "type": "object"
+      },
+      "StatusPagesShowStatusPageIncidentResultV2": {
+        "example": {
+          "status_page_incident": {
+            "affected_components": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational",
+                "status": "operational"
+              }
+            ],
+            "component_impacts": [
+              {
+                "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "status": "degraded_performance"
+              }
+            ],
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Elevated API latency",
+            "published_at": "2021-08-17T13:28:57.801578Z",
+            "status": "investigating",
+            "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "updates": [
+              {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational",
+                    "status": "operational"
+                  }
+                ],
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "message": "abc123",
+                "published_at": "2021-08-17T13:28:57.801578Z",
+                "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "to_status": "investigating"
+              }
+            ]
+          }
+        },
+        "properties": {
+          "status_page_incident": {
+            "$ref": "#/components/schemas/StatusPageIncidentV2"
+          }
+        },
+        "type": "object"
+      },
+      "StatusPagesShowStatusPageMaintenanceResultV2": {
+        "example": {
+          "status_page_maintenance": {
+            "component_impacts": [
+              {
+                "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "start_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Routine infrastructure upgrade",
+            "published_at": "2021-08-17T13:28:57.801578Z",
+            "status": "maintenance_scheduled",
+            "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "updates": [
+              {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational"
+                  }
+                ],
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "message": "abc123",
+                "published_at": "2021-08-17T13:28:57.801578Z",
+                "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "to_status": "maintenance_scheduled"
+              }
+            ]
+          }
+        },
+        "properties": {
+          "status_page_maintenance": {
+            "$ref": "#/components/schemas/StatusPageMaintenanceV2"
+          }
+        },
+        "type": "object"
+      },
+      "StatusPagesShowStatusPageStructureResultV2": {
+        "example": {
+          "current_structure": {
+            "items": [
+              {
+                "component": {
+                  "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                  "name": "App"
+                },
+                "group": {
+                  "components": [
+                    {
+                      "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                      "name": "App"
+                    }
+                  ],
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                  "name": "EU Data center"
+                }
+              }
+            ]
+          }
+        },
+        "properties": {
+          "current_structure": {
+            "$ref": "#/components/schemas/StatusPageStructureV2"
+          }
+        },
+        "required": [
+          "current_structure"
+        ],
+        "type": "object"
+      },
+      "StatusPagesUpdateStatusPageIncidentPayloadV2": {
+        "example": {
+          "name": "Elevated API latency"
+        },
+        "properties": {
+          "name": {
+            "description": "A title for the incident",
+            "example": "Elevated API latency",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "StatusPagesUpdateStatusPageIncidentResultV2": {
+        "example": {
+          "status_page_incident": {
+            "affected_components": [
+              {
+                "component_id": "abc123",
+                "current_status": "operational",
+                "status": "operational"
+              }
+            ],
+            "component_impacts": [
+              {
+                "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "status": "degraded_performance"
+              }
+            ],
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "name": "Elevated API latency",
+            "published_at": "2021-08-17T13:28:57.801578Z",
+            "status": "investigating",
+            "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "updates": [
+              {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational",
+                    "status": "operational"
+                  }
+                ],
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "message": "abc123",
+                "published_at": "2021-08-17T13:28:57.801578Z",
+                "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "to_status": "investigating"
+              }
+            ]
+          }
+        },
+        "properties": {
+          "status_page_incident": {
+            "$ref": "#/components/schemas/StatusPageIncidentV2"
+          }
+        },
         "type": "object"
       },
       "StepConfigPayloadV2": {
@@ -39788,7 +42317,7 @@
             "type": "string"
           },
           "postmortem_document_url": {
-            "description": "Description of the incident",
+            "description": "The URL of the incident post-mortem document",
             "example": "https://docs.google.com/my_doc_id",
             "type": "string"
           },
@@ -42773,8 +45302,8 @@
           ],
           "folder": "My folder 01",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "include_private_incidents": true,
           "include_private_escalations": true,
+          "include_private_incidents": true,
           "name": "My little workflow",
           "once_for": [
             {
@@ -43007,13 +45536,13 @@
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
             "type": "string"
           },
-          "include_private_incidents": {
-            "description": "Whether to include private incidents",
+          "include_private_escalations": {
+            "description": "Whether to include private escalations",
             "example": true,
             "type": "boolean"
           },
-          "include_private_escalations": {
-            "description": "Whether to include private escalations",
+          "include_private_incidents": {
+            "description": "Whether to include private incidents",
             "example": true,
             "type": "boolean"
           },
@@ -43121,6 +45650,7 @@
           "condition_groups",
           "steps",
           "include_private_incidents",
+          "include_private_escalations",
           "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents",
@@ -43306,8 +45836,8 @@
           ],
           "folder": "My folder 01",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-          "include_private_incidents": true,
           "include_private_escalations": true,
+          "include_private_incidents": true,
           "name": "My little workflow",
           "once_for": [
             {
@@ -43558,13 +46088,13 @@
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
             "type": "string"
           },
-          "include_private_incidents": {
-            "description": "Whether to include private incidents",
+          "include_private_escalations": {
+            "description": "Whether to include private escalations",
             "example": true,
             "type": "boolean"
           },
-          "include_private_escalations": {
-            "description": "Whether to include private escalations",
+          "include_private_incidents": {
+            "description": "Whether to include private incidents",
             "example": true,
             "type": "boolean"
           },
@@ -43690,6 +46220,7 @@
           "condition_groups",
           "steps",
           "include_private_incidents",
+          "include_private_escalations",
           "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents",
@@ -43843,8 +46374,8 @@
             }
           ],
           "folder": "My folder 01",
-          "include_private_incidents": true,
           "include_private_escalations": true,
+          "include_private_incidents": true,
           "name": "My little workflow",
           "once_for": [
             "incident.url"
@@ -44054,13 +46585,13 @@
             "example": "My folder 01",
             "type": "string"
           },
-          "include_private_incidents": {
-            "description": "Whether to include private incidents",
+          "include_private_escalations": {
+            "description": "Whether to include private escalations",
             "example": true,
             "type": "boolean"
           },
-          "include_private_escalations": {
-            "description": "Whether to include private escalations",
+          "include_private_incidents": {
+            "description": "Whether to include private incidents",
             "example": true,
             "type": "boolean"
           },
@@ -44357,6 +46888,7 @@
             ],
             "folder": "My folder 01",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "include_private_escalations": true,
             "include_private_incidents": true,
             "name": "My little workflow",
             "once_for": [
@@ -44601,6 +47133,7 @@
               ],
               "folder": "My folder 01",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "include_private_escalations": true,
               "include_private_incidents": true,
               "name": "My little workflow",
               "once_for": [
@@ -44814,6 +47347,7 @@
                 ],
                 "folder": "My folder 01",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "include_private_escalations": true,
                 "include_private_incidents": true,
                 "name": "My little workflow",
                 "once_for": [
@@ -45043,6 +47577,7 @@
             ],
             "folder": "My folder 01",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "include_private_escalations": true,
             "include_private_incidents": true,
             "name": "My little workflow",
             "once_for": [
@@ -45253,8 +47788,8 @@
             }
           ],
           "folder": "My folder 01",
-          "include_private_incidents": true,
           "include_private_escalations": true,
+          "include_private_incidents": true,
           "name": "My little workflow",
           "once_for": [
             "incident.url"
@@ -45266,6 +47801,7 @@
           ],
           "runs_on_incidents": "newly_created",
           "shortform": "page-the-ceo",
+          "skip_step_upgrades": false,
           "state": "active",
           "steps": [
             {
@@ -45463,13 +47999,13 @@
             "example": "My folder 01",
             "type": "string"
           },
-          "include_private_incidents": {
-            "description": "Whether to include private incidents",
+          "include_private_escalations": {
+            "description": "Whether to include private escalations",
             "example": true,
             "type": "boolean"
           },
-          "include_private_escalations": {
-            "description": "Whether to include private escalations",
+          "include_private_incidents": {
+            "description": "Whether to include private incidents",
             "example": true,
             "type": "boolean"
           },
@@ -45520,6 +48056,11 @@
             "description": "The shortform used to trigger this workflow (only applicable for manual triggers)",
             "example": "page-the-ceo",
             "type": "string"
+          },
+          "skip_step_upgrades": {
+            "description": "Skips workflow step upgrades, when the parameters for an existing workflow step change",
+            "example": false,
+            "type": "boolean"
           },
           "state": {
             "description": "What state this workflow is in",
@@ -45760,6 +48301,7 @@
             ],
             "folder": "My folder 01",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "include_private_escalations": true,
             "include_private_incidents": true,
             "name": "My little workflow",
             "once_for": [
@@ -49330,6 +51872,9 @@
                 },
                 "is_private": false,
                 "name": "Production incidents",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "updated_at": "2021-08-17T13:28:57.801578Z",
                 "version": 1
               },
@@ -49843,6 +52388,9 @@
                     },
                     "is_private": false,
                     "name": "Production incidents",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "updated_at": "2021-08-17T13:28:57.801578Z",
                     "version": 1
                   }
@@ -50409,6 +52957,9 @@
                     },
                     "is_private": false,
                     "name": "Production incidents",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "updated_at": "2021-08-17T13:28:57.801578Z",
                     "version": 1
                   }
@@ -50866,6 +53417,9 @@
                 },
                 "is_private": false,
                 "name": "Production incidents",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "updated_at": "2021-08-17T13:28:57.801578Z",
                 "version": 1
               },
@@ -51379,6 +53933,9 @@
                     },
                     "is_private": false,
                     "name": "Production incidents",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "updated_at": "2021-08-17T13:28:57.801578Z",
                     "version": 1
                   }
@@ -51423,6 +53980,9 @@
                         ]
                       },
                       "name": "Production Web Dashboard Alerts",
+                      "owning_team_ids": [
+                        "01G0J1EXE7AXZ2C93K61WBPYEH"
+                      ],
                       "secret_token": "some-secret-token",
                       "source_type": "alertmanager",
                       "template": {
@@ -51642,6 +54202,9 @@
                   ]
                 },
                 "name": "Production Web Dashboard Alerts",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "source_type": "alertmanager",
                 "template": {
                   "attributes": [
@@ -51823,6 +54386,9 @@
                       ]
                     },
                     "name": "Production Web Dashboard Alerts",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "secret_token": "some-secret-token",
                     "source_type": "alertmanager",
                     "template": {
@@ -52090,6 +54656,9 @@
                       ]
                     },
                     "name": "Production Web Dashboard Alerts",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "secret_token": "some-secret-token",
                     "source_type": "alertmanager",
                     "template": {
@@ -52322,6 +54891,9 @@
                   ]
                 },
                 "name": "Production Web Dashboard Alerts",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "template": {
                   "attributes": [
                     {
@@ -52502,6 +55074,9 @@
                       ]
                     },
                     "name": "Production Web Dashboard Alerts",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "secret_token": "some-secret-token",
                     "source_type": "alertmanager",
                     "template": {
@@ -54493,6 +57068,15 @@
               "application/json": {
                 "example": {
                   "escalation_path": {
+                    "current_responders": [
+                      {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      }
+                    ],
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Urgent Support",
                     "path": [
@@ -54656,6 +57240,15 @@
               "application/json": {
                 "example": {
                   "escalation_path": {
+                    "current_responders": [
+                      {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      }
+                    ],
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Urgent Support",
                     "path": [
@@ -54889,6 +57482,15 @@
               "application/json": {
                 "example": {
                   "escalation_path": {
+                    "current_responders": [
+                      {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "viewer",
+                        "slack_user_id": "U02AYNF2XJM"
+                      }
+                    ],
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "name": "Urgent Support",
                     "path": [
@@ -55179,6 +57781,36 @@
               "example": {
                 "gte": [
                   "2021-08-17"
+                ]
+              },
+              "type": "object"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "Filter on the idempotency key of the escalation. This is the key set when creating escalations via the API, and is distinct from alert deduplication keys. Accepted operators are 'is' for exact matches and 'starts_with' for prefix matching.",
+            "example": {
+              "starts_with": [
+                "team-a:"
+              ]
+            },
+            "in": "query",
+            "name": "idempotency_key",
+            "schema": {
+              "additionalProperties": {
+                "example": [
+                  "some_value"
+                ],
+                "items": {
+                  "example": "some_value",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "Filter on the idempotency key of the escalation. This is the key set when creating escalations via the API, and is distinct from alert deduplication keys. Accepted operators are 'is' for exact matches and 'starts_with' for prefix matching.",
+              "example": {
+                "starts_with": [
+                  "team-a:"
                 ]
               },
               "type": "object"
@@ -56251,7 +58883,7 @@
     },
     "/v2/incidents": {
       "get": {
-        "description": "List all incidents for an organisation.\n\nThis endpoint supports a number of filters, which can help find incidents matching certain\ncriteria.\n\nFilters are provided as query parameters, but due to the dynamic nature of what you can\nquery by (different accounts have different custom fields, statuses, etc) they are more\ncomplex than most.\n\nThe maximum page size that can be requested is 250.\n\nTo help, here are some exemplar curl requests with a human description of what they search\nfor.\n\nNote that:\n- Filters may be used together, and the result will be incidents that match all filters.\n- IDs are normally in UUID format, but have been replaced with shorter strings to improve\nreadability.\n- All query parameters must be URI encoded.\n\n### By status\n\nWith status of id=ABC, find all incidents that are set to that status:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[one_of]=ABC'\n\nOr all incidents that are not set to status with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[not_in]=ABC'\n\n### By created_at or updated_at\n\nFind all incidents that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and\n\"date_range\" (between two dates). The following example finds all incidents created before\nor on 2021-01-02T00:00:00Z:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[lte]=2021-01-02'\n\nTo find incidents created within a specific date range, use the date_range option with\ntilde-separated dates:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[date_range]=2024-12-02~2024-12-08'\n\n### By status category\n\nFind all incidents that are in a status category. Possible values are \"triage\",\n\"declined\", \"merged\", \"canceled\", \"live\", \"learning\" and \"closed\":\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[one_of]=live'\n\nOr all incidents that are not in a status category:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[not_in]=live'\n\n\n### By severity\n\nWith severity of id=ABC, find all incidents that are set to that severity:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[one_of]=ABC'\n\nOr all incidents where severity rank is greater-than-or-equal-to the rank of severity\nid=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[gte]=ABC'\n\nOr all incidents where severity rank is less-than-or-equal-to the rank of severity id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[lte]=ABC'\n\n### By incident type\n\nWith incident type of id=ABC, find all incidents that are of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[one_of]=ABC'\n\nOr all incidents not of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[not_in]=ABC'\n\n### By incident mode\n\nBy default, we return standard and retrospective incidents. This means that test and\ntutorial incidents are filtered out. To override this behaviour, you can use the\nmode filter to specify which modes you want to get.\n\nTo find incidents of all modes:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=standard\u0026mode[one_of]=retrospective\u0026mode[one_of]=test\u0026mode[one_of]=tutorial'\n\nTo find just test incidents:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=test'\n\n\n### By incident role\n\nRoles and custom fields have another nested layer in the query parameter, to account for\noperations against any of the roles or custom fields created in the account.\n\nWith incident role id=ABC, find all incidents where that role is unset:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_set]=true'\n\nOr where the role has been set:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_set]=false'\n\n### By option custom fields\n\nWith an option custom field id=ABC, all incidents that have field ABC set to the custom\nfield option of id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][one_of]=XYZ'\n\nOr all incidents that do not have custom field id=ABC set to option id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][not_in]=XYZ'\n",
+        "description": "List all incidents for an organisation.\n\nThis endpoint supports a number of filters, which can help find incidents matching certain\ncriteria.\n\nFilters are provided as query parameters, but due to the dynamic nature of what you can\nquery by (different accounts have different custom fields, statuses, etc) they are more\ncomplex than most.\n\nThe maximum page size that can be requested is 250.\n\nTo help, here are some exemplar curl requests with a human description of what they search\nfor.\n\nNote that:\n- Filters may be combined using the filter_mode parameter: 'all' (default) requires all filters\nto match (AND logic), while 'any' requires at least one filter to match (OR logic).\n- IDs are normally in UUID format, but have been replaced with shorter strings to improve\nreadability.\n- All query parameters must be URI encoded.\n\n### By status\n\nWith status of id=ABC, find all incidents that are set to that status:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[one_of]=ABC'\n\nOr all incidents that are not set to status with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[not_in]=ABC'\n\n### By created_at or updated_at\n\nFind all incidents that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and\n\"date_range\" (between two dates). The following example finds all incidents created before\nor on 2021-01-02T00:00:00Z:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[lte]=2021-01-02'\n\nTo find incidents created within a specific date range, use the date_range option with\ntilde-separated dates:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[date_range]=2024-12-02~2024-12-08'\n\n### By status category\n\nFind all incidents that are in a status category. Possible values are \"triage\",\n\"declined\", \"merged\", \"canceled\", \"live\", \"learning\" and \"closed\":\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[one_of]=live'\n\nOr all incidents that are not in a status category:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[not_in]=live'\n\n\n### By severity\n\nWith severity of id=ABC, find all incidents that are set to that severity:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[one_of]=ABC'\n\nOr all incidents where severity rank is greater-than-or-equal-to the rank of severity\nid=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[gte]=ABC'\n\nOr all incidents where severity rank is less-than-or-equal-to the rank of severity id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[lte]=ABC'\n\n### By incident type\n\nWith incident type of id=ABC, find all incidents that are of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[one_of]=ABC'\n\nOr all incidents not of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[not_in]=ABC'\n\n### By incident mode\n\nBy default, we return standard and retrospective incidents. This means that test and\ntutorial incidents are filtered out. To override this behaviour, you can use the\nmode filter to specify which modes you want to get.\n\nTo find incidents of all modes:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=standard\u0026mode[one_of]=retrospective\u0026mode[one_of]=test\u0026mode[one_of]=tutorial'\n\nTo find just test incidents:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=test'\n\n\n### By incident role\n\nRoles and custom fields have another nested layer in the query parameter, to account for\noperations against any of the roles or custom fields created in the account.\n\nWith incident role id=ABC, find all incidents where that role is unset:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_set]=true'\n\nOr where the role has been set:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_set]=false'\n\n### By option custom fields\n\nWith an option custom field id=ABC, all incidents that have field ABC set to the custom\nfield option of id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][one_of]=XYZ'\n\nOr all incidents that do not have custom field id=ABC set to option id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][not_in]=XYZ'\n",
         "operationId": "Incidents V2#List",
         "parameters": [
           {
@@ -56283,6 +58915,22 @@
             "schema": {
               "description": "An incident's ID. This endpoint will return a list of incidents after this ID in relation to the API response order.",
               "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "How to combine the filters: 'all' combines them with AND logic (all must match), 'any' combines them with OR logic (any can match). Defaults to 'all'.",
+            "example": "all",
+            "in": "query",
+            "name": "filter_mode",
+            "schema": {
+              "description": "How to combine the filters: 'all' combines them with AND logic (all must match), 'any' combines them with OR logic (any can match). Defaults to 'all'.",
+              "enum": [
+                "all",
+                "any"
+              ],
+              "example": "all",
               "type": "string"
             }
           },
@@ -58329,6 +60977,623 @@
         ]
       }
     },
+    "/v2/status_page_incident_updates": {
+      "post": {
+        "description": "Post an update on a Status Page incident.",
+        "operationId": "Status Pages V2#CreateStatusPageIncidentUpdate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational"
+                  }
+                ],
+                "message": "abc123",
+                "notify_subscribers": false,
+                "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "to_status": "investigating"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/StatusPagesCreateStatusPageIncidentUpdatePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "status_page_incident_update": {
+                    "component_statuses": [
+                      {
+                        "component_id": "abc123",
+                        "current_status": "operational",
+                        "status": "operational"
+                      }
+                    ],
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "message": "abc123",
+                    "published_at": "2021-08-17T13:28:57.801578Z",
+                    "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                    "to_status": "investigating"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesCreateStatusPageIncidentUpdateResultV2"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "CreateStatusPageIncidentUpdate Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ]
+      }
+    },
+    "/v2/status_page_incidents": {
+      "post": {
+        "description": "Create a status page incident.",
+        "operationId": "Status Pages V2#CreateStatusPageIncident",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational"
+                  }
+                ],
+                "idempotency_key": "abc123",
+                "message": "abc123",
+                "name": "Elevated API latency",
+                "notify_subscribers": false,
+                "status": "investigating",
+                "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/StatusPagesCreateStatusPageIncidentPayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "status_page_incident": {
+                    "affected_components": [
+                      {
+                        "component_id": "abc123",
+                        "current_status": "operational",
+                        "status": "operational"
+                      }
+                    ],
+                    "component_impacts": [
+                      {
+                        "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "start_at": "2021-08-17T13:28:57.801578Z",
+                        "status": "degraded_performance"
+                      }
+                    ],
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Elevated API latency",
+                    "published_at": "2021-08-17T13:28:57.801578Z",
+                    "status": "investigating",
+                    "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "updates": [
+                      {
+                        "component_statuses": [
+                          {
+                            "component_id": "abc123",
+                            "current_status": "operational",
+                            "status": "operational"
+                          }
+                        ],
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "message": "abc123",
+                        "published_at": "2021-08-17T13:28:57.801578Z",
+                        "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                        "to_status": "investigating"
+                      }
+                    ]
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesCreateStatusPageIncidentResultV2"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "CreateStatusPageIncident Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ]
+      }
+    },
+    "/v2/status_page_incidents/{status_page_incident_id}": {
+      "get": {
+        "description": "Show a status page incident.",
+        "operationId": "Status Pages V2#ShowStatusPageIncident",
+        "parameters": [
+          {
+            "description": "ID of the status page incident",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "in": "path",
+            "name": "status_page_incident_id",
+            "required": true,
+            "schema": {
+              "description": "ID of the status page incident",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "status_page_incident": {
+                    "affected_components": [
+                      {
+                        "component_id": "abc123",
+                        "current_status": "operational",
+                        "status": "operational"
+                      }
+                    ],
+                    "component_impacts": [
+                      {
+                        "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "start_at": "2021-08-17T13:28:57.801578Z",
+                        "status": "degraded_performance"
+                      }
+                    ],
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Elevated API latency",
+                    "published_at": "2021-08-17T13:28:57.801578Z",
+                    "status": "investigating",
+                    "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "updates": [
+                      {
+                        "component_statuses": [
+                          {
+                            "component_id": "abc123",
+                            "current_status": "operational",
+                            "status": "operational"
+                          }
+                        ],
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "message": "abc123",
+                        "published_at": "2021-08-17T13:28:57.801578Z",
+                        "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                        "to_status": "investigating"
+                      }
+                    ]
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesShowStatusPageIncidentResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ShowStatusPageIncident Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ]
+      },
+      "put": {
+        "description": "Update a status page incident.",
+        "operationId": "Status Pages V2#UpdateStatusPageIncident",
+        "parameters": [
+          {
+            "description": "ID of the status page incident",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "in": "path",
+            "name": "status_page_incident_id",
+            "required": true,
+            "schema": {
+              "description": "ID of the status page incident",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "name": "Elevated API latency"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/StatusPagesUpdateStatusPageIncidentPayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "status_page_incident": {
+                    "affected_components": [
+                      {
+                        "component_id": "abc123",
+                        "current_status": "operational",
+                        "status": "operational"
+                      }
+                    ],
+                    "component_impacts": [
+                      {
+                        "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "start_at": "2021-08-17T13:28:57.801578Z",
+                        "status": "degraded_performance"
+                      }
+                    ],
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Elevated API latency",
+                    "published_at": "2021-08-17T13:28:57.801578Z",
+                    "status": "investigating",
+                    "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "updates": [
+                      {
+                        "component_statuses": [
+                          {
+                            "component_id": "abc123",
+                            "current_status": "operational",
+                            "status": "operational"
+                          }
+                        ],
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "message": "abc123",
+                        "published_at": "2021-08-17T13:28:57.801578Z",
+                        "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                        "to_status": "investigating"
+                      }
+                    ]
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesUpdateStatusPageIncidentResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "UpdateStatusPageIncident Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ]
+      }
+    },
+    "/v2/status_page_maintenance_updates": {
+      "post": {
+        "description": "Post an update on a Status Page maintenance window",
+        "operationId": "Status Pages V2#CreateStatusPageMaintenanceUpdate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "component_statuses": [
+                  {
+                    "component_id": "abc123",
+                    "current_status": "operational"
+                  }
+                ],
+                "message": "abc123",
+                "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                "to_status": "maintenance_scheduled"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "status_page_maintenance_update": {
+                    "component_statuses": [
+                      {
+                        "component_id": "abc123",
+                        "current_status": "operational"
+                      }
+                    ],
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "message": "abc123",
+                    "published_at": "2021-08-17T13:28:57.801578Z",
+                    "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                    "to_status": "maintenance_scheduled"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesCreateStatusPageMaintenanceUpdateResultV2"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "CreateStatusPageMaintenanceUpdate Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ]
+      }
+    },
+    "/v2/status_page_maintenances": {
+      "post": {
+        "description": "Schedule a Status Page maintenance window",
+        "operationId": "Status Pages V2#CreateStatusPageMaintenance",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "affected_component_ids": [
+                  "abc123"
+                ],
+                "end_at": "1970-01-01T00:00:01Z",
+                "idempotency_key": "abc123",
+                "message": "abc123",
+                "name": "Routine infrastructure upgrade",
+                "start_at": "1970-01-01T00:00:01Z",
+                "status": "maintenance_scheduled",
+                "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/StatusPagesCreateStatusPageMaintenancePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "status_page_maintenance": {
+                    "component_impacts": [
+                      {
+                        "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "start_at": "2021-08-17T13:28:57.801578Z"
+                      }
+                    ],
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Routine infrastructure upgrade",
+                    "published_at": "2021-08-17T13:28:57.801578Z",
+                    "status": "maintenance_scheduled",
+                    "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "updates": [
+                      {
+                        "component_statuses": [
+                          {
+                            "component_id": "abc123",
+                            "current_status": "operational"
+                          }
+                        ],
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "message": "abc123",
+                        "published_at": "2021-08-17T13:28:57.801578Z",
+                        "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                        "to_status": "maintenance_scheduled"
+                      }
+                    ]
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesCreateStatusPageMaintenanceResultV2"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "CreateStatusPageMaintenance Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ]
+      }
+    },
+    "/v2/status_page_maintenances/{status_page_maintenance_id}": {
+      "get": {
+        "description": "Show a status page maintenance window.",
+        "operationId": "Status Pages V2#ShowStatusPageMaintenance",
+        "parameters": [
+          {
+            "description": "ID of the status page maintenance window",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+            "in": "path",
+            "name": "status_page_maintenance_id",
+            "required": true,
+            "schema": {
+              "description": "ID of the status page maintenance window",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG1",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "status_page_maintenance": {
+                    "component_impacts": [
+                      {
+                        "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "start_at": "2021-08-17T13:28:57.801578Z"
+                      }
+                    ],
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Routine infrastructure upgrade",
+                    "published_at": "2021-08-17T13:28:57.801578Z",
+                    "status": "maintenance_scheduled",
+                    "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "updates": [
+                      {
+                        "component_statuses": [
+                          {
+                            "component_id": "abc123",
+                            "current_status": "operational"
+                          }
+                        ],
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "message": "abc123",
+                        "published_at": "2021-08-17T13:28:57.801578Z",
+                        "status_page_maintenance_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                        "to_status": "maintenance_scheduled"
+                      }
+                    ]
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesShowStatusPageMaintenanceResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ShowStatusPageMaintenance Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ]
+      }
+    },
+    "/v2/status_page_structures/{status_page_id}": {
+      "get": {
+        "description": "Show the structure of a status page.",
+        "operationId": "Status Pages V2#ShowStatusPageStructure",
+        "parameters": [
+          {
+            "description": "ID of the status page",
+            "example": "abc123",
+            "in": "path",
+            "name": "status_page_id",
+            "required": true,
+            "schema": {
+              "description": "ID of the status page",
+              "example": "abc123",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "current_structure": {
+                    "items": [
+                      {
+                        "component": {
+                          "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                          "name": "App"
+                        },
+                        "group": {
+                          "components": [
+                            {
+                              "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                              "name": "App"
+                            }
+                          ],
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG1",
+                          "name": "EU Data center"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesShowStatusPageStructureResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ShowStatusPageStructure Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ]
+      }
+    },
+    "/v2/status_pages": {
+      "get": {
+        "description": "List status pages.",
+        "operationId": "Status Pages V2#ListStatusPages",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "after": "01FDAG4SAP5TYPT98WGR2N7W91",
+                "page_size": 25
+              },
+              "schema": {
+                "$ref": "#/components/schemas/StatusPagesListStatusPagesPayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  },
+                  "status_pages": [
+                    {
+                      "description": "This status page is our public status page.",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Our public status page",
+                      "public_url": "https://statuspage.incident.io/our-public-status-page"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesListStatusPagesResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ListStatusPages Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ]
+      }
+    },
     "/v2/users": {
       "get": {
         "description": "List users in your account.",
@@ -58679,6 +61944,7 @@
                       ],
                       "folder": "My folder 01",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "include_private_escalations": true,
                       "include_private_incidents": true,
                       "name": "My little workflow",
                       "once_for": [
@@ -58876,6 +62142,7 @@
                   }
                 ],
                 "folder": "My folder 01",
+                "include_private_escalations": true,
                 "include_private_incidents": true,
                 "name": "My little workflow",
                 "once_for": [
@@ -59108,6 +62375,7 @@
                     ],
                     "folder": "My folder 01",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "include_private_escalations": true,
                     "include_private_incidents": true,
                     "name": "My little workflow",
                     "once_for": [
@@ -59418,6 +62686,7 @@
                     ],
                     "folder": "My folder 01",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "include_private_escalations": true,
                     "include_private_incidents": true,
                     "name": "My little workflow",
                     "once_for": [
@@ -59651,6 +62920,7 @@
                   }
                 ],
                 "folder": "My folder 01",
+                "include_private_escalations": true,
                 "include_private_incidents": true,
                 "name": "My little workflow",
                 "once_for": [
@@ -59663,6 +62933,7 @@
                 ],
                 "runs_on_incidents": "newly_created",
                 "shortform": "page-the-ceo",
+                "skip_step_upgrades": false,
                 "state": "active",
                 "steps": [
                   {
@@ -59882,6 +63153,7 @@
                     ],
                     "folder": "My folder 01",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "include_private_escalations": true,
                     "include_private_incidents": true,
                     "name": "My little workflow",
                     "once_for": [
@@ -60098,7 +63370,8 @@
                   },
                   "pagination_meta": {
                     "after": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "page_size": 25
+                    "page_size": 25,
+                    "total_record_count": 238
                   }
                 },
                 "schema": {
@@ -60199,7 +63472,7 @@
     },
     "/v3/catalog_entries/actions/bulk_update": {
       "post": {
-        "description": "Update multiple catalog entries in a single operation. You can update up to 100 entries at once. This operation is atomic - either all entries are updated successfully, or none are updated.",
+        "description": "Update multiple catalog entries in a single operation. You can update up to 250 entries at once. This operation is atomic - either all entries are updated successfully, or none are updated.",
         "operationId": "Catalog V3#BulkUpdateEntries",
         "requestBody": {
           "content": {
@@ -61213,6 +64486,10 @@
       "name": "Status Pages V1"
     },
     {
+      "description": "Manage and publish to status pages.\n\nUsing this, you can list status pages, see the structure of status pages, declare and publish updates on status page incidents,\nand schedule and publish updates on maintenance windows on status pages.\n",
+      "name": "Status Pages V2"
+    },
+    {
       "description": "View users.\n\nUsers all have a single base role, and can be assigned multiple custom roles. They can be managed via your Slack workspace or SAML provider.\n",
       "name": "Users V2"
     },
@@ -61234,6 +64511,190 @@
     }
   ],
   "x-webhooks": {
+    "/x-audit-logs/alert_priority.created.1": {
+      "get": {
+        "description": "This entry is created whenever an alert priority is created",
+        "operationId": "AlertPriorityCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "alert_priority.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Urgent",
+                      "type": "alert_priority"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAlertPriorityCreatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/alert_priority.deleted.1": {
+      "get": {
+        "description": "This entry is created whenever an alert priority is deleted",
+        "operationId": "AlertPriorityDeletedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "alert_priority.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Urgent",
+                      "type": "alert_priority"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAlertPriorityDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/alert_priority.set_as_default.1": {
+      "get": {
+        "description": "This entry is created whenever an alert priority is set as the default",
+        "operationId": "AlertPrioritySetAsDefaultV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "alert_priority.set_as_default",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Urgent",
+                      "type": "alert_priority"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAlertPrioritySetAsDefaultV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/alert_priority.updated.1": {
+      "get": {
+        "description": "This entry is created whenever an alert priority is updated",
+        "operationId": "AlertPriorityUpdatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "alert_priority.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Urgent",
+                      "type": "alert_priority"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAlertPriorityUpdatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
     "/x-audit-logs/alert_route.created.1": {
       "get": {
         "description": "This entry is created whenever an alert route is created",
@@ -62039,6 +65500,144 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsCatalogTypeUpdatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/connector_config.created.1": {
+      "get": {
+        "description": "This entry is created whenever a connector config is created",
+        "operationId": "ConnectorConfigCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "connector_config.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "My Connector",
+                      "type": "connector_config"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsConnectorConfigCreatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/connector_config.token_generated.1": {
+      "get": {
+        "description": "This entry is created whenever a connector config token is regenerated",
+        "operationId": "ConnectorConfigTokenGeneratedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "connector_config.token_generated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "My Connector",
+                      "type": "connector_config"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsConnectorConfigTokenGeneratedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/connector_config.updated.1": {
+      "get": {
+        "description": "This entry is created whenever a connector config is updated",
+        "operationId": "ConnectorConfigUpdatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "connector_config.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "My Connector",
+                      "type": "connector_config"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsConnectorConfigUpdatedV1"
                 }
               }
             },
@@ -63944,6 +67543,108 @@
         ]
       }
     },
+    "/x-audit-logs/on_call_notification_method.created.1": {
+      "get": {
+        "description": "This entry is created whenever an on-call notification method is created by an actor that isn't the owning user",
+        "operationId": "OnCallNotificationMethodCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "on_call_notification_method.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Phone notification method",
+                      "type": "on_call_notification_method"
+                    },
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Bob the builder",
+                      "type": "user"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsOnCallNotificationMethodCreatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/on_call_notification_method.destroyed.1": {
+      "get": {
+        "description": "This entry is created whenever an on-call notification method is destroyed by an actor that isn't the owning user",
+        "operationId": "OnCallNotificationMethodDestroyedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "on_call_notification_method.destroyed",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Phone notification method",
+                      "type": "on_call_notification_method"
+                    },
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Bob the builder",
+                      "type": "user"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsOnCallNotificationMethodDestroyedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
     "/x-audit-logs/organisation_settings.updated.1": {
       "get": {
         "description": "This entry is created when certain organisation settings are updated",
@@ -64870,6 +68571,55 @@
         ]
       }
     },
+    "/x-audit-logs/private_escalation.access_attempted.1": {
+      "get": {
+        "description": "This entry is created whenever someone attempts to access a private escalation.",
+        "operationId": "PrivateEscalationAccessAttemptedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "private_escalation.access_attempted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "outcome": "granted"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Escalation (01KB0083ASNF7EPT8NHQNRDXFC)",
+                      "type": "escalation"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsPrivateEscalationAccessAttemptedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
     "/x-audit-logs/private_incident.access_attempted.1": {
       "get": {
         "description": "This entry is created whenever someone attempts to access a private incident.",
@@ -64954,6 +68704,52 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsPrivateIncidentAccessRequestedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/private_incident.accessed_via_bot.1": {
+      "get": {
+        "description": "This entry is created whenever someone accesses a private incident via the incident bot.",
+        "operationId": "PrivateIncidentAccessedViaBotV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "private_incident.accessed_via_bot",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "#INC-123 The website is slow",
+                      "type": "incident"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsPrivateIncidentAccessedViaBotV1"
                 }
               }
             },
@@ -66308,6 +70104,98 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsTeamSettingsUpdatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/telemetry_data_source.installed.1": {
+      "get": {
+        "description": "This entry is created whenever a telemetry data source is connected",
+        "operationId": "TelemetryDataSourceInstalledV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "telemetry_data_source.installed",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Grafana Cloud",
+                      "type": "telemetry_data_source"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTelemetryDataSourceInstalledV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/telemetry_data_source.uninstalled.1": {
+      "get": {
+        "description": "This entry is created whenever a telemetry data source is disconnected",
+        "operationId": "TelemetryDataSourceUninstalledV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "telemetry_data_source.uninstalled",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Grafana Cloud",
+                      "type": "telemetry_data_source"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTelemetryDataSourceUninstalledV1"
                 }
               }
             },

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -729,12 +729,12 @@ const (
 
 // Defines values for EscalationV2Status.
 const (
-	Acked     EscalationV2Status = "acked"
-	Cancelled EscalationV2Status = "cancelled"
-	Expired   EscalationV2Status = "expired"
-	Pending   EscalationV2Status = "pending"
-	Resolved  EscalationV2Status = "resolved"
-	Triggered EscalationV2Status = "triggered"
+	EscalationV2StatusAcked     EscalationV2Status = "acked"
+	EscalationV2StatusCancelled EscalationV2Status = "cancelled"
+	EscalationV2StatusExpired   EscalationV2Status = "expired"
+	EscalationV2StatusPending   EscalationV2Status = "pending"
+	EscalationV2StatusResolved  EscalationV2Status = "resolved"
+	EscalationV2StatusTriggered EscalationV2Status = "triggered"
 )
 
 // Defines values for ExpressionOperationPayloadV2OperationType.
@@ -840,6 +840,7 @@ const (
 	IdentityV1RolesSchedulesEditor           IdentityV1Roles = "schedules_editor"
 	IdentityV1RolesSchedulesReader           IdentityV1Roles = "schedules_reader"
 	IdentityV1RolesSecuritySettingsEditor    IdentityV1Roles = "security_settings_editor"
+	IdentityV1RolesStatusPagePublisher       IdentityV1Roles = "status_page_publisher"
 	IdentityV1RolesTeamMembershipsManage     IdentityV1Roles = "team_memberships_manage"
 	IdentityV1RolesViewer                    IdentityV1Roles = "viewer"
 	IdentityV1RolesWorkflowsEditor           IdentityV1Roles = "workflows_editor"
@@ -1091,6 +1092,103 @@ const (
 	ScheduleRotationWorkingIntervalV2WeekdayWednesday ScheduleRotationWorkingIntervalV2Weekday = "wednesday"
 )
 
+// Defines values for StatusPageIncidentAffectedComponentSlimV2CurrentStatus.
+const (
+	StatusPageIncidentAffectedComponentSlimV2CurrentStatusDegradedPerformance StatusPageIncidentAffectedComponentSlimV2CurrentStatus = "degraded_performance"
+	StatusPageIncidentAffectedComponentSlimV2CurrentStatusFullOutage          StatusPageIncidentAffectedComponentSlimV2CurrentStatus = "full_outage"
+	StatusPageIncidentAffectedComponentSlimV2CurrentStatusOperational         StatusPageIncidentAffectedComponentSlimV2CurrentStatus = "operational"
+	StatusPageIncidentAffectedComponentSlimV2CurrentStatusPartialOutage       StatusPageIncidentAffectedComponentSlimV2CurrentStatus = "partial_outage"
+)
+
+// Defines values for StatusPageIncidentAffectedComponentV2CurrentStatus.
+const (
+	StatusPageIncidentAffectedComponentV2CurrentStatusDegradedPerformance StatusPageIncidentAffectedComponentV2CurrentStatus = "degraded_performance"
+	StatusPageIncidentAffectedComponentV2CurrentStatusFullOutage          StatusPageIncidentAffectedComponentV2CurrentStatus = "full_outage"
+	StatusPageIncidentAffectedComponentV2CurrentStatusOperational         StatusPageIncidentAffectedComponentV2CurrentStatus = "operational"
+	StatusPageIncidentAffectedComponentV2CurrentStatusPartialOutage       StatusPageIncidentAffectedComponentV2CurrentStatus = "partial_outage"
+)
+
+// Defines values for StatusPageIncidentAffectedComponentV2Status.
+const (
+	StatusPageIncidentAffectedComponentV2StatusDegradedPerformance StatusPageIncidentAffectedComponentV2Status = "degraded_performance"
+	StatusPageIncidentAffectedComponentV2StatusFullOutage          StatusPageIncidentAffectedComponentV2Status = "full_outage"
+	StatusPageIncidentAffectedComponentV2StatusOperational         StatusPageIncidentAffectedComponentV2Status = "operational"
+	StatusPageIncidentAffectedComponentV2StatusPartialOutage       StatusPageIncidentAffectedComponentV2Status = "partial_outage"
+)
+
+// Defines values for StatusPageIncidentComponentImpactV2Status.
+const (
+	StatusPageIncidentComponentImpactV2StatusDegradedPerformance StatusPageIncidentComponentImpactV2Status = "degraded_performance"
+	StatusPageIncidentComponentImpactV2StatusFullOutage          StatusPageIncidentComponentImpactV2Status = "full_outage"
+	StatusPageIncidentComponentImpactV2StatusPartialOutage       StatusPageIncidentComponentImpactV2Status = "partial_outage"
+)
+
+// Defines values for StatusPageIncidentUpdateV2ToStatus.
+const (
+	StatusPageIncidentUpdateV2ToStatusIdentified    StatusPageIncidentUpdateV2ToStatus = "identified"
+	StatusPageIncidentUpdateV2ToStatusInvestigating StatusPageIncidentUpdateV2ToStatus = "investigating"
+	StatusPageIncidentUpdateV2ToStatusMonitoring    StatusPageIncidentUpdateV2ToStatus = "monitoring"
+	StatusPageIncidentUpdateV2ToStatusResolved      StatusPageIncidentUpdateV2ToStatus = "resolved"
+)
+
+// Defines values for StatusPageIncidentV2Status.
+const (
+	StatusPageIncidentV2StatusIdentified    StatusPageIncidentV2Status = "identified"
+	StatusPageIncidentV2StatusInvestigating StatusPageIncidentV2Status = "investigating"
+	StatusPageIncidentV2StatusMonitoring    StatusPageIncidentV2Status = "monitoring"
+	StatusPageIncidentV2StatusResolved      StatusPageIncidentV2Status = "resolved"
+)
+
+// Defines values for StatusPageMaintenanceAffectedComponentV2CurrentStatus.
+const (
+	Operational      StatusPageMaintenanceAffectedComponentV2CurrentStatus = "operational"
+	UnderMaintenance StatusPageMaintenanceAffectedComponentV2CurrentStatus = "under_maintenance"
+)
+
+// Defines values for StatusPageMaintenanceUpdateV2ToStatus.
+const (
+	StatusPageMaintenanceUpdateV2ToStatusMaintenanceComplete   StatusPageMaintenanceUpdateV2ToStatus = "maintenance_complete"
+	StatusPageMaintenanceUpdateV2ToStatusMaintenanceInProgress StatusPageMaintenanceUpdateV2ToStatus = "maintenance_in_progress"
+	StatusPageMaintenanceUpdateV2ToStatusMaintenanceScheduled  StatusPageMaintenanceUpdateV2ToStatus = "maintenance_scheduled"
+)
+
+// Defines values for StatusPageMaintenanceV2Status.
+const (
+	StatusPageMaintenanceV2StatusMaintenanceComplete   StatusPageMaintenanceV2Status = "maintenance_complete"
+	StatusPageMaintenanceV2StatusMaintenanceInProgress StatusPageMaintenanceV2Status = "maintenance_in_progress"
+	StatusPageMaintenanceV2StatusMaintenanceScheduled  StatusPageMaintenanceV2Status = "maintenance_scheduled"
+)
+
+// Defines values for StatusPagesCreateStatusPageIncidentPayloadV2Status.
+const (
+	StatusPagesCreateStatusPageIncidentPayloadV2StatusIdentified    StatusPagesCreateStatusPageIncidentPayloadV2Status = "identified"
+	StatusPagesCreateStatusPageIncidentPayloadV2StatusInvestigating StatusPagesCreateStatusPageIncidentPayloadV2Status = "investigating"
+	StatusPagesCreateStatusPageIncidentPayloadV2StatusMonitoring    StatusPagesCreateStatusPageIncidentPayloadV2Status = "monitoring"
+	StatusPagesCreateStatusPageIncidentPayloadV2StatusResolved      StatusPagesCreateStatusPageIncidentPayloadV2Status = "resolved"
+)
+
+// Defines values for StatusPagesCreateStatusPageIncidentUpdatePayloadV2ToStatus.
+const (
+	Identified    StatusPagesCreateStatusPageIncidentUpdatePayloadV2ToStatus = "identified"
+	Investigating StatusPagesCreateStatusPageIncidentUpdatePayloadV2ToStatus = "investigating"
+	Monitoring    StatusPagesCreateStatusPageIncidentUpdatePayloadV2ToStatus = "monitoring"
+	Resolved      StatusPagesCreateStatusPageIncidentUpdatePayloadV2ToStatus = "resolved"
+)
+
+// Defines values for StatusPagesCreateStatusPageMaintenancePayloadV2Status.
+const (
+	StatusPagesCreateStatusPageMaintenancePayloadV2StatusMaintenanceComplete   StatusPagesCreateStatusPageMaintenancePayloadV2Status = "maintenance_complete"
+	StatusPagesCreateStatusPageMaintenancePayloadV2StatusMaintenanceInProgress StatusPagesCreateStatusPageMaintenancePayloadV2Status = "maintenance_in_progress"
+	StatusPagesCreateStatusPageMaintenancePayloadV2StatusMaintenanceScheduled  StatusPagesCreateStatusPageMaintenancePayloadV2Status = "maintenance_scheduled"
+)
+
+// Defines values for StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatus.
+const (
+	StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatusMaintenanceComplete   StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatus = "maintenance_complete"
+	StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatusMaintenanceInProgress StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatus = "maintenance_in_progress"
+	StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatusMaintenanceScheduled  StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatus = "maintenance_scheduled"
+)
+
 // Defines values for UserV1Role.
 const (
 	UserV1RoleAdministrator UserV1Role = "administrator"
@@ -1255,6 +1353,12 @@ const (
 	Stream        FollowUpsV2ListParamsIncidentMode = "stream"
 	Test          FollowUpsV2ListParamsIncidentMode = "test"
 	Tutorial      FollowUpsV2ListParamsIncidentMode = "tutorial"
+)
+
+// Defines values for IncidentsV2ListParamsFilterMode.
+const (
+	All IncidentsV2ListParamsFilterMode = "all"
+	Any IncidentsV2ListParamsFilterMode = "any"
 )
 
 // APIKeyV1 defines model for APIKeyV1.
@@ -1661,7 +1765,7 @@ type AlertRouteIncidentConfigPayloadV2 struct {
 	ConditionGroups []ConditionGroupPayloadV2 `json:"condition_groups"`
 
 	// DeferTimeSeconds How long should the escalation defer time be?
-	DeferTimeSeconds int64 `json:"defer_time_seconds"`
+	DeferTimeSeconds int32 `json:"defer_time_seconds"`
 
 	// Enabled Whether incident creation is enabled for this alert route
 	Enabled bool `json:"enabled"`
@@ -1670,7 +1774,7 @@ type AlertRouteIncidentConfigPayloadV2 struct {
 	GroupingKeys []GroupingKeyV2 `json:"grouping_keys"`
 
 	// GroupingWindowSeconds How large should the grouping window be?
-	GroupingWindowSeconds int64 `json:"grouping_window_seconds"`
+	GroupingWindowSeconds int32 `json:"grouping_window_seconds"`
 }
 
 // AlertRouteIncidentConfigV2 defines model for AlertRouteIncidentConfigV2.
@@ -1685,7 +1789,7 @@ type AlertRouteIncidentConfigV2 struct {
 	ConditionGroups []ConditionGroupV2 `json:"condition_groups"`
 
 	// DeferTimeSeconds How long should the escalation defer time be?
-	DeferTimeSeconds int64 `json:"defer_time_seconds"`
+	DeferTimeSeconds int32 `json:"defer_time_seconds"`
 
 	// Enabled Whether incident creation is enabled for this alert route
 	Enabled bool `json:"enabled"`
@@ -1694,7 +1798,7 @@ type AlertRouteIncidentConfigV2 struct {
 	GroupingKeys []GroupingKeyV2 `json:"grouping_keys"`
 
 	// GroupingWindowSeconds How large should the grouping window be?
-	GroupingWindowSeconds int64 `json:"grouping_window_seconds"`
+	GroupingWindowSeconds int32 `json:"grouping_window_seconds"`
 }
 
 // AlertRouteIncidentTemplatePayloadV2 defines model for AlertRouteIncidentTemplatePayloadV2.
@@ -1799,7 +1903,7 @@ type AlertRouteV2 struct {
 	// Name The name of this alert route config, for the user's reference
 	Name string `json:"name"`
 
-	// OwningTeamIds Optional array of team IDs that are the owners of this alert route
+	// OwningTeamIds IDs of teams that own this alert route
 	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
 
 	// UpdatedAt The time of last update of this alert route
@@ -1838,7 +1942,7 @@ type AlertRoutesCreatePayloadV2 struct {
 	// Name The name of this alert route config, for the user's reference
 	Name string `json:"name"`
 
-	// OwningTeamIds Optional array of team IDs that are the owners of this alert route
+	// OwningTeamIds IDs of teams that own this alert route
 	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
 
 	// UpdatedAt The time of last update of this alert route
@@ -1893,7 +1997,7 @@ type AlertRoutesUpdatePayloadV2 struct {
 	// Name The name of this alert route config, for the user's reference
 	Name string `json:"name"`
 
-	// OwningTeamIds Optional array of team IDs that are the owners of this alert route
+	// OwningTeamIds IDs of teams that own this alert route
 	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
 
 	// UpdatedAt The time of last update of this alert route
@@ -1979,7 +2083,7 @@ type AlertSourceV2 struct {
 	// Name Unique name of the alert source
 	Name string `json:"name"`
 
-	// OwningTeamIds Optional array of team IDs that are the owners of this alert source
+	// OwningTeamIds IDs of teams that own this alert source
 	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
 
 	// SecretToken Secret token used to authenticate this source, if applicable. If applicable, this is the token that must be included in either the query string or the 'Authorization' header when sending events to this alert source.
@@ -2001,7 +2105,7 @@ type AlertSourcesCreatePayloadV2 struct {
 	// Name Unique name of the alert source
 	Name string `json:"name"`
 
-	// OwningTeamIds Optional array of team IDs that are the owners of this alert source
+	// OwningTeamIds IDs of teams that own this alert source
 	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
 
 	// SourceType Type of alert source
@@ -2035,7 +2139,7 @@ type AlertSourcesUpdatePayloadV2 struct {
 	// Name Unique name of the alert source
 	Name string `json:"name"`
 
-	// OwningTeamIds Optional array of team IDs that are the owners of this alert source
+	// OwningTeamIds IDs of teams that own this alert source
 	OwningTeamIds *[]string              `json:"owning_team_ids,omitempty"`
 	Template      AlertTemplatePayloadV2 `json:"template"`
 }
@@ -2152,7 +2256,7 @@ type CatalogBulkUpdateEntriesPayloadV3 struct {
 	// CatalogTypeId The unique identifier of the catalog type containing the entries
 	CatalogTypeId string `json:"catalog_type_id"`
 
-	// Entries A list of entries to update with their new values. Maximum 100 entries per request.
+	// Entries A list of entries to update with their new values. Maximum 250 entries per request.
 	Entries []PartialEntryPayloadV3 `json:"entries"`
 
 	// UpdateAttributes Optional list of specific attribute IDs to update across all entries. When provided, only these attributes in attribute_values will be updated and all other attributes will be preserved. This parameter only affects attribute_values - it does not affect core entry fields like name, rank, aliases, or external_id, which follow their individual omission rules.
@@ -2462,9 +2566,9 @@ type CatalogListEntriesResultV2 struct {
 
 // CatalogListEntriesResultV3 defines model for CatalogListEntriesResultV3.
 type CatalogListEntriesResultV3 struct {
-	CatalogEntries []CatalogEntryV3       `json:"catalog_entries"`
-	CatalogType    CatalogTypeV3          `json:"catalog_type"`
-	PaginationMeta PaginationMetaResultV3 `json:"pagination_meta"`
+	CatalogEntries []CatalogEntryV3                `json:"catalog_entries"`
+	CatalogType    CatalogTypeV3                   `json:"catalog_type"`
+	PaginationMeta PaginationMetaResultWithTotalV3 `json:"pagination_meta"`
 }
 
 // CatalogListResourcesResultV2 defines model for CatalogListResourcesResultV2.
@@ -3860,6 +3964,9 @@ type EscalationPathTargetV2Urgency string
 
 // EscalationPathV2 defines model for EscalationPathV2.
 type EscalationPathV2 struct {
+	// CurrentResponders Users who are currently on-call for this escalation path
+	CurrentResponders *[]UserV2 `json:"current_responders,omitempty"`
+
 	// Id Unique identifier for this escalation path.
 	Id string `json:"id"`
 
@@ -4404,7 +4511,7 @@ type IncidentEditPayloadV2 struct {
 	// IncidentRoleAssignments Assign incident roles to these people
 	IncidentRoleAssignments *[]IncidentRoleAssignmentPayloadV2 `json:"incident_role_assignments,omitempty"`
 
-	// IncidentStatusId Incident status to change incident to (you can only change an incident from one active status to another, any other lifecycle changes must be taken via the app.)
+	// IncidentStatusId Incident status to change incident to. You can only change an incident from one active status to another, or close an incident from a post-incident status. Any other lifecycle changes must be taken via the app.
 	IncidentStatusId *string `json:"incident_status_id,omitempty"`
 
 	// IncidentTimestampValues Assign the incident's timestamps to these values
@@ -4976,7 +5083,7 @@ type IncidentV1 struct {
 	// Permalink A permanent link to the homepage for this incident
 	Permalink *string `json:"permalink,omitempty"`
 
-	// PostmortemDocumentUrl Description of the incident
+	// PostmortemDocumentUrl The URL of the incident post-mortem document
 	PostmortemDocumentUrl *string `json:"postmortem_document_url,omitempty"`
 
 	// Reference Reference to this incident, as displayed across the product
@@ -5056,7 +5163,7 @@ type IncidentV2 struct {
 	// Permalink A permanent link to the homepage for this incident
 	Permalink *string `json:"permalink,omitempty"`
 
-	// PostmortemDocumentUrl Description of the incident
+	// PostmortemDocumentUrl The URL of the incident post-mortem document
 	PostmortemDocumentUrl *string `json:"postmortem_document_url,omitempty"`
 
 	// Reference Reference to this incident, as displayed across the product
@@ -5320,15 +5427,6 @@ type PaginationMetaResultV2 struct {
 	PageSize int64 `json:"page_size"`
 }
 
-// PaginationMetaResultV3 defines model for PaginationMetaResultV3.
-type PaginationMetaResultV3 struct {
-	// After If provided, pass this as the 'after' param to load the next page
-	After *string `json:"after,omitempty"`
-
-	// PageSize What was the maximum number of results requested
-	PageSize int64 `json:"page_size"`
-}
-
 // PaginationMetaResultWithTotalV1 defines model for PaginationMetaResultWithTotalV1.
 type PaginationMetaResultWithTotalV1 struct {
 	// After If provided, pass this as the 'after' param to load the next page
@@ -5343,6 +5441,18 @@ type PaginationMetaResultWithTotalV1 struct {
 
 // PaginationMetaResultWithTotalV2 defines model for PaginationMetaResultWithTotalV2.
 type PaginationMetaResultWithTotalV2 struct {
+	// After If provided, pass this as the 'after' param to load the next page
+	After *string `json:"after,omitempty"`
+
+	// PageSize What was the maximum number of results requested
+	PageSize int64 `json:"page_size"`
+
+	// TotalRecordCount How many matching records were there in total, if known
+	TotalRecordCount *int64 `json:"total_record_count,omitempty"`
+}
+
+// PaginationMetaResultWithTotalV3 defines model for PaginationMetaResultWithTotalV3.
+type PaginationMetaResultWithTotalV3 struct {
 	// After If provided, pass this as the 'after' param to load the next page
 	After *string `json:"after,omitempty"`
 
@@ -5843,6 +5953,108 @@ type SeverityV2 struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// StatusPageIncidentAffectedComponentSlimV2 defines model for StatusPageIncidentAffectedComponentSlimV2.
+type StatusPageIncidentAffectedComponentSlimV2 struct {
+	// ComponentId The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.
+	ComponentId string `json:"component_id"`
+
+	// CurrentStatus The status of the relevant component in a status page incident
+	CurrentStatus StatusPageIncidentAffectedComponentSlimV2CurrentStatus `json:"current_status"`
+}
+
+// StatusPageIncidentAffectedComponentSlimV2CurrentStatus The status of the relevant component in a status page incident
+type StatusPageIncidentAffectedComponentSlimV2CurrentStatus string
+
+// StatusPageIncidentAffectedComponentV2 defines model for StatusPageIncidentAffectedComponentV2.
+type StatusPageIncidentAffectedComponentV2 struct {
+	// ComponentId The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.
+	ComponentId string `json:"component_id"`
+
+	// CurrentStatus The status of the relevant component in a status page incident
+	CurrentStatus StatusPageIncidentAffectedComponentV2CurrentStatus `json:"current_status"`
+
+	// Status The status of the relevant component in a status page incident
+	Status StatusPageIncidentAffectedComponentV2Status `json:"status"`
+}
+
+// StatusPageIncidentAffectedComponentV2CurrentStatus The status of the relevant component in a status page incident
+type StatusPageIncidentAffectedComponentV2CurrentStatus string
+
+// StatusPageIncidentAffectedComponentV2Status The status of the relevant component in a status page incident
+type StatusPageIncidentAffectedComponentV2Status string
+
+// StatusPageIncidentComponentImpactV2 defines model for StatusPageIncidentComponentImpactV2.
+type StatusPageIncidentComponentImpactV2 struct {
+	// ComponentId The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.
+	ComponentId string `json:"component_id"`
+
+	// EndAt When the component left this status. If this is null, the impact is ongoing.
+	EndAt *time.Time `json:"end_at,omitempty"`
+
+	// StartAt When the component entered this status
+	StartAt time.Time `json:"start_at"`
+
+	// Status The status of the relevant component impact in a status page incident - this excludes the operational status.
+	Status StatusPageIncidentComponentImpactV2Status `json:"status"`
+}
+
+// StatusPageIncidentComponentImpactV2Status The status of the relevant component impact in a status page incident - this excludes the operational status.
+type StatusPageIncidentComponentImpactV2Status string
+
+// StatusPageIncidentUpdateV2 defines model for StatusPageIncidentUpdateV2.
+type StatusPageIncidentUpdateV2 struct {
+	// ComponentStatuses The updated statuses of affected components
+	ComponentStatuses []StatusPageIncidentAffectedComponentV2 `json:"component_statuses"`
+
+	// Id A unique ID for this status page incident update
+	Id string `json:"id"`
+
+	// Message Markdown update on what's changed about this status page incident
+	Message string `json:"message"`
+
+	// PublishedAt When this status page incident update was published to the status page
+	PublishedAt time.Time `json:"published_at"`
+
+	// StatusPageIncidentId The ID of the corresponding status page incident
+	StatusPageIncidentId string `json:"status_page_incident_id"`
+
+	// ToStatus Current status for this incident
+	ToStatus StatusPageIncidentUpdateV2ToStatus `json:"to_status"`
+}
+
+// StatusPageIncidentUpdateV2ToStatus Current status for this incident
+type StatusPageIncidentUpdateV2ToStatus string
+
+// StatusPageIncidentV2 defines model for StatusPageIncidentV2.
+type StatusPageIncidentV2 struct {
+	// AffectedComponents A summary of the affected components
+	AffectedComponents []StatusPageIncidentAffectedComponentV2 `json:"affected_components"`
+
+	// ComponentImpacts A list of time periods that this status page incident had an impact on a component
+	ComponentImpacts []StatusPageIncidentComponentImpactV2 `json:"component_impacts"`
+
+	// Id A unique ID for this status page incident
+	Id string `json:"id"`
+
+	// Name A title for the incident
+	Name string `json:"name"`
+
+	// PublishedAt When this status page incident was published to the status page
+	PublishedAt time.Time `json:"published_at"`
+
+	// Status Current status for this incident
+	Status StatusPageIncidentV2Status `json:"status"`
+
+	// StatusPageId The ID of the corresponding status page
+	StatusPageId string `json:"status_page_id"`
+
+	// Updates A list of updates posted to this status page incident
+	Updates []StatusPageIncidentUpdateV2 `json:"updates"`
+}
+
+// StatusPageIncidentV2Status Current status for this incident
+type StatusPageIncidentV2Status string
+
 // StatusPageLinkedResponseIncidentV1 defines model for StatusPageLinkedResponseIncidentV1.
 type StatusPageLinkedResponseIncidentV1 struct {
 	// Id ID of the Response incident
@@ -5852,9 +6064,289 @@ type StatusPageLinkedResponseIncidentV1 struct {
 	LinkedAt time.Time `json:"linked_at"`
 }
 
+// StatusPageMaintenanceAffectedComponentV2 defines model for StatusPageMaintenanceAffectedComponentV2.
+type StatusPageMaintenanceAffectedComponentV2 struct {
+	// ComponentId The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.
+	ComponentId string `json:"component_id"`
+
+	// CurrentStatus The status of the relevant component in a status page maintenance window
+	CurrentStatus StatusPageMaintenanceAffectedComponentV2CurrentStatus `json:"current_status"`
+}
+
+// StatusPageMaintenanceAffectedComponentV2CurrentStatus The status of the relevant component in a status page maintenance window
+type StatusPageMaintenanceAffectedComponentV2CurrentStatus string
+
+// StatusPageMaintenanceComponentImpactV2 defines model for StatusPageMaintenanceComponentImpactV2.
+type StatusPageMaintenanceComponentImpactV2 struct {
+	// ComponentId The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.
+	ComponentId string `json:"component_id"`
+
+	// EndAt When the component stopped being under maintenance. If this is null, the impact is ongoing.
+	EndAt *time.Time `json:"end_at,omitempty"`
+
+	// StartAt When the component started being under maintenance
+	StartAt time.Time `json:"start_at"`
+}
+
+// StatusPageMaintenanceUpdateV2 defines model for StatusPageMaintenanceUpdateV2.
+type StatusPageMaintenanceUpdateV2 struct {
+	// ComponentStatuses The updated statuses of affected components
+	ComponentStatuses []StatusPageMaintenanceAffectedComponentV2 `json:"component_statuses"`
+
+	// Id A unique ID for this status page maintenance update
+	Id string `json:"id"`
+
+	// Message Markdown update on what's changed about this status page maintenance window
+	Message string `json:"message"`
+
+	// PublishedAt When this status page maintenance update was published to the status page
+	PublishedAt time.Time `json:"published_at"`
+
+	// StatusPageMaintenanceId The ID of the corresponding status page maintenance window
+	StatusPageMaintenanceId string `json:"status_page_maintenance_id"`
+
+	// ToStatus Current status for this maintenance window
+	ToStatus StatusPageMaintenanceUpdateV2ToStatus `json:"to_status"`
+}
+
+// StatusPageMaintenanceUpdateV2ToStatus Current status for this maintenance window
+type StatusPageMaintenanceUpdateV2ToStatus string
+
+// StatusPageMaintenanceV2 defines model for StatusPageMaintenanceV2.
+type StatusPageMaintenanceV2 struct {
+	// ComponentImpacts A list of time periods that this status page maintenance window had an impact on components
+	ComponentImpacts []StatusPageMaintenanceComponentImpactV2 `json:"component_impacts"`
+
+	// Id A unique ID for this status page maintenance window
+	Id string `json:"id"`
+
+	// Name A title for the maintenance window
+	Name string `json:"name"`
+
+	// PublishedAt When this status page maintenance window was published to the status page
+	PublishedAt time.Time `json:"published_at"`
+
+	// Status Current status for this maintenance window
+	Status StatusPageMaintenanceV2Status `json:"status"`
+
+	// StatusPageId The ID of the corresponding status page
+	StatusPageId string `json:"status_page_id"`
+
+	// Updates A list of updates posted to this status page maintenance window
+	Updates []StatusPageMaintenanceUpdateV2 `json:"updates"`
+}
+
+// StatusPageMaintenanceV2Status Current status for this maintenance window
+type StatusPageMaintenanceV2Status string
+
+// StatusPageStructureComponentV2 defines model for StatusPageStructureComponentV2.
+type StatusPageStructureComponentV2 struct {
+	// ComponentId The ID of the affected component. This may be found by calling the ShowStatusPage endpoint.
+	ComponentId string `json:"component_id"`
+
+	// Name The name of this component
+	Name string `json:"name"`
+}
+
+// StatusPageStructureGroupV2 defines model for StatusPageStructureGroupV2.
+type StatusPageStructureGroupV2 struct {
+	// Components Array of components belonging to this group
+	Components []StatusPageStructureComponentV2 `json:"components"`
+
+	// Id Unique ID of this component group
+	Id string `json:"id"`
+
+	// Name The name of this component group
+	Name string `json:"name"`
+}
+
+// StatusPageStructureItemV2 defines model for StatusPageStructureItemV2.
+type StatusPageStructureItemV2 struct {
+	Component *StatusPageStructureComponentV2 `json:"component,omitempty"`
+	Group     *StatusPageStructureGroupV2     `json:"group,omitempty"`
+}
+
+// StatusPageStructureV2 defines model for StatusPageStructureV2.
+type StatusPageStructureV2 struct {
+	// Items Array of components and groups to display in the status page
+	Items []StatusPageStructureItemV2 `json:"items"`
+}
+
+// StatusPageV2 defines model for StatusPageV2.
+type StatusPageV2 struct {
+	// Description The description of this status page
+	Description *string `json:"description,omitempty"`
+
+	// Id Unique ID of this status page
+	Id string `json:"id"`
+
+	// Name The title of this status page
+	Name string `json:"name"`
+
+	// PublicUrl The public URL of this status page
+	PublicUrl *string `json:"public_url,omitempty"`
+}
+
+// StatusPagesCreateStatusPageIncidentPayloadV2 defines model for StatusPagesCreateStatusPageIncidentPayloadV2.
+type StatusPagesCreateStatusPageIncidentPayloadV2 struct {
+	// ComponentStatuses An array of mappings from component ID to current status
+	ComponentStatuses *[]StatusPageIncidentAffectedComponentSlimV2 `json:"component_statuses,omitempty"`
+
+	// IdempotencyKey A unique key to de-duplicate incidents
+	IdempotencyKey string `json:"idempotency_key"`
+
+	// Message Markdown initial update on this status page incident
+	Message string `json:"message"`
+
+	// Name A title for the incident
+	Name string `json:"name"`
+
+	// NotifySubscribers Whether to notify subscribers about this status page incident.
+	NotifySubscribers bool `json:"notify_subscribers"`
+
+	// Status Current status for this status page incident
+	Status StatusPagesCreateStatusPageIncidentPayloadV2Status `json:"status"`
+
+	// StatusPageId ID of the status page
+	StatusPageId string `json:"status_page_id"`
+}
+
+// StatusPagesCreateStatusPageIncidentPayloadV2Status Current status for this status page incident
+type StatusPagesCreateStatusPageIncidentPayloadV2Status string
+
+// StatusPagesCreateStatusPageIncidentResultV2 defines model for StatusPagesCreateStatusPageIncidentResultV2.
+type StatusPagesCreateStatusPageIncidentResultV2 struct {
+	StatusPageIncident *StatusPageIncidentV2 `json:"status_page_incident,omitempty"`
+}
+
+// StatusPagesCreateStatusPageIncidentUpdatePayloadV2 defines model for StatusPagesCreateStatusPageIncidentUpdatePayloadV2.
+type StatusPagesCreateStatusPageIncidentUpdatePayloadV2 struct {
+	// ComponentStatuses An array of mappings from component ID to component status. This must not be set if the status page incident status is being set to "resolved", as all components statuses will update to "operational".
+	ComponentStatuses *[]StatusPageIncidentAffectedComponentSlimV2 `json:"component_statuses,omitempty"`
+
+	// Message Markdown update on what's changed about this status page incident
+	Message string `json:"message"`
+
+	// NotifySubscribers Whether to notify subscribers about this incident update
+	NotifySubscribers bool `json:"notify_subscribers"`
+
+	// StatusPageIncidentId ID of the status page incident
+	StatusPageIncidentId string `json:"status_page_incident_id"`
+
+	// ToStatus New status for this status page incident. Setting to "resolved" will end the status page incident.
+	ToStatus *StatusPagesCreateStatusPageIncidentUpdatePayloadV2ToStatus `json:"to_status,omitempty"`
+}
+
+// StatusPagesCreateStatusPageIncidentUpdatePayloadV2ToStatus New status for this status page incident. Setting to "resolved" will end the status page incident.
+type StatusPagesCreateStatusPageIncidentUpdatePayloadV2ToStatus string
+
+// StatusPagesCreateStatusPageIncidentUpdateResultV2 defines model for StatusPagesCreateStatusPageIncidentUpdateResultV2.
+type StatusPagesCreateStatusPageIncidentUpdateResultV2 struct {
+	StatusPageIncidentUpdate *StatusPageIncidentUpdateV2 `json:"status_page_incident_update,omitempty"`
+}
+
+// StatusPagesCreateStatusPageMaintenancePayloadV2 defines model for StatusPagesCreateStatusPageMaintenancePayloadV2.
+type StatusPagesCreateStatusPageMaintenancePayloadV2 struct {
+	// AffectedComponentIds An array of IDs of component affected by the maintenance window
+	AffectedComponentIds []string `json:"affected_component_ids"`
+
+	// EndAt The time the maintenance window ends
+	EndAt time.Time `json:"end_at"`
+
+	// IdempotencyKey A unique key to de-duplicate maintenances
+	IdempotencyKey string `json:"idempotency_key"`
+
+	// Message Markdown initial update on this status page maintenance window
+	Message string `json:"message"`
+
+	// Name A title for the maintenance window
+	Name string `json:"name"`
+
+	// StartAt The time the maintenance window starts
+	StartAt time.Time `json:"start_at"`
+
+	// Status Current status for this status page maintenance window
+	Status StatusPagesCreateStatusPageMaintenancePayloadV2Status `json:"status"`
+
+	// StatusPageId ID of the status page
+	StatusPageId string `json:"status_page_id"`
+}
+
+// StatusPagesCreateStatusPageMaintenancePayloadV2Status Current status for this status page maintenance window
+type StatusPagesCreateStatusPageMaintenancePayloadV2Status string
+
+// StatusPagesCreateStatusPageMaintenanceResultV2 defines model for StatusPagesCreateStatusPageMaintenanceResultV2.
+type StatusPagesCreateStatusPageMaintenanceResultV2 struct {
+	StatusPageMaintenance *StatusPageMaintenanceV2 `json:"status_page_maintenance,omitempty"`
+}
+
+// StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2 defines model for StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2.
+type StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2 struct {
+	// ComponentStatuses An array of mappings from component ID to component status. This must not be set if the status page maintenance window status is being set to "maintenance_complete", as all components statuses will update to "operational".
+	ComponentStatuses *[]StatusPageMaintenanceAffectedComponentV2 `json:"component_statuses,omitempty"`
+
+	// Message Markdown update on what's changed about this status page maintenance window
+	Message string `json:"message"`
+
+	// StatusPageMaintenanceId ID of the status page maintenance window
+	StatusPageMaintenanceId string `json:"status_page_maintenance_id"`
+
+	// ToStatus Current status for this status page maintenance window
+	ToStatus *StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatus `json:"to_status,omitempty"`
+}
+
+// StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatus Current status for this status page maintenance window
+type StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2ToStatus string
+
+// StatusPagesCreateStatusPageMaintenanceUpdateResultV2 defines model for StatusPagesCreateStatusPageMaintenanceUpdateResultV2.
+type StatusPagesCreateStatusPageMaintenanceUpdateResultV2 struct {
+	StatusPageMaintenanceUpdate *StatusPageMaintenanceUpdateV2 `json:"status_page_maintenance_update,omitempty"`
+}
+
 // StatusPagesListResponseIncidentsResultV1 defines model for StatusPagesListResponseIncidentsResultV1.
 type StatusPagesListResponseIncidentsResultV1 struct {
 	Incidents []StatusPageLinkedResponseIncidentV1 `json:"incidents"`
+}
+
+// StatusPagesListStatusPagesPayloadV2 defines model for StatusPagesListStatusPagesPayloadV2.
+type StatusPagesListStatusPagesPayloadV2 struct {
+	// After An record's ID. This endpoint will return a list of records after this ID in relation to the API response order.
+	After *string `json:"after,omitempty"`
+
+	// PageSize Integer number of records to return
+	PageSize *int64 `json:"page_size,omitempty"`
+}
+
+// StatusPagesListStatusPagesResultV2 defines model for StatusPagesListStatusPagesResultV2.
+type StatusPagesListStatusPagesResultV2 struct {
+	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
+	StatusPages    []StatusPageV2         `json:"status_pages"`
+}
+
+// StatusPagesShowStatusPageIncidentResultV2 defines model for StatusPagesShowStatusPageIncidentResultV2.
+type StatusPagesShowStatusPageIncidentResultV2 struct {
+	StatusPageIncident *StatusPageIncidentV2 `json:"status_page_incident,omitempty"`
+}
+
+// StatusPagesShowStatusPageMaintenanceResultV2 defines model for StatusPagesShowStatusPageMaintenanceResultV2.
+type StatusPagesShowStatusPageMaintenanceResultV2 struct {
+	StatusPageMaintenance *StatusPageMaintenanceV2 `json:"status_page_maintenance,omitempty"`
+}
+
+// StatusPagesShowStatusPageStructureResultV2 defines model for StatusPagesShowStatusPageStructureResultV2.
+type StatusPagesShowStatusPageStructureResultV2 struct {
+	CurrentStructure StatusPageStructureV2 `json:"current_structure"`
+}
+
+// StatusPagesUpdateStatusPageIncidentPayloadV2 defines model for StatusPagesUpdateStatusPageIncidentPayloadV2.
+type StatusPagesUpdateStatusPageIncidentPayloadV2 struct {
+	// Name A title for the incident
+	Name string `json:"name"`
+}
+
+// StatusPagesUpdateStatusPageIncidentResultV2 defines model for StatusPagesUpdateStatusPageIncidentResultV2.
+type StatusPagesUpdateStatusPageIncidentResultV2 struct {
+	StatusPageIncident *StatusPageIncidentV2 `json:"status_page_incident,omitempty"`
 }
 
 // StepConfigPayloadV2 defines model for StepConfigPayloadV2.
@@ -6079,7 +6571,7 @@ type WorkflowSlimV2 struct {
 	Id string `json:"id"`
 
 	// IncludePrivateEscalations Whether to include private escalations
-	IncludePrivateEscalations *bool `json:"include_private_escalations,omitempty"`
+	IncludePrivateEscalations bool `json:"include_private_escalations"`
 
 	// IncludePrivateIncidents Whether to include private incidents
 	IncludePrivateIncidents bool `json:"include_private_incidents"`
@@ -6141,7 +6633,7 @@ type WorkflowV2 struct {
 	Id string `json:"id"`
 
 	// IncludePrivateEscalations Whether to include private escalations
-	IncludePrivateEscalations *bool `json:"include_private_escalations,omitempty"`
+	IncludePrivateEscalations bool `json:"include_private_escalations"`
 
 	// IncludePrivateIncidents Whether to include private incidents
 	IncludePrivateIncidents bool `json:"include_private_incidents"`
@@ -6297,6 +6789,9 @@ type WorkflowsUpdateWorkflowPayloadV2 struct {
 
 	// Shortform The shortform used to trigger this workflow (only applicable for manual triggers)
 	Shortform *string `json:"shortform,omitempty"`
+
+	// SkipStepUpgrades Skips workflow step upgrades, when the parameters for an existing workflow step change
+	SkipStepUpgrades *bool `json:"skip_step_upgrades,omitempty"`
 
 	// State What state this workflow is in
 	State *WorkflowsUpdateWorkflowPayloadV2State `json:"state,omitempty"`
@@ -6465,6 +6960,9 @@ type EscalationsV2ListParams struct {
 
 	// UpdatedAt Filter on the updated_at timestamp of the escalation. Accepted operators are 'gte', 'lte' and 'date_range'.
 	UpdatedAt *map[string][]string `form:"updated_at,omitempty" json:"updated_at,omitempty"`
+
+	// IdempotencyKey Filter on the idempotency key of the escalation. This is the key set when creating escalations via the API, and is distinct from alert deduplication keys. Accepted operators are 'is' for exact matches and 'starts_with' for prefix matching.
+	IdempotencyKey *map[string][]string `form:"idempotency_key,omitempty" json:"idempotency_key,omitempty"`
 }
 
 // FollowUpsV2ListParams defines parameters for FollowUpsV2List.
@@ -6514,6 +7012,9 @@ type IncidentsV2ListParams struct {
 	// After An incident's ID. This endpoint will return a list of incidents after this ID in relation to the API response order.
 	After *string `form:"after,omitempty" json:"after,omitempty"`
 
+	// FilterMode How to combine the filters: 'all' combines them with AND logic (all must match), 'any' combines them with OR logic (any can match). Defaults to 'all'.
+	FilterMode *IncidentsV2ListParamsFilterMode `form:"filter_mode,omitempty" json:"filter_mode,omitempty"`
+
 	// Status Filter on incident status. The accepted operators are 'one_of', or 'not_in'.
 	Status *map[string][]string `form:"status,omitempty" json:"status,omitempty"`
 
@@ -6541,6 +7042,9 @@ type IncidentsV2ListParams struct {
 	// Mode Filter on incident mode. The accepted operator is 'one_of'.  If this is not provided, this value defaults to `{"one_of": ["standard", "retrospective"] }`, meaning that test and tutorial incidents are not included.
 	Mode *map[string][]string `form:"mode,omitempty" json:"mode,omitempty"`
 }
+
+// IncidentsV2ListParamsFilterMode defines parameters for IncidentsV2List.
+type IncidentsV2ListParamsFilterMode string
 
 // SchedulesV2ListScheduleEntriesParams defines parameters for SchedulesV2ListScheduleEntries.
 type SchedulesV2ListScheduleEntriesParams struct {
@@ -6720,6 +7224,24 @@ type SchedulesV2CreateJSONRequestBody = SchedulesCreatePayloadV2
 
 // SchedulesV2UpdateJSONRequestBody defines body for SchedulesV2Update for application/json ContentType.
 type SchedulesV2UpdateJSONRequestBody = SchedulesUpdatePayloadV2
+
+// StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody defines body for StatusPagesV2CreateStatusPageIncidentUpdate for application/json ContentType.
+type StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody = StatusPagesCreateStatusPageIncidentUpdatePayloadV2
+
+// StatusPagesV2CreateStatusPageIncidentJSONRequestBody defines body for StatusPagesV2CreateStatusPageIncident for application/json ContentType.
+type StatusPagesV2CreateStatusPageIncidentJSONRequestBody = StatusPagesCreateStatusPageIncidentPayloadV2
+
+// StatusPagesV2UpdateStatusPageIncidentJSONRequestBody defines body for StatusPagesV2UpdateStatusPageIncident for application/json ContentType.
+type StatusPagesV2UpdateStatusPageIncidentJSONRequestBody = StatusPagesUpdateStatusPageIncidentPayloadV2
+
+// StatusPagesV2CreateStatusPageMaintenanceUpdateJSONRequestBody defines body for StatusPagesV2CreateStatusPageMaintenanceUpdate for application/json ContentType.
+type StatusPagesV2CreateStatusPageMaintenanceUpdateJSONRequestBody = StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2
+
+// StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody defines body for StatusPagesV2CreateStatusPageMaintenance for application/json ContentType.
+type StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody = StatusPagesCreateStatusPageMaintenancePayloadV2
+
+// StatusPagesV2ListStatusPagesJSONRequestBody defines body for StatusPagesV2ListStatusPages for application/json ContentType.
+type StatusPagesV2ListStatusPagesJSONRequestBody = StatusPagesListStatusPagesPayloadV2
 
 // WorkflowsV2CreateWorkflowJSONRequestBody defines body for WorkflowsV2CreateWorkflow for application/json ContentType.
 type WorkflowsV2CreateWorkflowJSONRequestBody = WorkflowsCreateWorkflowPayloadV2
@@ -7230,6 +7752,45 @@ type ClientInterface interface {
 	SchedulesV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SchedulesV2Update(ctx context.Context, id string, body SchedulesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2CreateStatusPageIncidentUpdateWithBody request with any body
+	StatusPagesV2CreateStatusPageIncidentUpdateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	StatusPagesV2CreateStatusPageIncidentUpdate(ctx context.Context, body StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2CreateStatusPageIncidentWithBody request with any body
+	StatusPagesV2CreateStatusPageIncidentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	StatusPagesV2CreateStatusPageIncident(ctx context.Context, body StatusPagesV2CreateStatusPageIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2ShowStatusPageIncident request
+	StatusPagesV2ShowStatusPageIncident(ctx context.Context, statusPageIncidentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2UpdateStatusPageIncidentWithBody request with any body
+	StatusPagesV2UpdateStatusPageIncidentWithBody(ctx context.Context, statusPageIncidentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	StatusPagesV2UpdateStatusPageIncident(ctx context.Context, statusPageIncidentId string, body StatusPagesV2UpdateStatusPageIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2CreateStatusPageMaintenanceUpdateWithBody request with any body
+	StatusPagesV2CreateStatusPageMaintenanceUpdateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	StatusPagesV2CreateStatusPageMaintenanceUpdate(ctx context.Context, body StatusPagesV2CreateStatusPageMaintenanceUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2CreateStatusPageMaintenanceWithBody request with any body
+	StatusPagesV2CreateStatusPageMaintenanceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	StatusPagesV2CreateStatusPageMaintenance(ctx context.Context, body StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2ShowStatusPageMaintenance request
+	StatusPagesV2ShowStatusPageMaintenance(ctx context.Context, statusPageMaintenanceId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2ShowStatusPageStructure request
+	StatusPagesV2ShowStatusPageStructure(ctx context.Context, statusPageId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2ListStatusPagesWithBody request with any body
+	StatusPagesV2ListStatusPagesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	StatusPagesV2ListStatusPages(ctx context.Context, body StatusPagesV2ListStatusPagesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UsersV2List request
 	UsersV2List(ctx context.Context, params *UsersV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -9110,6 +9671,186 @@ func (c *Client) SchedulesV2UpdateWithBody(ctx context.Context, id string, conte
 
 func (c *Client) SchedulesV2Update(ctx context.Context, id string, body SchedulesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSchedulesV2UpdateRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageIncidentUpdateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageIncidentUpdateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageIncidentUpdate(ctx context.Context, body StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageIncidentUpdateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageIncidentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageIncidentRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageIncident(ctx context.Context, body StatusPagesV2CreateStatusPageIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageIncidentRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2ShowStatusPageIncident(ctx context.Context, statusPageIncidentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2ShowStatusPageIncidentRequest(c.Server, statusPageIncidentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2UpdateStatusPageIncidentWithBody(ctx context.Context, statusPageIncidentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2UpdateStatusPageIncidentRequestWithBody(c.Server, statusPageIncidentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2UpdateStatusPageIncident(ctx context.Context, statusPageIncidentId string, body StatusPagesV2UpdateStatusPageIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2UpdateStatusPageIncidentRequest(c.Server, statusPageIncidentId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageMaintenanceUpdateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageMaintenanceUpdateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageMaintenanceUpdate(ctx context.Context, body StatusPagesV2CreateStatusPageMaintenanceUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageMaintenanceUpdateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageMaintenanceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageMaintenanceRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageMaintenance(ctx context.Context, body StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageMaintenanceRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2ShowStatusPageMaintenance(ctx context.Context, statusPageMaintenanceId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2ShowStatusPageMaintenanceRequest(c.Server, statusPageMaintenanceId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2ShowStatusPageStructure(ctx context.Context, statusPageId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2ShowStatusPageStructureRequest(c.Server, statusPageId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2ListStatusPagesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2ListStatusPagesRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2ListStatusPages(ctx context.Context, body StatusPagesV2ListStatusPagesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2ListStatusPagesRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -13098,6 +13839,22 @@ func NewEscalationsV2ListRequest(server string, params *EscalationsV2ListParams)
 
 		}
 
+		if params.IdempotencyKey != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "idempotency_key", runtime.ParamLocationQuery, *params.IdempotencyKey); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -13740,6 +14497,22 @@ func NewIncidentsV2ListRequest(server string, params *IncidentsV2ListParams) (*h
 		if params.After != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.FilterMode != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "filter_mode", runtime.ParamLocationQuery, *params.FilterMode); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -14397,6 +15170,355 @@ func NewSchedulesV2UpdateRequestWithBody(server string, id string, contentType s
 	}
 
 	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewStatusPagesV2CreateStatusPageIncidentUpdateRequest calls the generic StatusPagesV2CreateStatusPageIncidentUpdate builder with application/json body
+func NewStatusPagesV2CreateStatusPageIncidentUpdateRequest(server string, body StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewStatusPagesV2CreateStatusPageIncidentUpdateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewStatusPagesV2CreateStatusPageIncidentUpdateRequestWithBody generates requests for StatusPagesV2CreateStatusPageIncidentUpdate with any type of body
+func NewStatusPagesV2CreateStatusPageIncidentUpdateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_page_incident_updates")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewStatusPagesV2CreateStatusPageIncidentRequest calls the generic StatusPagesV2CreateStatusPageIncident builder with application/json body
+func NewStatusPagesV2CreateStatusPageIncidentRequest(server string, body StatusPagesV2CreateStatusPageIncidentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewStatusPagesV2CreateStatusPageIncidentRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewStatusPagesV2CreateStatusPageIncidentRequestWithBody generates requests for StatusPagesV2CreateStatusPageIncident with any type of body
+func NewStatusPagesV2CreateStatusPageIncidentRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_page_incidents")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewStatusPagesV2ShowStatusPageIncidentRequest generates requests for StatusPagesV2ShowStatusPageIncident
+func NewStatusPagesV2ShowStatusPageIncidentRequest(server string, statusPageIncidentId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "status_page_incident_id", runtime.ParamLocationPath, statusPageIncidentId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_page_incidents/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewStatusPagesV2UpdateStatusPageIncidentRequest calls the generic StatusPagesV2UpdateStatusPageIncident builder with application/json body
+func NewStatusPagesV2UpdateStatusPageIncidentRequest(server string, statusPageIncidentId string, body StatusPagesV2UpdateStatusPageIncidentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewStatusPagesV2UpdateStatusPageIncidentRequestWithBody(server, statusPageIncidentId, "application/json", bodyReader)
+}
+
+// NewStatusPagesV2UpdateStatusPageIncidentRequestWithBody generates requests for StatusPagesV2UpdateStatusPageIncident with any type of body
+func NewStatusPagesV2UpdateStatusPageIncidentRequestWithBody(server string, statusPageIncidentId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "status_page_incident_id", runtime.ParamLocationPath, statusPageIncidentId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_page_incidents/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewStatusPagesV2CreateStatusPageMaintenanceUpdateRequest calls the generic StatusPagesV2CreateStatusPageMaintenanceUpdate builder with application/json body
+func NewStatusPagesV2CreateStatusPageMaintenanceUpdateRequest(server string, body StatusPagesV2CreateStatusPageMaintenanceUpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewStatusPagesV2CreateStatusPageMaintenanceUpdateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewStatusPagesV2CreateStatusPageMaintenanceUpdateRequestWithBody generates requests for StatusPagesV2CreateStatusPageMaintenanceUpdate with any type of body
+func NewStatusPagesV2CreateStatusPageMaintenanceUpdateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_page_maintenance_updates")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewStatusPagesV2CreateStatusPageMaintenanceRequest calls the generic StatusPagesV2CreateStatusPageMaintenance builder with application/json body
+func NewStatusPagesV2CreateStatusPageMaintenanceRequest(server string, body StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewStatusPagesV2CreateStatusPageMaintenanceRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewStatusPagesV2CreateStatusPageMaintenanceRequestWithBody generates requests for StatusPagesV2CreateStatusPageMaintenance with any type of body
+func NewStatusPagesV2CreateStatusPageMaintenanceRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_page_maintenances")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewStatusPagesV2ShowStatusPageMaintenanceRequest generates requests for StatusPagesV2ShowStatusPageMaintenance
+func NewStatusPagesV2ShowStatusPageMaintenanceRequest(server string, statusPageMaintenanceId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "status_page_maintenance_id", runtime.ParamLocationPath, statusPageMaintenanceId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_page_maintenances/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewStatusPagesV2ShowStatusPageStructureRequest generates requests for StatusPagesV2ShowStatusPageStructure
+func NewStatusPagesV2ShowStatusPageStructureRequest(server string, statusPageId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "status_page_id", runtime.ParamLocationPath, statusPageId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_page_structures/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewStatusPagesV2ListStatusPagesRequest calls the generic StatusPagesV2ListStatusPages builder with application/json body
+func NewStatusPagesV2ListStatusPagesRequest(server string, body StatusPagesV2ListStatusPagesJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewStatusPagesV2ListStatusPagesRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewStatusPagesV2ListStatusPagesRequestWithBody generates requests for StatusPagesV2ListStatusPages with any type of body
+func NewStatusPagesV2ListStatusPagesRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_pages")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -15736,6 +16858,45 @@ type ClientWithResponsesInterface interface {
 	SchedulesV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateResponse, error)
 
 	SchedulesV2UpdateWithResponse(ctx context.Context, id string, body SchedulesV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateResponse, error)
+
+	// StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse request with any body
+	StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentUpdateResponse, error)
+
+	StatusPagesV2CreateStatusPageIncidentUpdateWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentUpdateResponse, error)
+
+	// StatusPagesV2CreateStatusPageIncidentWithBodyWithResponse request with any body
+	StatusPagesV2CreateStatusPageIncidentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentResponse, error)
+
+	StatusPagesV2CreateStatusPageIncidentWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentResponse, error)
+
+	// StatusPagesV2ShowStatusPageIncidentWithResponse request
+	StatusPagesV2ShowStatusPageIncidentWithResponse(ctx context.Context, statusPageIncidentId string, reqEditors ...RequestEditorFn) (*StatusPagesV2ShowStatusPageIncidentResponse, error)
+
+	// StatusPagesV2UpdateStatusPageIncidentWithBodyWithResponse request with any body
+	StatusPagesV2UpdateStatusPageIncidentWithBodyWithResponse(ctx context.Context, statusPageIncidentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2UpdateStatusPageIncidentResponse, error)
+
+	StatusPagesV2UpdateStatusPageIncidentWithResponse(ctx context.Context, statusPageIncidentId string, body StatusPagesV2UpdateStatusPageIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2UpdateStatusPageIncidentResponse, error)
+
+	// StatusPagesV2CreateStatusPageMaintenanceUpdateWithBodyWithResponse request with any body
+	StatusPagesV2CreateStatusPageMaintenanceUpdateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageMaintenanceUpdateResponse, error)
+
+	StatusPagesV2CreateStatusPageMaintenanceUpdateWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageMaintenanceUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageMaintenanceUpdateResponse, error)
+
+	// StatusPagesV2CreateStatusPageMaintenanceWithBodyWithResponse request with any body
+	StatusPagesV2CreateStatusPageMaintenanceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageMaintenanceResponse, error)
+
+	StatusPagesV2CreateStatusPageMaintenanceWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageMaintenanceResponse, error)
+
+	// StatusPagesV2ShowStatusPageMaintenanceWithResponse request
+	StatusPagesV2ShowStatusPageMaintenanceWithResponse(ctx context.Context, statusPageMaintenanceId string, reqEditors ...RequestEditorFn) (*StatusPagesV2ShowStatusPageMaintenanceResponse, error)
+
+	// StatusPagesV2ShowStatusPageStructureWithResponse request
+	StatusPagesV2ShowStatusPageStructureWithResponse(ctx context.Context, statusPageId string, reqEditors ...RequestEditorFn) (*StatusPagesV2ShowStatusPageStructureResponse, error)
+
+	// StatusPagesV2ListStatusPagesWithBodyWithResponse request with any body
+	StatusPagesV2ListStatusPagesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2ListStatusPagesResponse, error)
+
+	StatusPagesV2ListStatusPagesWithResponse(ctx context.Context, body StatusPagesV2ListStatusPagesJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2ListStatusPagesResponse, error)
 
 	// UsersV2ListWithResponse request
 	UsersV2ListWithResponse(ctx context.Context, params *UsersV2ListParams, reqEditors ...RequestEditorFn) (*UsersV2ListResponse, error)
@@ -18240,6 +19401,204 @@ func (r SchedulesV2UpdateResponse) StatusCode() int {
 	return 0
 }
 
+type StatusPagesV2CreateStatusPageIncidentUpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *StatusPagesCreateStatusPageIncidentUpdateResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2CreateStatusPageIncidentUpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2CreateStatusPageIncidentUpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StatusPagesV2CreateStatusPageIncidentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *StatusPagesCreateStatusPageIncidentResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2CreateStatusPageIncidentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2CreateStatusPageIncidentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StatusPagesV2ShowStatusPageIncidentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *StatusPagesShowStatusPageIncidentResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2ShowStatusPageIncidentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2ShowStatusPageIncidentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StatusPagesV2UpdateStatusPageIncidentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *StatusPagesUpdateStatusPageIncidentResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2UpdateStatusPageIncidentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2UpdateStatusPageIncidentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StatusPagesV2CreateStatusPageMaintenanceUpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *StatusPagesCreateStatusPageMaintenanceUpdateResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2CreateStatusPageMaintenanceUpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2CreateStatusPageMaintenanceUpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StatusPagesV2CreateStatusPageMaintenanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *StatusPagesCreateStatusPageMaintenanceResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2CreateStatusPageMaintenanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2CreateStatusPageMaintenanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StatusPagesV2ShowStatusPageMaintenanceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *StatusPagesShowStatusPageMaintenanceResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2ShowStatusPageMaintenanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2ShowStatusPageMaintenanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StatusPagesV2ShowStatusPageStructureResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *StatusPagesShowStatusPageStructureResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2ShowStatusPageStructureResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2ShowStatusPageStructureResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type StatusPagesV2ListStatusPagesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *StatusPagesListStatusPagesResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2ListStatusPagesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2ListStatusPagesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UsersV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -19993,6 +21352,135 @@ func (c *ClientWithResponses) SchedulesV2UpdateWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParseSchedulesV2UpdateResponse(rsp)
+}
+
+// StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse request with arbitrary body returning *StatusPagesV2CreateStatusPageIncidentUpdateResponse
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentUpdateResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageIncidentUpdateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageIncidentUpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageIncidentUpdateWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentUpdateResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageIncidentUpdate(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageIncidentUpdateResponse(rsp)
+}
+
+// StatusPagesV2CreateStatusPageIncidentWithBodyWithResponse request with arbitrary body returning *StatusPagesV2CreateStatusPageIncidentResponse
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageIncidentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageIncidentWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageIncidentResponse(rsp)
+}
+
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageIncidentWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageIncident(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageIncidentResponse(rsp)
+}
+
+// StatusPagesV2ShowStatusPageIncidentWithResponse request returning *StatusPagesV2ShowStatusPageIncidentResponse
+func (c *ClientWithResponses) StatusPagesV2ShowStatusPageIncidentWithResponse(ctx context.Context, statusPageIncidentId string, reqEditors ...RequestEditorFn) (*StatusPagesV2ShowStatusPageIncidentResponse, error) {
+	rsp, err := c.StatusPagesV2ShowStatusPageIncident(ctx, statusPageIncidentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2ShowStatusPageIncidentResponse(rsp)
+}
+
+// StatusPagesV2UpdateStatusPageIncidentWithBodyWithResponse request with arbitrary body returning *StatusPagesV2UpdateStatusPageIncidentResponse
+func (c *ClientWithResponses) StatusPagesV2UpdateStatusPageIncidentWithBodyWithResponse(ctx context.Context, statusPageIncidentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2UpdateStatusPageIncidentResponse, error) {
+	rsp, err := c.StatusPagesV2UpdateStatusPageIncidentWithBody(ctx, statusPageIncidentId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2UpdateStatusPageIncidentResponse(rsp)
+}
+
+func (c *ClientWithResponses) StatusPagesV2UpdateStatusPageIncidentWithResponse(ctx context.Context, statusPageIncidentId string, body StatusPagesV2UpdateStatusPageIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2UpdateStatusPageIncidentResponse, error) {
+	rsp, err := c.StatusPagesV2UpdateStatusPageIncident(ctx, statusPageIncidentId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2UpdateStatusPageIncidentResponse(rsp)
+}
+
+// StatusPagesV2CreateStatusPageMaintenanceUpdateWithBodyWithResponse request with arbitrary body returning *StatusPagesV2CreateStatusPageMaintenanceUpdateResponse
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageMaintenanceUpdateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageMaintenanceUpdateResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageMaintenanceUpdateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageMaintenanceUpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageMaintenanceUpdateWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageMaintenanceUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageMaintenanceUpdateResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageMaintenanceUpdate(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageMaintenanceUpdateResponse(rsp)
+}
+
+// StatusPagesV2CreateStatusPageMaintenanceWithBodyWithResponse request with arbitrary body returning *StatusPagesV2CreateStatusPageMaintenanceResponse
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageMaintenanceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageMaintenanceResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageMaintenanceWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageMaintenanceResponse(rsp)
+}
+
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageMaintenanceWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageMaintenanceResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageMaintenance(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageMaintenanceResponse(rsp)
+}
+
+// StatusPagesV2ShowStatusPageMaintenanceWithResponse request returning *StatusPagesV2ShowStatusPageMaintenanceResponse
+func (c *ClientWithResponses) StatusPagesV2ShowStatusPageMaintenanceWithResponse(ctx context.Context, statusPageMaintenanceId string, reqEditors ...RequestEditorFn) (*StatusPagesV2ShowStatusPageMaintenanceResponse, error) {
+	rsp, err := c.StatusPagesV2ShowStatusPageMaintenance(ctx, statusPageMaintenanceId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2ShowStatusPageMaintenanceResponse(rsp)
+}
+
+// StatusPagesV2ShowStatusPageStructureWithResponse request returning *StatusPagesV2ShowStatusPageStructureResponse
+func (c *ClientWithResponses) StatusPagesV2ShowStatusPageStructureWithResponse(ctx context.Context, statusPageId string, reqEditors ...RequestEditorFn) (*StatusPagesV2ShowStatusPageStructureResponse, error) {
+	rsp, err := c.StatusPagesV2ShowStatusPageStructure(ctx, statusPageId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2ShowStatusPageStructureResponse(rsp)
+}
+
+// StatusPagesV2ListStatusPagesWithBodyWithResponse request with arbitrary body returning *StatusPagesV2ListStatusPagesResponse
+func (c *ClientWithResponses) StatusPagesV2ListStatusPagesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2ListStatusPagesResponse, error) {
+	rsp, err := c.StatusPagesV2ListStatusPagesWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2ListStatusPagesResponse(rsp)
+}
+
+func (c *ClientWithResponses) StatusPagesV2ListStatusPagesWithResponse(ctx context.Context, body StatusPagesV2ListStatusPagesJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2ListStatusPagesResponse, error) {
+	rsp, err := c.StatusPagesV2ListStatusPages(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2ListStatusPagesResponse(rsp)
 }
 
 // UsersV2ListWithResponse request returning *UsersV2ListResponse
@@ -22955,6 +24443,240 @@ func ParseSchedulesV2UpdateResponse(rsp *http.Response) (*SchedulesV2UpdateRespo
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest SchedulesUpdateResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2CreateStatusPageIncidentUpdateResponse parses an HTTP response from a StatusPagesV2CreateStatusPageIncidentUpdateWithResponse call
+func ParseStatusPagesV2CreateStatusPageIncidentUpdateResponse(rsp *http.Response) (*StatusPagesV2CreateStatusPageIncidentUpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2CreateStatusPageIncidentUpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest StatusPagesCreateStatusPageIncidentUpdateResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2CreateStatusPageIncidentResponse parses an HTTP response from a StatusPagesV2CreateStatusPageIncidentWithResponse call
+func ParseStatusPagesV2CreateStatusPageIncidentResponse(rsp *http.Response) (*StatusPagesV2CreateStatusPageIncidentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2CreateStatusPageIncidentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest StatusPagesCreateStatusPageIncidentResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2ShowStatusPageIncidentResponse parses an HTTP response from a StatusPagesV2ShowStatusPageIncidentWithResponse call
+func ParseStatusPagesV2ShowStatusPageIncidentResponse(rsp *http.Response) (*StatusPagesV2ShowStatusPageIncidentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2ShowStatusPageIncidentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest StatusPagesShowStatusPageIncidentResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2UpdateStatusPageIncidentResponse parses an HTTP response from a StatusPagesV2UpdateStatusPageIncidentWithResponse call
+func ParseStatusPagesV2UpdateStatusPageIncidentResponse(rsp *http.Response) (*StatusPagesV2UpdateStatusPageIncidentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2UpdateStatusPageIncidentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest StatusPagesUpdateStatusPageIncidentResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2CreateStatusPageMaintenanceUpdateResponse parses an HTTP response from a StatusPagesV2CreateStatusPageMaintenanceUpdateWithResponse call
+func ParseStatusPagesV2CreateStatusPageMaintenanceUpdateResponse(rsp *http.Response) (*StatusPagesV2CreateStatusPageMaintenanceUpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2CreateStatusPageMaintenanceUpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest StatusPagesCreateStatusPageMaintenanceUpdateResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2CreateStatusPageMaintenanceResponse parses an HTTP response from a StatusPagesV2CreateStatusPageMaintenanceWithResponse call
+func ParseStatusPagesV2CreateStatusPageMaintenanceResponse(rsp *http.Response) (*StatusPagesV2CreateStatusPageMaintenanceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2CreateStatusPageMaintenanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest StatusPagesCreateStatusPageMaintenanceResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2ShowStatusPageMaintenanceResponse parses an HTTP response from a StatusPagesV2ShowStatusPageMaintenanceWithResponse call
+func ParseStatusPagesV2ShowStatusPageMaintenanceResponse(rsp *http.Response) (*StatusPagesV2ShowStatusPageMaintenanceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2ShowStatusPageMaintenanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest StatusPagesShowStatusPageMaintenanceResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2ShowStatusPageStructureResponse parses an HTTP response from a StatusPagesV2ShowStatusPageStructureWithResponse call
+func ParseStatusPagesV2ShowStatusPageStructureResponse(rsp *http.Response) (*StatusPagesV2ShowStatusPageStructureResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2ShowStatusPageStructureResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest StatusPagesShowStatusPageStructureResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2ListStatusPagesResponse parses an HTTP response from a StatusPagesV2ListStatusPagesWithResponse call
+func ParseStatusPagesV2ListStatusPagesResponse(rsp *http.Response) (*StatusPagesV2ListStatusPagesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2ListStatusPagesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest StatusPagesListStatusPagesResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/models/alert_route_v1_model.go
+++ b/internal/provider/models/alert_route_v1_model.go
@@ -451,10 +451,10 @@ func (AlertRouteResourceModel) FromAPIWithPlan(apiModel client.AlertRouteV2, pla
 	result.IncidentConfig = &AlertRouteIncidentConfigModel{
 		AutoDeclineEnabled:      types.BoolValue(apiModel.IncidentConfig.AutoDeclineEnabled),
 		AutoRelateGroupedAlerts: types.BoolValue(apiModel.IncidentConfig.AutoRelateGroupedAlerts),
-		DeferTimeSeconds:        types.Int64Value(apiModel.IncidentConfig.DeferTimeSeconds),
+		DeferTimeSeconds:        types.Int64Value(int64(apiModel.IncidentConfig.DeferTimeSeconds)),
 		Enabled:                 types.BoolValue(apiModel.IncidentConfig.Enabled),
 		GroupingKeys:            []AlertRouteGroupingKey{},
-		GroupingWindowSeconds:   types.Int64Value(apiModel.IncidentConfig.GroupingWindowSeconds),
+		GroupingWindowSeconds:   types.Int64Value(int64(apiModel.IncidentConfig.GroupingWindowSeconds)),
 	}
 
 	for _, gk := range apiModel.IncidentConfig.GroupingKeys {
@@ -757,11 +757,11 @@ func (m AlertRouteResourceModel) ToCreatePayload() client.AlertRoutesCreatePaylo
 		payload.IncidentConfig = client.AlertRouteIncidentConfigPayloadV2{
 			AutoDeclineEnabled:      m.IncidentConfig.AutoDeclineEnabled.ValueBool(),
 			AutoRelateGroupedAlerts: m.IncidentConfig.AutoRelateGroupedAlerts.ValueBoolPointer(),
-			DeferTimeSeconds:        m.IncidentConfig.DeferTimeSeconds.ValueInt64(),
+			DeferTimeSeconds:        int32(m.IncidentConfig.DeferTimeSeconds.ValueInt64()),
 			Enabled:                 m.IncidentConfig.Enabled.ValueBool(),
 			ConditionGroups:         m.IncidentConfig.ConditionGroups.ToPayload(),
 			GroupingKeys:            []client.GroupingKeyV2{},
-			GroupingWindowSeconds:   m.IncidentConfig.GroupingWindowSeconds.ValueInt64(),
+			GroupingWindowSeconds:   int32(m.IncidentConfig.GroupingWindowSeconds.ValueInt64()),
 		}
 
 		for _, gk := range m.IncidentConfig.GroupingKeys {

--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 	"github.com/incident-io/terraform-provider-incident/internal/provider/models"
@@ -49,7 +50,7 @@ func (r *IncidentWorkflowResource) buildModel(ctx context.Context, workflow clie
 		OnceFor:                   buildOnceFor(workflow.OnceFor),
 		RunsOnIncidentModes:       buildRunsOnIncidentModes(workflow.RunsOnIncidentModes),
 		IncludePrivateIncidents:   types.BoolValue(workflow.IncludePrivateIncidents),
-		IncludePrivateEscalations: types.BoolPointerValue(workflow.IncludePrivateEscalations),
+		IncludePrivateEscalations: types.BoolPointerValue(lo.ToPtr(workflow.IncludePrivateEscalations)),
 		ContinueOnStepError:       types.BoolValue(workflow.ContinueOnStepError),
 		RunsOnIncidents:           types.StringValue(string(workflow.RunsOnIncidents)),
 		State:                     types.StringValue(string(workflow.State)),


### PR DESCRIPTION
This PR updates the Incident.io client to the latest public API schema, exported from our internal codebase.

There are no breaking changes to the provider - only some descriptions and internal types have changed.