### PR TITLE
Fix for inconsistent auto_resolve_incident_alerts

### DIFF
--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -215,6 +215,7 @@ func (m useStateForUnknownIncludingNull) PlanModifyBool(ctx context.Context, req
 	resp.PlanValue = req.StateValue
 }
 
+
 func NewIncidentAlertSourceResource() resource.Resource {
 	return &IncidentAlertSourceResource{}
 }
@@ -486,7 +487,18 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 
 	tflog.Trace(ctx, fmt.Sprintf("created an alert source with id=%s", result.JSON200.AlertSource.Id))
 
+	// Save the planned value before overwriting with API response.
+	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
+
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+
+	// When auto_resolve_timeout_minutes isn't set, the API ignores
+	// auto_resolve_incident_alerts and won't return it. Preserve the
+	// planned value so Terraform doesn't see an inconsistent result.
+	if data.AutoResolveTimeoutMinutes.IsNull() && data.AutoResolveIncidentAlerts.IsNull() && !planAutoResolveIncidentAlerts.IsUnknown() {
+		data.AutoResolveIncidentAlerts = planAutoResolveIncidentAlerts
+	}
+
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
 		data.Template.Title = models.IncidentEngineParamBindingValue{}
 		data.Template.Description = models.IncidentEngineParamBindingValue{}
@@ -515,7 +527,18 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	// Save the prior state value before overwriting with API response.
+	stateAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
+
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+
+	// When auto_resolve_timeout_minutes isn't set, the API ignores
+	// auto_resolve_incident_alerts and won't return it. Preserve the
+	// prior state value so Terraform doesn't see a perpetual diff.
+	if data.AutoResolveTimeoutMinutes.IsNull() && data.AutoResolveIncidentAlerts.IsNull() && !stateAutoResolveIncidentAlerts.IsUnknown() {
+		data.AutoResolveIncidentAlerts = stateAutoResolveIncidentAlerts
+	}
+
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
 		data.Template.Title = models.IncidentEngineParamBindingValue{}
 		data.Template.Description = models.IncidentEngineParamBindingValue{}
@@ -570,7 +593,18 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 
 	claimResource(ctx, r.client, result.JSON200.AlertSource.Id, resp.Diagnostics, client.AlertSource, r.terraformVersion)
 
+	// Save the planned value before overwriting with API response.
+	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
+
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+
+	// When auto_resolve_timeout_minutes isn't set, the API ignores
+	// auto_resolve_incident_alerts and won't return it. Preserve the
+	// planned value so Terraform doesn't see an inconsistent result.
+	if data.AutoResolveTimeoutMinutes.IsNull() && data.AutoResolveIncidentAlerts.IsNull() && !planAutoResolveIncidentAlerts.IsUnknown() {
+		data.AutoResolveIncidentAlerts = planAutoResolveIncidentAlerts
+	}
+
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
 		data.Template.Title = models.IncidentEngineParamBindingValue{}
 		data.Template.Description = models.IncidentEngineParamBindingValue{}

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -486,7 +486,18 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 
 	tflog.Trace(ctx, fmt.Sprintf("created an alert source with id=%s", result.JSON200.AlertSource.Id))
 
+	// Save the planned value before overwriting with API response.
+	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
+
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+
+	// When auto_resolve_timeout_minutes isn't set, the API ignores
+	// auto_resolve_incident_alerts and won't return it. Preserve the
+	// planned value so Terraform doesn't see an inconsistent result.
+	if data.AutoResolveTimeoutMinutes.IsNull() && data.AutoResolveIncidentAlerts.IsNull() && !planAutoResolveIncidentAlerts.IsUnknown() {
+		data.AutoResolveIncidentAlerts = planAutoResolveIncidentAlerts
+	}
+
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
 		data.Template.Title = models.IncidentEngineParamBindingValue{}
 		data.Template.Description = models.IncidentEngineParamBindingValue{}
@@ -515,7 +526,18 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	// Save the prior state value before overwriting with API response.
+	stateAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
+
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+
+	// When auto_resolve_timeout_minutes isn't set, the API ignores
+	// auto_resolve_incident_alerts and won't return it. Preserve the
+	// prior state value so Terraform doesn't see a perpetual diff.
+	if data.AutoResolveTimeoutMinutes.IsNull() && data.AutoResolveIncidentAlerts.IsNull() && !stateAutoResolveIncidentAlerts.IsUnknown() {
+		data.AutoResolveIncidentAlerts = stateAutoResolveIncidentAlerts
+	}
+
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
 		data.Template.Title = models.IncidentEngineParamBindingValue{}
 		data.Template.Description = models.IncidentEngineParamBindingValue{}
@@ -570,7 +592,18 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 
 	claimResource(ctx, r.client, result.JSON200.AlertSource.Id, resp.Diagnostics, client.AlertSource, r.terraformVersion)
 
+	// Save the planned value before overwriting with API response.
+	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
+
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
+
+	// When auto_resolve_timeout_minutes isn't set, the API ignores
+	// auto_resolve_incident_alerts and won't return it. Preserve the
+	// planned value so Terraform doesn't see an inconsistent result.
+	if data.AutoResolveTimeoutMinutes.IsNull() && data.AutoResolveIncidentAlerts.IsNull() && !planAutoResolveIncidentAlerts.IsUnknown() {
+		data.AutoResolveIncidentAlerts = planAutoResolveIncidentAlerts
+	}
+
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
 		data.Template.Title = models.IncidentEngineParamBindingValue{}
 		data.Template.Description = models.IncidentEngineParamBindingValue{}


### PR DESCRIPTION
If you haven't set an auto_resolve_timeout_minutes then we won't return the auto resolve incident alerts from the server, so just persist whatever was in the plan so we don't get inconsistencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Terraform resource CRUD state reconciliation; incorrect handling could mask real diffs or keep stale state for `auto_resolve_incident_alerts` in edge cases.
> 
> **Overview**
> Fixes a Terraform state inconsistency for `incident_alert_source` when the API omits `auto_resolve_incident_alerts` unless `auto_resolve_timeout_minutes` is set.
> 
> On `Create`, `Read`, and `Update`, the provider now preserves the planned/prior `auto_resolve_incident_alerts` value if both auto-resolve fields come back null from the API, preventing inconsistent apply results and perpetual diffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e21f328e79044ed211c87877aeb58b01c4ca93ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->