### PR TITLE
Add plan-time source_type validation and document alert source variants

### DIFF
--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -19,111 +19,188 @@ We'd generally recommend building alert sources in our [web dashboard](https://a
 ## Example Usage
 
 ```terraform
-## Create a basic Alert Source that receives from an SNS Topic in AWS
+## Most alert sources share the same structure: a name, a source_type, and a template
+## that describes how to map the incoming payload to an incident alert.
+##
+## We'd generally recommend building alert sources in the incident.io web dashboard
+## (https://app.incident.io/~/alerts/configuration) and using the 'Export' flow to
+## generate your Terraform, rather than hand-crafting the template. The examples below
+## cover the structural variants — source types that require extra options blocks or
+## have different template rules.
+
+## -----------------------------------------------------------------------------
+## Generic webhook source (e.g. cloudwatch, datadog, grafana, sns, …)
+## -----------------------------------------------------------------------------
+## All standard webhook-based source types follow this pattern. The template
+## title and description are JSON-encoded rich-text documents; use the Export
+## flow in the dashboard to get the exact values for your source type.
 
 resource "incident_alert_source" "cloudwatch" {
   name        = "CloudWatch Alerts"
   source_type = "cloudwatch"
+
   template = {
     title = {
       literal = jsonencode({
-        content = [
-          {
-            content = [
-              {
-                attrs = {
-                  label   = "Payload → Title"
-                  missing = false
-                  name    = "title"
-                }
-                type = "varSpec"
-              },
-            ]
-            type = "paragraph"
-          },
-        ]
+        content = [{
+          content = [{
+            attrs = { label = "Payload → Title", missing = false, name = "title" }
+            type  = "varSpec"
+          }]
+          type = "paragraph"
+        }]
         type = "doc"
       })
     }
 
     description = {
       literal = jsonencode({
-        content = [
-          {
-            content = [
-              {
-                attrs = {
-                  label   = "Payload → Description"
-                  missing = false
-                  name    = "description"
-                }
-                type = "varSpec"
-              },
-            ]
-            type = "paragraph"
-          },
-        ]
+        content = [{
+          content = [{
+            attrs = { label = "Payload → Description", missing = false, name = "description" }
+            type  = "varSpec"
+          }]
+          type = "paragraph"
+        }]
         type = "doc"
       })
     }
 
-    ## Bind the `team` expression to an Alert Attribute we can use to label our Alerts
+    ## Bind the `team` expression to an Alert Attribute to label Alerts
     attributes = [
       {
         alert_attribute_id = data.incident_alert_attribute.team.id
         binding = {
-          value = {
-            ## Bind the expression below to this attribute for this Source
-            reference = "expressions[\"cloudwatch-team\"]"
-          }
-          ## Controls how the attribute value is handled when alert fires multiple times
+          value          = { reference = "expressions[\"cloudwatch-team\"]" }
           merge_strategy = "first_wins"
         }
       },
     ]
 
-    ## Query the `team` value from the endpoint referenced in the SNS Topic Subscription
+    ## Parse the `team` value from the SNS endpoint query string
     expressions = [
       {
-        label = "Team"
+        label          = "Team"
+        reference      = "cloudwatch-team"
+        root_reference = "payload"
         operations = [
           {
             operation_type = "parse"
             parse = {
-              returns = {
-                array = false
-                ## This'll bind to some Catalog Entry Type
-                type = "CatalogEntry[\"CatalogEntryID\"]"
-              }
-              source = "$['query_params']['team']"
+              returns = { array = false, type = "CatalogEntry[\"CatalogEntryID\"]" }
+              source  = "$['query_params']['team']"
             }
-        }]
-        reference      = "cloudwatch-team"
-        root_reference = "payload"
+          }
+        ]
       },
     ]
   }
 }
 
-## The `team` Alert Attribute we've configured to label Alerts and route alerts to schedules
-
-data "incident_alert_attribute" "squad" {
+data "incident_alert_attribute" "team" {
   name = "Team"
 }
-
-## AWS Resources
 
 resource "aws_sns_topic" "alerts" {
   name = "cloudwatch-alerts"
 }
-
-## SNS Topic Subscription that routes to the incident.io Alert Source created above
 
 resource "aws_sns_topic_subscription" "incidentio_alert_source" {
   endpoint               = "https://api.incident.io/v2/alert_events/cloudwatch/${incident_alert_source.cloudwatch.id}?team=platform"
   endpoint_auto_confirms = true
   protocol               = "https"
   topic_arn              = aws_sns_topic.alerts.arn
+}
+
+## -----------------------------------------------------------------------------
+## Heartbeat source
+## -----------------------------------------------------------------------------
+## Heartbeat sources fire an alert when a ping is NOT received on time. They
+## require a heartbeat_options block and must NOT set template title/description
+## (the API manages those automatically).
+
+resource "incident_alert_source" "heartbeat" {
+  name        = "Nightly Batch Job"
+  source_type = "heartbeat"
+
+  heartbeat_options = {
+    ## How often a ping is expected
+    interval_seconds = 86400
+    ## Grace period before the heartbeat is considered late (0 = fail immediately)
+    grace_period_seconds = 300
+    ## Number of consecutive missed pings before an alert fires
+    failure_threshold = 1
+  }
+
+  template = {
+    ## Title and description are managed automatically for heartbeat sources
+    title       = {}
+    description = {}
+    attributes  = []
+    expressions = []
+  }
+}
+
+## POST to this URL from your job to signal it is healthy
+output "heartbeat_ping_url" {
+  value = incident_alert_source.heartbeat.heartbeat_options.ping_url
+}
+
+## -----------------------------------------------------------------------------
+## Jira source
+## -----------------------------------------------------------------------------
+## Jira sources watch one or more Jira projects for new issues and turn them
+## into alerts. They require a jira_options block specifying which projects to
+## watch.
+
+resource "incident_alert_source" "jira" {
+  name        = "Jira Bug Reports"
+  source_type = "jira"
+
+  jira_options = {
+    ## IDs of Jira projects (or catalog entry IDs for the 'Jira Project' catalog type)
+    project_ids = ["10001", "10002"]
+  }
+
+  template = {
+    title       = { reference = "payload.fields.summary" }
+    description = { reference = "payload.fields.description" }
+    attributes  = []
+    expressions = []
+  }
+}
+
+## -----------------------------------------------------------------------------
+## HTTP Custom source
+## -----------------------------------------------------------------------------
+## HTTP Custom sources accept arbitrary webhook payloads and use a JavaScript
+## expression to transform them into an alert. They require an
+## http_custom_options block with a transform expression and a deduplication
+## key path.
+
+resource "incident_alert_source" "http_custom" {
+  name        = "Internal Platform Alerts"
+  source_type = "http_custom"
+
+  http_custom_options = {
+    ## JavaScript expression that returns an object with the alert fields
+    transform_expression = <<-JS
+      ({
+        title:       payload.alert_name,
+        description: payload.message,
+        status:      payload.status === "resolved" ? "resolved" : "firing",
+      })
+    JS
+    ## JSON path used to deduplicate repeated firings of the same alert
+    deduplication_key_path = "$.alert_id"
+  }
+
+  template = {
+    title       = { reference = "expressions[\"title\"]" }
+    description = { reference = "expressions[\"description\"]" }
+    attributes  = []
+    expressions = []
+  }
 }
 ```
 

