### PR TITLE
Increase escalation path nesting depth from 3 to 5 levels

### DIFF
--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -124,10 +124,10 @@ func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resourc
 			"path": schema.ListNestedAttribute{
 				MarkdownDescription: fmt.Sprintf("%s\n%s",
 					apischema.Docstring("EscalationPathV2", "path"),
-					"\n-->**Note** Although the `if_else` block is recursive, currently a maximum of 3 levels are supported. "+
-						"Attempting to configure more than 3 levels of nesting will result in a schema error.\n"),
+					"\n-->**Note** Although the `if_else` block is recursive, currently a maximum of 5 levels are supported. "+
+						"Attempting to configure more than 5 levels of nesting will result in a schema error.\n"),
 				Required:     true,
-				NestedObject: r.getPathSchema(4),
+				NestedObject: r.getPathSchema(6),
 			},
 			"working_hours": schema.ListNestedAttribute{
 				MarkdownDescription: apischema.Docstring("EscalationPathV2", "working_hours"),
@@ -162,8 +162,8 @@ func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resourc
 // Terraform doesn't support recursive schemas so we have to manually unpack the schema to
 // a finite depth to allow recursing back into our nodes.
 //
-// We support a maximum nesting depth of 3 levels of if_else nodes.
-// The schema definition should use a depth of 4 if we want to support 3 levels of
+// We support a maximum nesting depth of 5 levels of if_else nodes.
+// The schema definition should use a depth of 6 if we want to support 5 levels of
 // nesting, as it's zero-indexed.
 func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedAttributeObject {
 	result := schema.NestedAttributeObject{


### PR DESCRIPTION
The previous limit of 3 levels was insufficient for complex timezone-aware routing scenarios. For example:

Level 1: Check if priority is critical
Level 2: Check if priority is warning (inside else)
Level 3: Check if MST business hours active (inside then)
Level 4: Check if BST business hours active (inside else)

This change increases the depth from 4 to 6 (supporting 5 levels of nesting) to accommodate these more complex escalation patterns.

Fixes: Nested if_else structures failing with 'mismatch between struct and object' error