### PR TITLE
Support new escalation path schedule modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Support new escalation path schedule modes (`currently_on_call_for_rota`, `next_on_call_for_rota`, `next_on_call`) and the associated `selected_rota_id` target field
+
 ## v5.36.0
 
 - Add support for transform expressions on email alert source

--- a/docs/data-sources/escalation_path.md
+++ b/docs/data-sources/escalation_path.md
@@ -463,7 +463,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -485,7 +486,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -557,7 +559,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -579,7 +582,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -623,7 +627,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -645,7 +650,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -793,7 +799,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -815,7 +822,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -887,7 +895,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -909,7 +918,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -953,7 +963,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -975,7 +986,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1019,7 +1031,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1041,7 +1054,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1265,7 +1279,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1287,7 +1302,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1359,7 +1375,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1381,7 +1398,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1425,7 +1443,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1447,7 +1466,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1595,7 +1615,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1617,7 +1638,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1689,7 +1711,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1711,7 +1734,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1755,7 +1779,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1777,7 +1802,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1821,7 +1847,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1843,7 +1870,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1887,7 +1915,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -1909,7 +1938,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2209,7 +2239,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2231,7 +2262,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2303,7 +2335,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2325,7 +2358,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2369,7 +2403,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2391,7 +2426,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2539,7 +2575,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2561,7 +2598,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2633,7 +2671,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2655,7 +2694,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2699,7 +2739,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2721,7 +2762,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2765,7 +2807,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -2787,7 +2830,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3011,7 +3055,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3033,7 +3078,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3105,7 +3151,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3127,7 +3174,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3171,7 +3219,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3193,7 +3242,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3341,7 +3391,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3363,7 +3414,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3435,7 +3487,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3457,7 +3510,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3501,7 +3555,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3523,7 +3578,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3567,7 +3623,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3589,7 +3646,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3633,7 +3691,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3655,7 +3714,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3699,7 +3759,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -3721,7 +3782,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4097,7 +4159,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4119,7 +4182,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4191,7 +4255,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4213,7 +4278,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4257,7 +4323,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4279,7 +4346,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4427,7 +4495,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4449,7 +4518,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4521,7 +4591,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4543,7 +4614,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4587,7 +4659,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4609,7 +4682,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4653,7 +4727,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4675,7 +4750,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4899,7 +4975,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4921,7 +4998,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -4993,7 +5071,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5015,7 +5094,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5059,7 +5139,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5081,7 +5162,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5229,7 +5311,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5251,7 +5334,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5323,7 +5407,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5345,7 +5430,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5389,7 +5475,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5411,7 +5498,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5455,7 +5543,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5477,7 +5566,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5521,7 +5611,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5543,7 +5634,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5843,7 +5935,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5865,7 +5958,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5937,7 +6031,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -5959,7 +6054,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6003,7 +6099,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6025,7 +6122,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6173,7 +6271,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6195,7 +6294,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6267,7 +6367,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6289,7 +6390,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6333,7 +6435,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6355,7 +6458,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6399,7 +6503,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6421,7 +6526,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6645,7 +6751,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6667,7 +6774,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6739,7 +6847,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6761,7 +6870,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6805,7 +6915,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6827,7 +6938,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6975,7 +7087,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -6997,7 +7110,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7069,7 +7183,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7091,7 +7206,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7135,7 +7251,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7157,7 +7274,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7201,7 +7319,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7223,7 +7342,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7267,7 +7387,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7289,7 +7410,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7333,7 +7455,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7355,7 +7478,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7399,7 +7523,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 
@@ -7421,7 +7546,8 @@ Read-Only:
 Read-Only:
 
 - `id` (String) Uniquely identifies an entity of this type
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 - `type` (String) Controls what type of entity this target identifies, such as EscalationPolicy or User
 - `urgency` (String) The urgency of this escalation path target
 

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -612,7 +612,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -652,7 +653,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -724,7 +726,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -764,7 +767,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -805,7 +809,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -845,7 +850,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -999,7 +1005,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -1039,7 +1046,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -1111,7 +1119,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -1151,7 +1160,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -1192,7 +1202,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -1232,7 +1243,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -1273,7 +1285,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -1313,7 +1326,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -1549,7 +1563,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -1589,7 +1604,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -1661,7 +1677,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -1701,7 +1718,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -1742,7 +1760,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -1782,7 +1801,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -1936,7 +1956,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -1976,7 +1997,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -2048,7 +2070,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -2088,7 +2111,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -2129,7 +2153,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -2169,7 +2194,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -2210,7 +2236,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -2250,7 +2277,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -2291,7 +2319,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -2331,7 +2360,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -2649,7 +2679,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -2689,7 +2720,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -2761,7 +2793,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -2801,7 +2834,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -2842,7 +2876,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -2882,7 +2917,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -3036,7 +3072,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -3076,7 +3113,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -3148,7 +3186,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -3188,7 +3227,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -3229,7 +3269,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -3269,7 +3310,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -3310,7 +3352,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -3350,7 +3393,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -3586,7 +3630,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -3626,7 +3671,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -3698,7 +3744,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -3738,7 +3785,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -3779,7 +3827,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -3819,7 +3868,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -3973,7 +4023,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -4013,7 +4064,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -4085,7 +4137,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -4125,7 +4178,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -4166,7 +4220,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -4206,7 +4261,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -4247,7 +4303,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -4287,7 +4344,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -4328,7 +4386,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -4368,7 +4427,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -4409,7 +4469,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--then_path--level--round_robin_config"></a>
@@ -4449,7 +4510,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -4849,7 +4911,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -4889,7 +4952,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -4961,7 +5025,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -5001,7 +5066,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -5042,7 +5108,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -5082,7 +5149,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -5236,7 +5304,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -5276,7 +5345,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -5348,7 +5418,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -5388,7 +5459,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -5429,7 +5501,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -5469,7 +5542,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -5510,7 +5584,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -5550,7 +5625,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -5786,7 +5862,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -5826,7 +5903,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -5898,7 +5976,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -5938,7 +6017,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -5979,7 +6059,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -6019,7 +6100,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -6173,7 +6255,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -6213,7 +6296,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -6285,7 +6369,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -6325,7 +6410,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -6366,7 +6452,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -6406,7 +6493,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -6447,7 +6535,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -6487,7 +6576,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -6528,7 +6618,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -6568,7 +6659,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -6886,7 +6978,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -6926,7 +7019,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -6998,7 +7092,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -7038,7 +7133,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -7079,7 +7175,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -7119,7 +7216,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -7273,7 +7371,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -7313,7 +7412,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -7385,7 +7485,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -7425,7 +7526,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -7466,7 +7568,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -7506,7 +7609,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -7547,7 +7651,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -7587,7 +7692,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -7823,7 +7929,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -7863,7 +7970,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -7935,7 +8043,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -7975,7 +8084,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -8016,7 +8126,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -8056,7 +8167,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -8210,7 +8322,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -8250,7 +8363,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -8322,7 +8436,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -8362,7 +8477,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -8403,7 +8519,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -8443,7 +8560,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -8484,7 +8602,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -8524,7 +8643,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -8565,7 +8685,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -8605,7 +8726,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -8646,7 +8768,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--if_else--else_path--level--round_robin_config"></a>
@@ -8686,7 +8809,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 
@@ -8727,7 +8851,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 <a id="nestedatt--path--level--round_robin_config"></a>
@@ -8767,7 +8892,8 @@ Required:
 
 Optional:
 
-- `schedule_mode` (String) Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+- `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
+- `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
 
 
 

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -11435,6 +11435,8 @@
               "on_call_notification_method",
               "organisation_settings",
               "schedule_override",
+              "schedule_sync_rule",
+              "schedule_sync_target",
               "policy",
               "post_incident_task",
               "postmortem_template",
@@ -21144,6 +21146,306 @@
         ],
         "type": "object"
       },
+      "AuditLogsScheduleSyncRuleCreatedV1": {
+        "example": {
+          "action": "schedule_sync_rule.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "on_call sync rule to Slack user group S012345ABCD",
+              "type": "schedule_sync_rule"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "schedule_sync_rule.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "on_call sync rule to Slack user group S012345ABCD",
+                "type": "schedule_sync_rule"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsScheduleSyncRuleDeletedV1": {
+        "example": {
+          "action": "schedule_sync_rule.deleted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "on_call sync rule to Slack user group S012345ABCD",
+              "type": "schedule_sync_rule"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "schedule_sync_rule.deleted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "on_call sync rule to Slack user group S012345ABCD",
+                "type": "schedule_sync_rule"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsScheduleSyncTargetCreatedV1": {
+        "example": {
+          "action": "schedule_sync_target.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Slack user group S012345ABCD",
+              "type": "schedule_sync_target"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "schedule_sync_target.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Slack user group S012345ABCD",
+                "type": "schedule_sync_target"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsScheduleSyncTargetDeletedV1": {
+        "example": {
+          "action": "schedule_sync_target.deleted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Slack user group S012345ABCD",
+              "type": "schedule_sync_target"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "schedule_sync_target.deleted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Slack user group S012345ABCD",
+                "type": "schedule_sync_target"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
       "AuditLogsScheduleUpdatedV1": {
         "example": {
           "action": "schedule.updated",
@@ -30320,6 +30622,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -30333,6 +30636,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -30394,6 +30698,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -30407,6 +30712,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -30499,6 +30805,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -30512,6 +30819,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -30580,6 +30888,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -30593,6 +30902,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -30704,6 +31014,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -30717,6 +31028,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -30786,6 +31098,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -30799,6 +31112,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -30907,6 +31221,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -30920,6 +31235,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -30996,6 +31312,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -31009,6 +31326,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -31048,6 +31366,7 @@
             {
               "id": "lawrencejones",
               "schedule_mode": "currently_on_call",
+              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "type": "schedule",
               "urgency": "high"
             }
@@ -31075,6 +31394,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
+                "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "type": "schedule",
                 "urgency": "high"
               }
@@ -31116,6 +31436,7 @@
             {
               "id": "lawrencejones",
               "schedule_mode": "currently_on_call",
+              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "type": "schedule",
               "urgency": "high"
             }
@@ -31131,6 +31452,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
+                "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "type": "schedule",
                 "urgency": "high"
               }
@@ -31212,6 +31534,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
+                "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "type": "schedule",
                 "urgency": "high"
               }
@@ -31225,6 +31548,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
+                "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "type": "schedule",
                 "urgency": "high"
               }
@@ -31357,6 +31681,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
+                "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "type": "schedule",
                 "urgency": "high"
               }
@@ -31370,6 +31695,7 @@
               {
                 "id": "lawrencejones",
                 "schedule_mode": "currently_on_call",
+                "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "type": "schedule",
                 "urgency": "high"
               }
@@ -31478,6 +31804,7 @@
         "example": {
           "id": "lawrencejones",
           "schedule_mode": "currently_on_call",
+          "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "type": "schedule",
           "urgency": "high"
         },
@@ -31488,14 +31815,22 @@
             "type": "string"
           },
           "schedule_mode": {
-            "description": "Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule",
+            "description": "Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.",
             "enum": [
               "currently_on_call",
               "all_users_for_rota",
               "all_users",
+              "currently_on_call_for_rota",
+              "next_on_call_for_rota",
+              "next_on_call",
               ""
             ],
             "example": "currently_on_call",
+            "type": "string"
+          },
+          "selected_rota_id": {
+            "description": "For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
             "type": "string"
           },
           "type": {
@@ -31594,6 +31929,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -31607,6 +31943,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -31727,6 +32064,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -31740,6 +32078,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -32036,6 +32375,156 @@
         ],
         "type": "object"
       },
