### PR TITLE
Add validation for `catalog_type_attribute` `type` field.

### DIFF
--- a/internal/provider/incident_catalog_type_attribute_resource.go
+++ b/internal/provider/incident_catalog_type_attribute_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/samber/lo"
@@ -158,6 +159,9 @@ func (r *IncidentCatalogTypeAttributeResource) Schema(ctx context.Context, req r
 			"type": schema.StringAttribute{
 				Description: `The type of this attribute.`,
 				Required:    true,
+				Validators: []validator.String{
+					CatalogTypeAttributeTypeValidator{},
+				},
 			},
 			"array": schema.BoolAttribute{
 				Description: `Whether this attribute is an array or scalar.`,

--- a/internal/provider/incident_catalog_type_attribute_resource_test.go
+++ b/internal/provider/incident_catalog_type_attribute_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"testing"
 	"text/template"
 
@@ -136,6 +137,39 @@ func testAccIncidentCatalogTypeAttributeResourceConfig(attribute client.CatalogT
 	}
 
 	return buf.String()
+}
+
+func TestAccIncidentCatalogTypeAttributeResource_InvalidType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Attempt to create with invalid type
+			{
+				Config: testAccIncidentCatalogTypeAttributeResourceConfig(client.CatalogTypeAttributeV2{
+					Name: "Invalid",
+					Type: "DateTime",
+				}),
+				ExpectError: regexp.MustCompile("Invalid Catalog Type Attribute Type"),
+			},
+			// Another invalid type - lowercase
+			{
+				Config: testAccIncidentCatalogTypeAttributeResourceConfig(client.CatalogTypeAttributeV2{
+					Name: "Invalid",
+					Type: "string",
+				}),
+				ExpectError: regexp.MustCompile("Invalid Catalog Type Attribute Type"),
+			},
+			// Invalid Custom format
+			{
+				Config: testAccIncidentCatalogTypeAttributeResourceConfig(client.CatalogTypeAttributeV2{
+					Name: "Invalid",
+					Type: "Custom[Service]",
+				}),
+				ExpectError: regexp.MustCompile("Invalid Catalog Type Attribute Type"),
+			},
+		},
+	})
 }
 
 func TestAttributeToPayload_PreservesModes(t *testing.T) {


### PR DESCRIPTION
Validate that the type field only accepts valid primitive types (String, Text, Number, Bool) or Custom["TypeName"] references. This prevents users from using invalid types like DateTime or lowercase variations.

:warning: **Warning:** This is untested code written by Claude, and I have no idea whether it actually does what it claims to do. (Hence why I'm marking this as a draft pull request.) But maybe it's a useful starting point for someone else to take this on.