### PR TITLE
Add heartbeat monitoring alert source options

### DIFF
--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -141,6 +141,7 @@ resource "aws_sns_topic_subscription" "incidentio_alert_source" {
 - `auto_resolve_incident_alerts` (Boolean) Whether to auto-resolve incident alerts when the alert auto-resolves. Defaults to true. Only use in conjunction with auto_resolve_timeout_minutes.
 - `auto_resolve_timeout_minutes` (Number) When set, alerts from this source will automatically resolve after this many minutes.
 - `email_address` (String) Email address this alert source receives alerts to
+- `heartbeat_options` (Attributes) (see [below for nested schema](#nestedatt--heartbeat_options))
 - `http_custom_options` (Attributes) (see [below for nested schema](#nestedatt--http_custom_options))
 - `jira_options` (Attributes) (see [below for nested schema](#nestedatt--jira_options))
 - `owning_team_ids` (Set of String) IDs of teams that own this alert source
@@ -490,6 +491,23 @@ Optional:
 - `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
 
 
+
+
+<a id="nestedatt--heartbeat_options"></a>
+### Nested Schema for `heartbeat_options`
+
+Required:
+
+- `interval_seconds` (Number) How often a ping is expected, in seconds.
+
+Optional:
+
+- `failure_threshold` (Number) Number of consecutive missed pings before an alert fires.
+- `grace_period_seconds` (Number) How long after a missed ping before the heartbeat is considered late, in seconds. If zero, it transitions directly to failing.
+
+Read-Only:
+
+- `ping_url` (String) The URL to POST to in order to send a heartbeat ping.
 
 
 <a id="nestedatt--http_custom_options"></a>

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -56131,7 +56131,10 @@
         "summary": "List Actions V1",
         "tags": [
           "Actions V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Actions V1",
+        "x-docs-resource-type": "ActionV1"
       }
     },
     "/v1/actions/{id}": {
@@ -56192,7 +56195,10 @@
         "summary": "Show Actions V1",
         "tags": [
           "Actions V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Actions V1",
+        "x-docs-resource-type": "ActionV1"
       }
     },
     "/v1/api_keys": {
@@ -56286,7 +56292,10 @@
         "summary": "List API Keys V1",
         "tags": [
           "API Keys V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "API Keys V1",
+        "x-docs-resource-type": "APIKeyV1"
       },
       "post": {
         "description": "Create a new API key. The calling API key can only assign roles whose scopes are a subset of its own. The `api_keys_manage` role cannot be assigned via the API. An organization can have a maximum of 5000 active API keys.\n\nThis endpoint requires a valid API key with the `api_keys_manage` role at either the account level or team level.",
@@ -56367,7 +56376,10 @@
         "summary": "Create API Keys V1",
         "tags": [
           "API Keys V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "API Keys V1",
+        "x-docs-resource-type": "APIKeyV1"
       }
     },
     "/v1/api_keys/{id}": {
@@ -56396,7 +56408,10 @@
         "summary": "Delete API Keys V1",
         "tags": [
           "API Keys V1"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "API Keys V1",
+        "x-docs-resource-type": "APIKeyV1"
       },
       "get": {
         "description": "Show details of a specific API key, including its roles, team assignments and when its token was last issued.\n\nThis endpoint requires a valid API key with the `api_keys_manage` role at either the account level or team level.",
@@ -56467,7 +56482,10 @@
         "summary": "Show API Keys V1",
         "tags": [
           "API Keys V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "API Keys V1",
+        "x-docs-resource-type": "APIKeyV1"
       },
       "put": {
         "description": "Update an existing API key's name, roles, or team assignments. All fields must be provided (PUT semantics). The calling API key can only assign roles whose scopes are a subset of its own. An API key cannot edit itself, and the `api_keys_manage` role cannot be assigned via the API.\n\nThis endpoint requires a valid API key with the `api_keys_manage` role at either the account level or team level.",
@@ -56561,7 +56579,10 @@
         "summary": "Update API Keys V1",
         "tags": [
           "API Keys V1"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "API Keys V1",
+        "x-docs-resource-type": "APIKeyV1"
       }
     },
     "/v1/api_keys/{id}/actions/rotate": {
@@ -56648,7 +56669,10 @@
         "summary": "Rotate API Keys V1",
         "tags": [
           "API Keys V1"
-        ]
+        ],
+        "x-docs-display-name": "Rotate",
+        "x-docs-group-name": "API Keys V1",
+        "x-docs-resource-type": "APIKeyV1"
       }
     },
     "/v1/custom_field_options": {
@@ -56731,7 +56755,10 @@
         "summary": "List Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Custom Field Options V1",
+        "x-docs-resource-type": "CustomFieldOptionV1"
       },
       "post": {
         "description": "Create a custom field option. If the sort key is not supplied, it'll default to 1000, so the option appears near the end of the list.",
@@ -56774,7 +56801,10 @@
         "summary": "Create Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Custom Field Options V1",
+        "x-docs-resource-type": "CustomFieldOptionV1"
       }
     },
     "/v1/custom_field_options/{id}": {
@@ -56803,7 +56833,10 @@
         "summary": "Delete Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Custom Field Options V1",
+        "x-docs-resource-type": "CustomFieldOptionV1"
       },
       "get": {
         "description": "Get a single custom field option",
@@ -56845,7 +56878,10 @@
         "summary": "Show Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Custom Field Options V1",
+        "x-docs-resource-type": "CustomFieldOptionV1"
       },
       "put": {
         "description": "Update a custom field option",
@@ -56901,7 +56937,10 @@
         "summary": "Update Custom Field Options V1",
         "tags": [
           "Custom Field Options V1"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Custom Field Options V1",
+        "x-docs-resource-type": "CustomFieldOptionV1"
       }
     },
     "/v1/custom_fields": {
@@ -56951,7 +56990,10 @@
         "summary": "List Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Custom Fields V1",
+        "x-docs-resource-type": "CustomFieldV1"
       },
       "post": {
         "deprecated": true,
@@ -57018,7 +57060,10 @@
         "summary": "Create Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Custom Fields V1",
+        "x-docs-resource-type": "CustomFieldV1"
       }
     },
     "/v1/custom_fields/{id}": {
@@ -57048,7 +57093,10 @@
         "summary": "Delete Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Custom Fields V1",
+        "x-docs-resource-type": "CustomFieldV1"
       },
       "get": {
         "deprecated": true,
@@ -57108,7 +57156,10 @@
         "summary": "Show Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Custom Fields V1",
+        "x-docs-resource-type": "CustomFieldV1"
       },
       "put": {
         "deprecated": true,
@@ -57188,7 +57239,10 @@
         "summary": "Update Custom Fields V1",
         "tags": [
           "Custom Fields V1"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Custom Fields V1",
+        "x-docs-resource-type": "CustomFieldV1"
       }
     },
     "/v1/identity": {
@@ -57228,7 +57282,9 @@
         "summary": "Identity Utilities V1",
         "tags": [
           "Utilities V1"
-        ]
+        ],
+        "x-docs-display-name": "Show Identity",
+        "x-docs-group-name": "Utilities V1"
       }
     },
     "/v1/incident_attachments": {
@@ -57325,7 +57381,10 @@
         "summary": "List Incident Attachments V1",
         "tags": [
           "Incident Attachments V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incident Attachments V1",
+        "x-docs-resource-type": "IncidentAttachmentV1"
       },
       "post": {
         "description": "Attaches an external resource to an incident",
@@ -57374,7 +57433,10 @@
         "summary": "Create Incident Attachments V1",
         "tags": [
           "Incident Attachments V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Incident Attachments V1",
+        "x-docs-resource-type": "IncidentAttachmentV1"
       }
     },
     "/v1/incident_attachments/{id}": {
@@ -57403,7 +57465,10 @@
         "summary": "Delete Incident Attachments V1",
         "tags": [
           "Incident Attachments V1"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Incident Attachments V1",
+        "x-docs-resource-type": "IncidentAttachmentV1"
       }
     },
     "/v1/incident_memberships": {
@@ -57454,7 +57519,10 @@
         "summary": "Create Incident Memberships V1",
         "tags": [
           "Incident Memberships V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Incident Memberships V1",
+        "x-docs-resource-type": "IncidentMembershipV1"
       }
     },
     "/v1/incident_memberships/actions/revoke": {
@@ -57483,7 +57551,10 @@
         "summary": "Revoke Incident Memberships V1",
         "tags": [
           "Incident Memberships V1"
-        ]
+        ],
+        "x-docs-display-name": "Revoke",
+        "x-docs-group-name": "Incident Memberships V1",
+        "x-docs-resource-type": "IncidentMembershipV1"
       }
     },
     "/v1/incident_relationships": {
@@ -57563,7 +57634,10 @@
         "summary": "List Incident Relationships V1",
         "tags": [
           "Incident Relationships V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incident Relationships V1",
+        "x-docs-resource-type": "IncidentRelationshipV1"
       }
     },
     "/v1/incident_roles": {
@@ -57601,7 +57675,10 @@
         "summary": "List Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incident Roles V1",
+        "x-docs-resource-type": "IncidentRoleV1"
       },
       "post": {
         "deprecated": true,
@@ -57652,7 +57729,10 @@
         "summary": "Create Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Incident Roles V1",
+        "x-docs-resource-type": "IncidentRoleV1"
       }
     },
     "/v1/incident_roles/{id}": {
@@ -57682,7 +57762,10 @@
         "summary": "Delete Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Incident Roles V1",
+        "x-docs-resource-type": "IncidentRoleV1"
       },
       "get": {
         "deprecated": true,
@@ -57730,7 +57813,10 @@
         "summary": "Show Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Incident Roles V1",
+        "x-docs-resource-type": "IncidentRoleV1"
       },
       "put": {
         "deprecated": true,
@@ -57795,7 +57881,10 @@
         "summary": "Update Incident Roles V1",
         "tags": [
           "Incident Roles V1"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Incident Roles V1",
+        "x-docs-resource-type": "IncidentRoleV1"
       }
     },
     "/v1/incident_statuses": {
@@ -57830,7 +57919,10 @@
         "summary": "List Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incident Statuses V1",
+        "x-docs-resource-type": "IncidentStatusV1"
       },
       "post": {
         "description": "Create a new incident status",
@@ -57876,7 +57968,10 @@
         "summary": "Create Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Incident Statuses V1",
+        "x-docs-resource-type": "IncidentStatusV1"
       }
     },
     "/v1/incident_statuses/{id}": {
@@ -57905,7 +58000,10 @@
         "summary": "Delete Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Incident Statuses V1",
+        "x-docs-resource-type": "IncidentStatusV1"
       },
       "get": {
         "description": "Get a single incident status.",
@@ -57950,7 +58048,10 @@
         "summary": "Show Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Incident Statuses V1",
+        "x-docs-resource-type": "IncidentStatusV1"
       },
       "put": {
         "description": "Update an existing incident status",
@@ -58009,7 +58110,10 @@
         "summary": "Update Incident Statuses V1",
         "tags": [
           "Incident Statuses V1"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Incident Statuses V1",
+        "x-docs-resource-type": "IncidentStatusV1"
       }
     },
     "/v1/incident_types": {
@@ -58045,7 +58149,10 @@
         "summary": "List Incident Types V1",
         "tags": [
           "Incident Types V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incident Types V1",
+        "x-docs-resource-type": "IncidentTypeV1"
       }
     },
     "/v1/incident_types/{id}": {
@@ -58093,7 +58200,10 @@
         "summary": "Show Incident Types V1",
         "tags": [
           "Incident Types V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Incident Types V1",
+        "x-docs-resource-type": "IncidentTypeV1"
       }
     },
     "/v1/incidents": {
@@ -58295,7 +58405,10 @@
         "summary": "List Incidents V1",
         "tags": [
           "Incidents V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incidents V1",
+        "x-docs-resource-type": "IncidentV1"
       },
       "post": {
         "deprecated": true,
@@ -58483,7 +58596,10 @@
         "summary": "Create Incidents V1",
         "tags": [
           "Incidents V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Incidents V1",
+        "x-docs-resource-type": "IncidentV1"
       }
     },
     "/v1/incidents/{id}": {
@@ -58638,7 +58754,10 @@
         "summary": "Show Incidents V1",
         "tags": [
           "Incidents V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Incidents V1",
+        "x-docs-resource-type": "IncidentV1"
       }
     },
     "/v1/ip_allowlists": {
@@ -58673,7 +58792,10 @@
         "summary": "ShowIPAllowlist IPAllowlists V1",
         "tags": [
           "IPAllowlists V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "IPAllowlists V1",
+        "x-docs-resource-type": "IPAllowlistV1"
       },
       "put": {
         "description": "Update the IP allowlist for your organisation",
@@ -58726,7 +58848,10 @@
         "summary": "UpdateIPAllowlist IPAllowlists V1",
         "tags": [
           "IPAllowlists V1"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "IPAllowlists V1",
+        "x-docs-resource-type": "IPAllowlistV1"
       }
     },
     "/v1/maintenance_windows": {
@@ -58917,7 +59042,10 @@
         "summary": "List MaintenanceWindows V1",
         "tags": [
           "MaintenanceWindows V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "MaintenanceWindows V1",
+        "x-docs-resource-type": "MaintenanceWindowV1"
       },
       "post": {
         "description": "Create a new maintenance window.",
@@ -59134,7 +59262,10 @@
         "summary": "Create MaintenanceWindows V1",
         "tags": [
           "MaintenanceWindows V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "MaintenanceWindows V1",
+        "x-docs-resource-type": "MaintenanceWindowV1"
       }
     },
     "/v1/maintenance_windows/{id}": {
@@ -59163,7 +59294,10 @@
         "summary": "Delete MaintenanceWindows V1",
         "tags": [
           "MaintenanceWindows V1"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "MaintenanceWindows V1",
+        "x-docs-resource-type": "MaintenanceWindowV1"
       },
       "get": {
         "description": "Show a particular maintenance window.",
@@ -59308,7 +59442,10 @@
         "summary": "Show MaintenanceWindows V1",
         "tags": [
           "MaintenanceWindows V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "MaintenanceWindows V1",
+        "x-docs-resource-type": "MaintenanceWindowV1"
       },
       "put": {
         "description": "Update an existing maintenance window.",
@@ -59544,7 +59681,10 @@
         "summary": "Update MaintenanceWindows V1",
         "tags": [
           "MaintenanceWindows V1"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "MaintenanceWindows V1",
+        "x-docs-resource-type": "MaintenanceWindowV1"
       }
     },
     "/v1/openapi.json": {
@@ -59568,7 +59708,9 @@
         "summary": "OpenAPI Utilities V1",
         "tags": [
           "Utilities V1"
-        ]
+        ],
+        "x-docs-display-name": "Show OpenAPI V2 Spec",
+        "x-docs-group-name": "Utilities V1"
       }
     },
     "/v1/openapiV3.json": {
@@ -59591,7 +59733,9 @@
         "summary": "OpenAPIV3 Utilities V1",
         "tags": [
           "Utilities V1"
-        ]
+        ],
+        "x-docs-display-name": "Show OpenAPI V3 Spec",
+        "x-docs-group-name": "Utilities V1"
       }
     },
     "/v1/postmortem_documents": {
@@ -59706,7 +59850,10 @@
         "summary": "List PostmortemDocuments V1",
         "tags": [
           "PostmortemDocuments V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "PostmortemDocuments V1",
+        "x-docs-resource-type": "PostmortemDocumentV1"
       }
     },
     "/v1/postmortem_documents/{id}": {
@@ -59766,7 +59913,10 @@
         "summary": "Show PostmortemDocuments V1",
         "tags": [
           "PostmortemDocuments V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "PostmortemDocuments V1",
+        "x-docs-resource-type": "PostmortemDocumentV1"
       },
       "put": {
         "description": "Update the status of a post-mortem document.",
@@ -59837,7 +59987,10 @@
         "summary": "UpdateStatus PostmortemDocuments V1",
         "tags": [
           "PostmortemDocuments V1"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "PostmortemDocuments V1",
+        "x-docs-resource-type": "PostmortemDocumentV1"
       }
     },
     "/v1/postmortem_documents/{id}/content": {
@@ -59876,7 +60029,10 @@
         "summary": "ShowContent PostmortemDocuments V1",
         "tags": [
           "PostmortemDocuments V1"
-        ]
+        ],
+        "x-docs-display-name": "Show Content",
+        "x-docs-group-name": "PostmortemDocuments V1",
+        "x-docs-resource-type": "PostmortemDocumentV1"
       }
     },
     "/v1/severities": {
@@ -59910,7 +60066,10 @@
         "summary": "List Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Severities V1",
+        "x-docs-resource-type": "SeverityV1"
       },
       "post": {
         "description": "Create a new severity",
@@ -59955,7 +60114,10 @@
         "summary": "Create Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Severities V1",
+        "x-docs-resource-type": "SeverityV1"
       }
     },
     "/v1/severities/{id}": {
@@ -59984,7 +60146,10 @@
         "summary": "Delete Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Severities V1",
+        "x-docs-resource-type": "SeverityV1"
       },
       "get": {
         "description": "Get a single incident severity.",
@@ -60028,7 +60193,10 @@
         "summary": "Show Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Severities V1",
+        "x-docs-resource-type": "SeverityV1"
       },
       "put": {
         "description": "Update an existing severity",
@@ -60087,7 +60255,10 @@
         "summary": "Update Severities V1",
         "tags": [
           "Severities V1"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Severities V1",
+        "x-docs-resource-type": "SeverityV1"
       }
     },
     "/v1/status-pages/{id}/incidents/{incident_id}/response-incidents": {
@@ -60144,7 +60315,10 @@
         "tags": [
           "Status Pages V1"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Status Page Response Incidents V1",
+        "x-docs-resource-type": "StatusPageLinkedResponseIncidentV1"
       }
     },
     "/v2/actions": {
@@ -60245,7 +60419,10 @@
         "summary": "List Actions V2",
         "tags": [
           "Actions V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Actions V2",
+        "x-docs-resource-type": "ActionV2"
       }
     },
     "/v2/actions/{id}": {
@@ -60320,7 +60497,10 @@
         "summary": "Show Actions V2",
         "tags": [
           "Actions V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Actions V2",
+        "x-docs-resource-type": "ActionV2"
       }
     },
     "/v2/alert_attributes": {
@@ -60354,7 +60534,10 @@
         "summary": "List Alert Attributes V2",
         "tags": [
           "Alert Attributes V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Alert Attributes V2",
+        "x-docs-resource-type": "AlertAttributeV2"
       },
       "post": {
         "description": "Create a new alert attribute.",
@@ -60401,7 +60584,10 @@
         "summary": "Create Alert Attributes V2",
         "tags": [
           "Alert Attributes V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Alert Attributes V2",
+        "x-docs-resource-type": "AlertAttributeV2"
       }
     },
     "/v2/alert_attributes/{id}": {
@@ -60430,7 +60616,10 @@
         "summary": "Destroy Alert Attributes V2",
         "tags": [
           "Alert Attributes V2"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Alert Attributes V2",
+        "x-docs-resource-type": "AlertAttributeV2"
       },
       "get": {
         "description": "Show an alert attribute.",
@@ -60474,7 +60663,10 @@
         "summary": "Show Alert Attributes V2",
         "tags": [
           "Alert Attributes V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Alert Attributes V2",
+        "x-docs-resource-type": "AlertAttributeV2"
       },
       "put": {
         "description": "Update an alert attribute.",
@@ -60535,7 +60727,10 @@
         "summary": "Update Alert Attributes V2",
         "tags": [
           "Alert Attributes V2"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Alert Attributes V2",
+        "x-docs-resource-type": "AlertAttributeV2"
       }
     },
     "/v2/alert_events/http/{alert_source_config_id}": {
@@ -60616,7 +60811,10 @@
         "summary": "CreateHTTP Alert Events V2",
         "tags": [
           "Alert Events V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Alert Events V2",
+        "x-docs-resource-type": "AlertResultV2"
       }
     },
     "/v2/alert_routes": {
@@ -60687,7 +60885,10 @@
         "summary": "List Alert Routes V2",
         "tags": [
           "Alert Routes V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Alert Routes V2",
+        "x-docs-resource-type": "AlertRouteV2"
       },
       "post": {
         "description": "Create a new alert route in your account.",
@@ -61670,7 +61871,10 @@
         "summary": "Create Alert Routes V2",
         "tags": [
           "Alert Routes V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Alert Routes V2",
+        "x-docs-resource-type": "AlertRouteV2"
       }
     },
     "/v2/alert_routes/{id}": {
@@ -61699,7 +61903,10 @@
         "summary": "Delete Alert Routes V2",
         "tags": [
           "Alert Routes V2"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Alert Routes V2",
+        "x-docs-resource-type": "AlertRouteV2"
       },
       "get": {
         "description": "Load details about a specific alert route in your account.",
@@ -62253,7 +62460,10 @@
         "summary": "Show Alert Routes V2",
         "tags": [
           "Alert Routes V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Alert Routes V2",
+        "x-docs-resource-type": "AlertRouteV2"
       },
       "put": {
         "description": "Update an existing alert route in your account.",
@@ -63255,7 +63465,10 @@
         "summary": "Update Alert Routes V2",
         "tags": [
           "Alert Routes V2"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Alert Routes V2",
+        "x-docs-resource-type": "AlertRouteV2"
       }
     },
     "/v2/alert_sources": {
@@ -63496,7 +63709,10 @@
         "summary": "List Alert Sources V2",
         "tags": [
           "Alert Sources V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Alert Sources V2",
+        "x-docs-resource-type": "AlertSourceV2"
       },
       "post": {
         "description": "Create a new alert source in your account.",
@@ -63919,7 +64135,10 @@
         "summary": "Create Alert Sources V2",
         "tags": [
           "Alert Sources V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Alert Sources V2",
+        "x-docs-resource-type": "AlertSourceV2"
       }
     },
     "/v2/alert_sources/{id}": {
@@ -63948,7 +64167,10 @@
         "summary": "Delete Alert Sources V2",
         "tags": [
           "Alert Sources V2"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Alert Sources V2",
+        "x-docs-resource-type": "AlertSourceV2"
       },
       "get": {
         "description": "Load details about a specific alert source in your account.",
@@ -64199,7 +64421,10 @@
         "summary": "Show Alert Sources V2",
         "tags": [
           "Alert Sources V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Alert Sources V2",
+        "x-docs-resource-type": "AlertSourceV2"
       },
       "put": {
         "description": "Update an existing alert source in your account.",
@@ -64636,7 +64861,10 @@
         "summary": "Update Alert Sources V2",
         "tags": [
           "Alert Sources V2"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Alert Sources V2",
+        "x-docs-resource-type": "AlertSourceV2"
       }
     },
     "/v2/alerts": {
@@ -64891,7 +65119,10 @@
         "summary": "List Alerts V2",
         "tags": [
           "Alerts V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Alerts V2",
+        "x-docs-resource-type": "AlertV2"
       }
     },
     "/v2/alerts/{id}": {
@@ -64973,7 +65204,10 @@
         "summary": "Show Alerts V2",
         "tags": [
           "Alerts V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Alerts V2",
+        "x-docs-resource-type": "AlertV2"
       }
     },
     "/v2/catalog_entries": {
@@ -65146,7 +65380,10 @@
         "summary": "ListEntries Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Catalog Entries V2",
+        "x-docs-resource-type": "CatalogEntryV2"
       },
       "post": {
         "deprecated": true,
@@ -65257,7 +65494,10 @@
         "summary": "CreateEntry Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Catalog Entries V2",
+        "x-docs-resource-type": "CatalogEntryV2"
       }
     },
     "/v2/catalog_entries/{id}": {
@@ -65287,7 +65527,10 @@
         "summary": "DestroyEntry Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Catalog Entries V2",
+        "x-docs-resource-type": "CatalogEntryV2"
       },
       "get": {
         "deprecated": true,
@@ -65424,7 +65667,10 @@
         "summary": "ShowEntry Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Catalog Entries V2",
+        "x-docs-resource-type": "CatalogEntryV2"
       },
       "put": {
         "deprecated": true,
@@ -65594,7 +65840,10 @@
         "summary": "UpdateEntry Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Catalog Entries V2",
+        "x-docs-resource-type": "CatalogEntryV2"
       }
     },
     "/v2/catalog_resources": {
@@ -65628,7 +65877,10 @@
         "summary": "ListResources Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Catalog Resources V2",
+        "x-docs-resource-type": "CatalogResourceV2"
       }
     },
     "/v2/catalog_types": {
@@ -65701,7 +65953,10 @@
         "summary": "ListTypes Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Catalog Types V2",
+        "x-docs-resource-type": "CatalogTypeV2"
       },
       "post": {
         "deprecated": true,
@@ -65795,7 +66050,10 @@
         "summary": "CreateType Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Catalog Types V2",
+        "x-docs-resource-type": "CatalogTypeV2"
       }
     },
     "/v2/catalog_types/{id}": {
@@ -65825,7 +66083,10 @@
         "summary": "DestroyType Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Catalog Types V2",
+        "x-docs-resource-type": "CatalogTypeV2"
       },
       "get": {
         "deprecated": true,
@@ -65908,7 +66169,10 @@
         "summary": "ShowType Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Catalog Types V2",
+        "x-docs-resource-type": "CatalogTypeV2"
       },
       "put": {
         "deprecated": true,
@@ -66015,7 +66279,10 @@
         "summary": "UpdateType Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "Update Type",
+        "x-docs-group-name": "Catalog Types V2",
+        "x-docs-resource-type": "CatalogTypeV2"
       }
     },
     "/v2/catalog_types/{id}/actions/update_schema": {
@@ -66128,7 +66395,10 @@
         "summary": "UpdateTypeSchema Catalog V2",
         "tags": [
           "Catalog V2"
-        ]
+        ],
+        "x-docs-display-name": "Update Type Schema",
+        "x-docs-group-name": "Catalog Types V2",
+        "x-docs-resource-type": "CatalogTypeV2"
       }
     },
     "/v2/custom_fields": {
@@ -66169,7 +66439,10 @@
         "summary": "List Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Custom Fields V2",
+        "x-docs-resource-type": "CustomFieldV2"
       },
       "post": {
         "description": "Create a new custom field",
@@ -66228,7 +66501,10 @@
         "summary": "Create Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Custom Fields V2",
+        "x-docs-resource-type": "CustomFieldV2"
       }
     },
     "/v2/custom_fields/{id}": {
@@ -66257,7 +66533,10 @@
         "summary": "Delete Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Custom Fields V2",
+        "x-docs-resource-type": "CustomFieldV2"
       },
       "get": {
         "description": "Get a single custom field.",
@@ -66308,7 +66587,10 @@
         "summary": "Show Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Custom Fields V2",
+        "x-docs-resource-type": "CustomFieldV2"
       },
       "put": {
         "description": "Update the details of a custom field",
@@ -66379,7 +66661,10 @@
         "summary": "Update Custom Fields V2",
         "tags": [
           "Custom Fields V2"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Custom Fields V2",
+        "x-docs-resource-type": "CustomFieldV2"
       }
     },
     "/v2/escalation_paths": {
@@ -66556,7 +66841,10 @@
         "tags": [
           "Escalations V2"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Escalation Paths V2",
+        "x-docs-resource-type": "EscalationPathV2"
       },
       "post": {
         "description": "Create an escalation path.\n\nAn escalation path is a series of steps that describe how a page should be escalated,\nrepresented as graph, supporting conditional branches based on alert priority and working\nintervals.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
@@ -66803,7 +67091,10 @@
         "tags": [
           "Escalations V2"
         ],
-        "x-display-name": "Create"
+        "x-display-name": "Create",
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Escalation Paths V2",
+        "x-docs-resource-type": "EscalationPathV2"
       }
     },
     "/v2/escalation_paths/external": {
@@ -66930,7 +67221,10 @@
         "summary": "ListExternalEscalationPaths Escalations V2",
         "tags": [
           "Escalations V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "External Escalation Paths V2",
+        "x-docs-resource-type": "ExternalEscalationPathV2"
       },
       "post": {
         "description": "Import an external escalation path and its referenced schedules.\n\nTakes the ID of an external escalation path (as returned by the list endpoint) and\nimports it along with any referenced schedules that haven't already been imported.\n",
@@ -67081,7 +67375,10 @@
         "summary": "CreateExternalEscalationPath Escalations V2",
         "tags": [
           "Escalations V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "External Escalation Paths V2",
+        "x-docs-resource-type": "ExternalEscalationPathV2"
       }
     },
     "/v2/escalation_paths/{id}": {
@@ -67111,7 +67408,10 @@
         "tags": [
           "Escalations V2"
         ],
-        "x-display-name": "Destroy"
+        "x-display-name": "Destroy",
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Escalation Paths V2",
+        "x-docs-resource-type": "EscalationPathV2"
       },
       "get": {
         "description": "Show an escalation path.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
@@ -67264,7 +67564,10 @@
         "tags": [
           "Escalations V2"
         ],
-        "x-display-name": "Show"
+        "x-display-name": "Show",
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Escalation Paths V2",
+        "x-docs-resource-type": "EscalationPathV2"
       },
       "put": {
         "description": "Updates an escalation path.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
@@ -67525,7 +67828,10 @@
         "tags": [
           "Escalations V2"
         ],
-        "x-display-name": "Update"
+        "x-display-name": "Update",
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Escalation Paths V2",
+        "x-docs-resource-type": "EscalationPathV2"
       }
     },
     "/v2/escalations": {
@@ -67843,7 +68149,10 @@
         "summary": "List Escalations V2",
         "tags": [
           "Escalations V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Escalations V2",
+        "x-docs-resource-type": "EscalationV2"
       },
       "post": {
         "description": "Create an escalation.\n\nAn escalation pages people, either according to an escalation path, or directly to\nspecific users. You must provide either an escalation_path_id OR user_ids, but not both.\n\nWhen escalating via an escalation path, the escalation will follow the configured path\nwith its levels and timeouts, using your default [alert\npriority](https://app.incident.io/~/settings/alerts/configuration/priorities).\n\nWhen escalating directly to users, they will receive a high-urgency\nnotification, based on their notification rules.\n\nThis endpoint is rate-limited to 60 requests per minute, since it is intended for\ninteractive use cases (for example someone clicking a \"escalate to team\" button\nin your internal developer platform). To escalate based on automated alerts, we\nrecommend sending events to an alert source instead.\n",
@@ -67963,7 +68272,10 @@
         "summary": "Create Escalations V2",
         "tags": [
           "Escalations V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Escalations V2",
+        "x-docs-resource-type": "EscalationV2"
       }
     },
     "/v2/escalations/{id}": {
@@ -68079,7 +68391,10 @@
         "summary": "Show Escalations V2",
         "tags": [
           "Escalations V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Escalations V2",
+        "x-docs-resource-type": "EscalationV2"
       }
     },
     "/v2/follow_ups": {
@@ -68191,7 +68506,10 @@
         "summary": "List Follow-ups V2",
         "tags": [
           "Follow-ups V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Follow-ups V2",
+        "x-docs-resource-type": "FollowUpV2"
       }
     },
     "/v2/follow_ups/{id}": {
@@ -68282,7 +68600,10 @@
         "summary": "Show Follow-ups V2",
         "tags": [
           "Follow-ups V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Follow-ups V2",
+        "x-docs-resource-type": "FollowUpV2"
       }
     },
     "/v2/incident_alerts": {
@@ -68392,7 +68713,10 @@
         "summary": "ListIncidentAlerts Alerts V2",
         "tags": [
           "Alerts V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incident Alerts V2",
+        "x-docs-resource-type": "IncidentAlertV2"
       }
     },
     "/v2/incident_roles": {
@@ -68428,7 +68752,10 @@
         "summary": "List Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incident Roles V2",
+        "x-docs-resource-type": "IncidentRoleV2"
       },
       "post": {
         "description": "Create a new incident role",
@@ -68476,7 +68803,10 @@
         "summary": "Create Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Incident Roles V2",
+        "x-docs-resource-type": "IncidentRoleV2"
       }
     },
     "/v2/incident_roles/{id}": {
@@ -68505,7 +68835,10 @@
         "summary": "Delete Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Incident Roles V2",
+        "x-docs-resource-type": "IncidentRoleV2"
       },
       "get": {
         "description": "Get a single incident role.",
@@ -68551,7 +68884,10 @@
         "summary": "Show Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Incident Roles V2",
+        "x-docs-resource-type": "IncidentRoleV2"
       },
       "put": {
         "description": "Update an existing incident role",
@@ -68613,7 +68949,10 @@
         "summary": "Update Incident Roles V2",
         "tags": [
           "Incident Roles V2"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Incident Roles V2",
+        "x-docs-resource-type": "IncidentRoleV2"
       }
     },
     "/v2/incident_timestamps": {
@@ -68644,7 +68983,10 @@
         "summary": "List Incident Timestamps V2",
         "tags": [
           "Incident Timestamps V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incident Timestamps V2",
+        "x-docs-resource-type": "IncidentTimestampV2"
       }
     },
     "/v2/incident_timestamps/{id}": {
@@ -68687,7 +69029,10 @@
         "summary": "Show Incident Timestamps V2",
         "tags": [
           "Incident Timestamps V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Incident Timestamps V2",
+        "x-docs-resource-type": "IncidentTimestampV2"
       }
     },
     "/v2/incident_updates": {
@@ -68803,7 +69148,10 @@
         "summary": "List Incident Updates V2",
         "tags": [
           "Incident Updates V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incident Updates V2",
+        "x-docs-resource-type": "IncidentUpdateV2"
       }
     },
     "/v2/incidents": {
@@ -69359,7 +69707,10 @@
         "summary": "List Incidents V2",
         "tags": [
           "Incidents V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Incidents V2",
+        "x-docs-resource-type": "IncidentV2"
       },
       "post": {
         "description": "Create a new incident.\n\nNote that if the incident mode is set to \"retrospective\" then the new incident\nwill not be announced in Slack.\n",
@@ -69600,7 +69951,10 @@
         "summary": "Create Incidents V2",
         "tags": [
           "Incidents V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Incidents V2",
+        "x-docs-resource-type": "IncidentV2"
       }
     },
     "/v2/incidents/{id}": {
@@ -69798,7 +70152,10 @@
         "summary": "Show Incidents V2",
         "tags": [
           "Incidents V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Incidents V2",
+        "x-docs-resource-type": "IncidentV2"
       }
     },
     "/v2/incidents/{id}/actions/edit": {
@@ -70049,7 +70406,10 @@
         "summary": "Edit Incidents V2",
         "tags": [
           "Incidents V2"
-        ]
+        ],
+        "x-docs-display-name": "Edit",
+        "x-docs-group-name": "Incidents V2",
+        "x-docs-resource-type": "IncidentV2"
       }
     },
     "/v2/managed_resources": {
@@ -70099,7 +70459,10 @@
         "summary": "CreateManagedResource Managed Resources V2",
         "tags": [
           "Managed Resources V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Managed Resources V2",
+        "x-docs-resource-type": "ManagedResourceV2"
       }
     },
     "/v2/schedule_entries": {
@@ -70222,7 +70585,10 @@
         "tags": [
           "Schedules V2"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Schedule Entries V2",
+        "x-docs-resource-type": "ScheduleEntryV2"
       }
     },
     "/v2/schedule_overrides": {
@@ -70286,7 +70652,10 @@
         "tags": [
           "Schedules V2"
         ],
-        "x-display-name": "Create"
+        "x-display-name": "Create",
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Schedule Overrides V2",
+        "x-docs-resource-type": "ScheduleOverrideV2"
       }
     },
     "/v2/schedules": {
@@ -70450,7 +70819,10 @@
         "summary": "List Schedules V2",
         "tags": [
           "Schedules V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Schedules V2",
+        "x-docs-resource-type": "ScheduleV2"
       },
       "post": {
         "description": "Create a new schedule.",
@@ -70642,7 +71014,10 @@
         "summary": "Create Schedules V2",
         "tags": [
           "Schedules V2"
-        ]
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Schedules V2",
+        "x-docs-resource-type": "ScheduleV2"
       }
     },
     "/v2/schedules/{id}": {
@@ -70671,7 +71046,10 @@
         "summary": "Destroy Schedules V2",
         "tags": [
           "Schedules V2"
-        ]
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Schedules V2",
+        "x-docs-resource-type": "ScheduleV2"
       },
       "get": {
         "description": "Get a single schedule.",
@@ -70806,7 +71184,10 @@
         "summary": "Show Schedules V2",
         "tags": [
           "Schedules V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Schedules V2",
+        "x-docs-resource-type": "ScheduleV2"
       },
       "put": {
         "description": "Update a schedule.",
@@ -71012,7 +71393,10 @@
         "summary": "Update Schedules V2",
         "tags": [
           "Schedules V2"
-        ]
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Schedules V2",
+        "x-docs-resource-type": "ScheduleV2"
       }
     },
     "/v2/schedules/{schedule_id}/replicas": {
@@ -71076,7 +71460,10 @@
         "tags": [
           "Schedules V2"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Schedule Replicas V2",
+        "x-docs-resource-type": "ScheduleReplicaV2"
       },
       "post": {
         "description": "Create a new schedule replica.",
@@ -71159,7 +71546,10 @@
         "tags": [
           "Schedules V2"
         ],
-        "x-display-name": "Create"
+        "x-display-name": "Create",
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Schedule Replicas V2",
+        "x-docs-resource-type": "ScheduleReplicaV2"
       }
     },
     "/v2/schedules/{schedule_id}/replicas/{id}": {
@@ -71201,7 +71591,10 @@
         "tags": [
           "Schedules V2"
         ],
-        "x-display-name": "Destroy"
+        "x-display-name": "Destroy",
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Schedule Replicas V2",
+        "x-docs-resource-type": "ScheduleReplicaV2"
       },
       "get": {
         "description": "Get a single schedule replica.",
@@ -71273,7 +71666,10 @@
         "tags": [
           "Schedules V2"
         ],
-        "x-display-name": "Show"
+        "x-display-name": "Show",
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Schedule Replicas V2",
+        "x-docs-resource-type": "ScheduleReplicaV2"
       }
     },
     "/v2/status_page_incident_updates": {
@@ -71333,7 +71729,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "Create"
+        "x-display-name": "Create",
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Status Page Incident Updates V2",
+        "x-docs-resource-type": "StatusPageIncidentUpdateV2"
       }
     },
     "/v2/status_page_incidents": {
@@ -71498,7 +71897,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Status Page Incidents V2",
+        "x-docs-resource-type": "StatusPageIncidentV2"
       },
       "post": {
         "description": "Create a status page incident.\n\nThis endpoint requires an API key with the \"Create status page incidents, maintenance windows and publish updates\" scope.",
@@ -71575,7 +71977,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "Create"
+        "x-display-name": "Create",
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Status Page Incidents V2",
+        "x-docs-resource-type": "StatusPageIncidentV2"
       }
     },
     "/v2/status_page_incidents/{status_page_incident_id}": {
@@ -71644,7 +72049,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "Show"
+        "x-display-name": "Show",
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Status Page Incidents V2",
+        "x-docs-resource-type": "StatusPageIncidentV2"
       },
       "put": {
         "description": "Update a status page incident.\n\nThis endpoint requires an API key with the \"Create status page incidents, maintenance windows and publish updates\" scope.",
@@ -71724,7 +72132,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "Update"
+        "x-display-name": "Update",
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Status Page Incidents V2",
+        "x-docs-resource-type": "StatusPageIncidentV2"
       }
     },
     "/v2/status_page_maintenance_updates": {
@@ -71784,7 +72195,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "Create"
+        "x-display-name": "Create",
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Status Page Maintenance Updates V2",
+        "x-docs-resource-type": "StatusPageMaintenanceUpdateV2"
       }
     },
     "/v2/status_page_maintenances": {
@@ -71948,7 +72362,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Status Page Maintenances V2",
+        "x-docs-resource-type": "StatusPageMaintenanceV2"
       },
       "post": {
         "description": "Schedule a Status Page maintenance window.\n\nThis endpoint requires an API key with the \"Create status page incidents, maintenance windows and publish updates\" scope.",
@@ -72023,7 +72440,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "Create"
+        "x-display-name": "Create",
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Status Page Maintenances V2",
+        "x-docs-resource-type": "StatusPageMaintenanceV2"
       }
     },
     "/v2/status_page_maintenances/{status_page_maintenance_id}": {
@@ -72091,7 +72511,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "Show"
+        "x-display-name": "Show",
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Status Page Maintenances V2",
+        "x-docs-resource-type": "StatusPageMaintenanceV2"
       }
     },
     "/v2/status_page_structures/{status_page_id}": {
@@ -72172,7 +72595,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "Show"
+        "x-display-name": "Show",
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Status Pages V2",
+        "x-docs-resource-type": "StatusPageV2"
       }
     },
     "/v2/status_pages": {
@@ -72238,7 +72664,10 @@
         "tags": [
           "Status Pages V2"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Status Pages V2",
+        "x-docs-resource-type": "StatusPageV2"
       }
     },
     "/v2/telemetry/data_sources/{id}": {
@@ -72305,7 +72734,10 @@
         "tags": [
           "Telemetry V2"
         ],
-        "x-display-name": "Update"
+        "x-display-name": "Update",
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Telemetry V2",
+        "x-docs-resource-type": "TelemetryDataSourceV2"
       }
     },
     "/v2/users": {
@@ -72413,7 +72845,10 @@
         "summary": "List Users V2",
         "tags": [
           "Users V2"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Users V2",
+        "x-docs-resource-type": "UserWithRolesV2"
       }
     },
     "/v2/users/{id}": {
@@ -72476,7 +72911,10 @@
         "summary": "Show Users V2",
         "tags": [
           "Users V2"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Users V2",
+        "x-docs-resource-type": "UserWithRolesV2"
       }
     },
     "/v2/users/{user_id}/notification_methods": {
@@ -72523,7 +72961,10 @@
         "tags": [
           "Users V2"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Notification Methods V2",
+        "x-docs-resource-type": "OnCallNotificationMethodPublicV2"
       }
     },
     "/v2/users/{user_id}/notification_rules": {
@@ -72580,7 +73021,10 @@
         "tags": [
           "Users V2"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Notification Rules V2",
+        "x-docs-resource-type": "OnCallNotificationRulePublicV2"
       }
     },
     "/v2/workflows": {
@@ -72816,7 +73260,10 @@
         "tags": [
           "Workflows V2"
         ],
-        "x-display-name": "List"
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Workflows V2",
+        "x-docs-resource-type": "WorkflowV2"
       },
       "post": {
         "description": "Create a new workflow",
@@ -73265,7 +73712,10 @@
         "tags": [
           "Workflows V2"
         ],
-        "x-display-name": "Create"
+        "x-display-name": "Create",
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Workflows V2",
+        "x-docs-resource-type": "WorkflowV2"
       }
     },
     "/v2/workflows/{id}": {
@@ -73295,7 +73745,10 @@
         "tags": [
           "Workflows V2"
         ],
-        "x-display-name": "Destroy"
+        "x-display-name": "Destroy",
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Workflows V2",
+        "x-docs-resource-type": "WorkflowV2"
       },
       "get": {
         "description": "Show a workflow by ID",
@@ -73578,7 +74031,10 @@
         "tags": [
           "Workflows V2"
         ],
-        "x-display-name": "Show"
+        "x-display-name": "Show",
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Workflows V2",
+        "x-docs-resource-type": "WorkflowV2"
       },
       "put": {
         "description": "Updates a workflow",
@@ -74046,7 +74502,10 @@
         "tags": [
           "Workflows V2"
         ],
-        "x-display-name": "Update"
+        "x-display-name": "Update",
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Workflows V2",
+        "x-docs-resource-type": "WorkflowV2"
       }
     },
     "/v3/catalog_entries": {
@@ -74217,7 +74676,10 @@
         "summary": "ListEntries Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "List Entries",
+        "x-docs-group-name": "Catalog Entries V3",
+        "x-docs-resource-type": "CatalogEntryV3"
       },
       "post": {
         "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.\n\nIf you call this API with a payload where the external_id and catalog_type_id match an existing entry, the existing entry will be updated.",
@@ -74299,7 +74761,10 @@
         "summary": "CreateEntry Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Create Entry",
+        "x-docs-group-name": "Catalog Entries V3",
+        "x-docs-resource-type": "CatalogEntryV3"
       }
     },
     "/v3/catalog_entries/actions/bulk_update": {
@@ -74375,7 +74840,10 @@
         "summary": "BulkUpdateEntries Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Bulk Update Entries",
+        "x-docs-group-name": "Catalog Entries V3",
+        "x-docs-resource-type": "CatalogEntryV3"
       }
     },
     "/v3/catalog_entries/{id}": {
@@ -74404,7 +74872,10 @@
         "summary": "DestroyEntry Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Delete Entry",
+        "x-docs-group-name": "Catalog Entries V3",
+        "x-docs-resource-type": "CatalogEntryV3"
       },
       "get": {
         "description": "Show a single catalog entry.",
@@ -74527,7 +74998,10 @@
         "summary": "ShowEntry Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Show Entry",
+        "x-docs-group-name": "Catalog Entries V3",
+        "x-docs-resource-type": "CatalogEntryV3"
       },
       "put": {
         "description": "Updates an existing catalog entry.",
@@ -74672,7 +75146,10 @@
         "summary": "UpdateEntry Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Update Entry",
+        "x-docs-group-name": "Catalog Entries V3",
+        "x-docs-resource-type": "CatalogEntryV3"
       }
     },
     "/v3/catalog_resources": {
@@ -74705,7 +75182,10 @@
         "summary": "ListResources Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "List Resources",
+        "x-docs-group-name": "Catalog Resources V3",
+        "x-docs-resource-type": "CatalogResourceV3"
       }
     },
     "/v3/catalog_types": {
@@ -74778,7 +75258,10 @@
         "summary": "ListTypes Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "List Types",
+        "x-docs-group-name": "Catalog Types V3",
+        "x-docs-resource-type": "CatalogTypeV3"
       },
       "post": {
         "description": "Create a catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
@@ -74873,7 +75356,10 @@
         "summary": "CreateType Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Create Type",
+        "x-docs-group-name": "Catalog Types V3",
+        "x-docs-resource-type": "CatalogTypeV3"
       }
     },
     "/v3/catalog_types/{id}": {
@@ -74902,7 +75388,10 @@
         "summary": "DestroyType Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Delete Type",
+        "x-docs-group-name": "Catalog Types V3",
+        "x-docs-resource-type": "CatalogTypeV3"
       },
       "get": {
         "description": "Show a single catalog type.",
@@ -74985,7 +75474,10 @@
         "summary": "ShowType Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Show Type",
+        "x-docs-group-name": "Catalog Types V3",
+        "x-docs-resource-type": "CatalogTypeV3"
       },
       "put": {
         "description": "Updates an existing catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
@@ -75093,7 +75585,10 @@
         "summary": "UpdateType Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Update Type",
+        "x-docs-group-name": "Catalog Types V3",
+        "x-docs-resource-type": "CatalogTypeV3"
       }
     },
     "/v3/catalog_types/{id}/actions/update_schema": {
@@ -75206,7 +75701,10 @@
         "summary": "UpdateTypeSchema Catalog V3",
         "tags": [
           "Catalog V3"
-        ]
+        ],
+        "x-docs-display-name": "Update Type Schema",
+        "x-docs-group-name": "Catalog Types V3",
+        "x-docs-resource-type": "CatalogTypeV3"
       }
     },
     "/v3/teams": {
@@ -75281,7 +75779,10 @@
         "summary": "List Teams V3",
         "tags": [
           "Teams V3"
-        ]
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Teams V3",
+        "x-docs-resource-type": "TeamV3"
       }
     },
     "/v3/teams/{id}": {
@@ -75335,7 +75836,10 @@
         "summary": "Show Teams V3",
         "tags": [
           "Teams V3"
-        ]
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Teams V3",
+        "x-docs-resource-type": "TeamV3"
       }
     }
   },

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -78,6 +78,20 @@ func (r *IncidentAlertSourceResource) ValidateConfig(ctx context.Context, req re
 		return
 	}
 
+	if data.Template != nil && data.SourceType.ValueString() == "heartbeat" {
+		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+			"template cannot be set when source_type is heartbeat",
+			"Heartbeat alert sources manage their own template automatically."))
+		return
+	}
+
+	if data.Template == nil && !data.SourceType.IsUnknown() && data.SourceType.ValueString() != "heartbeat" {
+		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+			"template must be set for this source_type",
+			"template is required for all alert source types except heartbeat."))
+		return
+	}
+
 	// Validate visible_to_teams only set when is_private is true
 	if data.Template != nil && data.Template.VisibleToTeams != nil {
 		if data.Template.IsPrivate.IsNull() || !data.Template.IsPrivate.ValueBool() {
@@ -233,7 +247,8 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 				},
 			},
 			"template": schema.SingleNestedAttribute{
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
 				MarkdownDescription: apischema.Docstring("AlertSourceV2", "template"),
 				Attributes: map[string]schema.Attribute{
 					"expressions": models.ExpressionsAttribute(),

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -78,20 +78,6 @@ func (r *IncidentAlertSourceResource) ValidateConfig(ctx context.Context, req re
 		return
 	}
 
-	if data.Template != nil && data.SourceType.ValueString() == "heartbeat" {
-		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
-			"template cannot be set when source_type is heartbeat",
-			"Heartbeat alert sources manage their own template automatically."))
-		return
-	}
-
-	if data.Template == nil && !data.SourceType.IsUnknown() && data.SourceType.ValueString() != "heartbeat" {
-		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
-			"template must be set for this source_type",
-			"template is required for all alert source types except heartbeat."))
-		return
-	}
-
 	// Validate visible_to_teams only set when is_private is true
 	if data.Template != nil && data.Template.VisibleToTeams != nil {
 		if data.Template.IsPrivate.IsNull() || !data.Template.IsPrivate.ValueBool() {
@@ -247,8 +233,7 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 				},
 			},
 			"template": schema.SingleNestedAttribute{
-				Optional:            true,
-				Computed:            true,
+				Required:            true,
 				MarkdownDescription: apischema.Docstring("AlertSourceV2", "template"),
 				Attributes: map[string]schema.Attribute{
 					"expressions": models.ExpressionsAttribute(),
@@ -465,7 +450,12 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 
 	tflog.Trace(ctx, fmt.Sprintf("created an alert source with id=%s", result.JSON200.AlertSource.Id))
 
+	planTemplate := data.Template
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil && planTemplate != nil {
+		data.Template.Title = planTemplate.Title
+		data.Template.Description = planTemplate.Description
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -490,7 +480,13 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	stateTemplate := data.Template
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil && stateTemplate != nil {
+		data.Template.Title = stateTemplate.Title
+		data.Template.Description = stateTemplate.Description
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -540,7 +536,13 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 
 	claimResource(ctx, r.client, result.JSON200.AlertSource.Id, resp.Diagnostics, client.AlertSource, r.terraformVersion)
 
+	planTemplate := data.Template
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil && planTemplate != nil {
+		data.Template.Title = planTemplate.Title
+		data.Template.Description = planTemplate.Description
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -78,6 +78,41 @@ func (r *IncidentAlertSourceResource) ValidateConfig(ctx context.Context, req re
 		return
 	}
 
+	// Validate that heartbeat sources don't set template title or description,
+	// as the API normalizes these fields and the provider ignores the returned values.
+	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
+		title := data.Template.Title
+		if !title.Literal.IsNull() && !title.Literal.IsUnknown() {
+			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+				path.Root("template").AtName("title").AtName("literal"),
+				"template.title cannot be set for heartbeat alert sources",
+				"Heartbeat alert sources manage their own template title automatically."))
+			return
+		}
+		if !title.Reference.IsNull() && !title.Reference.IsUnknown() {
+			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+				path.Root("template").AtName("title").AtName("reference"),
+				"template.title cannot be set for heartbeat alert sources",
+				"Heartbeat alert sources manage their own template title automatically."))
+			return
+		}
+		desc := data.Template.Description
+		if !desc.Literal.IsNull() && !desc.Literal.IsUnknown() {
+			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+				path.Root("template").AtName("description").AtName("literal"),
+				"template.description cannot be set for heartbeat alert sources",
+				"Heartbeat alert sources manage their own template description automatically."))
+			return
+		}
+		if !desc.Reference.IsNull() && !desc.Reference.IsUnknown() {
+			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+				path.Root("template").AtName("description").AtName("reference"),
+				"template.description cannot be set for heartbeat alert sources",
+				"Heartbeat alert sources manage their own template description automatically."))
+			return
+		}
+	}
+
 	// Validate visible_to_teams only set when is_private is true
 	if data.Template != nil && data.Template.VisibleToTeams != nil {
 		if data.Template.IsPrivate.IsNull() || !data.Template.IsPrivate.ValueBool() {

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -319,6 +320,7 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 					"failure_threshold": schema.Int64Attribute{
 						Optional:            true,
 						Computed:            true,
+						Default:             int64default.StaticInt64(1),
 						MarkdownDescription: apischema.Docstring("AlertSourceHeartbeatOptionsPayloadV2", "failure_threshold"),
 					},
 					"grace_period_seconds": schema.Int64Attribute{

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -361,6 +361,7 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 					"grace_period_seconds": schema.Int64Attribute{
 						Optional:            true,
 						Computed:            true,
+						Default:             int64default.StaticInt64(0),
 						MarkdownDescription: apischema.Docstring("AlertSourceHeartbeatOptionsPayloadV2", "grace_period_seconds"),
 					},
 					"ping_url": schema.StringAttribute{

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -62,6 +62,21 @@ func (r *IncidentAlertSourceResource) ValidateConfig(ctx context.Context, req re
 		return
 	}
 
+	req.Config.GetAttribute(ctx, path.Root("heartbeat_options"), &data.HeartbeatOptions)
+	if data.HeartbeatOptions != nil && data.SourceType.ValueString() != "heartbeat" {
+		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+			"heartbeat_options can only be set when source_type is heartbeat",
+			"These options only apply to the 'heartbeat' source type"))
+		return
+	}
+
+	if data.HeartbeatOptions == nil && data.SourceType.ValueString() == "heartbeat" {
+		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+			"heartbeat_options must be set when source_type is heartbeat",
+			"These options are required for the 'heartbeat' source type, to specify the expected ping interval."))
+		return
+	}
+
 	// Validate visible_to_teams only set when is_private is true
 	if data.Template != nil && data.Template.VisibleToTeams != nil {
 		if data.Template.IsPrivate.IsNull() || !data.Template.IsPrivate.ValueBool() {
@@ -293,6 +308,33 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 					},
 				},
 			},
+			"heartbeat_options": schema.SingleNestedAttribute{
+				MarkdownDescription: apischema.Docstring("AlertSourceV2", "heartbeat_options"),
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"interval_seconds": schema.Int64Attribute{
+						Required:            true,
+						MarkdownDescription: apischema.Docstring("AlertSourceHeartbeatOptionsPayloadV2", "interval_seconds"),
+					},
+					"failure_threshold": schema.Int64Attribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: apischema.Docstring("AlertSourceHeartbeatOptionsPayloadV2", "failure_threshold"),
+					},
+					"grace_period_seconds": schema.Int64Attribute{
+						Optional:            true,
+						Computed:            true,
+						MarkdownDescription: apischema.Docstring("AlertSourceHeartbeatOptionsPayloadV2", "grace_period_seconds"),
+					},
+					"ping_url": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: apischema.Docstring("AlertSourceHeartbeatOptionsV2", "ping_url"),
+						PlanModifiers: []planmodifier.String{
+							useStateForUnknownIncludingNull{},
+						},
+					},
+				},
+			},
 			"email_address": schema.StringAttribute{
 				Computed:            true,
 				Optional:            true,
@@ -374,16 +416,27 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 			owningTeamIDs = &teamIDs
 		}
 
-		return r.client.AlertSourcesV2CreateWithResponse(ctx, client.AlertSourcesCreatePayloadV2{
-			Name:                      data.Name.ValueString(),
-			SourceType:                client.AlertSourcesCreatePayloadV2SourceType(data.SourceType.ValueString()),
-			Template:                  data.Template.ToPayload(),
-			JiraOptions:               data.JiraOptions.ToPayload(),
-			HttpCustomOptions:         data.HTTPCustomOptions.ToPayload(),
-			AutoResolveTimeoutMinutes: data.AutoResolveTimeoutMinutes.ValueInt64Pointer(),
-			AutoResolveIncidentAlerts: data.AutoResolveIncidentAlerts.ValueBoolPointer(),
-			OwningTeamIds:             owningTeamIDs,
-		})
+		payload := client.AlertSourcesCreatePayloadV2{
+			Name:              data.Name.ValueString(),
+			SourceType:        client.AlertSourcesCreatePayloadV2SourceType(data.SourceType.ValueString()),
+			Template:          data.Template.ToPayload(),
+			JiraOptions:       data.JiraOptions.ToPayload(),
+			HeartbeatOptions:  data.HeartbeatOptions.ToPayload(),
+			HttpCustomOptions: data.HTTPCustomOptions.ToPayload(),
+			OwningTeamIds:     owningTeamIDs,
+		}
+
+		// Only send auto-resolve fields when explicitly configured, as some
+		// source types (e.g. heartbeat) do not support them and the API will
+		// reject the request if they are present.
+		if !data.AutoResolveTimeoutMinutes.IsNull() && !data.AutoResolveTimeoutMinutes.IsUnknown() {
+			payload.AutoResolveTimeoutMinutes = data.AutoResolveTimeoutMinutes.ValueInt64Pointer()
+		}
+		if !data.AutoResolveIncidentAlerts.IsNull() && !data.AutoResolveIncidentAlerts.IsUnknown() {
+			payload.AutoResolveIncidentAlerts = data.AutoResolveIncidentAlerts.ValueBoolPointer()
+		}
+
+		return r.client.AlertSourcesV2CreateWithResponse(ctx, payload)
 	})
 
 	if err != nil {
@@ -444,15 +497,23 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 			owningTeamIDs = &teamIDs
 		}
 
-		return r.client.AlertSourcesV2UpdateWithResponse(ctx, data.ID.ValueString(), client.AlertSourcesUpdatePayloadV2{
-			Name:                      data.Name.ValueString(),
-			Template:                  data.Template.ToPayload(),
-			JiraOptions:               data.JiraOptions.ToPayload(),
-			HttpCustomOptions:         data.HTTPCustomOptions.ToPayload(),
-			AutoResolveTimeoutMinutes: data.AutoResolveTimeoutMinutes.ValueInt64Pointer(),
-			AutoResolveIncidentAlerts: data.AutoResolveIncidentAlerts.ValueBoolPointer(),
-			OwningTeamIds:             owningTeamIDs,
-		})
+		payload := client.AlertSourcesUpdatePayloadV2{
+			Name:              data.Name.ValueString(),
+			Template:          data.Template.ToPayload(),
+			JiraOptions:       data.JiraOptions.ToPayload(),
+			HeartbeatOptions:  data.HeartbeatOptions.ToPayload(),
+			HttpCustomOptions: data.HTTPCustomOptions.ToPayload(),
+			OwningTeamIds:     owningTeamIDs,
+		}
+
+		if !data.AutoResolveTimeoutMinutes.IsNull() && !data.AutoResolveTimeoutMinutes.IsUnknown() {
+			payload.AutoResolveTimeoutMinutes = data.AutoResolveTimeoutMinutes.ValueInt64Pointer()
+		}
+		if !data.AutoResolveIncidentAlerts.IsNull() && !data.AutoResolveIncidentAlerts.IsUnknown() {
+			payload.AutoResolveIncidentAlerts = data.AutoResolveIncidentAlerts.ValueBoolPointer()
+		}
+
+		return r.client.AlertSourcesV2UpdateWithResponse(ctx, data.ID.ValueString(), payload)
 	})
 
 	if err != nil {

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -485,11 +485,10 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 
 	tflog.Trace(ctx, fmt.Sprintf("created an alert source with id=%s", result.JSON200.AlertSource.Id))
 
-	planTemplate := data.Template
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
-	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil && planTemplate != nil {
-		data.Template.Title = planTemplate.Title
-		data.Template.Description = planTemplate.Description
+	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
+		data.Template.Title = models.IncidentEngineParamBindingValue{}
+		data.Template.Description = models.IncidentEngineParamBindingValue{}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -515,11 +514,10 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	stateTemplate := data.Template
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
-	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil && stateTemplate != nil {
-		data.Template.Title = stateTemplate.Title
-		data.Template.Description = stateTemplate.Description
+	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
+		data.Template.Title = models.IncidentEngineParamBindingValue{}
+		data.Template.Description = models.IncidentEngineParamBindingValue{}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -571,11 +569,10 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 
 	claimResource(ctx, r.client, result.JSON200.AlertSource.Id, resp.Diagnostics, client.AlertSource, r.terraformVersion)
 
-	planTemplate := data.Template
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
-	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil && planTemplate != nil {
-		data.Template.Title = planTemplate.Title
-		data.Template.Description = planTemplate.Description
+	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
+		data.Template.Title = models.IncidentEngineParamBindingValue{}
+		data.Template.Description = models.IncidentEngineParamBindingValue{}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -217,15 +217,30 @@ resource "incident_alert_source" "test" {
   name        = {{ quote .Name }}
   source_type = "heartbeat"
 
+  template = {
+    expressions = [],
+    title = {
+      literal = {{ quote .Title }}
+    },
+    description = {
+      literal = {{ quote .Description }}
+    },
+    attributes = []
+  }
+
   heartbeat_options = {
     interval_seconds = {{ .IntervalSeconds }}
   }
 }
 `, struct {
 		Name            string
+		Title           string
+		Description     string
 		IntervalSeconds int
 	}{
 		Name:            name,
+		Title:           testAlertSourceTitle,
+		Description:     testAlertSourceDescription,
 		IntervalSeconds: intervalSeconds,
 	})
 }

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -184,6 +184,67 @@ resource "incident_alert_source" "test" {
 	})
 }
 
+// TestAccAlertSourceResource_Heartbeat checks that heartbeat_options work.
+func TestAccAlertSourceResource_Heartbeat(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertSourceResourceConfigWithHeartbeat("heartbeat-source", 60),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_alert_source.test", "name", "heartbeat-source"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "source_type", "heartbeat"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "heartbeat_options.interval_seconds", "60"),
+					resource.TestCheckResourceAttrSet("incident_alert_source.test", "heartbeat_options.failure_threshold"),
+					resource.TestCheckResourceAttrSet("incident_alert_source.test", "heartbeat_options.grace_period_seconds"),
+					resource.TestCheckResourceAttrSet("incident_alert_source.test", "heartbeat_options.ping_url"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "incident_alert_source.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAlertSourceResourceConfigWithHeartbeat(name string, intervalSeconds int) string {
+	return testRunTemplate("incident_alert_source_heartbeat", `
+resource "incident_alert_source" "test" {
+  name        = {{ quote .Name }}
+  source_type = "heartbeat"
+
+  template = {
+    expressions = [],
+    title = {
+      literal = {{ quote .Title }}
+    },
+    description = {
+      literal = {{ quote .Description }}
+    },
+    attributes = []
+  }
+
+  heartbeat_options = {
+    interval_seconds = {{ .IntervalSeconds }}
+  }
+}
+`, struct {
+		Name            string
+		Title           string
+		Description     string
+		IntervalSeconds int
+	}{
+		Name:            name,
+		Title:           testAlertSourceTitle,
+		Description:     testAlertSourceDescription,
+		IntervalSeconds: intervalSeconds,
+	})
+}
+
 // TestAccAlertSourceResource_Jira checks that the jira_options work.
 //
 // NOTE: this only runs if TF_ACC_JIRA is in your environment, since it requires
@@ -247,6 +308,35 @@ resource "incident_alert_source" "test" {
 				}),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile("jira_options can only be set when source_type is jira"),
+			},
+			{
+				// Test heartbeat_options with wrong source_type
+				Config: testRunTemplate("incident_alert_source_invalid_heartbeat", `
+resource "incident_alert_source" "test" {
+  name = "Not Heartbeat, but with heartbeat options"
+  source_type = "datadog"
+
+  template = {
+    expressions = [],
+    title = {
+      literal = {{ quote .Title }}
+    },
+    description = {
+      literal = {{ quote .Description }}
+    },
+    attributes = []
+  }
+
+  heartbeat_options = {
+    interval_seconds = 60
+  }
+}
+`, struct{ Title, Description string }{
+					Title:       testAlertSourceTitle,
+					Description: testAlertSourceDescription,
+				}),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("heartbeat_options can only be set when source_type is heartbeat"),
 			},
 			{
 				// Test missing required template fields

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -217,30 +217,15 @@ resource "incident_alert_source" "test" {
   name        = {{ quote .Name }}
   source_type = "heartbeat"
 
-  template = {
-    expressions = [],
-    title = {
-      literal = {{ quote .Title }}
-    },
-    description = {
-      literal = {{ quote .Description }}
-    },
-    attributes = []
-  }
-
   heartbeat_options = {
     interval_seconds = {{ .IntervalSeconds }}
   }
 }
 `, struct {
 		Name            string
-		Title           string
-		Description     string
 		IntervalSeconds int
 	}{
 		Name:            name,
-		Title:           testAlertSourceTitle,
-		Description:     testAlertSourceDescription,
 		IntervalSeconds: intervalSeconds,
 	})
 }

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -219,13 +219,9 @@ resource "incident_alert_source" "test" {
 
   template = {
     expressions = [],
-    title = {
-      literal = {{ quote .Title }}
-    },
-    description = {
-      literal = {{ quote .Description }}
-    },
-    attributes = []
+    title       = {},
+    description = {},
+    attributes  = []
   }
 
   heartbeat_options = {
@@ -234,13 +230,9 @@ resource "incident_alert_source" "test" {
 }
 `, struct {
 		Name            string
-		Title           string
-		Description     string
 		IntervalSeconds int
 	}{
 		Name:            name,
-		Title:           testAlertSourceTitle,
-		Description:     testAlertSourceDescription,
 		IntervalSeconds: intervalSeconds,
 	})
 }

--- a/internal/provider/models/alert_source_v1_model.go
+++ b/internal/provider/models/alert_source_v1_model.go
@@ -16,6 +16,7 @@ type AlertSourceResourceModel struct {
 	AlertEventsURL            types.String                       `tfsdk:"alert_events_url"`
 	Template                  *AlertTemplateModel                `tfsdk:"template"`
 	JiraOptions               *AlertSourceJiraOptionsModel       `tfsdk:"jira_options"`
+	HeartbeatOptions          *AlertSourceHeartbeatOptionsModel  `tfsdk:"heartbeat_options"`
 	EmailAddress              types.String                       `tfsdk:"email_address"`
 	HTTPCustomOptions         *AlertSourceHTTPCustomOptionsModel `tfsdk:"http_custom_options"`
 	OwningTeamIDs             types.Set                          `tfsdk:"owning_team_ids"`
@@ -59,6 +60,7 @@ func (AlertSourceResourceModel) FromAPI(source client.AlertSourceV2) AlertSource
 			VisibleToTeams: visibleToTeams,
 		},
 		JiraOptions:               AlertSourceJiraOptionsModel{}.FromAPI(source.JiraOptions),
+		HeartbeatOptions:          AlertSourceHeartbeatOptionsModel{}.FromAPI(source.HeartbeatOptions),
 		EmailAddress:              types.StringPointerValue(emailAddress),
 		HTTPCustomOptions:         AlertSourceHTTPCustomOptionsModel{}.FromAPI(source.HttpCustomOptions),
 		OwningTeamIDs:             owningTeamIDs,
@@ -217,6 +219,38 @@ func (opts *AlertSourceJiraOptionsModel) ToPayload() *client.AlertSourceJiraOpti
 
 	return &client.AlertSourceJiraOptionsV2{
 		ProjectIds: projectIDs,
+	}
+}
+
+type AlertSourceHeartbeatOptionsModel struct {
+	IntervalSeconds    types.Int64  `tfsdk:"interval_seconds"`
+	FailureThreshold   types.Int64  `tfsdk:"failure_threshold"`
+	GracePeriodSeconds types.Int64  `tfsdk:"grace_period_seconds"`
+	PingURL            types.String `tfsdk:"ping_url"`
+}
+
+func (AlertSourceHeartbeatOptionsModel) FromAPI(opts *client.AlertSourceHeartbeatOptionsV2) *AlertSourceHeartbeatOptionsModel {
+	if opts == nil {
+		return nil
+	}
+
+	return &AlertSourceHeartbeatOptionsModel{
+		IntervalSeconds:    types.Int64Value(opts.IntervalSeconds),
+		FailureThreshold:   types.Int64Value(opts.FailureThreshold),
+		GracePeriodSeconds: types.Int64Value(opts.GracePeriodSeconds),
+		PingURL:            types.StringValue(opts.PingUrl),
+	}
+}
+
+func (opts *AlertSourceHeartbeatOptionsModel) ToPayload() *client.AlertSourceHeartbeatOptionsPayloadV2 {
+	if opts == nil {
+		return nil
+	}
+
+	return &client.AlertSourceHeartbeatOptionsPayloadV2{
+		IntervalSeconds:    opts.IntervalSeconds.ValueInt64(),
+		FailureThreshold:   opts.FailureThreshold.ValueInt64Pointer(),
+		GracePeriodSeconds: opts.GracePeriodSeconds.ValueInt64Pointer(),
 	}
 }
 

