### PR TITLE
fix: treat nil auto_resolve_incident_alerts API response as true

### DIFF
--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -202,18 +202,6 @@ func (m useStateForUnknownIncludingNull) PlanModifyString(ctx context.Context, r
 	resp.PlanValue = req.StateValue
 }
 
-func (m useStateForUnknownIncludingNull) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	if !req.PlanValue.IsUnknown() {
-		return
-	}
-	if req.ConfigValue.IsUnknown() {
-		return
-	}
-	if req.State.Raw.IsNull() {
-		return
-	}
-	resp.PlanValue = req.StateValue
-}
 
 func NewIncidentAlertSourceResource() resource.Resource {
 	return &IncidentAlertSourceResource{}
@@ -403,9 +391,6 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: apischema.Docstring("AlertSourceV2", "auto_resolve_incident_alerts"),
-				PlanModifiers: []planmodifier.Bool{
-					useStateForUnknownIncludingNull{},
-				},
 			},
 			"owning_team_ids": schema.SetAttribute{
 				Optional:            true,

--- a/internal/provider/models/alert_source_v1_model.go
+++ b/internal/provider/models/alert_source_v1_model.go
@@ -65,7 +65,8 @@ func (AlertSourceResourceModel) FromAPI(source client.AlertSourceV2) AlertSource
 		HTTPCustomOptions:         AlertSourceHTTPCustomOptionsModel{}.FromAPI(source.HttpCustomOptions),
 		OwningTeamIDs:             owningTeamIDs,
 		AutoResolveTimeoutMinutes: types.Int64PointerValue(source.AutoResolveTimeoutMinutes),
-		AutoResolveIncidentAlerts: types.BoolPointerValue(source.AutoResolveIncidentAlerts),
+		// The API omits this field when it equals the default (true), so treat nil as true.
+		AutoResolveIncidentAlerts: types.BoolValue(lo.FromPtrOr(source.AutoResolveIncidentAlerts, true)),
 	}
 }
 


### PR DESCRIPTION
## Summary

- The API omits `auto_resolve_incident_alerts` from `AlertSourceV2` responses when its value equals the documented default (`true`). The previous `FromAPI` code mapped `nil` → `types.BoolNull()`, causing a provider inconsistency error when the field was explicitly set to `true` in Terraform config.
- Fixed by using `lo.FromPtrOr(source.AutoResolveIncidentAlerts, true)` in `FromAPI` so nil is treated as the default `true` rather than null.
- Removed the now-dead `PlanModifyBool` method from `useStateForUnknownIncludingNull` (it was only serving this attribute, and the `FromAPI` fix makes it unnecessary).

## What was NOT changed

- No `Default` was added to the Terraform schema attribute — that approach would have broken the existing nil-guard that prevents sending `auto_resolve_incident_alerts` to heartbeat sources (which reject the field).

## Test plan

- [ ] Apply a `grafana_cloud` alert source with `auto_resolve_incident_alerts = true` — should no longer produce a provider inconsistency error
- [ ] Apply a `heartbeat` alert source without setting `auto_resolve_incident_alerts` — should not send the field to the API
- [ ] `go build ./...` and `go vet ./...` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small provider mapping/plan-modifier tweak to handle an API omission and prevent spurious diffs; main behavioral change is treating missing API data as `true` for a single attribute.
> 
> **Overview**
> Fixes Terraform state inconsistencies for `auto_resolve_incident_alerts` when the API omits the field by mapping a nil API value to `true` in `AlertSourceResourceModel.FromAPI` (instead of null).
> 
> Removes the custom bool plan-modifier (`useStateForUnknownIncludingNull.PlanModifyBool`) and stops applying it to the `auto_resolve_incident_alerts` schema attribute, since the corrected API-to-state mapping makes it unnecessary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 286fc7c6aa5ae7815df4abd6f6beb7163798aa31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->