--- a/examples/resources/incident_alert_source/resource.tf
+++ b/examples/resources/incident_alert_source/resource.tf
@@ -1,106 +1,183 @@
-## Create a basic Alert Source that receives from an SNS Topic in AWS
+## Most alert sources share the same structure: a name, a source_type, and a template
+## that describes how to map the incoming payload to an incident alert.
+##
+## We'd generally recommend building alert sources in the incident.io web dashboard
+## (https://app.incident.io/~/alerts/configuration) and using the 'Export' flow to
+## generate your Terraform, rather than hand-crafting the template. The examples below
+## cover the structural variants — source types that require extra options blocks or
+## have different template rules.
+
+## -----------------------------------------------------------------------------
+## Generic webhook source (e.g. cloudwatch, datadog, grafana, sns, …)
+## -----------------------------------------------------------------------------
+## All standard webhook-based source types follow this pattern. The template
+## title and description are JSON-encoded rich-text documents; use the Export
+## flow in the dashboard to get the exact values for your source type.
 
 resource "incident_alert_source" "cloudwatch" {
   name        = "CloudWatch Alerts"
   source_type = "cloudwatch"
+
   template = {
     title = {
       literal = jsonencode({
-        content = [
-          {
-            content = [
-              {
-                attrs = {
-                  label   = "Payload → Title"
-                  missing = false
-                  name    = "title"
-                }
-                type = "varSpec"
-              },
-            ]
-            type = "paragraph"
-          },
-        ]
+        content = [{
+          content = [{
+            attrs = { label = "Payload → Title", missing = false, name = "title" }
+            type  = "varSpec"
+          }]
+          type = "paragraph"
+        }]
         type = "doc"
       })
     }
 
     description = {
       literal = jsonencode({
-        content = [
-          {
-            content = [
-              {
-                attrs = {
-                  label   = "Payload → Description"
-                  missing = false
-                  name    = "description"
-                }
-                type = "varSpec"
-              },
-            ]
-            type = "paragraph"
-          },
-        ]
+        content = [{
+          content = [{
+            attrs = { label = "Payload → Description", missing = false, name = "description" }
+            type  = "varSpec"
+          }]
+          type = "paragraph"
+        }]
         type = "doc"
       })
     }
 
-    ## Bind the `team` expression to an Alert Attribute we can use to label our Alerts
+    ## Bind the `team` expression to an Alert Attribute to label Alerts
     attributes = [
       {
         alert_attribute_id = data.incident_alert_attribute.team.id
         binding = {
-          value = {
-            ## Bind the expression below to this attribute for this Source
-            reference = "expressions[\"cloudwatch-team\"]"
-          }
-          ## Controls how the attribute value is handled when alert fires multiple times
+          value          = { reference = "expressions[\"cloudwatch-team\"]" }
           merge_strategy = "first_wins"
         }
       },
     ]
 
-    ## Query the `team` value from the endpoint referenced in the SNS Topic Subscription
+    ## Parse the `team` value from the SNS endpoint query string
     expressions = [
       {
-        label = "Team"
+        label          = "Team"
+        reference      = "cloudwatch-team"
+        root_reference = "payload"
         operations = [
           {
             operation_type = "parse"
             parse = {
-              returns = {
-                array = false
-                ## This'll bind to some Catalog Entry Type
-                type = "CatalogEntry[\"CatalogEntryID\"]"
-              }
-              source = "$['query_params']['team']"
+              returns = { array = false, type = "CatalogEntry[\"CatalogEntryID\"]" }
+              source  = "$['query_params']['team']"
             }
-        }]
-        reference      = "cloudwatch-team"
-        root_reference = "payload"
+          }
+        ]
       },
     ]
   }
 }
 
