### PR TITLE
Improve docs for `incident_catalog_entries`.

### DIFF
--- a/docs/resources/catalog_entries.md
+++ b/docs/resources/catalog_entries.md
@@ -47,6 +47,49 @@ changes to one entry to an update to that same entry when the upstream changes.
 ## Example Usage
 
 ```terraform
+################################################################################
+# Simple Example
+################################################################################
+resource "incident_catalog_type" "simple_example" {
+  name            = "Simple Example"
+  description     = "A simple example catalog type"
+  source_repo_url = "https://example.com/myrepo"
+}
+
+resource "incident_catalog_type_attribute" "example_url" {
+  catalog_type_id = incident_catalog_type.simple_example.id
+  name            = "url"
+  type            = "String"
+}
+
+resource "incident_catalog_entries" "simple_example" {
+  id = incident_catalog_type.simple_example.id
+
+  entries = {
+    foo = {
+      name = "Foo"
+      attribute_values = {
+        # Map keys must be attribute ID (with parentheses for dynamic key), not attribute name
+        (incident_catalog_type_attribute.example_url.id) = {
+          value = "https://example.com/foo"
+        }
+      }
+    }
+    bar = {
+      name = "Bar"
+      attribute_values = {
+        (incident_catalog_type_attribute.example_url.id) = {
+          value = "https://example.com/bar"
+        }
+      }
+    }
+  }
+}
+
+################################################################################
+# Complex Example with JSON Data Source
+################################################################################
+#
 # Load a catalog from a JSON file. You may also use an HTTP endpoint or some
 # other data source, or prepare this file using a script before terraform runs.
 #
@@ -196,7 +239,7 @@ This can be used to allow other attributes of a catalog entry to be managed else
 
 Required:
 
-- `attribute_values` (Attributes Map) (see [below for nested schema](#nestedatt--entries--attribute_values))
+- `attribute_values` (Attributes Map) Map of attribute ID to attribute values. (Keys are the system-generated IDs.) (see [below for nested schema](#nestedatt--entries--attribute_values))
 - `name` (String) Name is the human readable name of this entry
 
 Optional:

--- a/docs/resources/catalog_type_attribute.md
+++ b/docs/resources/catalog_type_attribute.md
@@ -94,7 +94,13 @@ resource "incident_catalog_type_attribute" "service_tier_services" {
 
 - `catalog_type_id` (String) ID of this catalog type
 - `name` (String) The name of this attribute.
-- `type` (String) The type of this attribute.
+- `type` (String) The type of this attribute. Valid types include:
+
+- `Bool` - A boolean value (true/false)
+- `Number` - A numeric value
+- `String` - A single-line text string
+- `Text` - Rich text with formatting
+- `Custom["TypeName"]` - A reference to another catalog type (use `incident_catalog_type.other.type_name`)
 
 ### Optional
 

--- a/docs/resources/catalog_type_attribute.md
+++ b/docs/resources/catalog_type_attribute.md
@@ -94,13 +94,19 @@ resource "incident_catalog_type_attribute" "service_tier_services" {
 
 - `catalog_type_id` (String) ID of this catalog type
 - `name` (String) The name of this attribute.
-- `type` (String) The type of this attribute. Valid types include:
+- `type` (String) The type of this attribute. This is either one of the primitive types below, or a reference to any catalog type in your organisation.
 
-- `Bool` - A boolean value (true/false)
-- `Number` - A numeric value
-- `String` - A single-line text string
-- `Text` - Rich text with formatting
-- `Custom["TypeName"]` - A reference to another catalog type (use `incident_catalog_type.other.type_name`)
+Primitive types:
+
+- `String` - Simple text without formatting
+- `Text` - Rich text supporting formatting like italic, bold and otherwise
+- `Bool` - Boolean true or false value
+- `Number` - Floating point number
+- `Image["avatar"]` - A URL pointing to a person's avatar, rendered inline as a circular image
+
+Note that `Bool`, `Text` and `Number` attributes cannot be arrays, so may not be combined with `array = true`. The `Labels` primitive is not supported for catalog attributes.
+
+To reference another catalog type, use its type name. For types managed in Terraform this is the `type_name` attribute (e.g. `incident_catalog_type.service_tier.type_name`), which takes the form `Custom["ServiceTier"]`. Catalog types synced from integrations are referenced by their own name, such as `PagerDutyService` or `PagerDutyUser`.
 
 ### Optional
 

--- a/examples/resources/incident_catalog_entries/resource.tf
+++ b/examples/resources/incident_catalog_entries/resource.tf
@@ -1,3 +1,46 @@
+################################################################################
+# Simple Example
+################################################################################
+resource "incident_catalog_type" "simple_example" {
+  name            = "Simple Example"
+  description     = "A simple example catalog type"
+  source_repo_url = "https://example.com/myrepo"
+}
+
+resource "incident_catalog_type_attribute" "example_url" {
+  catalog_type_id = incident_catalog_type.simple_example.id
+  name            = "url"
+  type            = "String"
+}
+
+resource "incident_catalog_entries" "simple_example" {
+  id = incident_catalog_type.simple_example.id
+
+  entries = {
+    foo = {
+      name = "Foo"
+      attribute_values = {
+        # Map keys must be attribute ID (with parentheses for dynamic key), not attribute name
+        (incident_catalog_type_attribute.example_url.id) = {
+          value = "https://example.com/foo"
+        }
+      }
+    }
+    bar = {
+      name = "Bar"
+      attribute_values = {
+        (incident_catalog_type_attribute.example_url.id) = {
+          value = "https://example.com/bar"
+        }
+      }
+    }
+  }
+}
+
+################################################################################
+# Complex Example with JSON Data Source
+################################################################################
+#
 # Load a catalog from a JSON file. You may also use an HTTP endpoint or some
 # other data source, or prepare this file using a script before terraform runs.
 #

--- a/internal/provider/incident_catalog_entries_resource.go
+++ b/internal/provider/incident_catalog_entries_resource.go
@@ -130,7 +130,8 @@ changes to one entry to an update to that same entry when the upstream changes.
 							Default:             int64default.StaticInt64(0),
 						},
 						"attribute_values": schema.MapNestedAttribute{
-							Required: true,
+							MarkdownDescription: `Map of attribute ID to attribute values. (Keys are the system-generated IDs.)`,
+							Required:            true,
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"value": schema.StringAttribute{

--- a/internal/provider/incident_catalog_type_attribute_resource.go
+++ b/internal/provider/incident_catalog_type_attribute_resource.go
@@ -155,8 +155,13 @@ func (r *IncidentCatalogTypeAttributeResource) Schema(ctx context.Context, req r
 				Required:    true,
 			},
 			"type": schema.StringAttribute{
-				Description: `The type of this attribute.`,
-				Required:    true,
+				MarkdownDescription: "The type of this attribute. Valid types include:\n\n" +
+					"- `Bool` - A boolean value (true/false)\n" +
+					"- `Number` - A numeric value\n" +
+					"- `String` - A single-line text string\n" +
+					"- `Text` - Rich text with formatting\n" +
+					"- `Custom[\"TypeName\"]` - A reference to another catalog type (use `incident_catalog_type.other.type_name`)",
+				Required: true,
 			},
 			"array": schema.BoolAttribute{
 				Description: `Whether this attribute is an array or scalar.`,

--- a/internal/provider/incident_catalog_type_attribute_resource.go
+++ b/internal/provider/incident_catalog_type_attribute_resource.go
@@ -155,12 +155,21 @@ func (r *IncidentCatalogTypeAttributeResource) Schema(ctx context.Context, req r
 				Required:    true,
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: "The type of this attribute. Valid types include:\n\n" +
-					"- `Bool` - A boolean value (true/false)\n" +
-					"- `Number` - A numeric value\n" +
-					"- `String` - A single-line text string\n" +
-					"- `Text` - Rich text with formatting\n" +
-					"- `Custom[\"TypeName\"]` - A reference to another catalog type (use `incident_catalog_type.other.type_name`)",
+				MarkdownDescription: "The type of this attribute. This is either one of the primitive " +
+					"types below, or a reference to any catalog type in your organisation.\n\n" +
+					"Primitive types:\n\n" +
+					"- `String` - Simple text without formatting\n" +
+					"- `Text` - Rich text supporting formatting like italic, bold and otherwise\n" +
+					"- `Bool` - Boolean true or false value\n" +
+					"- `Number` - Floating point number\n" +
+					"- `Image[\"avatar\"]` - A URL pointing to a person's avatar, rendered inline as a circular image\n\n" +
+					"Note that `Bool`, `Text` and `Number` attributes cannot be arrays, so may not be " +
+					"combined with `array = true`. The `Labels` primitive is not supported for catalog " +
+					"attributes.\n\n" +
+					"To reference another catalog type, use its type name. For types managed in Terraform " +
+					"this is the `type_name` attribute (e.g. `incident_catalog_type.service_tier.type_name`), " +
+					"which takes the form `Custom[\"ServiceTier\"]`. Catalog types synced from integrations " +
+					"are referenced by their own name, such as `PagerDutyService` or `PagerDutyUser`.",
 				Required: true,
 			},
 			"array": schema.BoolAttribute{


### PR DESCRIPTION
### [Improve docs for incident_catalog_entries.](https://github.com/incident-io/terraform-provider-incident/pull/312/commits/fa3dac46bea12b3834ed093314bafea94e0cc50b)

* Add a description for the attribute_values map to make it more clear
  that the keys are supposed to be IDs, not the name.
* Add a simpler example without all the Backstage JSON stuff.

**Why?**

I initially thought the `attribute_values` map should take a map of attribute name to values like `attribute_values = { url = { value = "foo" }}`, but this is incorrect (and triggers an unfixed bug in the provider).


### [Document types for incident_catalog_type_attribute.](https://github.com/incident-io/terraform-provider-incident/pull/312/commits/22946f25e21eafc96fd3b8ddfd71e98c8d8874b6)

**Why?**
Previously there was no way for users to know what the possible values for attribute types should be. This doesn't appear to be documented in the API nor in the Terraform provider.

I guessed that the possible types are these, but this would be worth verifying:

- `Bool` - A boolean value (true/false)
- `Number` - A numeric value
- `String` - A single-line text string
- `Text` - Rich text with formatting
- `Custom["TypeName"]` - A reference to another catalog type (use `incident_catalog_type.other.type_name`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Terraform schema markdown only; no API or reconciliation logic changes.
> 
> **Overview**
> Improves **catalog Terraform docs** so users are less likely to misconfigure `incident_catalog_entries` and `incident_catalog_type_attribute`.
> 
> Adds a **minimal `incident_catalog_entries` example** (type + attribute + two entries) ahead of the existing Backstage/JSON workflow, including a comment that **`attribute_values` map keys must be attribute IDs** (dynamic key syntax), not attribute names like `url`. The same example is mirrored in `examples/resources/incident_catalog_entries/resource.tf` and the generated resource docs.
> 
> Documents **`entries.attribute_values`** as a map of **attribute ID → values** in provider schema markdown and the catalog entries resource schema (`MarkdownDescription` on `attribute_values`).
> 
> Expands **`incident_catalog_type_attribute.type`** documentation with allowed **primitive types**, **array limitations** (`Bool`/`Text`/`Number`, no `Labels`), and how to reference **other catalog types** (`type_name` / `Custom["..."]` vs integration type names like `PagerDutyService`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e814ce88828ed33fe28ac9e4e21aa22dd90a4730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->