### PR TITLE
Upgrade go version in mise.toml to 1.25.

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.23.7"
+go = "1.26.5"
 golangci-lint = "latest"
 node = "latest"
 


### PR DESCRIPTION
Go 1.23 reached end of life ~6 months ago and no longer receives security updates: https://endoflife.date/go

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer tooling pin only; no application or CI Go version logic is changed in this diff.
> 
> **Overview**
> Updates the **mise** toolchain pin from Go **1.23.7** to **1.26.5** so local development matches a supported release after 1.23 reached end of life.
> 
> This is a **mise.toml**-only change (plus a trailing newline on the `[env]` entry); CI already uses `go-version-file: go.mod` rather than mise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bd9bf95cf9ef5e98b510306199cfdd025af117b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->