-## The `team` Alert Attribute we've configured to label Alerts and route alerts to schedules
-
-data "incident_alert_attribute" "squad" {
+data "incident_alert_attribute" "team" {
   name = "Team"
 }
-
-## AWS Resources
 
 resource "aws_sns_topic" "alerts" {
   name = "cloudwatch-alerts"
 }
-
-## SNS Topic Subscription that routes to the incident.io Alert Source created above
 
 resource "aws_sns_topic_subscription" "incidentio_alert_source" {
   endpoint               = "https://api.incident.io/v2/alert_events/cloudwatch/${incident_alert_source.cloudwatch.id}?team=platform"
   endpoint_auto_confirms = true
   protocol               = "https"
   topic_arn              = aws_sns_topic.alerts.arn
+}
+
+## -----------------------------------------------------------------------------
+## Heartbeat source
+## -----------------------------------------------------------------------------
+## Heartbeat sources fire an alert when a ping is NOT received on time. They
+## require a heartbeat_options block and must NOT set template title/description
+## (the API manages those automatically).
+
+resource "incident_alert_source" "heartbeat" {
+  name        = "Nightly Batch Job"
+  source_type = "heartbeat"
+
+  heartbeat_options = {
+    ## How often a ping is expected
+    interval_seconds = 86400
+    ## Grace period before the heartbeat is considered late (0 = fail immediately)
+    grace_period_seconds = 300
+    ## Number of consecutive missed pings before an alert fires
+    failure_threshold = 1
+  }
+
+  template = {
+    ## Title and description are managed automatically for heartbeat sources
+    title       = {}
+    description = {}
+    attributes  = []
+    expressions = []
+  }
+}
+
+## POST to this URL from your job to signal it is healthy
+output "heartbeat_ping_url" {
+  value = incident_alert_source.heartbeat.heartbeat_options.ping_url
+}
+
+## -----------------------------------------------------------------------------
+## Jira source
+## -----------------------------------------------------------------------------
+## Jira sources watch one or more Jira projects for new issues and turn them
+## into alerts. They require a jira_options block specifying which projects to
+## watch.
+
+resource "incident_alert_source" "jira" {
+  name        = "Jira Bug Reports"
+  source_type = "jira"
+
+  jira_options = {
+    ## IDs of Jira projects (or catalog entry IDs for the 'Jira Project' catalog type)
+    project_ids = ["10001", "10002"]
+  }
+
+  template = {
+    title       = { reference = "payload.fields.summary" }
+    description = { reference = "payload.fields.description" }
+    attributes  = []
+    expressions = []
+  }
+}
+
+## -----------------------------------------------------------------------------
+## HTTP Custom source
+## -----------------------------------------------------------------------------
+## HTTP Custom sources accept arbitrary webhook payloads and use a JavaScript
+## expression to transform them into an alert. They require an
+## http_custom_options block with a transform expression and a deduplication
+## key path.
+
+resource "incident_alert_source" "http_custom" {
+  name        = "Internal Platform Alerts"
+  source_type = "http_custom"
+
+  http_custom_options = {
+    ## JavaScript expression that returns an object with the alert fields
+    transform_expression = <<-JS
+      ({
+        title:       payload.alert_name,
+        description: payload.message,
+        status:      payload.status === "resolved" ? "resolved" : "firing",
+      })
+    JS
+    ## JSON path used to deduplicate repeated firings of the same alert
+    deduplication_key_path = "$.alert_id"
+  }
+
+  template = {
+    title       = { reference = "expressions[\"title\"]" }
+    description = { reference = "expressions[\"description\"]" }
+    attributes  = []
+    expressions = []
+  }
 }

--- a/internal/apischema/schema.go
+++ b/internal/apischema/schema.go
@@ -61,3 +61,35 @@ func Docstring(definitionName, propertyName string) string {
 
 	return p.Value.Description
 }
+
+func DocstringWithEnum(definitionName, propertyName string) string {
+	p := Property(definitionName, propertyName)
+	if p.Value == nil {
+		panic(fmt.Sprintf("property %s has no value: %s", propertyName, spew.Sdump(p)))
+	}
+
+	if len(p.Value.Enum) == 0 {
+		return p.Value.Description
+	}
+
+	values := make([]string, len(p.Value.Enum))
+	for i, v := range p.Value.Enum {
+		values[i] = fmt.Sprintf("`%s`", v.(string))
+	}
+
+	return fmt.Sprintf("%s Possible values: %s.", p.Value.Description, strings.Join(values, ", "))
+}
+
+func EnumValues(definitionName, propertyName string) []string {
+	p := Property(definitionName, propertyName)
+	if p.Value == nil {
+		panic(fmt.Sprintf("property %s has no value: %s", propertyName, spew.Sdump(p)))
+	}
+
+	values := make([]string, len(p.Value.Enum))
+	for i, v := range p.Value.Enum {
+		values[i] = v.(string)
+	}
+
+	return values
+}

--- a/internal/apischema/schema.go
+++ b/internal/apischema/schema.go
@@ -62,24 +62,6 @@ func Docstring(definitionName, propertyName string) string {
 	return p.Value.Description
 }
 
-func DocstringWithEnum(definitionName, propertyName string) string {
-	p := Property(definitionName, propertyName)
-	if p.Value == nil {
-		panic(fmt.Sprintf("property %s has no value: %s", propertyName, spew.Sdump(p)))
-	}
-
-	if len(p.Value.Enum) == 0 {
-		return p.Value.Description
-	}
-
-	values := make([]string, len(p.Value.Enum))
-	for i, v := range p.Value.Enum {
-		values[i] = fmt.Sprintf("`%s`", v.(string))
-	}
-
-	return fmt.Sprintf("%s Possible values: %s.", p.Value.Description, strings.Join(values, ", "))
-}
-
 func EnumValues(definitionName, propertyName string) []string {
 	p := Property(definitionName, propertyName)
 	if p.Value == nil {

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -241,6 +242,9 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 			"source_type": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: apischema.Docstring("AlertSourceV2", "source_type"),
+				Validators: []validator.String{
+					StringOneOfValidator{AllowedValues: apischema.EnumValues("AlertSourceV2", "source_type")},
+				},
 				PlanModifiers: []planmodifier.String{
 					// This cannot be changed once the source is set up.
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -265,6 +265,60 @@ func TestAccAlertSourceResource_Jira(t *testing.T) {
 	})
 }
 
+// TestAccAlertSourceResource_HTTPCustom checks that http_custom_options work.
+func TestAccAlertSourceResource_HTTPCustom(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertSourceResourceConfigWithHTTPCustom("http-custom-source"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_alert_source.test", "name", "http-custom-source"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "source_type", "http_custom"),
+					resource.TestCheckResourceAttrSet("incident_alert_source.test", "http_custom_options.transform_expression"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "http_custom_options.deduplication_key_path", "$.alert_id"),
+					resource.TestCheckResourceAttrSet("incident_alert_source.test", "alert_events_url"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "incident_alert_source.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update name
+			{
+				Config: testAccAlertSourceResourceConfigWithHTTPCustom("http-custom-source-updated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_alert_source.test", "name", "http-custom-source-updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAlertSourceResourceConfigWithHTTPCustom(name string) string {
+	return testRunTemplate("incident_alert_source_http_custom", `
+resource "incident_alert_source" "test" {
+  name        = {{ quote .Name }}
+  source_type = "http_custom"
+
+  http_custom_options = {
+    transform_expression   = "({ title: payload.alert_name, description: payload.message, status: payload.status === 'resolved' ? 'resolved' : 'firing' })"
+    deduplication_key_path = "$.alert_id"
+  }
+
+  template = {
+    expressions = []
+    title       = { reference = "payload.alert_name" }
+    description = { reference = "payload.message" }
+    attributes  = []
+  }
+}
+`, struct{ Name string }{Name: name})
+}
+
 // TestAccAlertSourceResource_ValidationErrors checks that we return helpful
 // validation errors when possible.
 func TestAccAlertSourceResource_ValidationErrors(t *testing.T) {
@@ -272,6 +326,24 @@ func TestAccAlertSourceResource_ValidationErrors(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			{
+				// Test invalid source_type value
+				Config: `
+resource "incident_alert_source" "test" {
+  name        = "test-source"
+  source_type = "not-a-real-source"
+
+  template = {
+    expressions = []
+    title       = { literal = "test" }
+    description = { literal = "test" }
+    attributes  = []
+  }
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`"not-a-real-source" is not a valid value`),
+			},
 			{
 				// Test
 				Config: testRunTemplate("incident_alert_source_invalid", `

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -52,4 +53,36 @@ func (v RFC3339TimestampValidator) Description(ctx context.Context) string {
 
 func (v RFC3339TimestampValidator) MarkdownDescription(ctx context.Context) string {
 	return "Value must be a valid RFC3339 timestamp (YYYY-MM-DDThh:mm:ssZ)"
+}
+
+// StringOneOfValidator validates that a string value is one of the allowed values.
+type StringOneOfValidator struct {
+	AllowedValues []string
+}
+
+func (v StringOneOfValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := req.ConfigValue.ValueString()
+	for _, allowed := range v.AllowedValues {
+		if value == allowed {
+			return
+		}
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid value",
+		fmt.Sprintf("%q is not a valid value. Must be one of: %s", value, strings.Join(v.AllowedValues, ", ")),
+	)
+}
+
+func (v StringOneOfValidator) Description(ctx context.Context) string {
+	return fmt.Sprintf("Value must be one of: %s", strings.Join(v.AllowedValues, ", "))
+}
+
+func (v StringOneOfValidator) MarkdownDescription(ctx context.Context) string {
+	return fmt.Sprintf("Value must be one of: `%s`", strings.Join(v.AllowedValues, "`, `"))
 }


### PR DESCRIPTION
## Background

The recent addition of heartbeat monitoring to the `incident_alert_source` resource (v5.35.0) wasn't reflected in the docs. The `heartbeat_options` block was implemented and working, but there was no example showing how to use it — leaving users to figure out the structure themselves.

While looking into how to add that example, a few related gaps became apparent that were worth addressing at the same time.

## What was missing and why it matters

**No examples for structurally distinct source types**

The existing example only covered the generic webhook pattern (CloudWatch). But some source types are structurally different — they require extra options blocks or have different rules around the template. Without examples, users hitting `heartbeat`, `jira`, or `http_custom` for the first time would have no guidance on what those differences are.

The decision was to document one example per structural variant rather than one per source type. With 45 source types, most of which are identical webhooks, exhaustive documentation would be noise. The vendor's own recommendation to use the Export flow for template content reinforces this — the examples cover the *shape* of the config, not every possible source.

**No plan-time validation on `source_type`**

`source_type` accepts a string but had no validation. Combined with `RequiresReplace()` (changing source type destroys and recreates the resource), a typo meant: Terraform plans a destroy+create, you approve it, apply starts, the API rejects the value with a cryptic error, and you've already destroyed the original resource.

Adding `StringOneOfValidator` catches this at `terraform plan` before any infrastructure is touched. The list of valid values is derived from `EnumValues()` — a new helper in `apischema` that reads the enum directly from the OpenAPI schema JSON already in the repo, so it stays in sync automatically when new source types are added.

**`http_custom` had no test coverage**

Of the four structurally distinct source types, three already had acceptance tests. `http_custom` was the only one missing. This adds `TestAccAlertSourceResource_HTTPCustom` to close that gap.

## Decisions made

- Listing all 45 `source_type` values inline in the schema description was considered and rejected — a wall of backtick-wrapped values in the docs table hurts readability more than it helps. The validator error message is the right place for the full list; it appears exactly when needed.
- `StringOneOfValidator` was implemented as a custom validator consistent with the existing `NonEmptyListValidator` and `RFC3339TimestampValidator` in the codebase, rather than adding `terraform-plugin-framework-validators` as a new dependency.
- `EnumValues` was added to `apischema` to return `[]string` for use by `StringOneOfValidator`. This is intentionally separate from the existing `EnumValuesDescription` in `helpers.go`, which formats enum values as a human-readable string for descriptions — two different purposes, one helper each.
- An earlier iteration added `DocstringWithEnum` to `apischema` which duplicated `EnumValuesDescription`. This was caught in review and removed — `EnumValuesDescription` in `helpers.go` remains the single implementation for formatted enum descriptions.

## Test plan

- [x] `INCIDENT_API_KEY=dummy TF_ACC=1 go test ./internal/provider -run TestAccAlertSourceResource_ValidationErrors` — passes without a real API key
- [ ] `INCIDENT_API_KEY=<key> make testacc TESTARGS="-run TestAccAlertSourceResource_Heartbeat"` — requires real API
- [ ] `INCIDENT_API_KEY=<key> make testacc TESTARGS="-run TestAccAlertSourceResource_HTTPCustom"` — requires real API
- [x] `make generate` — regenerates `docs/resources/alert_source.md` cleanly