### PR TITLE
Fix "inconsistent result after apply" for http_custom_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix "Provider produced inconsistent result after apply" when creating or updating an `incident_alert_source` with `http_custom_options` (the API does not echo back the write-only `http_custom_options`, so the planned/prior value is now preserved)
+
 ## v5.38.0
 
 - Add `incident_schedule_sync_target` and `incident_schedule_sync_rule` resources for syncing schedules to Slack user groups

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -513,6 +513,7 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 	// Save the planned values before overwriting with API response.
 	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
 	planEmailOptions := data.EmailOptions
+	planHTTPCustomOptions := data.HTTPCustomOptions
 
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
 
@@ -529,6 +530,13 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 	// doesn't see an inconsistent result.
 	if planEmailOptions != nil && data.EmailOptions == nil {
 		data.EmailOptions = planEmailOptions
+	}
+
+	// http_custom_options is write-only: the API never echoes it back, so
+	// FromAPI returns nil. Restore the planned value so Terraform doesn't see
+	// an inconsistent result for http sources.
+	if planHTTPCustomOptions != nil && data.HTTPCustomOptions == nil {
+		data.HTTPCustomOptions = planHTTPCustomOptions
 	}
 
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
@@ -562,6 +570,7 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 	// Save the prior state values before overwriting with API response.
 	stateAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
 	stateEmailOptions := data.EmailOptions
+	stateHTTPCustomOptions := data.HTTPCustomOptions
 
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
 
@@ -576,6 +585,13 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 	// state had it (e.g. user configured email_options with empty redactions).
 	if stateEmailOptions != nil && data.EmailOptions == nil {
 		data.EmailOptions = stateEmailOptions
+	}
+
+	// http_custom_options is write-only: the API never echoes it back, so
+	// FromAPI returns nil. Preserve the prior state value to avoid a perpetual
+	// diff for http sources.
+	if stateHTTPCustomOptions != nil && data.HTTPCustomOptions == nil {
+		data.HTTPCustomOptions = stateHTTPCustomOptions
 	}
 
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
@@ -636,6 +652,7 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 	// Save the planned values before overwriting with API response.
 	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
 	planEmailOptions := data.EmailOptions
+	planHTTPCustomOptions := data.HTTPCustomOptions
 
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
 
@@ -652,6 +669,13 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 	// doesn't see an inconsistent result.
 	if planEmailOptions != nil && data.EmailOptions == nil {
 		data.EmailOptions = planEmailOptions
+	}
+
+	// http_custom_options is write-only: the API never echoes it back, so
+	// FromAPI returns nil. Restore the planned value so Terraform doesn't see
+	// an inconsistent result for http sources.
+	if planHTTPCustomOptions != nil && data.HTTPCustomOptions == nil {
+		data.HTTPCustomOptions = planHTTPCustomOptions
 	}
 
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -1159,6 +1159,69 @@ resource "incident_alert_source" "test" {
 	})
 }
 
+// Regression test: creating an http source with http_custom_options used to
+// fail with "Provider produced inconsistent result after apply" because the
+// API never echoes http_custom_options back (it's write-only), so FromAPI
+// returned nil against the planned value. The provider now restores the
+// planned/prior value in Create/Read/Update.
+func TestAccAlertSourceResource_HTTPCustomOptions(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertSourceResourceConfigWithHTTP("http-source"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_alert_source.test", "name", "http-source"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "source_type", "http"),
+					resource.TestCheckResourceAttrSet("incident_alert_source.test", "alert_events_url"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "http_custom_options.deduplication_key_path", "$.alert_id"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "http_custom_options.transform_expression", "payload"),
+				),
+			},
+			// ImportState testing. http_custom_options is write-only (the API
+			// never returns it), so it cannot be verified on a fresh import.
+			{
+				ResourceName:            "incident_alert_source.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"http_custom_options"},
+			},
+		},
+	})
+}
+
+func testAccAlertSourceResourceConfigWithHTTP(name string) string {
+	return testRunTemplate("incident_alert_source_http", `
+resource "incident_alert_source" "test" {
+  name        = {{ quote .Name }}
+  source_type = "http"
+
+  template = {
+    expressions = [],
+    title = {
+      literal = {{ quote .Title }}
+    },
+    description = {
+      literal = {{ quote .Description }}
+    },
+    attributes = []
+  }
+
+  http_custom_options = {
+    transform_expression   = "payload"
+    deduplication_key_path = "$.alert_id"
+  }
+}
+`, struct {
+		Name, Title, Description string
+	}{
+		Name:        name,
+		Title:       testAlertSourceTitle,
+		Description: testAlertSourceDescription,
+	})
+}
+
 func testAccAlertSourceResourceConfigWithDifferentOwningTeamIDs(name string) string {
 	return testRunTemplate("incident_alert_source_with_different_owning_teams", `
 # Look up the Team catalog type


### PR DESCRIPTION
Fixes #352.

### Problem

Creating (or updating) an `incident_alert_source` with `source_type = "http"` fails:

```
Error: Provider produced inconsistent result after apply
... .http_custom_options: was cty.ObjectVal(...), but now null.
```

The create/update API response does not echo back `http_custom_options` (it's write-only — `deduplication_key_path` is redacted in plans), so `AlertSourceHTTPCustomOptionsModel.FromAPI` returns nil and the planned non-null value becomes null in post-apply state.

### Fix

This mirrors the existing handling for `email_options` and `auto_resolve_incident_alerts`: when `FromAPI` returns nil for `http_custom_options`, restore the planned value in `Create`/`Update` and the prior-state value in `Read` (the latter avoids a perpetual diff). Three call sites in `internal/provider/incident_alert_source_resource.go`.

### Test

Adds `TestAccAlertSourceResource_HTTPCustomOptions`, which creates an http source with `http_custom_options` and asserts apply succeeds with no follow-up diff. The import step uses `ImportStateVerifyIgnore: ["http_custom_options"]` since the API never returns it.

### Checks run locally

- `gofmt -l` — clean
- `go build ./...` — ok
- `go vet ./internal/provider/` — ok
- Acceptance test requires a live incident.io API key (`TF_ACC`); not run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `Create`/`Read`/`Update` state reconciliation for `incident_alert_source`, which can affect diffs and state for HTTP sources if the preservation logic is incorrect. Scope is limited to a single write-only attribute and is covered by a new acceptance regression test.
> 
> **Overview**
> Fixes a Terraform **"inconsistent result after apply"** / perpetual diff for `incident_alert_source` when `http_custom_options` is set on `source_type = "http"`.
> 
> The provider now preserves `http_custom_options` from the plan (on `Create`/`Update`) or prior state (on `Read`) when the API response omits this *write-only* field, mirroring existing handling for `email_options` and `auto_resolve_incident_alerts`. Adds an acceptance regression test for HTTP sources and notes the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe007b78223706c0df9324f8972acc8b90c9612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->