### PR TITLE
Increase escalation_path if_else nesting from 3 to 4 levels

### DIFF
--- a/docs/data-sources/escalation_path.md
+++ b/docs/data-sources/escalation_path.md
@@ -340,6 +340,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
@@ -358,6 +359,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
@@ -434,6 +670,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
@@ -452,6 +689,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
@@ -670,6 +1142,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
@@ -688,6 +1161,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
@@ -764,6 +1472,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
@@ -782,6 +1491,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
@@ -1142,6 +2086,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
@@ -1160,6 +2105,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
@@ -1236,6 +2416,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
@@ -1254,6 +2435,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
@@ -1472,6 +2888,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
@@ -1490,6 +2907,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
@@ -1566,6 +3218,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
@@ -1584,6 +3237,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
@@ -2086,6 +3974,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
@@ -2104,6 +3993,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
@@ -2180,6 +4304,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
@@ -2198,6 +4323,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
@@ -2416,6 +4776,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
@@ -2434,6 +4795,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
@@ -2510,6 +5106,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
@@ -2528,6 +5125,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
@@ -2888,6 +5720,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
@@ -2906,6 +5739,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
@@ -2982,6 +6050,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
@@ -3000,6 +6069,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
@@ -3218,6 +6522,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
@@ -3236,6 +6541,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
@@ -3312,6 +6852,7 @@ Read-Only:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
@@ -3330,6 +6871,241 @@ Read-Only:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else`
+
+Read-Only:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions`
+
+Read-Only:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Read-Only:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Read-Only:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path`
+
+Read-Only:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.delay`
+
+Read-Only:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level`
+
+Read-Only:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Read-Only:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Read-Only:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
+- `urgency` (String) The urgency of this escalation path target
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.repeat`
+
+Read-Only:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -132,7 +132,7 @@ resource "incident_escalation_path" "urgent_support" {
 - `name` (String) The name of this escalation path, for the user's reference.
 - `path` (Attributes List) The nodes that form the levels and branches of this escalation path.
 
--->**Note** Although the `if_else` block is recursive, currently a maximum of 3 levels are supported. Attempting to configure more than 3 levels of nesting will result in a schema error. (see [below for nested schema](#nestedatt--path))
+-->**Note** Although the `if_else` block is recursive, currently a maximum of 4 levels are supported. Attempting to configure more than 4 levels of nesting will result in a schema error. (see [below for nested schema](#nestedatt--path))
 
 ### Optional
 
@@ -490,6 +490,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
@@ -502,6 +503,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
@@ -602,6 +877,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
@@ -614,6 +890,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
@@ -877,6 +1427,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
@@ -889,6 +1440,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
@@ -989,6 +1814,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
@@ -1001,6 +1827,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
@@ -1427,6 +2527,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
@@ -1439,6 +2540,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
@@ -1539,6 +2914,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
@@ -1551,6 +2927,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
@@ -1814,6 +3464,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
@@ -1826,6 +3477,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
@@ -1926,6 +3851,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
@@ -1938,6 +3864,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
@@ -2527,6 +4727,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
@@ -2539,6 +4740,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
@@ -2639,6 +5114,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
@@ -2651,6 +5127,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
@@ -2914,6 +5664,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
@@ -2926,6 +5677,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
@@ -3026,6 +6051,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
@@ -3038,6 +6064,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
@@ -3464,6 +6764,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
@@ -3476,6 +6777,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
@@ -3576,6 +7151,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
@@ -3588,6 +7164,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
@@ -3851,6 +7701,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
@@ -3863,6 +7714,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
@@ -3963,6 +8088,7 @@ Optional:
 - `id` (String) An ID for this node, unique within the escalation path.
 
 This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `if_else` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else))
 - `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
 - `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
 - `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
@@ -3975,6 +8101,280 @@ Optional:
 - `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
 - `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
 - `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else`
+
+Required:
+
+- `conditions` (Attributes List) The prerequisite conditions that must all be satisfied (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions))
+- `then_path` (Attributes List) Then path nodes (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path))
+
+Optional:
+
+- `else_path` (Attributes List) The nodes that form the levels if our condition is not met (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions`
+
+Required:
+
+- `operation` (String) The logical operation to be applied
+- `param_bindings` (Attributes List) Bindings for the operation parameters (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings))
+- `subject` (String) The subject of the condition, on which the operation is applied
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings`
+
+Optional:
+
+- `array_value` (Attributes List) The array of literal or reference parameter values (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value))
+- `value` (Attributes) The literal or reference parameter value (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--array_value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.array_value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--conditions--param_bindings--value"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.conditions.param_bindings.value`
+
+Optional:
+
+- `literal` (String) If set, this is the literal value of the step parameter
+- `reference` (String) If set, this is the reference into the trigger scope that is the value of this parameter
+
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path`
+
+Required:
+
+- `type` (String) The type of this node. Available types are:
+* level: A set of targets (users or schedules) that should be paged, either all at once, or with a round-robin configuration.
+* notify_channel: Send the escalation to a Slack channel, where it can be acked by anyone in the channel.
+* if_else: Branch the escalation based on a set of conditions.
+* repeat: Go back to a previous node and repeat the logic from there.
+* delay: Pause the escalation for a configured duration before advancing to the next node.
+
+Optional:
+
+- `delay` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay))
+- `id` (String) An ID for this node, unique within the escalation path.
+
+This allows you to reference the node in other nodes, such as when configuring a 'repeat' node.
+- `level` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level))
+- `notify_channel` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel))
+- `repeat` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat))
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--delay"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.delay`
+
+Optional:
+
+- `delay_interval_condition` (String) If the delay is relative to a time window, this defines whether we advance when the window is active or inactive
+- `delay_seconds` (Number) How long to delay before advancing to the next node in the path, in seconds
+- `delay_weekday_interval_config_id` (String) If the delay is relative to a time window, this identifies which window it is relative to
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level`
+
+Required:
+
+- `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
+
+Optional:
+
+- `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
+
+Required:
+
+- `enabled` (Boolean) Whether round robin is enabled for this level
+
+Optional:
+
+- `rotate_after_seconds` (Number) How long should we wait before rotating to the next target in a round robin, if not set will stick with a single target per level.
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel`
+
+Required:
+
+- `targets` (Attributes List) The targets (Slack channels) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets))
+
+Optional:
+
+- `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
+- `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before moving on to the next node in the path?
+- `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--notify_channel--targets"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.notify_channel.targets`
+
+Required:
+
+- `id` (String) Uniquely identifies an entity of this type
+- `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User. Possible values are: `schedule`, `user`, `slack_channel`, `msteams_channel`.
+- `urgency` (String) The urgency of this escalation path target. Possible values are: `high`, `low`.
+
+Optional:
+
+- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--repeat"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.repeat`
+
+Required:
+
+- `repeat_times` (Number) How many times to repeat these nodes
+- `to_node` (String) Which node ID we begin repeating from.
+
+
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level"></a>