--- a/internal/provider/models/alert_source_v1_model.go
+++ b/internal/provider/models/alert_source_v1_model.go
@@ -78,7 +78,14 @@ type AlertTemplateModel struct {
 	VisibleToTeams *IncidentEngineParamBinding     `tfsdk:"visible_to_teams"`
 }
 
-func (template AlertTemplateModel) ToPayload() client.AlertTemplatePayloadV2 {
+func (template *AlertTemplateModel) ToPayload() client.AlertTemplatePayloadV2 {
+	if template == nil {
+		return client.AlertTemplatePayloadV2{
+			Expressions: []client.ExpressionPayloadV2{},
+			Attributes:  []client.AlertTemplateAttributePayloadV2{},
+		}
+	}
+
 	var visibleToTeams *client.EngineParamBindingPayloadV2
 	if template.VisibleToTeams != nil {
 		visibleToTeams = lo.ToPtr(template.VisibleToTeams.ToPayload())

--- a/internal/provider/models/alert_source_v1_model.go
+++ b/internal/provider/models/alert_source_v1_model.go
@@ -78,14 +78,7 @@ type AlertTemplateModel struct {
 	VisibleToTeams *IncidentEngineParamBinding     `tfsdk:"visible_to_teams"`
 }
 
-func (template *AlertTemplateModel) ToPayload() client.AlertTemplatePayloadV2 {
-	if template == nil {
-		return client.AlertTemplatePayloadV2{
-			Expressions: []client.ExpressionPayloadV2{},
-			Attributes:  []client.AlertTemplateAttributePayloadV2{},
-		}
-	}
-
+func (template AlertTemplateModel) ToPayload() client.AlertTemplatePayloadV2 {
 	var visibleToTeams *client.EngineParamBindingPayloadV2
 	if template.VisibleToTeams != nil {
 		visibleToTeams = lo.ToPtr(template.VisibleToTeams.ToPayload())


### PR DESCRIPTION
So that you can create heartbeat alert sources through terraform

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new configuration surface and validation for `incident_alert_source`, plus changes payload construction to omit auto-resolve fields unless explicitly set; this could affect create/update behavior across multiple alert source types if edge cases are missed.
> 
> **Overview**
> Adds Terraform support for heartbeat-based alert sources by introducing `heartbeat_options` (interval, failure threshold, grace period, and computed `ping_url`) on `incident_alert_source`, including acceptance tests and generated resource docs.
> 
> Tightens provider validation for heartbeat sources (requires `heartbeat_options`, forbids it for other `source_type`s, and disallows setting `template.title`/`template.description`), and updates create/update requests to only send auto-resolve fields when explicitly configured to avoid API rejections for unsupported source types.
> 
> Regenerates the public OpenAPI v3 schema to include additional documentation metadata (`x-docs-*`) across many endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 945daae9dab50e30ddbdd4c2711a55877ac6731b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->