### PR TITLE
Regression test for spurious merge_strategy on literal bindings (#342)

### DIFF
--- a/internal/provider/incident_alert_route_resource_test.go
+++ b/internal/provider/incident_alert_route_resource_test.go
@@ -1498,7 +1498,7 @@ resource "incident_alert_route" "test" {
     condition_groups           = []
     defer_time_seconds         = 0
     grouping_keys              = []
-    grouping_window_seconds    = 0
+    grouping_window_seconds    = 1800 # Required to be non-zero when auto_relate_grouped_alerts is true
     enabled                    = true
   }
 

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccAlertSourceResource(t *testing.T) {
@@ -634,6 +636,361 @@ resource "incident_alert_source" "test" {
 		Title:        testAlertSourceTitle,
 		Description:  testAlertSourceDescription,
 		TeamTypeName: teamTypeName(),
+	})
+}
+
+// TestAccAlertSourceResource_Issue342_SpuriousMergeStrategy is a regression
+// test for https://github.com/incident-io/terraform-provider-incident/issues/342.
+//
+// Original bug: when adding a new element to template.attributes (a Set), the
+// framework couldn't reliably match an existing literal-only binding (e.g. the
+// Priority attribute) between prior state and new plan, because state had
+// merge_strategy=null and the plan resolved merge_strategy to Unknown. The
+// resulting plan deleted-and-recreated the priority element with a spurious
+// merge_strategy injected, which the API rejected with HTTP 422 (priority
+// bindings rejected merge_strategy entirely).
+//
+// Fix landed server-side: priority bindings now always carry
+// merge_strategy="last_wins" in the API response and accept either nil or
+// "last_wins" on write (matching the actual evaluation semantics, which
+// always overwrite the alert's PriorityID). With a concrete (non-null) value
+// in state, the standard UseStateForUnknown plan modifier preserves it, set
+// element identity stays stable, and the spurious diff disappears.
+//
+// The plan check asserts: no literal-only binding has merge_strategy marked
+// Unknown in the planned state (the original bug signature), and any
+// merge_strategy value present in `before` is preserved in `after`.
+func TestAccAlertSourceResource_Issue342_SpuriousMergeStrategy(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: alert source with priority (literal-only binding) plus
+			// three reference bindings that explicitly set merge_strategy.
+			{
+				Config: testAccAlertSourceResourceConfigIssue342(false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_alert_source.test", "template.attributes.#", "4"),
+				),
+			},
+			// Step 2: add a fifth attribute. The plan should add only that
+			// new element and leave existing elements (notably the priority
+			// binding) untouched.
+			{
+				Config: testAccAlertSourceResourceConfigIssue342(true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						noSpuriousMergeStrategyPlanCheck("incident_alert_source.test"),
+					},
+				},
+			},
+		},
+	})
+}
+
+// noSpuriousMergeStrategyPlanCheck asserts that adding a new element to
+// template.attributes does NOT cause the framework to lose track of an
+// existing literal-only binding's merge_strategy value. Specifically:
+//
+//   - No literal-only binding in the planned state has merge_strategy marked
+//     Unknown (that was the original bug signature — state had null,
+//     plan went Unknown, set diff treated the element as deleted-and-recreated).
+//   - Every literal-only binding present in the prior state survives into
+//     the planned state with the same merge_strategy value (matched by
+//     alert_attribute_id).
+func noSpuriousMergeStrategyPlanCheck(addr string) plancheck.PlanCheck {
+	return spuriousMergeStrategyCheck{addr: addr}
+}
+
+type spuriousMergeStrategyCheck struct {
+	addr string
+}
+
+func (c spuriousMergeStrategyCheck) CheckPlan(_ context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	for _, rc := range req.Plan.ResourceChanges {
+		if rc.Address != c.addr || rc.Change == nil {
+			continue
+		}
+
+		beforeAttrs := extractAttributes(rc.Change.Before)
+		afterAttrs := extractAttributes(rc.Change.After)
+		unknownAttrs := extractAttributes(rc.Change.AfterUnknown)
+
+		// Original bug signature: literal-only binding has merge_strategy
+		// marked Unknown in the planned state.
+		for i, planned := range afterAttrs {
+			if !isLiteralOnlyBinding(planned) {
+				continue
+			}
+			if i >= len(unknownAttrs) {
+				continue
+			}
+			ub, _ := unknownAttrs[i]["binding"].(map[string]any)
+			if ub == nil {
+				continue
+			}
+			if ums, ok := ub["merge_strategy"]; ok && ums == true {
+				resp.Error = fmt.Errorf(
+					"plan marks merge_strategy as Unknown on literal-only binding at template.attributes[%d] (alert_attribute_id=%v); this is the issue #342 bug signature",
+					i, planned["alert_attribute_id"],
+				)
+				return
+			}
+		}
+
+		// Stronger check: every literal-only binding in prior state must
+		// survive into the planned state with the same merge_strategy.
+		afterByID := make(map[string]map[string]any, len(afterAttrs))
+		for _, a := range afterAttrs {
+			id, _ := a["alert_attribute_id"].(string)
+			if id != "" {
+				afterByID[id] = a
+			}
+		}
+		for _, prior := range beforeAttrs {
+			if !isLiteralOnlyBinding(prior) {
+				continue
+			}
+			id, _ := prior["alert_attribute_id"].(string)
+			planned, ok := afterByID[id]
+			if !ok {
+				resp.Error = fmt.Errorf(
+					"prior state's literal-only binding (alert_attribute_id=%s) is not present in the planned state; the plan would delete and recreate it",
+					id,
+				)
+				return
+			}
+			pBinding, _ := prior["binding"].(map[string]any)
+			aBinding, _ := planned["binding"].(map[string]any)
+			if !mergeStrategiesEqual(pBinding, aBinding) {
+				resp.Error = fmt.Errorf(
+					"merge_strategy on literal-only binding (alert_attribute_id=%s) changed between state (%v) and plan (%v) without any config change",
+					id, pBinding["merge_strategy"], aBinding["merge_strategy"],
+				)
+				return
+			}
+		}
+	}
+}
+
+func isLiteralOnlyBinding(attr map[string]any) bool {
+	binding, _ := attr["binding"].(map[string]any)
+	if binding == nil {
+		return false
+	}
+	value, _ := binding["value"].(map[string]any)
+	if value == nil {
+		return false
+	}
+	literal, _ := value["literal"].(string)
+	reference, _ := value["reference"].(string)
+	arrayValue := binding["array_value"]
+	return literal != "" && reference == "" && arrayValue == nil
+}
+
+func mergeStrategiesEqual(a, b map[string]any) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a["merge_strategy"] == b["merge_strategy"]
+}
+
+func extractAttributes(after any) []map[string]any {
+	root, _ := after.(map[string]any)
+	if root == nil {
+		return nil
+	}
+	template, _ := root["template"].(map[string]any)
+	if template == nil {
+		return nil
+	}
+	rawAttrs, _ := template["attributes"].([]any)
+	out := make([]map[string]any, 0, len(rawAttrs))
+	for _, a := range rawAttrs {
+		if m, ok := a.(map[string]any); ok {
+			out = append(out, m)
+		} else {
+			out = append(out, nil)
+		}
+	}
+	return out
+}
+
+func testAccAlertSourceResourceConfigIssue342(withThirdAttribute bool) string {
+	return testRunTemplate("incident_alert_source_issue_342", `
+data "incident_alert_attribute" "priority" {
+  name = "Priority"
+}
+
+data "incident_catalog_type" "alert_priority" {
+  type_name = "AlertPriority"
+}
+
+data "incident_catalog_entries" "priorities" {
+  catalog_type_id = data.incident_catalog_type.alert_priority.id
+}
+
+# A handful of regular attributes mirroring the user's setup (url, country,
+# environment, service). They all use reference bindings with
+# merge_strategy = "first_wins", which sits alongside the literal-only
+# priority binding.
+resource "incident_alert_attribute" "url" {
+  name  = "issue-342-url"
+  type  = "String"
+  array = false
+}
+
+resource "incident_alert_attribute" "country" {
+  name  = "issue-342-country"
+  type  = "String"
+  array = false
+}
+
+resource "incident_alert_attribute" "environment" {
+  name  = "issue-342-environment"
+  type  = "String"
+  array = false
+}
+
+resource "incident_alert_attribute" "service" {
+  name  = "issue-342-service"
+  type  = "String"
+  array = false
+}
+
+resource "incident_alert_source" "test" {
+  name        = "issue-342-test-source"
+  source_type = "datadog"
+
+  template = {
+    expressions = [
+      {
+        label          = "url"
+        reference      = "url"
+        root_reference = "payload"
+        operations = [{
+          operation_type = "parse"
+          parse = {
+            source = "$.url"
+            returns = {
+              type  = "String"
+              array = false
+            }
+          }
+        }]
+      },
+      {
+        label          = "country"
+        reference      = "country"
+        root_reference = "payload"
+        operations = [{
+          operation_type = "parse"
+          parse = {
+            source = "$.country"
+            returns = {
+              type  = "String"
+              array = false
+            }
+          }
+        }]
+      },
+      {
+        label          = "environment"
+        reference      = "environment"
+        root_reference = "payload"
+        operations = [{
+          operation_type = "parse"
+          parse = {
+            source = "$.environment"
+            returns = {
+              type  = "String"
+              array = false
+            }
+          }
+        }]
+      },
+      {
+        label          = "service"
+        reference      = "service"
+        root_reference = "payload"
+        operations = [{
+          operation_type = "parse"
+          parse = {
+            source = "$.service"
+            returns = {
+              type  = "String"
+              array = false
+            }
+          }
+        }]
+      },
+    ]
+    title = {
+      literal = {{ quote .Title }}
+    }
+    description = {
+      literal = {{ quote .Description }}
+    }
+
+    attributes = concat(
+      [
+        # Priority binding: literal-only, no merge_strategy. The API stores no
+        # merge_strategy server-side for this binding.
+        {
+          alert_attribute_id = data.incident_alert_attribute.priority.id
+          binding = {
+            value = {
+              literal = data.incident_catalog_entries.priorities.catalog_entries[0].id
+            }
+          }
+        },
+        # Reference bindings with merge_strategy. Several of these alongside the
+        # literal-only priority binding is what triggers the Set-diff bug when
+        # we add another element in step 2.
+        {
+          alert_attribute_id = incident_alert_attribute.url.id
+          binding = {
+            value          = { reference = "expressions[\"url\"]" }
+            merge_strategy = "first_wins"
+          }
+        },
+        {
+          alert_attribute_id = incident_alert_attribute.country.id
+          binding = {
+            value          = { reference = "expressions[\"country\"]" }
+            merge_strategy = "first_wins"
+          }
+        },
+        {
+          alert_attribute_id = incident_alert_attribute.environment.id
+          binding = {
+            value          = { reference = "expressions[\"environment\"]" }
+            merge_strategy = "first_wins"
+          }
+        },
+      ],
+      {{ if .WithThird }}[
+        # The new element added in step 2. Adding this should NOT cause any
+        # change to the priority binding above, but the bug causes the
+        # framework to plan merge_strategy = "first_wins" on it anyway.
+        {
+          alert_attribute_id = incident_alert_attribute.service.id
+          binding = {
+            value          = { reference = "expressions[\"service\"]" }
+            merge_strategy = "first_wins"
+          }
+        },
+      ]{{ else }}[]{{ end }},
+    )
+  }
+}
+`, struct {
+		Title, Description string
+		WithThird          bool
+	}{
+		Title:       testAlertSourceTitle,
+		Description: testAlertSourceDescription,
+		WithThird:   withThirdAttribute,
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds an acceptance test reproducing the bug in #342: adding a new element to `incident_alert_source.template.attributes` could cause an existing literal-only binding (notably the Priority attribute) to be planned as deleted-and-recreated, with a spurious `merge_strategy` injected that the API then rejected.

The test asserts that every literal-only binding present in prior state survives into the planned state with its `merge_strategy` value preserved (matched by `alert_attribute_id`), and that no literal-only binding ends up with `merge_strategy` marked Unknown in the planned state.

The fix itself is on the API side — the test passes once that ships and is in place as a regression guard. No provider schema changes.

## Test plan

- [x] Test fails against the current API behaviour (priority binding returned with no `merge_strategy`)
- [x] Test passes once the API consistently surfaces `merge_strategy` on priority bindings
- [x] Other alert source acceptance tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)