+      "EscalationWithStatusChangeV2": {
+        "example": {
+          "actor": {
+            "alert": {
+              "id": "01GW2G3V0S59R238FAHPDS1R66",
+              "title": "*errors.withMessage: PG::Error failed to connect"
+            },
+            "api_key": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My test API key"
+            },
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "owner",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "workflow": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My little workflow"
+            }
+          },
+          "escalation": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "events": [
+              {
+                "channels": [
+                  {
+                    "microsoft_teams_channel_id": "abc123",
+                    "microsoft_teams_team_id": "abc123",
+                    "slack_channel_id": "abc123",
+                    "slack_team_id": "abc123"
+                  }
+                ],
+                "event": "entered_grace_period",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "occurred_at": "2021-08-17T13:28:57.801578Z",
+                "urgency": "high",
+                "users": [
+                  {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "owner",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                ]
+              }
+            ],
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "priority": {
+              "name": "P1"
+            },
+            "related_alerts": [
+              {
+                "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "deduplication_key": "4293868629",
+                "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "resolved_at": "2021-08-17T14:28:57.801578Z",
+                "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                "status": "firing",
+                "title": "*errors.withMessage: PG::Error failed to connect",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "related_incidents": [
+              {
+                "external_id": 123,
+                "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                "name": "Our database is sad",
+                "reference": "INC-123",
+                "status_category": "triage",
+                "summary": "Our database is really really sad, and we don't know why yet.",
+                "visibility": "public"
+              }
+            ],
+            "status": "pending",
+            "title": "Database CPU is high",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "new_status": "pending",
+          "previous_status": "pending"
+        },
+        "properties": {
+          "actor": {
+            "$ref": "#/components/schemas/ActorV2"
+          },
+          "escalation": {
+            "$ref": "#/components/schemas/EscalationV2"
+          },
+          "new_status": {
+            "description": "The new status of the escalation",
+            "enum": [
+              "pending",
+              "triggered",
+              "acked",
+              "resolved",
+              "expired",
+              "cancelled",
+              "snoozed",
+              "delayed",
+              "pending_repeat"
+            ],
+            "example": "pending",
+            "type": "string"
+          },
+          "previous_status": {
+            "description": "The previous status of the escalation",
+            "enum": [
+              "pending",
+              "triggered",
+              "acked",
+              "resolved",
+              "expired",
+              "cancelled",
+              "snoozed",
+              "delayed",
+              "pending_repeat"
+            ],
+            "example": "pending",
+            "type": "string"
+          }
+        },
+        "required": [
+          "escalation",
+          "new_status"
+        ],
+        "type": "object"
+      },
       "EscalationsCreateExternalEscalationPathPayloadV2": {
         "example": {
           "external_escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH"
@@ -32120,6 +32609,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -32133,6 +32623,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -32230,6 +32721,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -32243,6 +32735,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -32334,6 +32827,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -32347,6 +32841,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -32477,6 +32972,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -32490,6 +32986,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -32839,6 +33336,7 @@
                       {
                         "id": "lawrencejones",
                         "schedule_mode": "currently_on_call",
+                        "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "type": "schedule",
                         "urgency": "high"
                       }
@@ -32852,6 +33350,7 @@
                       {
                         "id": "lawrencejones",
                         "schedule_mode": "currently_on_call",
+                        "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "type": "schedule",
                         "urgency": "high"
                       }
@@ -32964,6 +33463,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
+                          "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "type": "schedule",
                           "urgency": "high"
                         }
@@ -32977,6 +33477,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
+                          "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "type": "schedule",
                           "urgency": "high"
                         }
@@ -33282,6 +33783,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -33295,6 +33797,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -33483,6 +33986,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -33496,6 +34000,7 @@
                   {
                     "id": "lawrencejones",
                     "schedule_mode": "currently_on_call",
+                    "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "type": "schedule",
                     "urgency": "high"
                   }
@@ -33587,6 +34092,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -33600,6 +34106,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -33730,6 +34237,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -33743,6 +34251,7 @@
                     {
                       "id": "lawrencejones",
                       "schedule_mode": "currently_on_call",
+                      "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "type": "schedule",
                       "urgency": "high"
                     }
@@ -44305,6 +44814,7 @@
         "type": "object"
       },
       "ScheduleEntriesListPayloadV2": {
+        "description": "The schedule entries for a window of time, grouped by where they come from.\n\n`scheduled` are the entries produced by the schedule's rotation rules before\nany overrides are taken into account. `overrides` are the one-off changes that\napply within the window. `final` is the effective schedule after overrides\nhave been merged in — this is normally the list to use when working out who\nis on-call.",
         "example": {
           "final": [
             {
@@ -44360,6 +44870,7 @@
         },
         "properties": {
           "final": {
+            "description": "The effective schedule after overrides have been merged in",
             "example": [
               {
                 "end_at": "2021-08-17T13:28:57.801578Z",
@@ -44383,6 +44894,7 @@
             "type": "array"
           },
           "overrides": {
+            "description": "Overrides that apply within the requested window",
             "example": [
               {
                 "end_at": "2021-08-17T13:28:57.801578Z",
@@ -44406,6 +44918,7 @@
             "type": "array"
           },
           "scheduled": {
+            "description": "Entries from the schedule's rotation rules, before overrides are applied",
             "example": [
               {
                 "end_at": "2021-08-17T13:28:57.801578Z",
@@ -44437,6 +44950,7 @@
         "type": "object"
       },
       "ScheduleEntryV2": {
+        "description": "A single shift on a schedule, representing who is on-call between a start\nand end time. When present, `rotation_id` and `layer_id` tell you which\nrotation and which layer within that rotation the entry belongs to. A\nschedule may have multiple rotations (for example, a primary and a secondary\nrotation) and each rotation can be made up of several layers — entries are\nreturned for every rotation and layer on the schedule.\n\nEntries come from two places: they are either generated from a schedule's\nrotation configuration (the regular pattern of who is on-call) or created by\nan override (a one-off change that replaces the normal rotation for a period\nof time). When you call the List schedule entries endpoint we return both\nkinds separately, along with the merged `final` schedule that reflects what\nwill actually happen.\n\n`entry_id` is only populated for entries that correspond to a stored\nrecord. Scheduled entries are projections computed from the rotation rules\non the fly and don't have a persisted ID, so `entry_id` will be absent for\nthose. Use `fingerprint` if you need a stable identifier to deduplicate or\ndiff a shift across requests.",
         "example": {
           "end_at": "2021-08-17T13:28:57.801578Z",
           "entry_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
@@ -44469,7 +44983,7 @@
             "type": "string"
           },
           "layer_id": {
-            "description": "If present, the layer this entry applies to on the rota",
+            "description": "If present, the layer this entry applies to on the rotation",
             "example": "01G0J1EXE7AXZ2C93K61WBPYNH",
             "type": "string"
           },
@@ -45459,6 +45973,409 @@
         ],
         "type": "object"
       },
+      "ScheduleShiftChangeV2": {
+        "example": {
+          "current_users": [
+            {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "owner",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          ],
+          "previous_users": [
+            {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "owner",
+              "slack_user_id": "U02AYNF2XJM"
+            }
+          ],
+          "schedule": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "name": "Primary On-Call Schedule",
+            "team_ids": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
+            "timezone": "Europe/London",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "current_users": {
+            "description": "Users who are now on-call (empty array if shift ending)",
+            "example": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/UserV2"
+            },
+            "type": "array"
+          },
+          "previous_users": {
+            "description": "Users who were previously on-call (empty array if shift starting)",
+            "example": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/UserV2"
+            },
+            "type": "array"
+          },
+          "schedule": {
+            "$ref": "#/components/schemas/ScheduleSlimV2"
+          }
+        },
+        "required": [
+          "schedule",
+          "previous_users",
+          "current_users"
+        ],
+        "type": "object"
+      },
+      "ScheduleSlimV2": {
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "name": "Primary On-Call Schedule",
+          "team_ids": [
+            "01JPQA75EPNEES4479P16P4XAB"
+          ],
+          "timezone": "Europe/London",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "properties": {
+          "created_at": {
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique internal ID of the schedule",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human readable name synced from external provider",
+            "example": "Primary On-Call Schedule",
+            "type": "string"
+          },
+          "team_ids": {
+            "description": "IDs of teams that own this schedule",
+            "example": [
+              "01JPQA75EPNEES4479P16P4XAB"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "timezone": {
+            "description": "Timezone of the schedule, as interpreted at the point of generating the report",
+            "example": "Europe/London",
+            "type": "string"
+          },
+          "updated_at": {
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "timezone",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "ScheduleSyncRuleCreatePayloadV2": {
+        "example": {
+          "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+          "sync_type": "on_call"
+        },
+        "properties": {
+          "schedule_sync_target_id": {
+            "description": "The sync target to link to",
+            "example": "01JXYZ000000000000000000AB",
+            "type": "string"
+          },
+          "sync_type": {
+            "description": "Which schedule members sync to the user group",
+            "enum": [
+              "on_call",
+              "all_users"
+            ],
+            "example": "on_call",
+            "type": "string"
+          }
+        },
+        "required": [
+          "schedule_sync_target_id",
+          "sync_type"
+        ],
+        "type": "object"
+      },
+      "ScheduleSyncRuleV2": {
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "id": "01JXYZ000000000000000000CD",
+          "schedule_id": "01JXYZ000000000000000000EF",
+          "schedule_sync_target": {
+            "add_bot_to_group": true,
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01JXYZ000000000000000000AB",
+            "slack_team_id": "T02A1AZHG3J",
+            "slack_user_group_id": "S06MNNU5BMK",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+          "sync_type": "on_call",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "properties": {
+          "created_at": {
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the sync rule",
+            "example": "01JXYZ000000000000000000CD",
+            "type": "string"
+          },
+          "schedule_id": {
+            "description": "The schedule this rule belongs to",
+            "example": "01JXYZ000000000000000000EF",
+            "type": "string"
+          },
+          "schedule_sync_target": {
+            "$ref": "#/components/schemas/ScheduleSyncTargetResourceV2"
+          },
+          "schedule_sync_target_id": {
+            "description": "The sync target ID this rule links to",
+            "example": "01JXYZ000000000000000000AB",
+            "type": "string"
+          },
+          "sync_type": {
+            "description": "Which schedule members sync to the user group",
+            "enum": [
+              "on_call",
+              "all_users"
+            ],
+            "example": "on_call",
+            "type": "string"
+          },
+          "updated_at": {
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "schedule_id",
+          "schedule_sync_target_id",
+          "schedule_sync_target",
+          "sync_type",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "ScheduleSyncTargetCreatePayloadV2": {
+        "example": {
+          "add_bot_to_group": true,
+          "slack_user_group_id": "S06MNNU5BMK"
+        },
+        "properties": {
+          "add_bot_to_group": {
+            "description": "Whether the incident.io bot should be added to the group",
+            "example": true,
+            "type": "boolean"
+          },
+          "slack_user_group_id": {
+            "description": "Slack ID for the user group to sync to",
+            "example": "S06MNNU5BMK",
+            "type": "string"
+          }
+        },
+        "required": [
+          "slack_user_group_id",
+          "add_bot_to_group"
+        ],
+        "type": "object"
+      },
+      "ScheduleSyncTargetResourceV2": {
+        "example": {
+          "add_bot_to_group": true,
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "id": "01JXYZ000000000000000000AB",
+          "slack_team_id": "T02A1AZHG3J",
+          "slack_user_group_id": "S06MNNU5BMK",
+          "updated_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "properties": {
+          "add_bot_to_group": {
+            "description": "Whether the incident.io bot should be added to the group",
+            "example": true,
+            "type": "boolean"
+          },
+          "created_at": {
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the sync target",
+            "example": "01JXYZ000000000000000000AB",
+            "type": "string"
+          },
+          "slack_team_id": {
+            "description": "Slack team ID for the user group",
+            "example": "T02A1AZHG3J",
+            "type": "string"
+          },
+          "slack_user_group_id": {
+            "description": "Slack ID for the user group synced to",
+            "example": "S06MNNU5BMK",
+            "type": "string"
+          },
+          "updated_at": {
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "slack_user_group_id",
+          "slack_team_id",
+          "add_bot_to_group",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "ScheduleSyncTargetsCreatePayloadV2": {
+        "example": {
+          "schedule_sync_target": {
+            "add_bot_to_group": true,
+            "slack_user_group_id": "S06MNNU5BMK"
+          }
+        },
+        "properties": {
+          "schedule_sync_target": {
+            "$ref": "#/components/schemas/ScheduleSyncTargetCreatePayloadV2"
+          }
+        },
+        "required": [
+          "schedule_sync_target"
+        ],
+        "type": "object"
+      },
+      "ScheduleSyncTargetsCreateResultV2": {
+        "example": {
+          "schedule_sync_target": {
+            "add_bot_to_group": true,
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01JXYZ000000000000000000AB",
+            "slack_team_id": "T02A1AZHG3J",
+            "slack_user_group_id": "S06MNNU5BMK",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "schedule_sync_target": {
+            "$ref": "#/components/schemas/ScheduleSyncTargetResourceV2"
+          }
+        },
+        "required": [
+          "schedule_sync_target"
+        ],
+        "type": "object"
+      },
+      "ScheduleSyncTargetsListResultV2": {
+        "example": {
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          },
+          "schedule_sync_targets": [
+            {
+              "add_bot_to_group": true,
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "id": "01JXYZ000000000000000000AB",
+              "slack_team_id": "T02A1AZHG3J",
+              "slack_user_group_id": "S06MNNU5BMK",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          },
+          "schedule_sync_targets": {
+            "example": [
+              {
+                "add_bot_to_group": true,
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "id": "01JXYZ000000000000000000AB",
+                "slack_team_id": "T02A1AZHG3J",
+                "slack_user_group_id": "S06MNNU5BMK",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ScheduleSyncTargetResourceV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schedule_sync_targets"
+        ],
+        "type": "object"
+      },
+      "ScheduleSyncTargetsShowResultV2": {
+        "example": {
+          "schedule_sync_target": {
+            "add_bot_to_group": true,
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01JXYZ000000000000000000AB",
+            "slack_team_id": "T02A1AZHG3J",
+            "slack_user_group_id": "S06MNNU5BMK",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "schedule_sync_target": {
+            "$ref": "#/components/schemas/ScheduleSyncTargetResourceV2"
+          }
+        },
+        "required": [
+          "schedule_sync_target"
+        ],
+        "type": "object"
+      },
       "ScheduleUpdatePayloadV2": {
         "example": {
           "annotations": {
@@ -46106,6 +47023,52 @@
         ],
         "type": "object"
       },
+      "SchedulesCreateScheduleSyncRulePayloadV2": {
+        "example": {
+          "schedule_sync_rule": {
+            "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+            "sync_type": "on_call"
+          }
+        },
+        "properties": {
+          "schedule_sync_rule": {
+            "$ref": "#/components/schemas/ScheduleSyncRuleCreatePayloadV2"
+          }
+        },
+        "required": [
+          "schedule_sync_rule"
+        ],
+        "type": "object"
+      },
+      "SchedulesCreateScheduleSyncRuleResultV2": {
+        "example": {
+          "schedule_sync_rule": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01JXYZ000000000000000000CD",
+            "schedule_id": "01JXYZ000000000000000000EF",
+            "schedule_sync_target": {
+              "add_bot_to_group": true,
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "id": "01JXYZ000000000000000000AB",
+              "slack_team_id": "T02A1AZHG3J",
+              "slack_user_group_id": "S06MNNU5BMK",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+            "sync_type": "on_call",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "schedule_sync_rule": {
+            "$ref": "#/components/schemas/ScheduleSyncRuleV2"
+          }
+        },
+        "required": [
+          "schedule_sync_rule"
+        ],
+        "type": "object"
+      },
       "SchedulesListResultV2": {
         "example": {
           "pagination_meta": {
@@ -46473,6 +47436,65 @@
         ],
         "type": "object"
       },
+      "SchedulesListScheduleSyncRulesResultV2": {
+        "example": {
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          },
+          "schedule_sync_rules": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "id": "01JXYZ000000000000000000CD",
+              "schedule_id": "01JXYZ000000000000000000EF",
+              "schedule_sync_target": {
+                "add_bot_to_group": true,
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "id": "01JXYZ000000000000000000AB",
+                "slack_team_id": "T02A1AZHG3J",
+                "slack_user_group_id": "S06MNNU5BMK",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              },
+              "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+              "sync_type": "on_call",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          },
+          "schedule_sync_rules": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "id": "01JXYZ000000000000000000CD",
+                "schedule_id": "01JXYZ000000000000000000EF",
+                "schedule_sync_target": {
+                  "add_bot_to_group": true,
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "id": "01JXYZ000000000000000000AB",
+                  "slack_team_id": "T02A1AZHG3J",
+                  "slack_user_group_id": "S06MNNU5BMK",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                },
+                "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+                "sync_type": "on_call",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ScheduleSyncRuleV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schedule_sync_rules"
+        ],
+        "type": "object"
+      },
       "SchedulesShowResultV2": {
         "example": {
           "schedule": {
@@ -46619,6 +47641,35 @@
         },
         "required": [
           "schedule_replica"
+        ],
+        "type": "object"
+      },
+      "SchedulesShowScheduleSyncRuleResultV2": {
+        "example": {
+          "schedule_sync_rule": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "id": "01JXYZ000000000000000000CD",
+            "schedule_id": "01JXYZ000000000000000000EF",
+            "schedule_sync_target": {
+              "add_bot_to_group": true,
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "id": "01JXYZ000000000000000000AB",
+              "slack_team_id": "T02A1AZHG3J",
+              "slack_user_group_id": "S06MNNU5BMK",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+            "sync_type": "on_call",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "schedule_sync_rule": {
+            "$ref": "#/components/schemas/ScheduleSyncRuleV2"
+          }
+        },
+        "required": [
+          "schedule_sync_rule"
         ],
         "type": "object"
       },
@@ -49729,6 +50780,25 @@
         ],
         "type": "object"
       },
+      "UsersShowPagingProviderResultV2": {
+        "example": {
+          "preferred_escalation_provider": "native"
+        },
+        "properties": {
+          "preferred_escalation_provider": {
+            "description": "The user's effective escalation provider.",
+            "enum": [
+              "native",
+              "opsgenie",
+              "pagerduty",
+              "splunk_on_call"
+            ],
+            "example": "native",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "UsersShowResultV2": {
         "example": {
           "user": {
@@ -49764,6 +50834,28 @@
         },
         "required": [
           "user"
+        ],
+        "type": "object"
+      },
+      "UsersUpdatePagingProviderPayloadV2": {
+        "example": {
+          "preferred_escalation_provider": "native"
+        },
+        "properties": {
+          "preferred_escalation_provider": {
+            "description": "The preferred escalation provider for the user.",
+            "enum": [
+              "native",
+              "opsgenie",
+              "pagerduty",
+              "splunk_on_call"
+            ],
+            "example": "native",
+            "type": "string"
+          }
+        },
+        "required": [
+          "preferred_escalation_provider"
         ],
         "type": "object"
       },
@@ -50295,6 +51387,15 @@
           "private_alert.alert_created_v1": {
             "id": "abc123"
           },
+          "private_alert.alert_resolved_v1": {
+            "id": "abc123"
+          },
+          "private_escalation.escalation_created_v1": {
+            "id": "abc123"
+          },
+          "private_escalation.escalation_status_updated_v1": {
+            "id": "abc123"
+          },
           "private_incident.action_created_v1": {
             "id": "abc123"
           },
@@ -50375,6 +51476,231 @@
             "status": "firing",
             "title": "*errors.withMessage: PG::Error failed to connect",
             "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_alert.alert_resolved_v1": {
+            "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+            "attributes": [
+              {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "label": "Payments Team",
+                    "literal": "SEV123"
+                  }
+                ],
+                "attribute": {
+                  "array": false,
+                  "emoji": "fire",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "name": "service",
+                  "required": false,
+                  "type": "CatalogEntry[\"01GW2G3V0S59R238FAHPDS1R67\"]"
+                },
+                "value": {
+                  "catalog_entry": {
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Primary On-call"
+                  },
+                  "label": "Payments Team",
+                  "literal": "SEV123"
+                }
+              }
+            ],
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "deduplication_key": "4293868629",
+            "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+            "id": "01GW2G3V0S59R238FAHPDS1R66",
+            "resolved_at": "2021-08-17T14:28:57.801578Z",
+            "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+            "status": "firing",
+            "title": "*errors.withMessage: PG::Error failed to connect",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_escalation.escalation_created_v1": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "events": [
+              {
+                "channels": [
+                  {
+                    "microsoft_teams_channel_id": "abc123",
+                    "microsoft_teams_team_id": "abc123",
+                    "slack_channel_id": "abc123",
+                    "slack_team_id": "abc123"
+                  }
+                ],
+                "event": "entered_grace_period",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "occurred_at": "2021-08-17T13:28:57.801578Z",
+                "urgency": "high",
+                "users": [
+                  {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "owner",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                ]
+              }
+            ],
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "priority": {
+              "name": "P1"
+            },
+            "related_alerts": [
+              {
+                "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "deduplication_key": "4293868629",
+                "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "resolved_at": "2021-08-17T14:28:57.801578Z",
+                "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                "status": "firing",
+                "title": "*errors.withMessage: PG::Error failed to connect",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "related_incidents": [
+              {
+                "external_id": 123,
+                "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                "name": "Our database is sad",
+                "reference": "INC-123",
+                "status_category": "triage",
+                "summary": "Our database is really really sad, and we don't know why yet.",
+                "visibility": "public"
+              }
+            ],
+            "status": "pending",
+            "title": "Database CPU is high",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          },
+          "public_escalation.escalation_status_updated_v1": {
+            "actor": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "escalation": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "alert": {
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "title": "*errors.withMessage: PG::Error failed to connect"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "owner",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "workflow": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My little workflow"
+                }
+              },
+              "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "events": [
+                {
+                  "channels": [
+                    {
+                      "microsoft_teams_channel_id": "abc123",
+                      "microsoft_teams_team_id": "abc123",
+                      "slack_channel_id": "abc123",
+                      "slack_team_id": "abc123"
+                    }
+                  ],
+                  "event": "entered_grace_period",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "urgency": "high",
+                  "users": [
+                    {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "owner",
+                      "slack_user_id": "U02AYNF2XJM"
+                    }
+                  ]
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "priority": {
+                "name": "P1"
+              },
+              "related_alerts": [
+                {
+                  "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "deduplication_key": "4293868629",
+                  "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "resolved_at": "2021-08-17T14:28:57.801578Z",
+                  "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                  "status": "firing",
+                  "title": "*errors.withMessage: PG::Error failed to connect",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              ],
+              "related_incidents": [
+                {
+                  "external_id": 123,
+                  "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                  "name": "Our database is sad",
+                  "reference": "INC-123",
+                  "status_category": "triage",
+                  "summary": "Our database is really really sad, and we don't know why yet.",
+                  "visibility": "public"
+                }
+              ],
+              "status": "pending",
+              "title": "Database CPU is high",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "new_status": "pending",
+            "previous_status": "pending"
           },
           "public_incident.action_created_v1": {
             "assignee": {
@@ -51105,6 +52431,36 @@
               "updated_at": "abc123"
             },
             "previous_status": "review"
+          },
+          "schedule.shift_change_v1": {
+            "current_users": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
+            "previous_users": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
+            "schedule": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Primary On-Call Schedule",
+              "team_ids": [
+                "01JPQA75EPNEES4479P16P4XAB"
+              ],
+              "timezone": "Europe/London",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
           }
         },
         "properties": {
@@ -51130,15 +52486,31 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.incident_created_v2",
             "type": "string"
           },
           "private_alert.alert_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_alert.alert_resolved_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_escalation.escalation_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          },
+          "private_escalation.escalation_status_updated_v1": {
             "$ref": "#/components/schemas/WebhookPrivateResourceV2"
           },
           "private_incident.action_created_v1": {
@@ -51177,6 +52549,15 @@
           "public_alert.alert_created_v1": {
             "$ref": "#/components/schemas/AlertV2"
           },
+          "public_alert.alert_resolved_v1": {
+            "$ref": "#/components/schemas/AlertV2"
+          },
+          "public_escalation.escalation_created_v1": {
+            "$ref": "#/components/schemas/EscalationV2"
+          },
+          "public_escalation.escalation_status_updated_v1": {
+            "$ref": "#/components/schemas/EscalationWithStatusChangeV2"
+          },
           "public_incident.action_created_v1": {
             "$ref": "#/components/schemas/ActionV1"
           },
@@ -51206,6 +52587,9 @@
           },
           "public_incident.postmortem_document_status_updated_v1": {
             "$ref": "#/components/schemas/PostmortemDocumentWithStatusChangeV1"
+          },
+          "schedule.shift_change_v1": {
+            "$ref": "#/components/schemas/ScheduleShiftChangeV2"
           }
         },
         "required": [
@@ -51243,10 +52627,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_alert.alert_created_v1",
             "type": "string"
@@ -51258,6 +52649,171 @@
         "required": [
           "event_type",
           "private_alert.alert_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateAlertResolvedV1ResponseBody": {
+        "example": {
+          "event_type": "private_alert.alert_resolved_v1",
+          "private_alert.alert_resolved_v1": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "public_alert.alert_created_v1",
+              "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1",
+              "public_incident.postmortem_document_status_updated_v1",
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
+            ],
+            "example": "private_alert.alert_resolved_v1",
+            "type": "string"
+          },
+          "private_alert.alert_resolved_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_alert.alert_resolved_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateEscalationCreatedV1ResponseBody": {
+        "example": {
+          "event_type": "private_escalation.escalation_created_v1",
+          "private_escalation.escalation_created_v1": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "public_alert.alert_created_v1",
+              "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1",
+              "public_incident.postmortem_document_status_updated_v1",
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
+            ],
+            "example": "private_escalation.escalation_created_v1",
+            "type": "string"
+          },
+          "private_escalation.escalation_created_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_escalation.escalation_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPrivateEscalationStatusUpdatedV1ResponseBody": {
+        "example": {
+          "event_type": "private_escalation.escalation_status_updated_v1",
+          "private_escalation.escalation_status_updated_v1": {
+            "id": "abc123"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "public_alert.alert_created_v1",
+              "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1",
+              "public_incident.postmortem_document_status_updated_v1",
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
+            ],
+            "example": "private_escalation.escalation_status_updated_v1",
+            "type": "string"
+          },
+          "private_escalation.escalation_status_updated_v1": {
+            "$ref": "#/components/schemas/WebhookPrivateResourceV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "private_escalation.escalation_status_updated_v1"
         ],
         "type": "object"
       },
@@ -51291,10 +52847,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.action_created_v1",
             "type": "string"
@@ -51339,10 +52902,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.action_updated_v1",
             "type": "string"
@@ -51387,10 +52957,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.follow_up_created_v1",
             "type": "string"
@@ -51435,10 +53012,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.follow_up_created_v2",
             "type": "string"
@@ -51483,10 +53067,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.follow_up_updated_v1",
             "type": "string"
@@ -51531,10 +53122,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.follow_up_updated_v2",
             "type": "string"
@@ -51579,10 +53177,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.incident_created_v2",
             "type": "string"
@@ -51627,10 +53232,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.incident_updated_v2",
             "type": "string"
@@ -51677,10 +53289,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.membership_granted_v1",
             "type": "string"
@@ -51727,10 +53346,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.membership_revoked_v1",
             "type": "string"
@@ -51775,10 +53401,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "private_incident.postmortem_document_status_updated_v1",
             "type": "string"
@@ -51864,10 +53497,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_alert.alert_created_v1",
             "type": "string"
@@ -51879,6 +53519,387 @@
         "required": [
           "event_type",
           "public_alert.alert_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicAlertResolvedV1ResponseBody": {
+        "example": {
+          "event_type": "public_alert.alert_resolved_v1",
+          "public_alert.alert_resolved_v1": {
+            "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+            "attributes": [
+              {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "label": "Payments Team",
+                    "literal": "SEV123"
+                  }
+                ],
+                "attribute": {
+                  "array": false,
+                  "emoji": "fire",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "name": "service",
+                  "required": false,
+                  "type": "CatalogEntry[\"01GW2G3V0S59R238FAHPDS1R67\"]"
+                },
+                "value": {
+                  "catalog_entry": {
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Primary On-call"
+                  },
+                  "label": "Payments Team",
+                  "literal": "SEV123"
+                }
+              }
+            ],
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "deduplication_key": "4293868629",
+            "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+            "id": "01GW2G3V0S59R238FAHPDS1R66",
+            "resolved_at": "2021-08-17T14:28:57.801578Z",
+            "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+            "status": "firing",
+            "title": "*errors.withMessage: PG::Error failed to connect",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "public_alert.alert_created_v1",
+              "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1",
+              "public_incident.postmortem_document_status_updated_v1",
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
+            ],
+            "example": "public_alert.alert_resolved_v1",
+            "type": "string"
+          },
+          "public_alert.alert_resolved_v1": {
+            "$ref": "#/components/schemas/AlertV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_alert.alert_resolved_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicEscalationCreatedV1ResponseBody": {
+        "example": {
+          "event_type": "public_escalation.escalation_created_v1",
+          "public_escalation.escalation_created_v1": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "events": [
+              {
+                "channels": [
+                  {
+                    "microsoft_teams_channel_id": "abc123",
+                    "microsoft_teams_team_id": "abc123",
+                    "slack_channel_id": "abc123",
+                    "slack_team_id": "abc123"
+                  }
+                ],
+                "event": "entered_grace_period",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "occurred_at": "2021-08-17T13:28:57.801578Z",
+                "urgency": "high",
+                "users": [
+                  {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "owner",
+                    "slack_user_id": "U02AYNF2XJM"
+                  }
+                ]
+              }
+            ],
+            "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "priority": {
+              "name": "P1"
+            },
+            "related_alerts": [
+              {
+                "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "deduplication_key": "4293868629",
+                "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "resolved_at": "2021-08-17T14:28:57.801578Z",
+                "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                "status": "firing",
+                "title": "*errors.withMessage: PG::Error failed to connect",
+                "updated_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "related_incidents": [
+              {
+                "external_id": 123,
+                "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                "name": "Our database is sad",
+                "reference": "INC-123",
+                "status_category": "triage",
+                "summary": "Our database is really really sad, and we don't know why yet.",
+                "visibility": "public"
+              }
+            ],
+            "status": "pending",
+            "title": "Database CPU is high",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "public_alert.alert_created_v1",
+              "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1",
+              "public_incident.postmortem_document_status_updated_v1",
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
+            ],
+            "example": "public_escalation.escalation_created_v1",
+            "type": "string"
+          },
+          "public_escalation.escalation_created_v1": {
+            "$ref": "#/components/schemas/EscalationV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_escalation.escalation_created_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksPublicEscalationStatusUpdatedV1ResponseBody": {
+        "example": {
+          "event_type": "public_escalation.escalation_status_updated_v1",
+          "public_escalation.escalation_status_updated_v1": {
+            "actor": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "escalation": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "creator": {
+                "alert": {
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "title": "*errors.withMessage: PG::Error failed to connect"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "owner",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "workflow": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My little workflow"
+                }
+              },
+              "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "events": [
+                {
+                  "channels": [
+                    {
+                      "microsoft_teams_channel_id": "abc123",
+                      "microsoft_teams_team_id": "abc123",
+                      "slack_channel_id": "abc123",
+                      "slack_team_id": "abc123"
+                    }
+                  ],
+                  "event": "entered_grace_period",
+                  "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "urgency": "high",
+                  "users": [
+                    {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "owner",
+                      "slack_user_id": "U02AYNF2XJM"
+                    }
+                  ]
+                }
+              ],
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "priority": {
+                "name": "P1"
+              },
+              "related_alerts": [
+                {
+                  "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "created_at": "2021-08-17T13:28:57.801578Z",
+                  "deduplication_key": "4293868629",
+                  "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "resolved_at": "2021-08-17T14:28:57.801578Z",
+                  "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                  "status": "firing",
+                  "title": "*errors.withMessage: PG::Error failed to connect",
+                  "updated_at": "2021-08-17T13:28:57.801578Z"
+                }
+              ],
+              "related_incidents": [
+                {
+                  "external_id": 123,
+                  "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                  "name": "Our database is sad",
+                  "reference": "INC-123",
+                  "status_category": "triage",
+                  "summary": "Our database is really really sad, and we don't know why yet.",
+                  "visibility": "public"
+                }
+              ],
+              "status": "pending",
+              "title": "Database CPU is high",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            },
+            "new_status": "pending",
+            "previous_status": "pending"
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "public_alert.alert_created_v1",
+              "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1",
+              "public_incident.postmortem_document_status_updated_v1",
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
+            ],
+            "example": "public_escalation.escalation_status_updated_v1",
+            "type": "string"
+          },
+          "public_escalation.escalation_status_updated_v1": {
+            "$ref": "#/components/schemas/EscalationWithStatusChangeV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "public_escalation.escalation_status_updated_v1"
         ],
         "type": "object"
       },
@@ -51931,10 +53952,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.action_created_v1",
             "type": "string"
@@ -51998,10 +54026,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.action_updated_v1",
             "type": "string"
@@ -52065,10 +54100,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.follow_up_created_v1",
             "type": "string"
@@ -52163,10 +54205,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.follow_up_created_v2",
             "type": "string"
@@ -52230,10 +54279,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.follow_up_updated_v1",
             "type": "string"
@@ -52328,10 +54384,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.follow_up_updated_v2",
             "type": "string"
@@ -52537,10 +54600,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.incident_created_v2",
             "type": "string"
@@ -52763,10 +54833,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.incident_status_updated_v2",
             "type": "string"
@@ -52972,10 +55049,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.incident_updated_v2",
             "type": "string"
@@ -53044,10 +55128,17 @@
               "private_incident.action_updated_v1",
               "public_alert.alert_created_v1",
               "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
               "private_incident.membership_granted_v1",
               "private_incident.membership_revoked_v1",
               "public_incident.postmortem_document_status_updated_v1",
-              "private_incident.postmortem_document_status_updated_v1"
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
             ],
             "example": "public_incident.postmortem_document_status_updated_v1",
             "type": "string"
@@ -53059,6 +55150,88 @@
         "required": [
           "event_type",
           "public_incident.postmortem_document_status_updated_v1"
+        ],
+        "type": "object"
+      },
+      "WebhooksScheduleShiftChangeV1ResponseBody": {
+        "example": {
+          "event_type": "schedule.shift_change_v1",
+          "schedule.shift_change_v1": {
+            "current_users": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
+            "previous_users": [
+              {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            ],
+            "schedule": {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "name": "Primary On-Call Schedule",
+              "team_ids": [
+                "01JPQA75EPNEES4479P16P4XAB"
+              ],
+              "timezone": "Europe/London",
+              "updated_at": "2021-08-17T13:28:57.801578Z"
+            }
+          }
+        },
+        "properties": {
+          "event_type": {
+            "description": "What type of event is this webhook for?",
+            "enum": [
+              "public_incident.incident_created_v2",
+              "private_incident.incident_created_v2",
+              "public_incident.incident_updated_v2",
+              "private_incident.incident_updated_v2",
+              "public_incident.incident_status_updated_v2",
+              "public_incident.follow_up_created_v1",
+              "private_incident.follow_up_created_v1",
+              "public_incident.follow_up_updated_v1",
+              "private_incident.follow_up_updated_v1",
+              "public_incident.follow_up_created_v2",
+              "private_incident.follow_up_created_v2",
+              "public_incident.follow_up_updated_v2",
+              "private_incident.follow_up_updated_v2",
+              "public_incident.action_created_v1",
+              "private_incident.action_created_v1",
+              "public_incident.action_updated_v1",
+              "private_incident.action_updated_v1",
+              "public_alert.alert_created_v1",
+              "private_alert.alert_created_v1",
+              "public_alert.alert_resolved_v1",
+              "private_alert.alert_resolved_v1",
+              "public_escalation.escalation_created_v1",
+              "private_escalation.escalation_created_v1",
+              "public_escalation.escalation_status_updated_v1",
+              "private_escalation.escalation_status_updated_v1",
+              "private_incident.membership_granted_v1",
+              "private_incident.membership_revoked_v1",
+              "public_incident.postmortem_document_status_updated_v1",
+              "private_incident.postmortem_document_status_updated_v1",
+              "schedule.shift_change_v1"
+            ],
+            "example": "schedule.shift_change_v1",
+            "type": "string"
+          },
+          "schedule.shift_change_v1": {
+            "$ref": "#/components/schemas/ScheduleShiftChangeV2"
+          }
+        },
+        "required": [
+          "event_type",
+          "schedule.shift_change_v1"
         ],
         "type": "object"
       },
@@ -67219,6 +69392,7 @@
                               {
                                 "id": "lawrencejones",
                                 "schedule_mode": "currently_on_call",
+                                "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                                 "type": "schedule",
                                 "urgency": "high"
                               }
@@ -67232,6 +69406,7 @@
                               {
                                 "id": "lawrencejones",
                                 "schedule_mode": "currently_on_call",
+                                "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                                 "type": "schedule",
                                 "urgency": "high"
                               }
@@ -67346,6 +69521,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
+                          "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "type": "schedule",
                           "urgency": "high"
                         }
@@ -67359,6 +69535,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
+                          "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "type": "schedule",
                           "urgency": "high"
                         }
@@ -67474,6 +69651,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
+                              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "type": "schedule",
                               "urgency": "high"
                             }
@@ -67487,6 +69665,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
+                              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "type": "schedule",
                               "urgency": "high"
                             }
@@ -67759,6 +69938,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
+                              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "type": "schedule",
                               "urgency": "high"
                             }
@@ -67772,6 +69952,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
+                              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "type": "schedule",
                               "urgency": "high"
                             }
@@ -67947,6 +70128,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
+                              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "type": "schedule",
                               "urgency": "high"
                             }
@@ -67960,6 +70142,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
+                              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "type": "schedule",
                               "urgency": "high"
                             }
@@ -68083,6 +70266,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
+                          "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "type": "schedule",
                           "urgency": "high"
                         }
@@ -68096,6 +70280,7 @@
                         {
                           "id": "lawrencejones",
                           "schedule_mode": "currently_on_call",
+                          "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                           "type": "schedule",
                           "urgency": "high"
                         }
@@ -68211,6 +70396,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
+                              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "type": "schedule",
                               "urgency": "high"
                             }
@@ -68224,6 +70410,7 @@
                             {
                               "id": "lawrencejones",
                               "schedule_mode": "currently_on_call",
+                              "selected_rota_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                               "type": "schedule",
                               "urgency": "high"
                             }
@@ -71082,7 +73269,7 @@
     },
     "/v2/schedule_entries": {
       "get": {
-        "description": "Get a list of schedule entries. The endpoint will return all entries that overlap with the given window, if one is provided.",
+        "description": "List the schedule entries for a schedule over a window of time.\n\nUse this endpoint to find out who is on-call for a schedule, either right now or\nat any point in the future. Common uses include:\n\n- Building a calendar or timeline view of who is on-call.\n- Looking up who was on-call at a particular moment (for example, when an\n  incident fired).\n- Exporting upcoming shifts into another system, such as a payroll or\n  scheduling tool.\n\nThe response groups entries into three lists: `scheduled` (the entries the\nrotation rules produce, before any overrides), `overrides` (any one-off\noverrides that apply in the window) and `final` (the effective schedule\nafter overrides have been merged in — this is normally the list you want).\n\nEach entry includes the `rotation_id` and `layer_id` it belongs to.\nSchedules can be made up of multiple rotations (for example, a primary and\na secondary rotation) and each rotation can have several layers, and we\nreturn entries for every rotation and layer on the schedule.\n\nThe endpoint returns all entries that overlap with the given window. If no\nwindow is provided we default to a sensible range starting from now.",
         "operationId": "Schedules V2#ListScheduleEntries",
         "parameters": [
           {
@@ -71271,6 +73458,210 @@
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Schedule Overrides V2",
         "x-docs-resource-type": "ScheduleOverrideV2"
+      }
+    },
+    "/v2/schedule_sync_targets": {
+      "get": {
+        "description": "List all schedule sync targets for this organisation.",
+        "operationId": "Schedule Sync Targets V2#List",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "description": "Integer number of records to return",
+            "example": 25,
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 25,
+              "description": "Integer number of records to return",
+              "example": 25,
+              "format": "int64",
+              "maximum": 250,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "A sync target's ID. This endpoint will return a list of sync targets after this ID in relation to the API response order.",
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": "01FDAG4SAP5TYPT98WGR2N7W91"
+              }
+            },
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "description": "A sync target's ID. This endpoint will return a list of sync targets after this ID in relation to the API response order.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  },
+                  "schedule_sync_targets": [
+                    {
+                      "add_bot_to_group": true,
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "id": "01JXYZ000000000000000000AB",
+                      "slack_team_id": "T02A1AZHG3J",
+                      "slack_user_group_id": "S06MNNU5BMK",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleSyncTargetsListResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "List Schedule Sync Targets V2",
+        "tags": [
+          "Schedule Sync Targets V2"
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Schedule Sync Targets V2",
+        "x-docs-resource-type": "ScheduleSyncTargetResourceV2"
+      },
+      "post": {
+        "description": "Create a new schedule sync target for a Slack user group.",
+        "operationId": "Schedule Sync Targets V2#Create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "schedule_sync_target": {
+                  "add_bot_to_group": true,
+                  "slack_user_group_id": "S06MNNU5BMK"
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleSyncTargetsCreatePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "schedule_sync_target": {
+                    "add_bot_to_group": true,
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "id": "01JXYZ000000000000000000AB",
+                    "slack_team_id": "T02A1AZHG3J",
+                    "slack_user_group_id": "S06MNNU5BMK",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleSyncTargetsCreateResultV2"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "Create Schedule Sync Targets V2",
+        "tags": [
+          "Schedule Sync Targets V2"
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Schedule Sync Targets V2",
+        "x-docs-resource-type": "ScheduleSyncTargetResourceV2"
+      }
+    },
+    "/v2/schedule_sync_targets/{id}": {
+      "delete": {
+        "description": "Archive a schedule sync target. Will fail if any active sync rules reference this target.",
+        "operationId": "Schedule Sync Targets V2#Destroy",
+        "parameters": [
+          {
+            "description": "The sync target ID to archive",
+            "example": "abc123",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The sync target ID to archive",
+              "example": "abc123",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        },
+        "summary": "Destroy Schedule Sync Targets V2",
+        "tags": [
+          "Schedule Sync Targets V2"
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Schedule Sync Targets V2",
+        "x-docs-resource-type": "ScheduleSyncTargetResourceV2"
+      },
+      "get": {
+        "description": "Get a single schedule sync target.",
+        "operationId": "Schedule Sync Targets V2#Show",
+        "parameters": [
+          {
+            "description": "The sync target ID",
+            "example": "abc123",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The sync target ID",
+              "example": "abc123",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "schedule_sync_target": {
+                    "add_bot_to_group": true,
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "id": "01JXYZ000000000000000000AB",
+                    "slack_team_id": "T02A1AZHG3J",
+                    "slack_user_group_id": "S06MNNU5BMK",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleSyncTargetsShowResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "Show Schedule Sync Targets V2",
+        "tags": [
+          "Schedule Sync Targets V2"
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Schedule Sync Targets V2",
+        "x-docs-resource-type": "ScheduleSyncTargetResourceV2"
       }
     },
     "/v2/schedules": {
@@ -72289,6 +74680,284 @@
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Schedule Replicas V2",
         "x-docs-resource-type": "ScheduleReplicaV2"
+      }
+    },
+    "/v2/schedules/{schedule_id}/sync_rules": {
+      "get": {
+        "description": "List the sync rules configured on this schedule.",
+        "operationId": "Schedules V2#ListScheduleSyncRules",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "description": "Integer number of records to return",
+            "example": 25,
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 25,
+              "description": "Integer number of records to return",
+              "example": 25,
+              "format": "int64",
+              "maximum": 250,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "A sync rule's ID. This endpoint will return a list of sync rules after this ID in relation to the API response order.",
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": "01JXYZ000000000000000000CD"
+              }
+            },
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "description": "A sync rule's ID. This endpoint will return a list of sync rules after this ID in relation to the API response order.",
+              "example": "01JXYZ000000000000000000CD",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The schedule to list sync rules for",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "path",
+            "name": "schedule_id",
+            "required": true,
+            "schema": {
+              "description": "The schedule to list sync rules for",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  },
+                  "schedule_sync_rules": [
+                    {
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "id": "01JXYZ000000000000000000CD",
+                      "schedule_id": "01JXYZ000000000000000000EF",
+                      "schedule_sync_target": {
+                        "add_bot_to_group": true,
+                        "created_at": "2021-08-17T13:28:57.801578Z",
+                        "id": "01JXYZ000000000000000000AB",
+                        "slack_team_id": "T02A1AZHG3J",
+                        "slack_user_group_id": "S06MNNU5BMK",
+                        "updated_at": "2021-08-17T13:28:57.801578Z"
+                      },
+                      "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+                      "sync_type": "on_call",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SchedulesListScheduleSyncRulesResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ListScheduleSyncRules Schedules V2",
+        "tags": [
+          "Schedules V2"
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Schedule Sync Rules V2",
+        "x-docs-resource-type": "ScheduleSyncRuleV2"
+      },
+      "post": {
+        "description": "Create a new sync rule linking a schedule to a sync target.",
+        "operationId": "Schedules V2#CreateScheduleSyncRule",
+        "parameters": [
+          {
+            "description": "The schedule to create a sync rule for",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "path",
+            "name": "schedule_id",
+            "required": true,
+            "schema": {
+              "description": "The schedule to create a sync rule for",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "schedule_sync_rule": {
+                  "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+                  "sync_type": "on_call"
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SchedulesCreateScheduleSyncRulePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "schedule_sync_rule": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "id": "01JXYZ000000000000000000CD",
+                    "schedule_id": "01JXYZ000000000000000000EF",
+                    "schedule_sync_target": {
+                      "add_bot_to_group": true,
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "id": "01JXYZ000000000000000000AB",
+                      "slack_team_id": "T02A1AZHG3J",
+                      "slack_user_group_id": "S06MNNU5BMK",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    },
+                    "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+                    "sync_type": "on_call",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SchedulesCreateScheduleSyncRuleResultV2"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "CreateScheduleSyncRule Schedules V2",
+        "tags": [
+          "Schedules V2"
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Schedule Sync Rules V2",
+        "x-docs-resource-type": "ScheduleSyncRuleV2"
+      }
+    },
+    "/v2/schedules/{schedule_id}/sync_rules/{id}": {
+      "delete": {
+        "description": "Archive a sync rule, unlinking the schedule from the sync target.",
+        "operationId": "Schedules V2#DestroyScheduleSyncRule",
+        "parameters": [
+          {
+            "description": "The parent schedule ID",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "path",
+            "name": "schedule_id",
+            "required": true,
+            "schema": {
+              "description": "The parent schedule ID",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The sync rule ID to archive",
+            "example": "01JXYZ000000000000000000CD",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The sync rule ID to archive",
+              "example": "01JXYZ000000000000000000CD",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        },
+        "summary": "DestroyScheduleSyncRule Schedules V2",
+        "tags": [
+          "Schedules V2"
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Schedule Sync Rules V2",
+        "x-docs-resource-type": "ScheduleSyncRuleV2"
+      },
+      "get": {
+        "description": "Get a single sync rule for a schedule.",
+        "operationId": "Schedules V2#ShowScheduleSyncRule",
+        "parameters": [
+          {
+            "description": "The parent schedule ID",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "path",
+            "name": "schedule_id",
+            "required": true,
+            "schema": {
+              "description": "The parent schedule ID",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The sync rule ID",
+            "example": "01JXYZ000000000000000000CD",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The sync rule ID",
+              "example": "01JXYZ000000000000000000CD",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "schedule_sync_rule": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "id": "01JXYZ000000000000000000CD",
+                    "schedule_id": "01JXYZ000000000000000000EF",
+                    "schedule_sync_target": {
+                      "add_bot_to_group": true,
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "id": "01JXYZ000000000000000000AB",
+                      "slack_team_id": "T02A1AZHG3J",
+                      "slack_user_group_id": "S06MNNU5BMK",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    },
+                    "schedule_sync_target_id": "01JXYZ000000000000000000AB",
+                    "sync_type": "on_call",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SchedulesShowScheduleSyncRuleResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ShowScheduleSyncRule Schedules V2",
+        "tags": [
+          "Schedules V2"
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Schedule Sync Rules V2",
+        "x-docs-resource-type": "ScheduleSyncRuleV2"
       }
     },
     "/v2/status_page_incident_updates": {
@@ -73644,6 +76313,87 @@
         "x-docs-display-name": "List",
         "x-docs-group-name": "Notification Rules V2",
         "x-docs-resource-type": "OnCallNotificationRulePublicV2"
+      }
+    },
+    "/v2/users/{user_id}/paging_provider": {
+      "get": {
+        "description": "Show the paging provider that would be used to escalate to this user. Reflects their explicit preference if set; otherwise resolves to the effective fallback (typically `native` for on-call seat users, or a linked external provider otherwise). May be omitted only when the user cannot be escalated to at all (no seat and no linked external user).",
+        "operationId": "Users V2#ShowPagingProvider",
+        "parameters": [
+          {
+            "description": "The ID of the user.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The ID of the user.",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "preferred_escalation_provider": "native"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/UsersShowPagingProviderResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ShowPagingProvider Users V2",
+        "tags": [
+          "Users V2"
+        ],
+        "x-docs-group-name": "Users V2"
+      },
+      "post": {
+        "description": "Update a user's preferred paging provider.",
+        "operationId": "Users V2#UpdatePagingProvider",
+        "parameters": [
+          {
+            "description": "The ID of the user to update.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The ID of the user to update.",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "preferred_escalation_provider": "native"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/UsersUpdatePagingProviderPayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        },
+        "summary": "UpdatePagingProvider Users V2",
+        "tags": [
+          "Users V2"
+        ],
+        "x-docs-group-name": "Users V2"
       }
     },
     "/v2/users/{user_id}/policies/{policy_id}/open": {
@@ -76646,6 +79396,10 @@
     {
       "description": "Manage post-mortem documents.\n\nPost-mortem documents capture the learnings from an incident, and are associated with a specific\nincident. Use this API to list and retrieve post-mortem documents, update their status, and fetch\nthe full document's content.\n",
       "name": "PostmortemDocuments V1"
+    },
+    {
+      "description": "Manage schedule sync targets (Slack user groups that schedules can sync to).",
+      "name": "Schedule Sync Targets V2"
     },
     {
       "description": "View and manage schedules.\nManage your full schedule of on-call rotations, including the users and rotation configuration.\n",
@@ -82614,6 +85368,190 @@
         ]
       }
     },
+    "/x-audit-logs/schedule_sync_rule.created.1": {
+      "get": {
+        "description": "This entry is created whenever a schedule sync rule is created",
+        "operationId": "ScheduleSyncRuleCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "schedule_sync_rule.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "on_call sync rule to Slack user group S012345ABCD",
+                      "type": "schedule_sync_rule"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsScheduleSyncRuleCreatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/schedule_sync_rule.deleted.1": {
+      "get": {
+        "description": "This entry is created whenever a schedule sync rule is deleted",
+        "operationId": "ScheduleSyncRuleDeletedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "schedule_sync_rule.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "on_call sync rule to Slack user group S012345ABCD",
+                      "type": "schedule_sync_rule"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsScheduleSyncRuleDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/schedule_sync_target.created.1": {
+      "get": {
+        "description": "This entry is created whenever a schedule sync target is created",
+        "operationId": "ScheduleSyncTargetCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "schedule_sync_target.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Slack user group S012345ABCD",
+                      "type": "schedule_sync_target"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsScheduleSyncTargetCreatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/schedule_sync_target.deleted.1": {
+      "get": {
+        "description": "This entry is created whenever a schedule sync target is deleted",
+        "operationId": "ScheduleSyncTargetDeletedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "schedule_sync_target.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Slack user group S012345ABCD",
+                      "type": "schedule_sync_target"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsScheduleSyncTargetDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
     "/x-audit-logs/scim_group.role_mappings_updated.1": {
       "get": {
         "description": "This entry is created whenever a SCIM group is mapped to a new RBAC role",
@@ -83991,6 +86929,87 @@
         ]
       }
     },
+    "/x-webhooks/private_alert.alert_resolved_v1": {
+      "get": {
+        "description": "This webhook is emitted whenever a private alert is resolved.",
+        "operationId": "PrivateAlertResolvedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "private_alert.alert_resolved_v1",
+                  "private_alert.alert_resolved_v1": {
+                    "id": "abc123"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPrivateAlertResolvedV1ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
+    "/x-webhooks/private_escalation.escalation_created_v1": {
+      "get": {
+        "description": "This webhook is emitted whenever a private escalation is created.",
+        "operationId": "PrivateEscalationCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "private_escalation.escalation_created_v1",
+                  "private_escalation.escalation_created_v1": {
+                    "id": "abc123"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPrivateEscalationCreatedV1ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
+    "/x-webhooks/private_escalation.escalation_status_updated_v1": {
+      "get": {
+        "description": "This webhook is emitted whenever a private escalation changes status.",
+        "operationId": "PrivateEscalationStatusUpdatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "private_escalation.escalation_status_updated_v1",
+                  "private_escalation.escalation_status_updated_v1": {
+                    "id": "abc123"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPrivateEscalationStatusUpdatedV1ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
     "/x-webhooks/private_incident.action_created_v1": {
       "get": {
         "description": "This webhook is emitted whenever a follow-up for a private incident is created.",
@@ -84349,6 +87368,303 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/WebhooksPublicAlertCreatedV1ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
+    "/x-webhooks/public_alert.alert_resolved_v1": {
+      "get": {
+        "description": "This webhook is emitted whenever an alert is resolved.",
+        "operationId": "PublicAlertResolvedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "public_alert.alert_resolved_v1",
+                  "public_alert.alert_resolved_v1": {
+                    "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "attributes": [
+                      {
+                        "array_value": [
+                          {
+                            "catalog_entry": {
+                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Primary On-call"
+                            },
+                            "label": "Payments Team",
+                            "literal": "SEV123"
+                          }
+                        ],
+                        "attribute": {
+                          "array": false,
+                          "emoji": "fire",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "name": "service",
+                          "required": false,
+                          "type": "CatalogEntry[\"01GW2G3V0S59R238FAHPDS1R67\"]"
+                        },
+                        "value": {
+                          "catalog_entry": {
+                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "name": "Primary On-call"
+                          },
+                          "label": "Payments Team",
+                          "literal": "SEV123"
+                        }
+                      }
+                    ],
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "deduplication_key": "4293868629",
+                    "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                    "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "resolved_at": "2021-08-17T14:28:57.801578Z",
+                    "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                    "status": "firing",
+                    "title": "*errors.withMessage: PG::Error failed to connect",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPublicAlertResolvedV1ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
+    "/x-webhooks/public_escalation.escalation_created_v1": {
+      "get": {
+        "description": "This webhook is emitted whenever an escalation is created.",
+        "operationId": "PublicEscalationCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "public_escalation.escalation_created_v1",
+                  "public_escalation.escalation_created_v1": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "creator": {
+                      "alert": {
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "title": "*errors.withMessage: PG::Error failed to connect"
+                      },
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "owner",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
+                      }
+                    },
+                    "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "events": [
+                      {
+                        "channels": [
+                          {
+                            "microsoft_teams_channel_id": "abc123",
+                            "microsoft_teams_team_id": "abc123",
+                            "slack_channel_id": "abc123",
+                            "slack_team_id": "abc123"
+                          }
+                        ],
+                        "event": "entered_grace_period",
+                        "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                        "occurred_at": "2021-08-17T13:28:57.801578Z",
+                        "urgency": "high",
+                        "users": [
+                          {
+                            "email": "lisa@incident.io",
+                            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "name": "Lisa Karlin Curtis",
+                            "role": "owner",
+                            "slack_user_id": "U02AYNF2XJM"
+                          }
+                        ]
+                      }
+                    ],
+                    "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                    "priority": {
+                      "name": "P1"
+                    },
+                    "related_alerts": [
+                      {
+                        "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "created_at": "2021-08-17T13:28:57.801578Z",
+                        "deduplication_key": "4293868629",
+                        "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "resolved_at": "2021-08-17T14:28:57.801578Z",
+                        "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                        "status": "firing",
+                        "title": "*errors.withMessage: PG::Error failed to connect",
+                        "updated_at": "2021-08-17T13:28:57.801578Z"
+                      }
+                    ],
+                    "related_incidents": [
+                      {
+                        "external_id": 123,
+                        "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                        "name": "Our database is sad",
+                        "reference": "INC-123",
+                        "status_category": "triage",
+                        "summary": "Our database is really really sad, and we don't know why yet.",
+                        "visibility": "public"
+                      }
+                    ],
+                    "status": "pending",
+                    "title": "Database CPU is high",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPublicEscalationCreatedV1ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
+    "/x-webhooks/public_escalation.escalation_status_updated_v1": {
+      "get": {
+        "description": "This webhook is emitted whenever an escalation changes status. See [escalation statuses](https://docs.incident.io/on-call/escalation-statuses) for details on each status value.",
+        "operationId": "PublicEscalationStatusUpdatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "public_escalation.escalation_status_updated_v1",
+                  "public_escalation.escalation_status_updated_v1": {
+                    "actor": {
+                      "alert": {
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "title": "*errors.withMessage: PG::Error failed to connect"
+                      },
+                      "api_key": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My test API key"
+                      },
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "owner",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
+                      }
+                    },
+                    "escalation": {
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "creator": {
+                        "alert": {
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "title": "*errors.withMessage: PG::Error failed to connect"
+                        },
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "owner",
+                          "slack_user_id": "U02AYNF2XJM"
+                        },
+                        "workflow": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My little workflow"
+                        }
+                      },
+                      "escalation_path_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "events": [
+                        {
+                          "channels": [
+                            {
+                              "microsoft_teams_channel_id": "abc123",
+                              "microsoft_teams_team_id": "abc123",
+                              "slack_channel_id": "abc123",
+                              "slack_team_id": "abc123"
+                            }
+                          ],
+                          "event": "entered_grace_period",
+                          "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                          "occurred_at": "2021-08-17T13:28:57.801578Z",
+                          "urgency": "high",
+                          "users": [
+                            {
+                              "email": "lisa@incident.io",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Lisa Karlin Curtis",
+                              "role": "owner",
+                              "slack_user_id": "U02AYNF2XJM"
+                            }
+                          ]
+                        }
+                      ],
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "priority": {
+                        "name": "P1"
+                      },
+                      "related_alerts": [
+                        {
+                          "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "created_at": "2021-08-17T13:28:57.801578Z",
+                          "deduplication_key": "4293868629",
+                          "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "resolved_at": "2021-08-17T14:28:57.801578Z",
+                          "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                          "status": "firing",
+                          "title": "*errors.withMessage: PG::Error failed to connect",
+                          "updated_at": "2021-08-17T13:28:57.801578Z"
+                        }
+                      ],
+                      "related_incidents": [
+                        {
+                          "external_id": 123,
+                          "id": "01FDAG4SAP5TYPT98WGR2N7W91",
+                          "name": "Our database is sad",
+                          "reference": "INC-123",
+                          "status_category": "triage",
+                          "summary": "Our database is really really sad, and we don't know why yet.",
+                          "visibility": "public"
+                        }
+                      ],
+                      "status": "pending",
+                      "title": "Database CPU is high",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    },
+                    "new_status": "pending",
+                    "previous_status": "pending"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksPublicEscalationStatusUpdatedV1ResponseBody"
                 }
               }
             },
@@ -85319,6 +88635,60 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/WebhooksPublicIncidentPostmortemDocumentStatusUpdatedV1ResponseBody"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Webhooks"
+        ]
+      }
+    },
+    "/x-webhooks/schedule.shift_change_v1": {
+      "get": {
+        "description": "This webhook is emitted whenever the on-call user(s) change on a schedule.",
+        "operationId": "ScheduleShiftChangeV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "event_type": "schedule.shift_change_v1",
+                  "schedule.shift_change_v1": {
+                    "current_users": [
+                      {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "owner",
+                        "slack_user_id": "U02AYNF2XJM"
+                      }
+                    ],
+                    "previous_users": [
+                      {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "owner",
+                        "slack_user_id": "U02AYNF2XJM"
+                      }
+                    ],
+                    "schedule": {
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "name": "Primary On-Call Schedule",
+                      "team_ids": [
+                        "01JPQA75EPNEES4479P16P4XAB"
+                      ],
+                      "timezone": "Europe/London",
+                      "updated_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksScheduleShiftChangeV1ResponseBody"
                 }
               }
             },

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -862,10 +862,13 @@ const (
 
 // Defines values for EscalationPathTargetV2ScheduleMode.
 const (
-	AllUsers        EscalationPathTargetV2ScheduleMode = "all_users"
-	AllUsersForRota EscalationPathTargetV2ScheduleMode = "all_users_for_rota"
-	CurrentlyOnCall EscalationPathTargetV2ScheduleMode = "currently_on_call"
-	Empty           EscalationPathTargetV2ScheduleMode = ""
+	EscalationPathTargetV2ScheduleModeAllUsers               EscalationPathTargetV2ScheduleMode = "all_users"
+	EscalationPathTargetV2ScheduleModeAllUsersForRota        EscalationPathTargetV2ScheduleMode = "all_users_for_rota"
+	EscalationPathTargetV2ScheduleModeCurrentlyOnCall        EscalationPathTargetV2ScheduleMode = "currently_on_call"
+	EscalationPathTargetV2ScheduleModeCurrentlyOnCallForRota EscalationPathTargetV2ScheduleMode = "currently_on_call_for_rota"
+	EscalationPathTargetV2ScheduleModeEmpty                  EscalationPathTargetV2ScheduleMode = ""
+	EscalationPathTargetV2ScheduleModeNextOnCall             EscalationPathTargetV2ScheduleMode = "next_on_call"
+	EscalationPathTargetV2ScheduleModeNextOnCallForRota      EscalationPathTargetV2ScheduleMode = "next_on_call_for_rota"
 )
 
 // Defines values for EscalationPathTargetV2Type.
@@ -1355,6 +1358,18 @@ const (
 	ScheduleRotationWorkingIntervalV2WeekdayWednesday ScheduleRotationWorkingIntervalV2Weekday = "wednesday"
 )
 
+// Defines values for ScheduleSyncRuleCreatePayloadV2SyncType.
+const (
+	ScheduleSyncRuleCreatePayloadV2SyncTypeAllUsers ScheduleSyncRuleCreatePayloadV2SyncType = "all_users"
+	ScheduleSyncRuleCreatePayloadV2SyncTypeOnCall   ScheduleSyncRuleCreatePayloadV2SyncType = "on_call"
+)
+
+// Defines values for ScheduleSyncRuleV2SyncType.
+const (
+	AllUsers ScheduleSyncRuleV2SyncType = "all_users"
+	OnCall   ScheduleSyncRuleV2SyncType = "on_call"
+)
+
 // Defines values for StatusPageIncidentAffectedComponentV2ComponentStatus.
 const (
 	StatusPageIncidentAffectedComponentV2ComponentStatusDegradedPerformance StatusPageIncidentAffectedComponentV2ComponentStatus = "degraded_performance"
@@ -1475,6 +1490,22 @@ const (
 	Responder     UserWithRolesV2Role = "responder"
 	Unset         UserWithRolesV2Role = "unset"
 	Viewer        UserWithRolesV2Role = "viewer"
+)
+
+// Defines values for UsersShowPagingProviderResultV2PreferredEscalationProvider.
+const (
+	UsersShowPagingProviderResultV2PreferredEscalationProviderNative       UsersShowPagingProviderResultV2PreferredEscalationProvider = "native"
+	UsersShowPagingProviderResultV2PreferredEscalationProviderOpsgenie     UsersShowPagingProviderResultV2PreferredEscalationProvider = "opsgenie"
+	UsersShowPagingProviderResultV2PreferredEscalationProviderPagerduty    UsersShowPagingProviderResultV2PreferredEscalationProvider = "pagerduty"
+	UsersShowPagingProviderResultV2PreferredEscalationProviderSplunkOnCall UsersShowPagingProviderResultV2PreferredEscalationProvider = "splunk_on_call"
+)
+
+// Defines values for UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider.
+const (
+	UsersUpdatePagingProviderPayloadV2PreferredEscalationProviderNative       UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "native"
+	UsersUpdatePagingProviderPayloadV2PreferredEscalationProviderOpsgenie     UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "opsgenie"
+	UsersUpdatePagingProviderPayloadV2PreferredEscalationProviderPagerduty    UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "pagerduty"
+	UsersUpdatePagingProviderPayloadV2PreferredEscalationProviderSplunkOnCall UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "splunk_on_call"
 )
 
 // Defines values for WeekdayIntervalV2Weekday.
@@ -4512,8 +4543,11 @@ type EscalationPathTargetV2 struct {
 	// Id Uniquely identifies an entity of this type
 	Id string `json:"id"`
 
-	// ScheduleMode Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+	// ScheduleMode Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 	ScheduleMode *EscalationPathTargetV2ScheduleMode `json:"schedule_mode,omitempty"`
+
+	// SelectedRotaId For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+	SelectedRotaId *string `json:"selected_rota_id,omitempty"`
 
 	// Type Controls what type of entity this target identifies, such as EscalationPolicy or User
 	Type EscalationPathTargetV2Type `json:"type"`
@@ -4522,7 +4556,7 @@ type EscalationPathTargetV2 struct {
 	Urgency EscalationPathTargetV2Urgency `json:"urgency"`
 }
 
-// EscalationPathTargetV2ScheduleMode Only set for schedule targets, and either currently_on_call, all_users or all_users_for_rota and specifies which users to fetch from the schedule
+// EscalationPathTargetV2ScheduleMode Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 type EscalationPathTargetV2ScheduleMode string
 
 // EscalationPathTargetV2Type Controls what type of entity this target identifies, such as EscalationPolicy or User
@@ -6605,14 +6639,43 @@ type ScheduleCreatePayloadV2 struct {
 	Timezone *string `json:"timezone,omitempty"`
 }
 
-// ScheduleEntriesListPayloadV2 defines model for ScheduleEntriesListPayloadV2.
+// ScheduleEntriesListPayloadV2 The schedule entries for a window of time, grouped by where they come from.
+//
+// `scheduled` are the entries produced by the schedule's rotation rules before
+// any overrides are taken into account. `overrides` are the one-off changes that
+// apply within the window. `final` is the effective schedule after overrides
+// have been merged in — this is normally the list to use when working out who
+// is on-call.
 type ScheduleEntriesListPayloadV2 struct {
-	Final     []ScheduleEntryV2 `json:"final"`
+	// Final The effective schedule after overrides have been merged in
+	Final []ScheduleEntryV2 `json:"final"`
+
+	// Overrides Overrides that apply within the requested window
 	Overrides []ScheduleEntryV2 `json:"overrides"`
+
+	// Scheduled Entries from the schedule's rotation rules, before overrides are applied
 	Scheduled []ScheduleEntryV2 `json:"scheduled"`
 }
 
-// ScheduleEntryV2 defines model for ScheduleEntryV2.
+// ScheduleEntryV2 A single shift on a schedule, representing who is on-call between a start
+// and end time. When present, `rotation_id` and `layer_id` tell you which
+// rotation and which layer within that rotation the entry belongs to. A
+// schedule may have multiple rotations (for example, a primary and a secondary
+// rotation) and each rotation can be made up of several layers — entries are
+// returned for every rotation and layer on the schedule.
+//
+// Entries come from two places: they are either generated from a schedule's
+// rotation configuration (the regular pattern of who is on-call) or created by
+// an override (a one-off change that replaces the normal rotation for a period
+// of time). When you call the List schedule entries endpoint we return both
+// kinds separately, along with the merged `final` schedule that reflects what
+// will actually happen.
+//
+// `entry_id` is only populated for entries that correspond to a stored
+// record. Scheduled entries are projections computed from the rotation rules
+// on the fly and don't have a persisted ID, so `entry_id` will be absent for
+// those. Use `fingerprint` if you need a stable identifier to deduplicate or
+// diff a shift across requests.
 type ScheduleEntryV2 struct {
 	EndAt time.Time `json:"end_at"`
 
@@ -6622,7 +6685,7 @@ type ScheduleEntryV2 struct {
 	// Fingerprint A unique identifier for this entry, used to determine a unique shift
 	Fingerprint *string `json:"fingerprint,omitempty"`
 
-	// LayerId If present, the layer this entry applies to on the rota
+	// LayerId If present, the layer this entry applies to on the rotation
 	LayerId *string `json:"layer_id,omitempty"`
 
 	// RotationId If present, the rotation this entry applies to on the schedule
@@ -6903,6 +6966,87 @@ type ScheduleRotationWorkingIntervalV2 struct {
 // ScheduleRotationWorkingIntervalV2Weekday Weekdays for use with a schedule
 type ScheduleRotationWorkingIntervalV2Weekday string
 
+// ScheduleSyncRuleCreatePayloadV2 defines model for ScheduleSyncRuleCreatePayloadV2.
+type ScheduleSyncRuleCreatePayloadV2 struct {
+	// ScheduleSyncTargetId The sync target to link to
+	ScheduleSyncTargetId string `json:"schedule_sync_target_id"`
+
+	// SyncType Which schedule members sync to the user group
+	SyncType ScheduleSyncRuleCreatePayloadV2SyncType `json:"sync_type"`
+}
+
+// ScheduleSyncRuleCreatePayloadV2SyncType Which schedule members sync to the user group
+type ScheduleSyncRuleCreatePayloadV2SyncType string
+
+// ScheduleSyncRuleV2 defines model for ScheduleSyncRuleV2.
+type ScheduleSyncRuleV2 struct {
+	CreatedAt time.Time `json:"created_at"`
+
+	// Id Unique identifier of the sync rule
+	Id string `json:"id"`
+
+	// ScheduleId The schedule this rule belongs to
+	ScheduleId         string                       `json:"schedule_id"`
+	ScheduleSyncTarget ScheduleSyncTargetResourceV2 `json:"schedule_sync_target"`
+
+	// ScheduleSyncTargetId The sync target ID this rule links to
+	ScheduleSyncTargetId string `json:"schedule_sync_target_id"`
+
+	// SyncType Which schedule members sync to the user group
+	SyncType  ScheduleSyncRuleV2SyncType `json:"sync_type"`
+	UpdatedAt time.Time                  `json:"updated_at"`
+}
+
+// ScheduleSyncRuleV2SyncType Which schedule members sync to the user group
+type ScheduleSyncRuleV2SyncType string
+
+// ScheduleSyncTargetCreatePayloadV2 defines model for ScheduleSyncTargetCreatePayloadV2.
+type ScheduleSyncTargetCreatePayloadV2 struct {
+	// AddBotToGroup Whether the incident.io bot should be added to the group
+	AddBotToGroup bool `json:"add_bot_to_group"`
+
+	// SlackUserGroupId Slack ID for the user group to sync to
+	SlackUserGroupId string `json:"slack_user_group_id"`
+}
+
+// ScheduleSyncTargetResourceV2 defines model for ScheduleSyncTargetResourceV2.
+type ScheduleSyncTargetResourceV2 struct {
+	// AddBotToGroup Whether the incident.io bot should be added to the group
+	AddBotToGroup bool      `json:"add_bot_to_group"`
+	CreatedAt     time.Time `json:"created_at"`
+
+	// Id Unique identifier of the sync target
+	Id string `json:"id"`
+
+	// SlackTeamId Slack team ID for the user group
+	SlackTeamId string `json:"slack_team_id"`
+
+	// SlackUserGroupId Slack ID for the user group synced to
+	SlackUserGroupId string    `json:"slack_user_group_id"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+// ScheduleSyncTargetsCreatePayloadV2 defines model for ScheduleSyncTargetsCreatePayloadV2.
+type ScheduleSyncTargetsCreatePayloadV2 struct {
+	ScheduleSyncTarget ScheduleSyncTargetCreatePayloadV2 `json:"schedule_sync_target"`
+}
+
+// ScheduleSyncTargetsCreateResultV2 defines model for ScheduleSyncTargetsCreateResultV2.
+type ScheduleSyncTargetsCreateResultV2 struct {
+	ScheduleSyncTarget ScheduleSyncTargetResourceV2 `json:"schedule_sync_target"`
+}
+
+// ScheduleSyncTargetsListResultV2 defines model for ScheduleSyncTargetsListResultV2.
+type ScheduleSyncTargetsListResultV2 struct {
+	PaginationMeta      *PaginationMetaResultV2        `json:"pagination_meta,omitempty"`
+	ScheduleSyncTargets []ScheduleSyncTargetResourceV2 `json:"schedule_sync_targets"`
+}
+
+// ScheduleSyncTargetsShowResultV2 defines model for ScheduleSyncTargetsShowResultV2.
+type ScheduleSyncTargetsShowResultV2 struct {
+	ScheduleSyncTarget ScheduleSyncTargetResourceV2 `json:"schedule_sync_target"`
+}
+
 // ScheduleUpdatePayloadV2 defines model for ScheduleUpdatePayloadV2.
 type ScheduleUpdatePayloadV2 struct {
 	// Annotations Annotations that can track metadata about the schedule
@@ -6992,6 +7136,16 @@ type SchedulesCreateScheduleReplicaResultV2 struct {
 	ScheduleReplica ScheduleReplicaV2 `json:"schedule_replica"`
 }
 
+// SchedulesCreateScheduleSyncRulePayloadV2 defines model for SchedulesCreateScheduleSyncRulePayloadV2.
+type SchedulesCreateScheduleSyncRulePayloadV2 struct {
+	ScheduleSyncRule ScheduleSyncRuleCreatePayloadV2 `json:"schedule_sync_rule"`
+}
+
+// SchedulesCreateScheduleSyncRuleResultV2 defines model for SchedulesCreateScheduleSyncRuleResultV2.
+type SchedulesCreateScheduleSyncRuleResultV2 struct {
+	ScheduleSyncRule ScheduleSyncRuleV2 `json:"schedule_sync_rule"`
+}
+
 // SchedulesListResultV2 defines model for SchedulesListResultV2.
 type SchedulesListResultV2 struct {
 	PaginationMeta *PaginationMetaResultWithTotalV2 `json:"pagination_meta,omitempty"`
@@ -7000,13 +7154,27 @@ type SchedulesListResultV2 struct {
 
 // SchedulesListScheduleEntriesResultV2 defines model for SchedulesListScheduleEntriesResultV2.
 type SchedulesListScheduleEntriesResultV2 struct {
-	PaginationMeta  *AfterPaginationMetaResultV2 `json:"pagination_meta,omitempty"`
+	PaginationMeta *AfterPaginationMetaResultV2 `json:"pagination_meta,omitempty"`
+
+	// ScheduleEntries The schedule entries for a window of time, grouped by where they come from.
+	//
+	// `scheduled` are the entries produced by the schedule's rotation rules before
+	// any overrides are taken into account. `overrides` are the one-off changes that
+	// apply within the window. `final` is the effective schedule after overrides
+	// have been merged in — this is normally the list to use when working out who
+	// is on-call.
 	ScheduleEntries ScheduleEntriesListPayloadV2 `json:"schedule_entries"`
 }
 
 // SchedulesListScheduleReplicasResultV2 defines model for SchedulesListScheduleReplicasResultV2.
 type SchedulesListScheduleReplicasResultV2 struct {
 	ScheduleReplicas []ScheduleReplicaV2 `json:"schedule_replicas"`
+}
+
+// SchedulesListScheduleSyncRulesResultV2 defines model for SchedulesListScheduleSyncRulesResultV2.
+type SchedulesListScheduleSyncRulesResultV2 struct {
+	PaginationMeta    *PaginationMetaResultV2 `json:"pagination_meta,omitempty"`
+	ScheduleSyncRules []ScheduleSyncRuleV2    `json:"schedule_sync_rules"`
 }
 
 // SchedulesShowResultV2 defines model for SchedulesShowResultV2.
@@ -7017,6 +7185,11 @@ type SchedulesShowResultV2 struct {
 // SchedulesShowScheduleReplicaResultV2 defines model for SchedulesShowScheduleReplicaResultV2.
 type SchedulesShowScheduleReplicaResultV2 struct {
 	ScheduleReplica ScheduleReplicaV2 `json:"schedule_replica"`
+}
+
+// SchedulesShowScheduleSyncRuleResultV2 defines model for SchedulesShowScheduleSyncRuleResultV2.
+type SchedulesShowScheduleSyncRuleResultV2 struct {
+	ScheduleSyncRule ScheduleSyncRuleV2 `json:"schedule_sync_rule"`
 }
 
 // SchedulesUpdatePayloadV2 defines model for SchedulesUpdatePayloadV2.
@@ -7785,10 +7958,28 @@ type UsersListResultV2 struct {
 	Users          []UserWithRolesV2      `json:"users"`
 }
 
+// UsersShowPagingProviderResultV2 defines model for UsersShowPagingProviderResultV2.
+type UsersShowPagingProviderResultV2 struct {
+	// PreferredEscalationProvider The user's effective escalation provider.
+	PreferredEscalationProvider *UsersShowPagingProviderResultV2PreferredEscalationProvider `json:"preferred_escalation_provider,omitempty"`
+}
+
+// UsersShowPagingProviderResultV2PreferredEscalationProvider The user's effective escalation provider.
+type UsersShowPagingProviderResultV2PreferredEscalationProvider string
+
 // UsersShowResultV2 defines model for UsersShowResultV2.
 type UsersShowResultV2 struct {
 	User UserWithRolesV2 `json:"user"`
 }
+
+// UsersUpdatePagingProviderPayloadV2 defines model for UsersUpdatePagingProviderPayloadV2.
+type UsersUpdatePagingProviderPayloadV2 struct {
+	// PreferredEscalationProvider The preferred escalation provider for the user.
+	PreferredEscalationProvider UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider `json:"preferred_escalation_provider"`
+}
+
+// UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider The preferred escalation provider for the user.
+type UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider string
 
 // UtilitiesIdentityResultV1 defines model for UtilitiesIdentityResultV1.
 type UtilitiesIdentityResultV1 struct {
@@ -8440,12 +8631,30 @@ type SchedulesV2ListScheduleEntriesParams struct {
 	EntryWindowEnd *time.Time `form:"entry_window_end,omitempty" json:"entry_window_end,omitempty"`
 }
 
+// ScheduleSyncTargetsV2ListParams defines parameters for ScheduleSyncTargetsV2List.
+type ScheduleSyncTargetsV2ListParams struct {
+	// PageSize Integer number of records to return
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// After A sync target's ID. This endpoint will return a list of sync targets after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
+}
+
 // SchedulesV2ListParams defines parameters for SchedulesV2List.
 type SchedulesV2ListParams struct {
 	// PageSize Note that next_shifts will only be returned when the page size is 25 or lower.
 	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
 
 	// After A schedule's ID. This endpoint will return a list of schedules after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
+}
+
+// SchedulesV2ListScheduleSyncRulesParams defines parameters for SchedulesV2ListScheduleSyncRules.
+type SchedulesV2ListScheduleSyncRulesParams struct {
+	// PageSize Integer number of records to return
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// After A sync rule's ID. This endpoint will return a list of sync rules after this ID in relation to the API response order.
 	After *string `form:"after,omitempty" json:"after,omitempty"`
 }
 
@@ -8703,6 +8912,9 @@ type ManagedResourcesV2CreateManagedResourceJSONRequestBody = ManagedResourcesCr
 // SchedulesV2CreateOverrideJSONRequestBody defines body for SchedulesV2CreateOverride for application/json ContentType.
 type SchedulesV2CreateOverrideJSONRequestBody = SchedulesCreateOverridePayloadV2
 
+// ScheduleSyncTargetsV2CreateJSONRequestBody defines body for ScheduleSyncTargetsV2Create for application/json ContentType.
+type ScheduleSyncTargetsV2CreateJSONRequestBody = ScheduleSyncTargetsCreatePayloadV2
+
 // SchedulesV2CreateJSONRequestBody defines body for SchedulesV2Create for application/json ContentType.
 type SchedulesV2CreateJSONRequestBody = SchedulesCreatePayloadV2
 
@@ -8711,6 +8923,9 @@ type SchedulesV2UpdateJSONRequestBody = SchedulesUpdatePayloadV2
 
 // SchedulesV2CreateScheduleReplicaJSONRequestBody defines body for SchedulesV2CreateScheduleReplica for application/json ContentType.
 type SchedulesV2CreateScheduleReplicaJSONRequestBody = SchedulesCreateScheduleReplicaPayloadV2
+
+// SchedulesV2CreateScheduleSyncRuleJSONRequestBody defines body for SchedulesV2CreateScheduleSyncRule for application/json ContentType.
+type SchedulesV2CreateScheduleSyncRuleJSONRequestBody = SchedulesCreateScheduleSyncRulePayloadV2
 
 // StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody defines body for StatusPagesV2CreateStatusPageIncidentUpdate for application/json ContentType.
 type StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody = StatusPagesCreateStatusPageIncidentUpdatePayloadV2
@@ -8729,6 +8944,9 @@ type StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody = StatusPagesCreate
 
 // TelemetryV2UpdateDataSourceJSONRequestBody defines body for TelemetryV2UpdateDataSource for application/json ContentType.
 type TelemetryV2UpdateDataSourceJSONRequestBody = TelemetryUpdateDataSourcePayloadV2
+
+// UsersV2UpdatePagingProviderJSONRequestBody defines body for UsersV2UpdatePagingProvider for application/json ContentType.
+type UsersV2UpdatePagingProviderJSONRequestBody = UsersUpdatePagingProviderPayloadV2
 
 // WorkflowsV2CreateWorkflowJSONRequestBody defines body for WorkflowsV2CreateWorkflow for application/json ContentType.
 type WorkflowsV2CreateWorkflowJSONRequestBody = WorkflowsCreateWorkflowPayloadV2
@@ -9300,6 +9518,20 @@ type ClientInterface interface {
 
 	SchedulesV2CreateOverride(ctx context.Context, body SchedulesV2CreateOverrideJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ScheduleSyncTargetsV2List request
+	ScheduleSyncTargetsV2List(ctx context.Context, params *ScheduleSyncTargetsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ScheduleSyncTargetsV2CreateWithBody request with any body
+	ScheduleSyncTargetsV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ScheduleSyncTargetsV2Create(ctx context.Context, body ScheduleSyncTargetsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ScheduleSyncTargetsV2Destroy request
+	ScheduleSyncTargetsV2Destroy(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ScheduleSyncTargetsV2Show request
+	ScheduleSyncTargetsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// SchedulesV2List request
 	SchedulesV2List(ctx context.Context, params *SchedulesV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -9332,6 +9564,20 @@ type ClientInterface interface {
 
 	// SchedulesV2ShowScheduleReplica request
 	SchedulesV2ShowScheduleReplica(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2ListScheduleSyncRules request
+	SchedulesV2ListScheduleSyncRules(ctx context.Context, scheduleId string, params *SchedulesV2ListScheduleSyncRulesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2CreateScheduleSyncRuleWithBody request with any body
+	SchedulesV2CreateScheduleSyncRuleWithBody(ctx context.Context, scheduleId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SchedulesV2CreateScheduleSyncRule(ctx context.Context, scheduleId string, body SchedulesV2CreateScheduleSyncRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2DestroyScheduleSyncRule request
+	SchedulesV2DestroyScheduleSyncRule(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2ShowScheduleSyncRule request
+	SchedulesV2ShowScheduleSyncRule(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// StatusPagesV2CreateStatusPageIncidentUpdateWithBody request with any body
 	StatusPagesV2CreateStatusPageIncidentUpdateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -9392,6 +9638,14 @@ type ClientInterface interface {
 
 	// UsersV2ListNotificationRules request
 	UsersV2ListNotificationRules(ctx context.Context, userId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UsersV2ShowPagingProvider request
+	UsersV2ShowPagingProvider(ctx context.Context, userId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UsersV2UpdatePagingProviderWithBody request with any body
+	UsersV2UpdatePagingProviderWithBody(ctx context.Context, userId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UsersV2UpdatePagingProvider(ctx context.Context, userId string, body UsersV2UpdatePagingProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PoliciesV2HasOpenForUser request
 	PoliciesV2HasOpenForUser(ctx context.Context, userId string, policyId string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -11549,6 +11803,66 @@ func (c *Client) SchedulesV2CreateOverride(ctx context.Context, body SchedulesV2
 	return c.Client.Do(req)
 }
 
+func (c *Client) ScheduleSyncTargetsV2List(ctx context.Context, params *ScheduleSyncTargetsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewScheduleSyncTargetsV2ListRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ScheduleSyncTargetsV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewScheduleSyncTargetsV2CreateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ScheduleSyncTargetsV2Create(ctx context.Context, body ScheduleSyncTargetsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewScheduleSyncTargetsV2CreateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ScheduleSyncTargetsV2Destroy(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewScheduleSyncTargetsV2DestroyRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ScheduleSyncTargetsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewScheduleSyncTargetsV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) SchedulesV2List(ctx context.Context, params *SchedulesV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSchedulesV2ListRequest(c.Server, params)
 	if err != nil {
@@ -11683,6 +11997,66 @@ func (c *Client) SchedulesV2DestroyScheduleReplica(ctx context.Context, schedule
 
 func (c *Client) SchedulesV2ShowScheduleReplica(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSchedulesV2ShowScheduleReplicaRequest(c.Server, scheduleId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2ListScheduleSyncRules(ctx context.Context, scheduleId string, params *SchedulesV2ListScheduleSyncRulesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2ListScheduleSyncRulesRequest(c.Server, scheduleId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2CreateScheduleSyncRuleWithBody(ctx context.Context, scheduleId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2CreateScheduleSyncRuleRequestWithBody(c.Server, scheduleId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2CreateScheduleSyncRule(ctx context.Context, scheduleId string, body SchedulesV2CreateScheduleSyncRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2CreateScheduleSyncRuleRequest(c.Server, scheduleId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2DestroyScheduleSyncRule(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2DestroyScheduleSyncRuleRequest(c.Server, scheduleId, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2ShowScheduleSyncRule(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2ShowScheduleSyncRuleRequest(c.Server, scheduleId, id)
 	if err != nil {
 		return nil, err
 	}
@@ -11947,6 +12321,42 @@ func (c *Client) UsersV2ListNotificationMethods(ctx context.Context, userId stri
 
 func (c *Client) UsersV2ListNotificationRules(ctx context.Context, userId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUsersV2ListNotificationRulesRequest(c.Server, userId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UsersV2ShowPagingProvider(ctx context.Context, userId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUsersV2ShowPagingProviderRequest(c.Server, userId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UsersV2UpdatePagingProviderWithBody(ctx context.Context, userId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUsersV2UpdatePagingProviderRequestWithBody(c.Server, userId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UsersV2UpdatePagingProvider(ctx context.Context, userId string, body UsersV2UpdatePagingProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUsersV2UpdatePagingProviderRequest(c.Server, userId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -18207,6 +18617,179 @@ func NewSchedulesV2CreateOverrideRequestWithBody(server string, contentType stri
 	return req, nil
 }
 
+// NewScheduleSyncTargetsV2ListRequest generates requests for ScheduleSyncTargetsV2List
+func NewScheduleSyncTargetsV2ListRequest(server string, params *ScheduleSyncTargetsV2ListParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedule_sync_targets")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PageSize != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page_size", runtime.ParamLocationQuery, *params.PageSize); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.After != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewScheduleSyncTargetsV2CreateRequest calls the generic ScheduleSyncTargetsV2Create builder with application/json body
+func NewScheduleSyncTargetsV2CreateRequest(server string, body ScheduleSyncTargetsV2CreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewScheduleSyncTargetsV2CreateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewScheduleSyncTargetsV2CreateRequestWithBody generates requests for ScheduleSyncTargetsV2Create with any type of body
+func NewScheduleSyncTargetsV2CreateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedule_sync_targets")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewScheduleSyncTargetsV2DestroyRequest generates requests for ScheduleSyncTargetsV2Destroy
+func NewScheduleSyncTargetsV2DestroyRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedule_sync_targets/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewScheduleSyncTargetsV2ShowRequest generates requests for ScheduleSyncTargetsV2Show
+func NewScheduleSyncTargetsV2ShowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedule_sync_targets/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewSchedulesV2ListRequest generates requests for SchedulesV2List
 func NewSchedulesV2ListRequest(server string, params *SchedulesV2ListParams) (*http.Request, error) {
 	var err error
@@ -18573,6 +19156,207 @@ func NewSchedulesV2ShowScheduleReplicaRequest(server string, scheduleId string, 
 	}
 
 	operationPath := fmt.Sprintf("/v2/schedules/%s/replicas/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSchedulesV2ListScheduleSyncRulesRequest generates requests for SchedulesV2ListScheduleSyncRules
+func NewSchedulesV2ListScheduleSyncRulesRequest(server string, scheduleId string, params *SchedulesV2ListScheduleSyncRulesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "schedule_id", runtime.ParamLocationPath, scheduleId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedules/%s/sync_rules", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PageSize != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page_size", runtime.ParamLocationQuery, *params.PageSize); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.After != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSchedulesV2CreateScheduleSyncRuleRequest calls the generic SchedulesV2CreateScheduleSyncRule builder with application/json body
+func NewSchedulesV2CreateScheduleSyncRuleRequest(server string, scheduleId string, body SchedulesV2CreateScheduleSyncRuleJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSchedulesV2CreateScheduleSyncRuleRequestWithBody(server, scheduleId, "application/json", bodyReader)
+}
+
+// NewSchedulesV2CreateScheduleSyncRuleRequestWithBody generates requests for SchedulesV2CreateScheduleSyncRule with any type of body
+func NewSchedulesV2CreateScheduleSyncRuleRequestWithBody(server string, scheduleId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "schedule_id", runtime.ParamLocationPath, scheduleId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedules/%s/sync_rules", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewSchedulesV2DestroyScheduleSyncRuleRequest generates requests for SchedulesV2DestroyScheduleSyncRule
+func NewSchedulesV2DestroyScheduleSyncRuleRequest(server string, scheduleId string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "schedule_id", runtime.ParamLocationPath, scheduleId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedules/%s/sync_rules/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSchedulesV2ShowScheduleSyncRuleRequest generates requests for SchedulesV2ShowScheduleSyncRule
+func NewSchedulesV2ShowScheduleSyncRuleRequest(server string, scheduleId string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "schedule_id", runtime.ParamLocationPath, scheduleId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedules/%s/sync_rules/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -19520,6 +20304,87 @@ func NewUsersV2ListNotificationRulesRequest(server string, userId string) (*http
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewUsersV2ShowPagingProviderRequest generates requests for UsersV2ShowPagingProvider
+func NewUsersV2ShowPagingProviderRequest(server string, userId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "user_id", runtime.ParamLocationPath, userId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/users/%s/paging_provider", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUsersV2UpdatePagingProviderRequest calls the generic UsersV2UpdatePagingProvider builder with application/json body
+func NewUsersV2UpdatePagingProviderRequest(server string, userId string, body UsersV2UpdatePagingProviderJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUsersV2UpdatePagingProviderRequestWithBody(server, userId, "application/json", bodyReader)
+}
+
+// NewUsersV2UpdatePagingProviderRequestWithBody generates requests for UsersV2UpdatePagingProvider with any type of body
+func NewUsersV2UpdatePagingProviderRequestWithBody(server string, userId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "user_id", runtime.ParamLocationPath, userId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/users/%s/paging_provider", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -20946,6 +21811,20 @@ type ClientWithResponsesInterface interface {
 
 	SchedulesV2CreateOverrideWithResponse(ctx context.Context, body SchedulesV2CreateOverrideJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2CreateOverrideResponse, error)
 
+	// ScheduleSyncTargetsV2ListWithResponse request
+	ScheduleSyncTargetsV2ListWithResponse(ctx context.Context, params *ScheduleSyncTargetsV2ListParams, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2ListResponse, error)
+
+	// ScheduleSyncTargetsV2CreateWithBodyWithResponse request with any body
+	ScheduleSyncTargetsV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2CreateResponse, error)
+
+	ScheduleSyncTargetsV2CreateWithResponse(ctx context.Context, body ScheduleSyncTargetsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2CreateResponse, error)
+
+	// ScheduleSyncTargetsV2DestroyWithResponse request
+	ScheduleSyncTargetsV2DestroyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2DestroyResponse, error)
+
+	// ScheduleSyncTargetsV2ShowWithResponse request
+	ScheduleSyncTargetsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2ShowResponse, error)
+
 	// SchedulesV2ListWithResponse request
 	SchedulesV2ListWithResponse(ctx context.Context, params *SchedulesV2ListParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListResponse, error)
 
@@ -20978,6 +21857,20 @@ type ClientWithResponsesInterface interface {
 
 	// SchedulesV2ShowScheduleReplicaWithResponse request
 	SchedulesV2ShowScheduleReplicaWithResponse(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*SchedulesV2ShowScheduleReplicaResponse, error)
+
+	// SchedulesV2ListScheduleSyncRulesWithResponse request
+	SchedulesV2ListScheduleSyncRulesWithResponse(ctx context.Context, scheduleId string, params *SchedulesV2ListScheduleSyncRulesParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListScheduleSyncRulesResponse, error)
+
+	// SchedulesV2CreateScheduleSyncRuleWithBodyWithResponse request with any body
+	SchedulesV2CreateScheduleSyncRuleWithBodyWithResponse(ctx context.Context, scheduleId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2CreateScheduleSyncRuleResponse, error)
+
+	SchedulesV2CreateScheduleSyncRuleWithResponse(ctx context.Context, scheduleId string, body SchedulesV2CreateScheduleSyncRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2CreateScheduleSyncRuleResponse, error)
+
+	// SchedulesV2DestroyScheduleSyncRuleWithResponse request
+	SchedulesV2DestroyScheduleSyncRuleWithResponse(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*SchedulesV2DestroyScheduleSyncRuleResponse, error)
+
+	// SchedulesV2ShowScheduleSyncRuleWithResponse request
+	SchedulesV2ShowScheduleSyncRuleWithResponse(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*SchedulesV2ShowScheduleSyncRuleResponse, error)
 
 	// StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse request with any body
 	StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentUpdateResponse, error)
@@ -21038,6 +21931,14 @@ type ClientWithResponsesInterface interface {
 
 	// UsersV2ListNotificationRulesWithResponse request
 	UsersV2ListNotificationRulesWithResponse(ctx context.Context, userId string, reqEditors ...RequestEditorFn) (*UsersV2ListNotificationRulesResponse, error)
+
+	// UsersV2ShowPagingProviderWithResponse request
+	UsersV2ShowPagingProviderWithResponse(ctx context.Context, userId string, reqEditors ...RequestEditorFn) (*UsersV2ShowPagingProviderResponse, error)
+
+	// UsersV2UpdatePagingProviderWithBodyWithResponse request with any body
+	UsersV2UpdatePagingProviderWithBodyWithResponse(ctx context.Context, userId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UsersV2UpdatePagingProviderResponse, error)
+
+	UsersV2UpdatePagingProviderWithResponse(ctx context.Context, userId string, body UsersV2UpdatePagingProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*UsersV2UpdatePagingProviderResponse, error)
 
 	// PoliciesV2HasOpenForUserWithResponse request
 	PoliciesV2HasOpenForUserWithResponse(ctx context.Context, userId string, policyId string, reqEditors ...RequestEditorFn) (*PoliciesV2HasOpenForUserResponse, error)
@@ -23894,6 +24795,93 @@ func (r SchedulesV2CreateOverrideResponse) StatusCode() int {
 	return 0
 }
 
+type ScheduleSyncTargetsV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ScheduleSyncTargetsListResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r ScheduleSyncTargetsV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ScheduleSyncTargetsV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ScheduleSyncTargetsV2CreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ScheduleSyncTargetsCreateResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r ScheduleSyncTargetsV2CreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ScheduleSyncTargetsV2CreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ScheduleSyncTargetsV2DestroyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r ScheduleSyncTargetsV2DestroyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ScheduleSyncTargetsV2DestroyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ScheduleSyncTargetsV2ShowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ScheduleSyncTargetsShowResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r ScheduleSyncTargetsV2ShowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ScheduleSyncTargetsV2ShowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type SchedulesV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -24084,6 +25072,93 @@ func (r SchedulesV2ShowScheduleReplicaResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r SchedulesV2ShowScheduleReplicaResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SchedulesV2ListScheduleSyncRulesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SchedulesListScheduleSyncRulesResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2ListScheduleSyncRulesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2ListScheduleSyncRulesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SchedulesV2CreateScheduleSyncRuleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *SchedulesCreateScheduleSyncRuleResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2CreateScheduleSyncRuleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2CreateScheduleSyncRuleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SchedulesV2DestroyScheduleSyncRuleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2DestroyScheduleSyncRuleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2DestroyScheduleSyncRuleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SchedulesV2ShowScheduleSyncRuleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SchedulesShowScheduleSyncRuleResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2ShowScheduleSyncRuleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2ShowScheduleSyncRuleResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -24436,6 +25511,49 @@ func (r UsersV2ListNotificationRulesResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UsersV2ListNotificationRulesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UsersV2ShowPagingProviderResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *UsersShowPagingProviderResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r UsersV2ShowPagingProviderResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UsersV2ShowPagingProviderResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UsersV2UpdatePagingProviderResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UsersV2UpdatePagingProviderResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UsersV2UpdatePagingProviderResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -26411,6 +27529,50 @@ func (c *ClientWithResponses) SchedulesV2CreateOverrideWithResponse(ctx context.
 	return ParseSchedulesV2CreateOverrideResponse(rsp)
 }
 
+// ScheduleSyncTargetsV2ListWithResponse request returning *ScheduleSyncTargetsV2ListResponse
+func (c *ClientWithResponses) ScheduleSyncTargetsV2ListWithResponse(ctx context.Context, params *ScheduleSyncTargetsV2ListParams, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2ListResponse, error) {
+	rsp, err := c.ScheduleSyncTargetsV2List(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScheduleSyncTargetsV2ListResponse(rsp)
+}
+
+// ScheduleSyncTargetsV2CreateWithBodyWithResponse request with arbitrary body returning *ScheduleSyncTargetsV2CreateResponse
+func (c *ClientWithResponses) ScheduleSyncTargetsV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2CreateResponse, error) {
+	rsp, err := c.ScheduleSyncTargetsV2CreateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScheduleSyncTargetsV2CreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) ScheduleSyncTargetsV2CreateWithResponse(ctx context.Context, body ScheduleSyncTargetsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2CreateResponse, error) {
+	rsp, err := c.ScheduleSyncTargetsV2Create(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScheduleSyncTargetsV2CreateResponse(rsp)
+}
+
+// ScheduleSyncTargetsV2DestroyWithResponse request returning *ScheduleSyncTargetsV2DestroyResponse
+func (c *ClientWithResponses) ScheduleSyncTargetsV2DestroyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2DestroyResponse, error) {
+	rsp, err := c.ScheduleSyncTargetsV2Destroy(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScheduleSyncTargetsV2DestroyResponse(rsp)
+}
+
+// ScheduleSyncTargetsV2ShowWithResponse request returning *ScheduleSyncTargetsV2ShowResponse
+func (c *ClientWithResponses) ScheduleSyncTargetsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ScheduleSyncTargetsV2ShowResponse, error) {
+	rsp, err := c.ScheduleSyncTargetsV2Show(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScheduleSyncTargetsV2ShowResponse(rsp)
+}
+
 // SchedulesV2ListWithResponse request returning *SchedulesV2ListResponse
 func (c *ClientWithResponses) SchedulesV2ListWithResponse(ctx context.Context, params *SchedulesV2ListParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListResponse, error) {
 	rsp, err := c.SchedulesV2List(ctx, params, reqEditors...)
@@ -26514,6 +27676,50 @@ func (c *ClientWithResponses) SchedulesV2ShowScheduleReplicaWithResponse(ctx con
 		return nil, err
 	}
 	return ParseSchedulesV2ShowScheduleReplicaResponse(rsp)
+}
+
+// SchedulesV2ListScheduleSyncRulesWithResponse request returning *SchedulesV2ListScheduleSyncRulesResponse
+func (c *ClientWithResponses) SchedulesV2ListScheduleSyncRulesWithResponse(ctx context.Context, scheduleId string, params *SchedulesV2ListScheduleSyncRulesParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListScheduleSyncRulesResponse, error) {
+	rsp, err := c.SchedulesV2ListScheduleSyncRules(ctx, scheduleId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2ListScheduleSyncRulesResponse(rsp)
+}
+
+// SchedulesV2CreateScheduleSyncRuleWithBodyWithResponse request with arbitrary body returning *SchedulesV2CreateScheduleSyncRuleResponse
+func (c *ClientWithResponses) SchedulesV2CreateScheduleSyncRuleWithBodyWithResponse(ctx context.Context, scheduleId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2CreateScheduleSyncRuleResponse, error) {
+	rsp, err := c.SchedulesV2CreateScheduleSyncRuleWithBody(ctx, scheduleId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2CreateScheduleSyncRuleResponse(rsp)
+}
+
+func (c *ClientWithResponses) SchedulesV2CreateScheduleSyncRuleWithResponse(ctx context.Context, scheduleId string, body SchedulesV2CreateScheduleSyncRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2CreateScheduleSyncRuleResponse, error) {
+	rsp, err := c.SchedulesV2CreateScheduleSyncRule(ctx, scheduleId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2CreateScheduleSyncRuleResponse(rsp)
+}
+
+// SchedulesV2DestroyScheduleSyncRuleWithResponse request returning *SchedulesV2DestroyScheduleSyncRuleResponse
+func (c *ClientWithResponses) SchedulesV2DestroyScheduleSyncRuleWithResponse(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*SchedulesV2DestroyScheduleSyncRuleResponse, error) {
+	rsp, err := c.SchedulesV2DestroyScheduleSyncRule(ctx, scheduleId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2DestroyScheduleSyncRuleResponse(rsp)
+}
+
+// SchedulesV2ShowScheduleSyncRuleWithResponse request returning *SchedulesV2ShowScheduleSyncRuleResponse
+func (c *ClientWithResponses) SchedulesV2ShowScheduleSyncRuleWithResponse(ctx context.Context, scheduleId string, id string, reqEditors ...RequestEditorFn) (*SchedulesV2ShowScheduleSyncRuleResponse, error) {
+	rsp, err := c.SchedulesV2ShowScheduleSyncRule(ctx, scheduleId, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2ShowScheduleSyncRuleResponse(rsp)
 }
 
 // StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse request with arbitrary body returning *StatusPagesV2CreateStatusPageIncidentUpdateResponse
@@ -26706,6 +27912,32 @@ func (c *ClientWithResponses) UsersV2ListNotificationRulesWithResponse(ctx conte
 		return nil, err
 	}
 	return ParseUsersV2ListNotificationRulesResponse(rsp)
+}
+
+// UsersV2ShowPagingProviderWithResponse request returning *UsersV2ShowPagingProviderResponse
+func (c *ClientWithResponses) UsersV2ShowPagingProviderWithResponse(ctx context.Context, userId string, reqEditors ...RequestEditorFn) (*UsersV2ShowPagingProviderResponse, error) {
+	rsp, err := c.UsersV2ShowPagingProvider(ctx, userId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUsersV2ShowPagingProviderResponse(rsp)
+}
+
+// UsersV2UpdatePagingProviderWithBodyWithResponse request with arbitrary body returning *UsersV2UpdatePagingProviderResponse
+func (c *ClientWithResponses) UsersV2UpdatePagingProviderWithBodyWithResponse(ctx context.Context, userId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UsersV2UpdatePagingProviderResponse, error) {
+	rsp, err := c.UsersV2UpdatePagingProviderWithBody(ctx, userId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUsersV2UpdatePagingProviderResponse(rsp)
+}
+
+func (c *ClientWithResponses) UsersV2UpdatePagingProviderWithResponse(ctx context.Context, userId string, body UsersV2UpdatePagingProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*UsersV2UpdatePagingProviderResponse, error) {
+	rsp, err := c.UsersV2UpdatePagingProvider(ctx, userId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUsersV2UpdatePagingProviderResponse(rsp)
 }
 
 // PoliciesV2HasOpenForUserWithResponse request returning *PoliciesV2HasOpenForUserResponse
@@ -30073,6 +31305,100 @@ func ParseSchedulesV2CreateOverrideResponse(rsp *http.Response) (*SchedulesV2Cre
 	return response, nil
 }
 
+// ParseScheduleSyncTargetsV2ListResponse parses an HTTP response from a ScheduleSyncTargetsV2ListWithResponse call
+func ParseScheduleSyncTargetsV2ListResponse(rsp *http.Response) (*ScheduleSyncTargetsV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ScheduleSyncTargetsV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ScheduleSyncTargetsListResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseScheduleSyncTargetsV2CreateResponse parses an HTTP response from a ScheduleSyncTargetsV2CreateWithResponse call
+func ParseScheduleSyncTargetsV2CreateResponse(rsp *http.Response) (*ScheduleSyncTargetsV2CreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ScheduleSyncTargetsV2CreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ScheduleSyncTargetsCreateResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseScheduleSyncTargetsV2DestroyResponse parses an HTTP response from a ScheduleSyncTargetsV2DestroyWithResponse call
+func ParseScheduleSyncTargetsV2DestroyResponse(rsp *http.Response) (*ScheduleSyncTargetsV2DestroyResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ScheduleSyncTargetsV2DestroyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseScheduleSyncTargetsV2ShowResponse parses an HTTP response from a ScheduleSyncTargetsV2ShowWithResponse call
+func ParseScheduleSyncTargetsV2ShowResponse(rsp *http.Response) (*ScheduleSyncTargetsV2ShowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ScheduleSyncTargetsV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ScheduleSyncTargetsShowResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseSchedulesV2ListResponse parses an HTTP response from a SchedulesV2ListWithResponse call
 func ParseSchedulesV2ListResponse(rsp *http.Response) (*SchedulesV2ListResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -30277,6 +31603,100 @@ func ParseSchedulesV2ShowScheduleReplicaResponse(rsp *http.Response) (*Schedules
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest SchedulesShowScheduleReplicaResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2ListScheduleSyncRulesResponse parses an HTTP response from a SchedulesV2ListScheduleSyncRulesWithResponse call
+func ParseSchedulesV2ListScheduleSyncRulesResponse(rsp *http.Response) (*SchedulesV2ListScheduleSyncRulesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2ListScheduleSyncRulesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SchedulesListScheduleSyncRulesResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2CreateScheduleSyncRuleResponse parses an HTTP response from a SchedulesV2CreateScheduleSyncRuleWithResponse call
+func ParseSchedulesV2CreateScheduleSyncRuleResponse(rsp *http.Response) (*SchedulesV2CreateScheduleSyncRuleResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2CreateScheduleSyncRuleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest SchedulesCreateScheduleSyncRuleResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2DestroyScheduleSyncRuleResponse parses an HTTP response from a SchedulesV2DestroyScheduleSyncRuleWithResponse call
+func ParseSchedulesV2DestroyScheduleSyncRuleResponse(rsp *http.Response) (*SchedulesV2DestroyScheduleSyncRuleResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2DestroyScheduleSyncRuleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2ShowScheduleSyncRuleResponse parses an HTTP response from a SchedulesV2ShowScheduleSyncRuleWithResponse call
+func ParseSchedulesV2ShowScheduleSyncRuleResponse(rsp *http.Response) (*SchedulesV2ShowScheduleSyncRuleResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2ShowScheduleSyncRuleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SchedulesShowScheduleSyncRuleResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -30698,6 +32118,48 @@ func ParseUsersV2ListNotificationRulesResponse(rsp *http.Response) (*UsersV2List
 		}
 		response.JSON200 = &dest
 
+	}
+
+	return response, nil
+}
+
+// ParseUsersV2ShowPagingProviderResponse parses an HTTP response from a UsersV2ShowPagingProviderWithResponse call
+func ParseUsersV2ShowPagingProviderResponse(rsp *http.Response) (*UsersV2ShowPagingProviderResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UsersV2ShowPagingProviderResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UsersShowPagingProviderResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUsersV2UpdatePagingProviderResponse parses an HTTP response from a UsersV2UpdatePagingProviderWithResponse call
+func ParseUsersV2UpdatePagingProviderResponse(rsp *http.Response) (*UsersV2UpdatePagingProviderResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UsersV2UpdatePagingProviderResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
 	}
 
 	return response, nil

--- a/internal/provider/incident_escalation_path_data_source.go
+++ b/internal/provider/incident_escalation_path_data_source.go
@@ -198,6 +198,10 @@ func (d *IncidentEscalationPathDataSource) getPathSchema(depth int) schema.Neste
 									Computed:            true,
 									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "schedule_mode"),
 								},
+								"selected_rota_id": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "selected_rota_id"),
+								},
 							},
 						},
 					},
@@ -270,6 +274,10 @@ func (d *IncidentEscalationPathDataSource) getPathSchema(depth int) schema.Neste
 								"schedule_mode": schema.StringAttribute{
 									Computed:            true,
 									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "schedule_mode"),
+								},
+								"selected_rota_id": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "selected_rota_id"),
 								},
 							},
 						},

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -26,8 +27,9 @@ import (
 )
 
 var (
-	_ resource.Resource                = &IncidentEscalationPathResource{}
-	_ resource.ResourceWithImportState = &IncidentEscalationPathResource{}
+	_ resource.Resource                   = &IncidentEscalationPathResource{}
+	_ resource.ResourceWithImportState    = &IncidentEscalationPathResource{}
+	_ resource.ResourceWithValidateConfig = &IncidentEscalationPathResource{}
 )
 
 type IncidentEscalationPathResource struct {
@@ -94,10 +96,11 @@ type IncidentEscalationRoundRobinConfig struct {
 }
 
 type IncidentEscalationPathTarget struct {
-	ID           types.String `tfsdk:"id"`
-	Type         types.String `tfsdk:"type"`
-	Urgency      types.String `tfsdk:"urgency"`
-	ScheduleMode types.String `tfsdk:"schedule_mode"`
+	ID             types.String `tfsdk:"id"`
+	Type           types.String `tfsdk:"type"`
+	Urgency        types.String `tfsdk:"urgency"`
+	ScheduleMode   types.String `tfsdk:"schedule_mode"`
+	SelectedRotaID types.String `tfsdk:"selected_rota_id"`
 }
 
 type IncidentEscalationPathRepeatConfig struct {
@@ -213,6 +216,10 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 									Optional:            true,
 									Computed:            true,
 								},
+								"selected_rota_id": schema.StringAttribute{
+									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "selected_rota_id"),
+									Optional:            true,
+								},
 							},
 						},
 					},
@@ -291,6 +298,10 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "schedule_mode"),
 									Optional:            true,
 									Computed:            true,
+								},
+								"selected_rota_id": schema.StringAttribute{
+									MarkdownDescription: apischema.Docstring("EscalationPathTargetV2", "selected_rota_id"),
+									Optional:            true,
 								},
 							},
 						},
@@ -375,6 +386,69 @@ func (r *IncidentEscalationPathResource) Configure(ctx context.Context, req reso
 
 	r.client = client.Client
 	r.terraformVersion = client.TerraformVersion
+}
+
+func (r *IncidentEscalationPathResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data *IncidentEscalationPathResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() || data == nil {
+		return
+	}
+
+	validateEscalationPathTargets(data.Path, &resp.Diagnostics)
+}
+
+// rotaRequiredScheduleModes is the set of schedule_mode values that require a
+// selected_rota_id. Other modes must leave selected_rota_id unset.
+var rotaRequiredScheduleModes = map[string]bool{
+	string(client.EscalationPathTargetV2ScheduleModeAllUsersForRota):        true,
+	string(client.EscalationPathTargetV2ScheduleModeCurrentlyOnCallForRota): true,
+	string(client.EscalationPathTargetV2ScheduleModeNextOnCallForRota):      true,
+}
+
+func validateEscalationPathTargets(nodes []IncidentEscalationPathNode, diags *diag.Diagnostics) {
+	for _, node := range nodes {
+		if node.Level != nil {
+			for _, target := range node.Level.Targets {
+				validateEscalationPathTarget(target, diags)
+			}
+		}
+		if node.NotifyChannel != nil {
+			for _, target := range node.NotifyChannel.Targets {
+				validateEscalationPathTarget(target, diags)
+			}
+		}
+		if node.IfElse != nil {
+			validateEscalationPathTargets(node.IfElse.ThenPath, diags)
+			validateEscalationPathTargets(node.IfElse.ElsePath, diags)
+		}
+	}
+}
+
+func validateEscalationPathTarget(target IncidentEscalationPathTarget, diags *diag.Diagnostics) {
+	if target.ScheduleMode.IsUnknown() || target.SelectedRotaID.IsUnknown() {
+		return
+	}
+
+	mode := target.ScheduleMode.ValueString()
+	rotaID := target.SelectedRotaID.ValueString()
+
+	if rotaRequiredScheduleModes[mode] {
+		if rotaID == "" {
+			diags.Append(diag.NewErrorDiagnostic(
+				"Missing selected_rota_id",
+				fmt.Sprintf("Escalation path target with schedule_mode %q requires selected_rota_id to be set.", mode),
+			))
+		}
+		return
+	}
+
+	if rotaID != "" {
+		diags.Append(diag.NewErrorDiagnostic(
+			"Unexpected selected_rota_id",
+			fmt.Sprintf("Escalation path target with schedule_mode %q must not set selected_rota_id; it is only valid for all_users_for_rota, currently_on_call_for_rota, and next_on_call_for_rota.", mode),
+		))
+	}
 }
 
 func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -613,11 +687,17 @@ func (r *IncidentEscalationPathResource) toPathModel(nodes []client.EscalationPa
 							scheduleMode = types.StringValue(string(*target.ScheduleMode))
 						}
 
+						selectedRotaID := types.StringNull()
+						if target.SelectedRotaId != nil && *target.SelectedRotaId != "" {
+							selectedRotaID = types.StringValue(*target.SelectedRotaId)
+						}
+
 						return IncidentEscalationPathTarget{
-							ID:           types.StringValue(target.Id),
-							Type:         types.StringValue(string(target.Type)),
-							Urgency:      types.StringValue(string(target.Urgency)),
-							ScheduleMode: scheduleMode,
+							ID:             types.StringValue(target.Id),
+							Type:           types.StringValue(string(target.Type)),
+							Urgency:        types.StringValue(string(target.Urgency)),
+							ScheduleMode:   scheduleMode,
+							SelectedRotaID: selectedRotaID,
 						}
 					}),
 			}
@@ -653,11 +733,17 @@ func (r *IncidentEscalationPathResource) toPathModel(nodes []client.EscalationPa
 							scheduleMode = types.StringValue(string(*target.ScheduleMode))
 						}
 
+						selectedRotaID := types.StringNull()
+						if target.SelectedRotaId != nil && *target.SelectedRotaId != "" {
+							selectedRotaID = types.StringValue(*target.SelectedRotaId)
+						}
+
 						return IncidentEscalationPathTarget{
-							ID:           types.StringValue(target.Id),
-							Type:         types.StringValue(string(target.Type)),
-							Urgency:      types.StringValue(string(target.Urgency)),
-							ScheduleMode: scheduleMode,
+							ID:             types.StringValue(target.Id),
+							Type:           types.StringValue(string(target.Type)),
+							Urgency:        types.StringValue(string(target.Urgency)),
+							ScheduleMode:   scheduleMode,
+							SelectedRotaID: selectedRotaID,
 						}
 					}),
 			}
@@ -733,6 +819,10 @@ func (r *IncidentEscalationPathResource) toPathPayload(path []IncidentEscalation
 						targetPayload.ScheduleMode = lo.ToPtr(client.EscalationPathTargetV2ScheduleMode(target.ScheduleMode.ValueString()))
 					}
 
+					if target.SelectedRotaID.ValueString() != "" {
+						targetPayload.SelectedRotaId = lo.ToPtr(target.SelectedRotaID.ValueString())
+					}
+
 					return targetPayload
 				}),
 				TimeToAckIntervalCondition: intervalCondition,
@@ -772,6 +862,10 @@ func (r *IncidentEscalationPathResource) toPathPayload(path []IncidentEscalation
 
 					if target.ScheduleMode.ValueString() != "" {
 						targetPayload.ScheduleMode = lo.ToPtr(client.EscalationPathTargetV2ScheduleMode(target.ScheduleMode.ValueString()))
+					}
+
+					if target.SelectedRotaID.ValueString() != "" {
+						targetPayload.SelectedRotaId = lo.ToPtr(target.SelectedRotaID.ValueString())
 					}
 
 					return targetPayload

--- a/internal/provider/incident_escalation_path_resource_test.go
+++ b/internal/provider/incident_escalation_path_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -500,4 +501,167 @@ resource "incident_escalation_path" "example" {
   team_ids = []
 }
 `
+}
+
+func TestAccIncidentEscalationPathSelectedRotaID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentEscalationPathResourceConfigWithSelectedRotaID(
+					StableSuffix("EP rota-mode"),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.rota_modes", "path.0.level.targets.0.schedule_mode", "currently_on_call_for_rota"),
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.rota_modes", "path.0.level.targets.0.selected_rota_id", "primary"),
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.rota_modes", "path.0.level.targets.1.schedule_mode", "next_on_call"),
+					resource.TestCheckNoResourceAttr(
+						"incident_escalation_path.rota_modes", "path.0.level.targets.1.selected_rota_id"),
+				),
+			},
+			{
+				ResourceName:      "incident_escalation_path.rota_modes",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccIncidentEscalationPathResourceConfigWithSelectedRotaID(name string) string {
+	return fmt.Sprintf(`
+data "incident_catalog_type" "team" {
+  name = %q
+}
+
+resource "incident_catalog_entry" "terraform_rota_modes" {
+  catalog_type_id    = data.incident_catalog_type.team.id
+  external_id        = "tf-acceptance-test-rota-modes"
+  name               = "Terraform test team rota modes"
+  attribute_values   = []
+  managed_attributes = []
+}
+
+resource "incident_schedule" "rota_modes" {
+  name     = %q
+  timezone = "Europe/London"
+  rotations = [{
+    id   = "primary"
+    name = "Primary"
+    versions = [{
+      handover_start_at = "2024-05-01T12:00:00Z"
+      users             = []
+      layers = [{
+        id   = "primary"
+        name = "Primary"
+      }]
+      handovers = [{
+        interval_type = "daily"
+        interval      = 1
+      }]
+    }]
+  }]
+  team_ids = [incident_catalog_entry.terraform_rota_modes.id]
+}
+
+resource "incident_escalation_path" "rota_modes" {
+  name = %q
+
+  path = [
+    {
+      type = "level"
+      level = {
+        targets = [
+          {
+            type             = "schedule"
+            id               = incident_schedule.rota_modes.id
+            urgency          = "high"
+            schedule_mode    = "currently_on_call_for_rota"
+            selected_rota_id = "primary"
+          },
+          {
+            type          = "schedule"
+            id            = incident_schedule.rota_modes.id
+            urgency       = "high"
+            schedule_mode = "next_on_call"
+          },
+        ]
+        time_to_ack_seconds = 300
+      }
+    }
+  ]
+
+  team_ids = [incident_catalog_entry.terraform_rota_modes.id]
+}
+`, teamTypeName(), name, name)
+}
+
+func TestAccIncidentEscalationPathSelectedRotaIDValidation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// schedule_mode requires selected_rota_id but it is missing
+			{
+				Config:      testAccIncidentEscalationPathResourceConfigMissingSelectedRotaID(),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Missing selected_rota_id`),
+			},
+			// schedule_mode does not allow selected_rota_id but it is set
+			{
+				Config:      testAccIncidentEscalationPathResourceConfigUnexpectedSelectedRotaID(),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Unexpected selected_rota_id`),
+			},
+		},
+	})
+}
+
+func testAccIncidentEscalationPathResourceConfigMissingSelectedRotaID() string {
+	return `
+resource "incident_escalation_path" "invalid_missing_rota" {
+  name = "invalid-missing-rota"
+
+  path = [
+    {
+      type = "level"
+      level = {
+        targets = [{
+          type          = "schedule"
+          id            = "01HKZWAAAAAAAAAAAAAAAAAAA1"
+          urgency       = "high"
+          schedule_mode = "currently_on_call_for_rota"
+        }]
+        time_to_ack_seconds = 300
+      }
+    }
+  ]
+}`
+}
+
+func testAccIncidentEscalationPathResourceConfigUnexpectedSelectedRotaID() string {
+	return `
+resource "incident_escalation_path" "invalid_unexpected_rota" {
+  name = "invalid-unexpected-rota"
+
+  path = [
+    {
+      type = "level"
+      level = {
+        targets = [{
+          type             = "schedule"
+          id               = "01HKZWAAAAAAAAAAAAAAAAAAA1"
+          urgency          = "high"
+          schedule_mode    = "currently_on_call"
+          selected_rota_id = "primary"
+        }]
+        time_to_ack_seconds = 300
+      }
+    }
+  ]
+}`
 }


### PR DESCRIPTION
## Summary

Adds support on `incident_escalation_path` for the three new `schedule_mode` values exposed by the public API ([ONC-11582](https://linear.app/incident-io/issue/ONC-11582/terraform-provider-support-new-schedule-modes-chunk-8)):

- `currently_on_call_for_rota`
- `next_on_call_for_rota`
- `next_on_call`

The first two scope to a specific rota on a schedule, so this also adds a new `selected_rota_id` attribute to escalation path targets, plus a `ValidateConfig` check that enforces the same rules as the public API: `selected_rota_id` is required for `all_users_for_rota` / `currently_on_call_for_rota` / `next_on_call_for_rota`, and must be omitted otherwise.

## Notable diff scope

The vendored `internal/apischema/public-schema-v3-including-secret-endpoints.json` was refreshed from `core` (the previous copy was stale), so the regenerated `client.gen.go` also picks up unrelated additions (schedule sync rules/targets, paging-provider endpoints, enum-constant renames). None of those are wired into resources or data sources — they're inert until something starts using them.

## Test plan

- [x] `make build` — passes locally
- [x] `make testacc TESTARGS='-run=TestAccIncidentEscalationPathSelectedRotaID'` (covers both the round-trip and the ValidateConfig negative cases)
- [x] `make testacc TESTARGS='-run=TestAccIncidentEscalationPathResource'` (regression on existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the `incident_escalation_path` schema/model and adds new config validation, which can change plan/apply behavior for existing configurations using `schedule_mode` and may block previously-accepted configs.
> 
> **Overview**
> Adds support in `incident_escalation_path` (resource and data source) for new `schedule_mode` values (`currently_on_call_for_rota`, `next_on_call_for_rota`, `next_on_call`) and a new `selected_rota_id` field on schedule targets, including payload/state mapping.
> 
> Introduces plan-time validation to require `selected_rota_id` for rota-scoped schedule modes (and forbid it otherwise), plus new acceptance tests covering round-trip/import and negative validation cases. Updates the `CHANGELOG` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a2638d53a2295cf0534248bed7c8c2792bafa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->