--- a/docs/superpowers/specs/2026-03-18-schedule-rotation-versions-design.md
+++ b/docs/superpowers/specs/2026-03-18-schedule-rotation-versions-design.md
@@ -1,0 +1,301 @@
+# Schedule Rotation Versions as Independent Terraform Resources
+
+## Problem
+
+The `incident_schedule` Terraform resource manages schedules as a single monolith — metadata, rotations, and all rotation versions are deeply nested in one resource. This causes:
+
+- **Unreadable diffs**: Changes to a rotation version are buried 3 levels deep in `terraform plan` output
+- **Easy to accidentally mutate**: Users modify existing versions instead of creating new ones
+- **Hard to copy-paste**: Adding a new version means editing nested arrays rather than duplicating a resource block
+
+Customers (notably Vercel) have asked for rotation versions to be their own Terraform resources, enabling an append-only workflow where adding a person or changing a schedule means copying a resource block and setting a new `effective_from`.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Backend changes | New API endpoints | Clean sub-resource CRUD, no race conditions from provider-side read-modify-write |
+| New TF resource name | `incident_schedule_rotation_version` | Matches the `versions` key in the internal data model |
+| Backward compatibility | Breaking change (v6) | `incident_schedule` becomes metadata-only, `rotations` field removed |
+| Migration | Import-based with UUID backfill | Toolbox backfill assigns version UUIDs, users import existing versions into new resources |
+
+## Terraform Interface
+
+### `incident_schedule` (v6, metadata only)
+
+```hcl
+resource "incident_schedule" "primary" {
+  name     = "Primary On-call"
+  timezone = "Europe/London"
+  team_ids = [data.incident_team.platform.id]
+
+  holidays_public_config = {
+    country_codes = ["GB", "FR"]
+  }
+}
+```
+
+Fields: `id` (computed), `name`, `timezone`, `team_ids` (optional), `holidays_public_config` (optional).
+
+The `rotations` field is removed entirely.
+
+### `incident_schedule_rotation_version` (new)
+
+```hcl
+resource "incident_schedule_rotation_version" "emea_v1" {
+  schedule_id   = incident_schedule.primary.id
+  rotation_id   = "emea"
+  rotation_name = "EMEA Rotation"
+
+  handover_start_at = "2024-05-01T12:00:00Z"
+
+  users = [
+    data.incident_user.alice.id,
+    data.incident_user.bob.id,
+  ]
+
+  layers = [{
+    id   = "primary"
+    name = "Primary"
+  }]
+
+  handovers = [{
+    interval_type = "weekly"
+    interval      = 1
+  }]
+}
+
+# New version: copy-paste, set effective_from, change what's needed
+resource "incident_schedule_rotation_version" "emea_v2" {
+  schedule_id   = incident_schedule.primary.id
+  rotation_id   = "emea"
+  rotation_name = "EMEA Rotation"
+
+  effective_from    = "2024-06-01T12:00:00Z"
+  handover_start_at = "2024-05-01T12:00:00Z"
+
+  users = [
+    data.incident_user.alice.id,
+    data.incident_user.bob.id,
+    data.incident_user.charlie.id,
+  ]
+
+  layers = [{
+    id   = "primary"
+    name = "Primary"
+  }]
+
+  handovers = [{
+    interval_type = "weekly"
+    interval      = 1
+  }]
+}
+```
+
+#### Schema
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | string | computed | Server-generated UUID for this version entry |
+| `schedule_id` | string | required | Parent schedule ID |
+| `rotation_id` | string | required | User-provided ID grouping versions of the same rotation |
+| `rotation_name` | string | required | Display name for the rotation |
+| `effective_from` | string | optional | RFC3339 timestamp; absent = the base version |
+| `handover_start_at` | string | required | RFC3339 timestamp for handover cadence start |
+| `users` | list(string) | required | User IDs on this rotation |
+| `layers` | list(object) | required | Layer definitions (`id`, `name`) |
+| `handovers` | list(object) | required | Handover rules (`interval`, `interval_type`) |
+| `working_intervals` | list(object) | optional | Weekday time restrictions (`start_time`, `end_time`, `weekday`) |
+| `scheduling_mode` | string | optional | Scheduling algorithm: `fair` or `sequential`. Defaults to backend default if omitted. |
+
+The `users` field is a flat list of user ID strings in the Terraform schema. The provider converts these to `UserReferencePayloadV2` objects (`{id: "..."}`) when calling the API, matching the existing convention used by the current schedule resource.
+
+## Backend API Endpoints
+
+New public V2 endpoints for managing individual rotation version entries within a schedule's config. These follow the existing path conventions under the public V2 API (alongside `/schedules`, `/schedule_entries`, etc.).
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/schedule_rotation_versions` | Create a rotation version |
+| `GET` | `/schedule_rotation_versions/{id}` | Show a specific rotation version |
+| `PUT` | `/schedule_rotation_versions/{id}` | Update a rotation version |
+| `DELETE` | `/schedule_rotation_versions/{id}` | Remove a rotation version |
+| `GET` | `/schedule_rotation_versions?schedule_id={id}` | List versions for a schedule |
+
+These are defined as `ServicePublicV2` methods, matching the existing schedules service pattern.
+
+### Data Model Change
+
+Add a `VersionID` field to the `ScheduleRotation` struct in the config JSONB:
+
+```go
+type ScheduleRotation struct {
+    VersionID        string     `json:"version_id,omitempty"` // NEW — unique ID for this entry
+    ID               string     `json:"id"`                   // existing — rotation group ID
+    Name             string     `json:"name"`
+    EffectiveFrom    *time.Time `json:"effective_from,omitempty"`
+    HandoverStartAt  time.Time  `json:"handover_start_at"`
+    SchedulingMode   string     `json:"scheduling_mode,omitempty"`
+    Handovers        []ScheduleRotationHandover
+    UserIDs          []string
+    WorkingIntervals []ScheduleRotationWorkingInterval
+    Layers           []ScheduleLayer
+}
+```
+
+The `omitempty` tag on `VersionID` ensures backward compatibility: existing JSONB entries without the field deserialize cleanly as empty string, and the backfill command populates them.
+
+### Behavior
+
+- **Create**: Generates a UUID for `VersionID`, adds the entry to the schedule's config, triggers the normal schedule version snapshot (audit trail). Returns the full version object including `schedule_id`.
+- **Show**: Reads the schedule config, finds the entry by `VersionID`, returns it along with `schedule_id`. This enables import by `VersionID` alone.
+- **Update**: Finds the entry by `VersionID`, replaces it, writes back. Creates a new schedule version snapshot.
+- **Delete**: Removes the entry by `VersionID`. If this was the last version of a rotation, the rotation ceases to exist.
+- **List**: Returns all rotation entries for a given schedule, with their `VersionID`s.
+
+### Concurrency
+
+Each write operation (create/update/delete) executes within a single transaction that:
+
+1. Acquires a row-level lock on the schedule via `SELECT ... FOR UPDATE` (matching the existing `SchedulesV2Update` pattern)
+2. Reads the current config
+3. Modifies the target rotation entry
+4. Bumps the config version number
+5. Writes back and commits
+
+Each write also increments `Config.Version`, maintaining consistency with the existing optimistic locking used by `SchedulesV2Update`. This ensures that if a dashboard user loaded a schedule before a Terraform apply, their subsequent save gets a version mismatch error rather than silently overwriting Terraform's changes.
+
+Concurrent Terraform operations against the same schedule serialize at the database level — if Terraform applies two `incident_schedule_rotation_version` resources in parallel, the second transaction blocks on `FOR UPDATE` until the first completes, then reads the up-to-date config. No stale reads, no conflicts.
+
+If a conflict does occur (e.g., due to a dashboard update racing with Terraform), the endpoint returns HTTP 409 Conflict. The Terraform provider should implement retry logic (retry up to 3 times with short backoff) on 409 responses, since these are transient.
+
+### Validation
+
+- `effective_from` values must be unique within a rotation group. Two versions with the same `rotation_id` and the same `effective_from` (including both being null) are rejected. This matches the existing backend validation.
+- A rotation group may have zero or one version without `effective_from`. There is no requirement for a "base" version — all versions can have explicit `effective_from` dates. (The existing backend/dashboard already permits this.)
+- All versions sharing a `rotation_id` must have the same `rotation_name`. The backend validates this on create/update and rejects mismatches. To rename a rotation, update any one version — the backend propagates the name change to all versions of that rotation in the same transaction.
+
+### Import
+
+The `incident_schedule_rotation_version` resource supports import by `VersionID` alone:
+
+```bash
+terraform import incident_schedule_rotation_version.emea_v1 <version-uuid>
+```
+
+The `ImportState` implementation calls the Show endpoint with the `VersionID`, which returns all fields including `schedule_id` and `rotation_id`, fully reconstructing the state.
+
+## Dashboard Compatibility
+
+The existing `SchedulesV2Update` endpoint (full config replacement) continues to work. The web dashboard uses this.
+
+When the dashboard updates a schedule:
+- If rotation entries already have `VersionID` fields, the full config replacement round-trips them — the `VersionID` values are preserved in the JSONB.
+- If the dashboard adds a new rotation entry without a `VersionID`, the backend assigns one automatically on write (same as the Create endpoint).
+- Terraform state remains consistent because the provider reads state from the API on each `terraform plan`/`apply` — if the dashboard has modified config, Terraform detects the drift via the normal read path.
+
+## Schedule Deletion
+
+When a user deletes the `incident_schedule` resource, the schedule is archived (soft-deleted) on the backend, which implicitly removes all rotation versions. Any `incident_schedule_rotation_version` resources referencing that schedule will fail their next Read with a 404, and Terraform will remove them from state.
+
+To ensure clean ordering, the `incident_schedule_rotation_version` resource should declare an implicit dependency on its `schedule_id` reference (which Terraform infers automatically from the `incident_schedule.primary.id` interpolation). Terraform will delete rotation versions before the schedule.
+
+## Backfill: Toolbox Command
+
+Existing schedules have rotation entries without `VersionID`s. A toolbox backfill populates them so they can be referenced by the new endpoints and imported into Terraform.
+
+### Command
+
+```bash
+./toolbox backfill --name=backfill-schedule-rotation-version-ids
+```
+
+### Behavior
+
+1. Iterate over all schedules (all organisations)
+2. For each rotation entry in the schedule's config JSONB where `VersionID` is empty:
+   - Generate a new UUID
+   - Assign it as the entry's `VersionID`
+3. Write the updated config back within a transaction (using `SELECT ... FOR UPDATE`)
+4. Log each schedule updated with the count of IDs assigned
+
+Idempotent — running twice is safe (entries that already have a `VersionID` are skipped).
+
+### Implementation Pattern
+
+```go
+package backfill
+
+func init() {
+    backfill.Register("backfill-schedule-rotation-version-ids", runBackfillVersionIDs)
+}
+
+func runBackfillVersionIDs(ctx context.Context, db *gorm.DB, options backfill.Options) error {
+    // 1. Load all schedules with their configs
+    // 2. For each schedule, check each rotation entry
+    // 3. If VersionID is empty, assign uuid.New().String()
+    // 4. Write back within transaction with FOR UPDATE lock
+    // 5. Log progress
+    return nil
+}
+```
+
+### Deployment Order
+
+1. Deploy backend with `VersionID` field added to `ScheduleRotation` struct (backward-compatible, `omitempty`)
+2. Run backfill: `./toolbox backfill --name=backfill-schedule-rotation-version-ids`
+3. Deploy new `/schedule_rotation_versions` endpoints (they can now assume all entries have `VersionID`s; the endpoints also assign UUIDs to any entries that were created between step 1 and 3 without one)
+4. Release Terraform provider v6
+
+## Migration Guide (for v6 changelog)
+
+### Steps
+
+1. Update the provider to v6
+2. Discover existing rotation version IDs:
+   ```bash
+   curl -H "Authorization: Bearer $API_KEY" \
+     https://api.incident.io/v2/schedule_rotation_versions?schedule_id=SCHEDULE_ID
+   ```
+3. Write `incident_schedule_rotation_version` resources for each version
+4. Import them:
+   ```bash
+   terraform import incident_schedule_rotation_version.emea_v1 <version-uuid>
+   terraform import incident_schedule_rotation_version.emea_v2 <version-uuid>
+   ```
+5. Remove `rotations` from the `incident_schedule` resource in your `.tf` files
+6. Run `terraform plan` — should show no changes
+
+## Edge Cases
+
+- **Rotation name consistency**: All versions sharing a `rotation_id` must have the same `rotation_name`. The backend enforces this. To rename, update any version and the backend propagates.
+- **Schedule with no rotations**: Valid — represents a schedule with nobody on-call.
+- **Deletion ordering**: Terraform deletes rotation versions before the schedule due to the implicit dependency from `schedule_id`. Within rotation versions of the same schedule, deletion order doesn't matter — each removal is independent. Deleting the last version of a rotation group simply removes the rotation entirely.
+- **Between deploy and backfill**: Rotation entries without `VersionID` may exist briefly. The new endpoints handle this gracefully by assigning a UUID on write if one is missing. The Show/List endpoints skip entries without `VersionID` (they're not yet addressable).
+
+## Plan readability improvement
+
+The core UX win — what the `terraform plan` diff looks like:
+
+**Before (v5, nested):**
+```diff
+~ resource "incident_schedule" "primary" {
+    ~ rotations = [
+        ~ { versions = [
+            ~ { users = [...] → [...] }  # buried 3 levels deep
+          ]
+        }
+      ]
+  }
+```
+
+**After (v6, flat):**
+```diff
++ resource "incident_schedule_rotation_version" "emea_v2" {
+    rotation_id = "emea"
+    users       = ["alice", "bob", "charlie"]
+    ...
+  }
+```

--- a/internal/provider/incident_escalation_path_data_source.go
+++ b/internal/provider/incident_escalation_path_data_source.go
@@ -95,7 +95,7 @@ func (d *IncidentEscalationPathDataSource) Schema(ctx context.Context, req datas
 			"path": schema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: apischema.Docstring("EscalationPathV2", "path"),
-				NestedObject:        d.getPathSchema(4),
+				NestedObject:        d.getPathSchema(5),
 			},
 			"working_hours": schema.ListNestedAttribute{
 				Computed:            true,

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -131,10 +131,10 @@ func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resourc
 			"path": schema.ListNestedAttribute{
 				MarkdownDescription: fmt.Sprintf("%s\n%s",
 					apischema.Docstring("EscalationPathV2", "path"),
-					"\n-->**Note** Although the `if_else` block is recursive, currently a maximum of 3 levels are supported. "+
-						"Attempting to configure more than 3 levels of nesting will result in a schema error.\n"),
+					"\n-->**Note** Although the `if_else` block is recursive, currently a maximum of 4 levels are supported. "+
+						"Attempting to configure more than 4 levels of nesting will result in a schema error.\n"),
 				Required:     true,
-				NestedObject: r.getPathSchema(4),
+				NestedObject: r.getPathSchema(5),
 			},
 			"working_hours": schema.ListNestedAttribute{
 				MarkdownDescription: apischema.Docstring("EscalationPathV2", "working_hours"),
@@ -169,8 +169,8 @@ func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resourc
 // Terraform doesn't support recursive schemas so we have to manually unpack the schema to
 // a finite depth to allow recursing back into our nodes.
 //
-// We support a maximum nesting depth of 3 levels of if_else nodes.
-// The schema definition should use a depth of 4 if we want to support 3 levels of
+// We support a maximum nesting depth of 4 levels of if_else nodes.
+// The schema definition should use a depth of 5 if we want to support 4 levels of
 // nesting, as it's zero-indexed.
 func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedAttributeObject {
 	result := schema.NestedAttributeObject{
@@ -334,7 +334,7 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 		},
 	}
 
-	// Only include if_else attribute if we haven't reached the maximum nesting depth (3 levels)
+	// Only include if_else attribute if we haven't reached the maximum nesting depth (4 levels)
 	if depth > 0 {
 		result.Attributes["if_else"] = schema.SingleNestedAttribute{
 			MarkdownDescription: apischema.Docstring("EscalationPathNodeV2", "if_else"),

--- a/internal/provider/incident_escalation_path_resource_test.go
+++ b/internal/provider/incident_escalation_path_resource_test.go
@@ -388,7 +388,7 @@ resource "incident_schedule" "primary_on_call" {
   team_ids = []
 }
 
-# Create a path with deeply nested if_else nodes (4 levels deep)
+# Create a path with deeply nested if_else nodes (5 levels deep)
 resource "incident_escalation_path" "example" {
   name = "Deeply Nested Path Test"
 
@@ -439,14 +439,29 @@ resource "incident_escalation_path" "example" {
                           ]
                           then_path = [
                             {
-                              type = "level"
-                              level = {
-                                targets = [{
-                                  type    = "schedule"
-                                  id      = incident_schedule.primary_on_call.id
-                                  urgency  = "high"
-                                }]
-                                time_to_ack_seconds = 300
+                              type = "if_else"
+                              if_else = {
+                                conditions = [
+                                  {
+                                    operation = "is_active",
+                                    param_bindings = []
+                                    subject = "escalation.working_hours[\"UK\"]"
+                                  }
+                                ]
+                                then_path = [
+                                  {
+                                    type = "level"
+                                    level = {
+                                      targets = [{
+                                        type    = "schedule"
+                                        id      = incident_schedule.primary_on_call.id
+                                        urgency  = "high"
+                                      }]
+                                      time_to_ack_seconds = 300
+                                    }
+                                  }
+                                ],
+                                else_path = []
                               }
                             }
                           ],


### PR DESCRIPTION
## Summary

- Bumps the unrolled schema depth on both the `incident_escalation_path` resource and data source from `4` → `5`, allowing one more level of recursive `if_else` (3 → 4 levels). Terraform doesn't support recursive schemas, so we manually unroll to a finite depth — see `getPathSchema` in `internal/provider/incident_escalation_path_resource.go`.
- `TestAccIncidentEscalationPathResourceValidateMaxDepth` now nests 5 `if_else` blocks (was 4), keeping the assertion that one-past-the-limit fails the schema validation.
- Doc note and inline comments updated to reflect the new max. Generated docs regenerated via `go generate ./...`.

The bulk of the diff is auto-generated docs (`docs/{resources,data-sources}/escalation_path.md`) — each extra level roughly doubles them since `if_else` recurses through both `then_path` and `else_path`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3db22d821aa7da31b3095ee3d5eee78e274e3410. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->