### PR TITLE
Mark sync targets and sync rules as managed by Terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Mark `incident_schedule_sync_target` and `incident_schedule_sync_rule` resources as managed by Terraform
+
 ## v5.38.0
 
 - Add `incident_schedule_sync_target` and `incident_schedule_sync_rule` resources for syncing schedules to Slack user groups

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -48481,9 +48481,23 @@
       },
       "SchedulesUpdateScheduleSyncRulePayloadV2": {
         "example": {
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          },
           "sync_type": "on_call"
         },
         "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "type": "object"
+          },
           "sync_type": {
             "description": "Which schedule members sync to the user group",
             "enum": [
@@ -75978,6 +75992,9 @@
           "content": {
             "application/json": {
               "example": {
+                "annotations": {
+                  "incident.io/terraform/version": "3.0.0"
+                },
                 "sync_type": "on_call"
               },
               "schema": {

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -10934,6 +10934,63 @@
         ],
         "type": "object"
       },
+      "AlertsResolveResultV2": {
+        "example": {
+          "alert": {
+            "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+            "attributes": [
+              {
+                "array_value": [
+                  {
+                    "catalog_entry": {
+                      "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Primary On-call"
+                    },
+                    "label": "Payments Team",
+                    "literal": "SEV123"
+                  }
+                ],
+                "attribute": {
+                  "array": false,
+                  "emoji": "fire",
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "name": "service",
+                  "required": false,
+                  "type": "CatalogEntry[\"01GW2G3V0S59R238FAHPDS1R67\"]"
+                },
+                "value": {
+                  "catalog_entry": {
+                    "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Primary On-call"
+                  },
+                  "label": "Payments Team",
+                  "literal": "SEV123"
+                }
+              }
+            ],
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "deduplication_key": "4293868629",
+            "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+            "id": "01GW2G3V0S59R238FAHPDS1R66",
+            "resolved_at": "2021-08-17T14:28:57.801578Z",
+            "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+            "status": "firing",
+            "title": "*errors.withMessage: PG::Error failed to connect",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "alert": {
+            "$ref": "#/components/schemas/AlertV2"
+          }
+        },
+        "required": [
+          "alert"
+        ],
+        "type": "object"
+      },
       "AlertsShowResultV2": {
         "example": {
           "alert": {
@@ -43569,6 +43626,8 @@
               "alert_source",
               "escalation_path",
               "schedule",
+              "schedule_sync_target",
+              "schedule_sync_rule",
               "workflow"
             ],
             "example": "alert_route",
@@ -43621,6 +43680,8 @@
               "alert_source",
               "escalation_path",
               "schedule",
+              "schedule_sync_target",
+              "schedule_sync_rule",
               "workflow"
             ],
             "example": "alert_route",
@@ -45820,6 +45881,10 @@
             "x-public-api-version": "v2"
           }
         },
+        "required": [
+          "interval_type",
+          "interval"
+        ],
         "type": "object"
       },
       "ScheduleRotationUpdatePayloadV2": {
@@ -46332,10 +46397,24 @@
       },
       "ScheduleSyncRuleCreatePayloadV2": {
         "example": {
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          },
           "schedule_sync_target_id": "01JXYZ000000000000000000AB",
           "sync_type": "on_call"
         },
         "properties": {
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "type": "object"
+          },
           "schedule_sync_target_id": {
             "description": "The sync target to link to",
             "example": "01JXYZ000000000000000000AB",
@@ -46361,6 +46440,13 @@
         "example": {
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01JXYZ000000000000000000CD",
+          "management_meta": {
+            "annotations": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "managed_by": "dashboard",
+            "source_url": "https://github.com/my-company/infrastructure"
+          },
           "schedule_id": "01JXYZ000000000000000000EF",
           "schedule_sync_target": {
             "add_bot_to_group": true,
@@ -46375,6 +46461,13 @@
                 ]
               }
             ],
+            "management_meta": {
+              "annotations": {
+                "incident.io/terraform/version": "3.0.0"
+              },
+              "managed_by": "dashboard",
+              "source_url": "https://github.com/my-company/infrastructure"
+            },
             "slack_team_id": "T02A1AZHG3J",
             "slack_user_group_id": "S06MNNU5BMK",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46393,6 +46486,9 @@
             "description": "Unique identifier of the sync rule",
             "example": "01JXYZ000000000000000000CD",
             "type": "string"
+          },
+          "management_meta": {
+            "$ref": "#/components/schemas/ManagementMetaV2"
           },
           "schedule_id": {
             "description": "The schedule this rule belongs to",
@@ -46436,6 +46532,9 @@
       "ScheduleSyncTargetCreatePayloadV2": {
         "example": {
           "add_bot_to_group": true,
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          },
           "new_slack_user_group": {
             "description": "The team responsible for Project A",
             "handle": "project-team-a",
@@ -46449,6 +46548,17 @@
             "description": "Whether the incident.io bot should be added to the group",
             "example": true,
             "type": "boolean"
+          },
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "type": "object"
           },
           "new_slack_user_group": {
             "$ref": "#/components/schemas/NewSlackUserGroupPayloadV2"
@@ -46478,6 +46588,13 @@
               ]
             }
           ],
+          "management_meta": {
+            "annotations": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "managed_by": "dashboard",
+            "source_url": "https://github.com/my-company/infrastructure"
+          },
           "slack_team_id": "T02A1AZHG3J",
           "slack_user_group_id": "S06MNNU5BMK",
           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46514,6 +46631,9 @@
             },
             "type": "array"
           },
+          "management_meta": {
+            "$ref": "#/components/schemas/ManagementMetaV2"
+          },
           "slack_team_id": {
             "description": "Slack team ID for the user group",
             "example": "T02A1AZHG3J",
@@ -46545,6 +46665,9 @@
         "example": {
           "schedule_sync_target": {
             "add_bot_to_group": true,
+            "annotations": {
+              "incident.io/terraform/version": "3.0.0"
+            },
             "new_slack_user_group": {
               "description": "The team responsible for Project A",
               "handle": "project-team-a",
@@ -46579,6 +46702,13 @@
                 ]
               }
             ],
+            "management_meta": {
+              "annotations": {
+                "incident.io/terraform/version": "3.0.0"
+              },
+              "managed_by": "dashboard",
+              "source_url": "https://github.com/my-company/infrastructure"
+            },
             "slack_team_id": "T02A1AZHG3J",
             "slack_user_group_id": "S06MNNU5BMK",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46614,6 +46744,13 @@
                   ]
                 }
               ],
+              "management_meta": {
+                "annotations": {
+                  "incident.io/terraform/version": "3.0.0"
+                },
+                "managed_by": "dashboard",
+                "source_url": "https://github.com/my-company/infrastructure"
+              },
               "slack_team_id": "T02A1AZHG3J",
               "slack_user_group_id": "S06MNNU5BMK",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46639,6 +46776,13 @@
                     ]
                   }
                 ],
+                "management_meta": {
+                  "annotations": {
+                    "incident.io/terraform/version": "3.0.0"
+                  },
+                  "managed_by": "dashboard",
+                  "source_url": "https://github.com/my-company/infrastructure"
+                },
                 "slack_team_id": "T02A1AZHG3J",
                 "slack_user_group_id": "S06MNNU5BMK",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46670,6 +46814,13 @@
                 ]
               }
             ],
+            "management_meta": {
+              "annotations": {
+                "incident.io/terraform/version": "3.0.0"
+              },
+              "managed_by": "dashboard",
+              "source_url": "https://github.com/my-company/infrastructure"
+            },
             "slack_team_id": "T02A1AZHG3J",
             "slack_user_group_id": "S06MNNU5BMK",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46687,13 +46838,27 @@
       },
       "ScheduleSyncTargetsUpdatePayloadV2": {
         "example": {
-          "add_bot_to_group": true
+          "add_bot_to_group": true,
+          "annotations": {
+            "incident.io/terraform/version": "3.0.0"
+          }
         },
         "properties": {
           "add_bot_to_group": {
             "description": "Whether the incident.io bot should be added to the group",
             "example": true,
             "type": "boolean"
+          },
+          "annotations": {
+            "additionalProperties": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "description": "Annotations that track metadata about this resource",
+            "example": {
+              "incident.io/terraform/version": "3.0.0"
+            },
+            "type": "object"
           }
         },
         "required": [
@@ -46716,6 +46881,13 @@
                 ]
               }
             ],
+            "management_meta": {
+              "annotations": {
+                "incident.io/terraform/version": "3.0.0"
+              },
+              "managed_by": "dashboard",
+              "source_url": "https://github.com/my-company/infrastructure"
+            },
             "slack_team_id": "T02A1AZHG3J",
             "slack_user_group_id": "S06MNNU5BMK",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -47381,6 +47553,9 @@
       "SchedulesCreateScheduleSyncRulePayloadV2": {
         "example": {
           "schedule_sync_rule": {
+            "annotations": {
+              "incident.io/terraform/version": "3.0.0"
+            },
             "schedule_sync_target_id": "01JXYZ000000000000000000AB",
             "sync_type": "on_call"
           }
@@ -47400,6 +47575,13 @@
           "schedule_sync_rule": {
             "created_at": "2021-08-17T13:28:57.801578Z",
             "id": "01JXYZ000000000000000000CD",
+            "management_meta": {
+              "annotations": {
+                "incident.io/terraform/version": "3.0.0"
+              },
+              "managed_by": "dashboard",
+              "source_url": "https://github.com/my-company/infrastructure"
+            },
             "schedule_id": "01JXYZ000000000000000000EF",
             "schedule_sync_target": {
               "add_bot_to_group": true,
@@ -47414,6 +47596,13 @@
                   ]
                 }
               ],
+              "management_meta": {
+                "annotations": {
+                  "incident.io/terraform/version": "3.0.0"
+                },
+                "managed_by": "dashboard",
+                "source_url": "https://github.com/my-company/infrastructure"
+              },
               "slack_team_id": "T02A1AZHG3J",
               "slack_user_group_id": "S06MNNU5BMK",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -47810,6 +47999,13 @@
             {
               "created_at": "2021-08-17T13:28:57.801578Z",
               "id": "01JXYZ000000000000000000CD",
+              "management_meta": {
+                "annotations": {
+                  "incident.io/terraform/version": "3.0.0"
+                },
+                "managed_by": "dashboard",
+                "source_url": "https://github.com/my-company/infrastructure"
+              },
               "schedule_id": "01JXYZ000000000000000000EF",
               "schedule_sync_target": {
                 "add_bot_to_group": true,
@@ -47824,6 +48020,13 @@
                     ]
                   }
                 ],
+                "management_meta": {
+                  "annotations": {
+                    "incident.io/terraform/version": "3.0.0"
+                  },
+                  "managed_by": "dashboard",
+                  "source_url": "https://github.com/my-company/infrastructure"
+                },
                 "slack_team_id": "T02A1AZHG3J",
                 "slack_user_group_id": "S06MNNU5BMK",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -47843,6 +48046,13 @@
               {
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "id": "01JXYZ000000000000000000CD",
+                "management_meta": {
+                  "annotations": {
+                    "incident.io/terraform/version": "3.0.0"
+                  },
+                  "managed_by": "dashboard",
+                  "source_url": "https://github.com/my-company/infrastructure"
+                },
                 "schedule_id": "01JXYZ000000000000000000EF",
                 "schedule_sync_target": {
                   "add_bot_to_group": true,
@@ -47857,6 +48067,13 @@
                       ]
                     }
                   ],
+                  "management_meta": {
+                    "annotations": {
+                      "incident.io/terraform/version": "3.0.0"
+                    },
+                    "managed_by": "dashboard",
+                    "source_url": "https://github.com/my-company/infrastructure"
+                  },
                   "slack_team_id": "T02A1AZHG3J",
                   "slack_user_group_id": "S06MNNU5BMK",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -48031,6 +48248,13 @@
           "schedule_sync_rule": {
             "created_at": "2021-08-17T13:28:57.801578Z",
             "id": "01JXYZ000000000000000000CD",
+            "management_meta": {
+              "annotations": {
+                "incident.io/terraform/version": "3.0.0"
+              },
+              "managed_by": "dashboard",
+              "source_url": "https://github.com/my-company/infrastructure"
+            },
             "schedule_id": "01JXYZ000000000000000000EF",
             "schedule_sync_target": {
               "add_bot_to_group": true,
@@ -48045,6 +48269,13 @@
                   ]
                 }
               ],
+              "management_meta": {
+                "annotations": {
+                  "incident.io/terraform/version": "3.0.0"
+                },
+                "managed_by": "dashboard",
+                "source_url": "https://github.com/my-company/infrastructure"
+              },
               "slack_team_id": "T02A1AZHG3J",
               "slack_user_group_id": "S06MNNU5BMK",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -48273,6 +48504,13 @@
           "schedule_sync_rule": {
             "created_at": "2021-08-17T13:28:57.801578Z",
             "id": "01JXYZ000000000000000000CD",
+            "management_meta": {
+              "annotations": {
+                "incident.io/terraform/version": "3.0.0"
+              },
+              "managed_by": "dashboard",
+              "source_url": "https://github.com/my-company/infrastructure"
+            },
             "schedule_id": "01JXYZ000000000000000000EF",
             "schedule_sync_target": {
               "add_bot_to_group": true,
@@ -48287,6 +48525,13 @@
                   ]
                 }
               ],
+              "management_meta": {
+                "annotations": {
+                  "incident.io/terraform/version": "3.0.0"
+                },
+                "managed_by": "dashboard",
+                "source_url": "https://github.com/my-company/infrastructure"
+              },
               "slack_team_id": "T02A1AZHG3J",
               "slack_user_group_id": "S06MNNU5BMK",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -68278,6 +68523,91 @@
         "x-docs-resource-type": "AlertV2"
       }
     },
+    "/v2/alerts/{id}/actions/resolve": {
+      "post": {
+        "description": "Resolve a currently firing alert.\n\nThis marks the alert as resolved with the current time, attributing the resolution to the API key that made the request. Resolving an already-resolved alert is a no-op and returns the alert unchanged.\n\nSome alert sources are 'externally resolved' (for example, Datadog) — those alerts can only be resolved by the third-party system itself, and this endpoint will return a 422 explaining that.\n\nPrivate alerts: an API key without the 'view all alerts' scope can only resolve non-private alerts; private alerts will return a 404. Grant the API key a role that includes the global alerts access scope to resolve private alerts.\n",
+        "operationId": "Alerts V2#Resolve",
+        "parameters": [
+          {
+            "description": "Unique identifier for the alert",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Unique identifier for the alert",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "alert": {
+                    "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "attributes": [
+                      {
+                        "array_value": [
+                          {
+                            "catalog_entry": {
+                              "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                              "name": "Primary On-call"
+                            },
+                            "label": "Payments Team",
+                            "literal": "SEV123"
+                          }
+                        ],
+                        "attribute": {
+                          "array": false,
+                          "emoji": "fire",
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "name": "service",
+                          "required": false,
+                          "type": "CatalogEntry[\"01GW2G3V0S59R238FAHPDS1R67\"]"
+                        },
+                        "value": {
+                          "catalog_entry": {
+                            "catalog_type_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                            "name": "Primary On-call"
+                          },
+                          "label": "Payments Team",
+                          "literal": "SEV123"
+                        }
+                      }
+                    ],
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "deduplication_key": "4293868629",
+                    "description": "CPU on the payments service has exceeded 75 percent for 5 minutes",
+                    "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "resolved_at": "2021-08-17T14:28:57.801578Z",
+                    "source_url": "https://www.my-alerting-platform.com/alerts/my-alert-123",
+                    "status": "firing",
+                    "title": "*errors.withMessage: PG::Error failed to connect",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AlertsResolveResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "Resolve Alerts V2",
+        "tags": [
+          "Alerts V2"
+        ],
+        "x-docs-display-name": "Resolve",
+        "x-docs-group-name": "Alerts V2",
+        "x-docs-resource-type": "AlertV2"
+      }
+    },
     "/v2/catalog_entries": {
       "get": {
         "deprecated": true,
@@ -73970,6 +74300,13 @@
                           ]
                         }
                       ],
+                      "management_meta": {
+                        "annotations": {
+                          "incident.io/terraform/version": "3.0.0"
+                        },
+                        "managed_by": "dashboard",
+                        "source_url": "https://github.com/my-company/infrastructure"
+                      },
                       "slack_team_id": "T02A1AZHG3J",
                       "slack_user_group_id": "S06MNNU5BMK",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -74001,6 +74338,9 @@
               "example": {
                 "schedule_sync_target": {
                   "add_bot_to_group": true,
+                  "annotations": {
+                    "incident.io/terraform/version": "3.0.0"
+                  },
                   "new_slack_user_group": {
                     "description": "The team responsible for Project A",
                     "handle": "project-team-a",
@@ -74035,6 +74375,13 @@
                         ]
                       }
                     ],
+                    "management_meta": {
+                      "annotations": {
+                        "incident.io/terraform/version": "3.0.0"
+                      },
+                      "managed_by": "dashboard",
+                      "source_url": "https://github.com/my-company/infrastructure"
+                    },
                     "slack_team_id": "T02A1AZHG3J",
                     "slack_user_group_id": "S06MNNU5BMK",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -74123,6 +74470,13 @@
                         ]
                       }
                     ],
+                    "management_meta": {
+                      "annotations": {
+                        "incident.io/terraform/version": "3.0.0"
+                      },
+                      "managed_by": "dashboard",
+                      "source_url": "https://github.com/my-company/infrastructure"
+                    },
                     "slack_team_id": "T02A1AZHG3J",
                     "slack_user_group_id": "S06MNNU5BMK",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -74165,7 +74519,10 @@
           "content": {
             "application/json": {
               "example": {
-                "add_bot_to_group": true
+                "add_bot_to_group": true,
+                "annotations": {
+                  "incident.io/terraform/version": "3.0.0"
+                }
               },
               "schema": {
                 "$ref": "#/components/schemas/ScheduleSyncTargetsUpdatePayloadV2"
@@ -74192,6 +74549,13 @@
                         ]
                       }
                     ],
+                    "management_meta": {
+                      "annotations": {
+                        "incident.io/terraform/version": "3.0.0"
+                      },
+                      "managed_by": "dashboard",
+                      "source_url": "https://github.com/my-company/infrastructure"
+                    },
                     "slack_team_id": "T02A1AZHG3J",
                     "slack_user_group_id": "S06MNNU5BMK",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -75296,6 +75660,13 @@
                     {
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "id": "01JXYZ000000000000000000CD",
+                      "management_meta": {
+                        "annotations": {
+                          "incident.io/terraform/version": "3.0.0"
+                        },
+                        "managed_by": "dashboard",
+                        "source_url": "https://github.com/my-company/infrastructure"
+                      },
                       "schedule_id": "01JXYZ000000000000000000EF",
                       "schedule_sync_target": {
                         "add_bot_to_group": true,
@@ -75310,6 +75681,13 @@
                             ]
                           }
                         ],
+                        "management_meta": {
+                          "annotations": {
+                            "incident.io/terraform/version": "3.0.0"
+                          },
+                          "managed_by": "dashboard",
+                          "source_url": "https://github.com/my-company/infrastructure"
+                        },
                         "slack_team_id": "T02A1AZHG3J",
                         "slack_user_group_id": "S06MNNU5BMK",
                         "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -75358,6 +75736,9 @@
             "application/json": {
               "example": {
                 "schedule_sync_rule": {
+                  "annotations": {
+                    "incident.io/terraform/version": "3.0.0"
+                  },
                   "schedule_sync_target_id": "01JXYZ000000000000000000AB",
                   "sync_type": "on_call"
                 }
@@ -75377,6 +75758,13 @@
                   "schedule_sync_rule": {
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "id": "01JXYZ000000000000000000CD",
+                    "management_meta": {
+                      "annotations": {
+                        "incident.io/terraform/version": "3.0.0"
+                      },
+                      "managed_by": "dashboard",
+                      "source_url": "https://github.com/my-company/infrastructure"
+                    },
                     "schedule_id": "01JXYZ000000000000000000EF",
                     "schedule_sync_target": {
                       "add_bot_to_group": true,
@@ -75391,6 +75779,13 @@
                           ]
                         }
                       ],
+                      "management_meta": {
+                        "annotations": {
+                          "incident.io/terraform/version": "3.0.0"
+                        },
+                        "managed_by": "dashboard",
+                        "source_url": "https://github.com/my-company/infrastructure"
+                      },
                       "slack_team_id": "T02A1AZHG3J",
                       "slack_user_group_id": "S06MNNU5BMK",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -75497,6 +75892,13 @@
                   "schedule_sync_rule": {
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "id": "01JXYZ000000000000000000CD",
+                    "management_meta": {
+                      "annotations": {
+                        "incident.io/terraform/version": "3.0.0"
+                      },
+                      "managed_by": "dashboard",
+                      "source_url": "https://github.com/my-company/infrastructure"
+                    },
                     "schedule_id": "01JXYZ000000000000000000EF",
                     "schedule_sync_target": {
                       "add_bot_to_group": true,
@@ -75511,6 +75913,13 @@
                           ]
                         }
                       ],
+                      "management_meta": {
+                        "annotations": {
+                          "incident.io/terraform/version": "3.0.0"
+                        },
+                        "managed_by": "dashboard",
+                        "source_url": "https://github.com/my-company/infrastructure"
+                      },
                       "slack_team_id": "T02A1AZHG3J",
                       "slack_user_group_id": "S06MNNU5BMK",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -75586,6 +75995,13 @@
                   "schedule_sync_rule": {
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "id": "01JXYZ000000000000000000CD",
+                    "management_meta": {
+                      "annotations": {
+                        "incident.io/terraform/version": "3.0.0"
+                      },
+                      "managed_by": "dashboard",
+                      "source_url": "https://github.com/my-company/infrastructure"
+                    },
                     "schedule_id": "01JXYZ000000000000000000EF",
                     "schedule_sync_target": {
                       "add_bot_to_group": true,
@@ -75600,6 +76016,13 @@
                           ]
                         }
                       ],
+                      "management_meta": {
+                        "annotations": {
+                          "incident.io/terraform/version": "3.0.0"
+                        },
+                        "managed_by": "dashboard",
+                        "source_url": "https://github.com/my-company/infrastructure"
+                      },
                       "slack_team_id": "T02A1AZHG3J",
                       "slack_user_group_id": "S06MNNU5BMK",
                       "updated_at": "2021-08-17T13:28:57.801578Z"

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -83,7 +83,8 @@
               "status_page_publisher",
               "postmortems_manage",
               "api_keys_manage",
-              "notification_methods_manage"
+              "notification_methods_manage",
+              "act_on_behalf_of_users"
             ],
             "example": "viewer",
             "type": "string",
@@ -298,7 +299,8 @@
                 "status_page_publisher",
                 "postmortems_manage",
                 "api_keys_manage",
-                "notification_methods_manage"
+                "notification_methods_manage",
+                "act_on_behalf_of_users"
               ],
               "example": "viewer",
               "type": "string"
@@ -672,7 +674,8 @@
                 "status_page_publisher",
                 "postmortems_manage",
                 "api_keys_manage",
-                "notification_methods_manage"
+                "notification_methods_manage",
+                "act_on_behalf_of_users"
               ],
               "example": "viewer",
               "type": "string"
@@ -36966,7 +36969,8 @@
                 "status_page_publisher",
                 "postmortems_manage",
                 "api_keys_manage",
-                "notification_methods_manage"
+                "notification_methods_manage",
+                "act_on_behalf_of_users"
               ],
               "example": "viewer",
               "type": "string",
@@ -46440,13 +46444,6 @@
         "example": {
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01JXYZ000000000000000000CD",
-          "management_meta": {
-            "annotations": {
-              "incident.io/terraform/version": "3.0.0"
-            },
-            "managed_by": "dashboard",
-            "source_url": "https://github.com/my-company/infrastructure"
-          },
           "schedule_id": "01JXYZ000000000000000000EF",
           "schedule_sync_target": {
             "add_bot_to_group": true,
@@ -46461,13 +46458,6 @@
                 ]
               }
             ],
-            "management_meta": {
-              "annotations": {
-                "incident.io/terraform/version": "3.0.0"
-              },
-              "managed_by": "dashboard",
-              "source_url": "https://github.com/my-company/infrastructure"
-            },
             "slack_team_id": "T02A1AZHG3J",
             "slack_user_group_id": "S06MNNU5BMK",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46486,9 +46476,6 @@
             "description": "Unique identifier of the sync rule",
             "example": "01JXYZ000000000000000000CD",
             "type": "string"
-          },
-          "management_meta": {
-            "$ref": "#/components/schemas/ManagementMetaV2"
           },
           "schedule_id": {
             "description": "The schedule this rule belongs to",
@@ -46588,13 +46575,6 @@
               ]
             }
           ],
-          "management_meta": {
-            "annotations": {
-              "incident.io/terraform/version": "3.0.0"
-            },
-            "managed_by": "dashboard",
-            "source_url": "https://github.com/my-company/infrastructure"
-          },
           "slack_team_id": "T02A1AZHG3J",
           "slack_user_group_id": "S06MNNU5BMK",
           "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46630,9 +46610,6 @@
               "$ref": "#/components/schemas/LinkedScheduleV2"
             },
             "type": "array"
-          },
-          "management_meta": {
-            "$ref": "#/components/schemas/ManagementMetaV2"
           },
           "slack_team_id": {
             "description": "Slack team ID for the user group",
@@ -46702,13 +46679,6 @@
                 ]
               }
             ],
-            "management_meta": {
-              "annotations": {
-                "incident.io/terraform/version": "3.0.0"
-              },
-              "managed_by": "dashboard",
-              "source_url": "https://github.com/my-company/infrastructure"
-            },
             "slack_team_id": "T02A1AZHG3J",
             "slack_user_group_id": "S06MNNU5BMK",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46744,13 +46714,6 @@
                   ]
                 }
               ],
-              "management_meta": {
-                "annotations": {
-                  "incident.io/terraform/version": "3.0.0"
-                },
-                "managed_by": "dashboard",
-                "source_url": "https://github.com/my-company/infrastructure"
-              },
               "slack_team_id": "T02A1AZHG3J",
               "slack_user_group_id": "S06MNNU5BMK",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46776,13 +46739,6 @@
                     ]
                   }
                 ],
-                "management_meta": {
-                  "annotations": {
-                    "incident.io/terraform/version": "3.0.0"
-                  },
-                  "managed_by": "dashboard",
-                  "source_url": "https://github.com/my-company/infrastructure"
-                },
                 "slack_team_id": "T02A1AZHG3J",
                 "slack_user_group_id": "S06MNNU5BMK",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46814,13 +46770,6 @@
                 ]
               }
             ],
-            "management_meta": {
-              "annotations": {
-                "incident.io/terraform/version": "3.0.0"
-              },
-              "managed_by": "dashboard",
-              "source_url": "https://github.com/my-company/infrastructure"
-            },
             "slack_team_id": "T02A1AZHG3J",
             "slack_user_group_id": "S06MNNU5BMK",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -46881,13 +46830,6 @@
                 ]
               }
             ],
-            "management_meta": {
-              "annotations": {
-                "incident.io/terraform/version": "3.0.0"
-              },
-              "managed_by": "dashboard",
-              "source_url": "https://github.com/my-company/infrastructure"
-            },
             "slack_team_id": "T02A1AZHG3J",
             "slack_user_group_id": "S06MNNU5BMK",
             "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -47575,13 +47517,6 @@
           "schedule_sync_rule": {
             "created_at": "2021-08-17T13:28:57.801578Z",
             "id": "01JXYZ000000000000000000CD",
-            "management_meta": {
-              "annotations": {
-                "incident.io/terraform/version": "3.0.0"
-              },
-              "managed_by": "dashboard",
-              "source_url": "https://github.com/my-company/infrastructure"
-            },
             "schedule_id": "01JXYZ000000000000000000EF",
             "schedule_sync_target": {
               "add_bot_to_group": true,
@@ -47596,13 +47531,6 @@
                   ]
                 }
               ],
-              "management_meta": {
-                "annotations": {
-                  "incident.io/terraform/version": "3.0.0"
-                },
-                "managed_by": "dashboard",
-                "source_url": "https://github.com/my-company/infrastructure"
-              },
               "slack_team_id": "T02A1AZHG3J",
               "slack_user_group_id": "S06MNNU5BMK",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -47999,13 +47927,6 @@
             {
               "created_at": "2021-08-17T13:28:57.801578Z",
               "id": "01JXYZ000000000000000000CD",
-              "management_meta": {
-                "annotations": {
-                  "incident.io/terraform/version": "3.0.0"
-                },
-                "managed_by": "dashboard",
-                "source_url": "https://github.com/my-company/infrastructure"
-              },
               "schedule_id": "01JXYZ000000000000000000EF",
               "schedule_sync_target": {
                 "add_bot_to_group": true,
@@ -48020,13 +47941,6 @@
                     ]
                   }
                 ],
-                "management_meta": {
-                  "annotations": {
-                    "incident.io/terraform/version": "3.0.0"
-                  },
-                  "managed_by": "dashboard",
-                  "source_url": "https://github.com/my-company/infrastructure"
-                },
                 "slack_team_id": "T02A1AZHG3J",
                 "slack_user_group_id": "S06MNNU5BMK",
                 "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -48046,13 +47960,6 @@
               {
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "id": "01JXYZ000000000000000000CD",
-                "management_meta": {
-                  "annotations": {
-                    "incident.io/terraform/version": "3.0.0"
-                  },
-                  "managed_by": "dashboard",
-                  "source_url": "https://github.com/my-company/infrastructure"
-                },
                 "schedule_id": "01JXYZ000000000000000000EF",
                 "schedule_sync_target": {
                   "add_bot_to_group": true,
@@ -48067,13 +47974,6 @@
                       ]
                     }
                   ],
-                  "management_meta": {
-                    "annotations": {
-                      "incident.io/terraform/version": "3.0.0"
-                    },
-                    "managed_by": "dashboard",
-                    "source_url": "https://github.com/my-company/infrastructure"
-                  },
                   "slack_team_id": "T02A1AZHG3J",
                   "slack_user_group_id": "S06MNNU5BMK",
                   "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -48248,13 +48148,6 @@
           "schedule_sync_rule": {
             "created_at": "2021-08-17T13:28:57.801578Z",
             "id": "01JXYZ000000000000000000CD",
-            "management_meta": {
-              "annotations": {
-                "incident.io/terraform/version": "3.0.0"
-              },
-              "managed_by": "dashboard",
-              "source_url": "https://github.com/my-company/infrastructure"
-            },
             "schedule_id": "01JXYZ000000000000000000EF",
             "schedule_sync_target": {
               "add_bot_to_group": true,
@@ -48269,13 +48162,6 @@
                   ]
                 }
               ],
-              "management_meta": {
-                "annotations": {
-                  "incident.io/terraform/version": "3.0.0"
-                },
-                "managed_by": "dashboard",
-                "source_url": "https://github.com/my-company/infrastructure"
-              },
               "slack_team_id": "T02A1AZHG3J",
               "slack_user_group_id": "S06MNNU5BMK",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -48518,13 +48404,6 @@
           "schedule_sync_rule": {
             "created_at": "2021-08-17T13:28:57.801578Z",
             "id": "01JXYZ000000000000000000CD",
-            "management_meta": {
-              "annotations": {
-                "incident.io/terraform/version": "3.0.0"
-              },
-              "managed_by": "dashboard",
-              "source_url": "https://github.com/my-company/infrastructure"
-            },
             "schedule_id": "01JXYZ000000000000000000EF",
             "schedule_sync_target": {
               "add_bot_to_group": true,
@@ -48539,13 +48418,6 @@
                   ]
                 }
               ],
-              "management_meta": {
-                "annotations": {
-                  "incident.io/terraform/version": "3.0.0"
-                },
-                "managed_by": "dashboard",
-                "source_url": "https://github.com/my-company/infrastructure"
-              },
               "slack_team_id": "T02A1AZHG3J",
               "slack_user_group_id": "S06MNNU5BMK",
               "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -74314,13 +74186,6 @@
                           ]
                         }
                       ],
-                      "management_meta": {
-                        "annotations": {
-                          "incident.io/terraform/version": "3.0.0"
-                        },
-                        "managed_by": "dashboard",
-                        "source_url": "https://github.com/my-company/infrastructure"
-                      },
                       "slack_team_id": "T02A1AZHG3J",
                       "slack_user_group_id": "S06MNNU5BMK",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -74389,13 +74254,6 @@
                         ]
                       }
                     ],
-                    "management_meta": {
-                      "annotations": {
-                        "incident.io/terraform/version": "3.0.0"
-                      },
-                      "managed_by": "dashboard",
-                      "source_url": "https://github.com/my-company/infrastructure"
-                    },
                     "slack_team_id": "T02A1AZHG3J",
                     "slack_user_group_id": "S06MNNU5BMK",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -74484,13 +74342,6 @@
                         ]
                       }
                     ],
-                    "management_meta": {
-                      "annotations": {
-                        "incident.io/terraform/version": "3.0.0"
-                      },
-                      "managed_by": "dashboard",
-                      "source_url": "https://github.com/my-company/infrastructure"
-                    },
                     "slack_team_id": "T02A1AZHG3J",
                     "slack_user_group_id": "S06MNNU5BMK",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -74563,13 +74414,6 @@
                         ]
                       }
                     ],
-                    "management_meta": {
-                      "annotations": {
-                        "incident.io/terraform/version": "3.0.0"
-                      },
-                      "managed_by": "dashboard",
-                      "source_url": "https://github.com/my-company/infrastructure"
-                    },
                     "slack_team_id": "T02A1AZHG3J",
                     "slack_user_group_id": "S06MNNU5BMK",
                     "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -75674,13 +75518,6 @@
                     {
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "id": "01JXYZ000000000000000000CD",
-                      "management_meta": {
-                        "annotations": {
-                          "incident.io/terraform/version": "3.0.0"
-                        },
-                        "managed_by": "dashboard",
-                        "source_url": "https://github.com/my-company/infrastructure"
-                      },
                       "schedule_id": "01JXYZ000000000000000000EF",
                       "schedule_sync_target": {
                         "add_bot_to_group": true,
@@ -75695,13 +75532,6 @@
                             ]
                           }
                         ],
-                        "management_meta": {
-                          "annotations": {
-                            "incident.io/terraform/version": "3.0.0"
-                          },
-                          "managed_by": "dashboard",
-                          "source_url": "https://github.com/my-company/infrastructure"
-                        },
                         "slack_team_id": "T02A1AZHG3J",
                         "slack_user_group_id": "S06MNNU5BMK",
                         "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -75772,13 +75602,6 @@
                   "schedule_sync_rule": {
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "id": "01JXYZ000000000000000000CD",
-                    "management_meta": {
-                      "annotations": {
-                        "incident.io/terraform/version": "3.0.0"
-                      },
-                      "managed_by": "dashboard",
-                      "source_url": "https://github.com/my-company/infrastructure"
-                    },
                     "schedule_id": "01JXYZ000000000000000000EF",
                     "schedule_sync_target": {
                       "add_bot_to_group": true,
@@ -75793,13 +75616,6 @@
                           ]
                         }
                       ],
-                      "management_meta": {
-                        "annotations": {
-                          "incident.io/terraform/version": "3.0.0"
-                        },
-                        "managed_by": "dashboard",
-                        "source_url": "https://github.com/my-company/infrastructure"
-                      },
                       "slack_team_id": "T02A1AZHG3J",
                       "slack_user_group_id": "S06MNNU5BMK",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -75906,13 +75722,6 @@
                   "schedule_sync_rule": {
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "id": "01JXYZ000000000000000000CD",
-                    "management_meta": {
-                      "annotations": {
-                        "incident.io/terraform/version": "3.0.0"
-                      },
-                      "managed_by": "dashboard",
-                      "source_url": "https://github.com/my-company/infrastructure"
-                    },
                     "schedule_id": "01JXYZ000000000000000000EF",
                     "schedule_sync_target": {
                       "add_bot_to_group": true,
@@ -75927,13 +75736,6 @@
                           ]
                         }
                       ],
-                      "management_meta": {
-                        "annotations": {
-                          "incident.io/terraform/version": "3.0.0"
-                        },
-                        "managed_by": "dashboard",
-                        "source_url": "https://github.com/my-company/infrastructure"
-                      },
                       "slack_team_id": "T02A1AZHG3J",
                       "slack_user_group_id": "S06MNNU5BMK",
                       "updated_at": "2021-08-17T13:28:57.801578Z"
@@ -76012,13 +75814,6 @@
                   "schedule_sync_rule": {
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "id": "01JXYZ000000000000000000CD",
-                    "management_meta": {
-                      "annotations": {
-                        "incident.io/terraform/version": "3.0.0"
-                      },
-                      "managed_by": "dashboard",
-                      "source_url": "https://github.com/my-company/infrastructure"
-                    },
                     "schedule_id": "01JXYZ000000000000000000EF",
                     "schedule_sync_target": {
                       "add_bot_to_group": true,
@@ -76033,13 +75828,6 @@
                           ]
                         }
                       ],
-                      "management_meta": {
-                        "annotations": {
-                          "incident.io/terraform/version": "3.0.0"
-                        },
-                        "managed_by": "dashboard",
-                        "source_url": "https://github.com/my-company/infrastructure"
-                      },
                       "slack_team_id": "T02A1AZHG3J",
                       "slack_user_group_id": "S06MNNU5BMK",
                       "updated_at": "2021-08-17T13:28:57.801578Z"

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -20,6 +20,7 @@ import (
 
 // Defines values for APIKeyRoleV1Name.
 const (
+	APIKeyRoleV1NameActOnBehalfOfUsers        APIKeyRoleV1Name = "act_on_behalf_of_users"
 	APIKeyRoleV1NameApiKeysManage             APIKeyRoleV1Name = "api_keys_manage"
 	APIKeyRoleV1NameCatalogEditor             APIKeyRoleV1Name = "catalog_editor"
 	APIKeyRoleV1NameCatalogViewer             APIKeyRoleV1Name = "catalog_viewer"
@@ -57,6 +58,7 @@ const (
 
 // Defines values for APIKeysCreatePayloadV1RoleNames.
 const (
+	APIKeysCreatePayloadV1RoleNamesActOnBehalfOfUsers        APIKeysCreatePayloadV1RoleNames = "act_on_behalf_of_users"
 	APIKeysCreatePayloadV1RoleNamesApiKeysManage             APIKeysCreatePayloadV1RoleNames = "api_keys_manage"
 	APIKeysCreatePayloadV1RoleNamesCatalogEditor             APIKeysCreatePayloadV1RoleNames = "catalog_editor"
 	APIKeysCreatePayloadV1RoleNamesCatalogViewer             APIKeysCreatePayloadV1RoleNames = "catalog_viewer"
@@ -94,6 +96,7 @@ const (
 
 // Defines values for APIKeysUpdatePayloadV1RoleNames.
 const (
+	APIKeysUpdatePayloadV1RoleNamesActOnBehalfOfUsers        APIKeysUpdatePayloadV1RoleNames = "act_on_behalf_of_users"
 	APIKeysUpdatePayloadV1RoleNamesApiKeysManage             APIKeysUpdatePayloadV1RoleNames = "api_keys_manage"
 	APIKeysUpdatePayloadV1RoleNamesCatalogEditor             APIKeysUpdatePayloadV1RoleNames = "catalog_editor"
 	APIKeysUpdatePayloadV1RoleNamesCatalogViewer             APIKeysUpdatePayloadV1RoleNames = "catalog_viewer"
@@ -1004,6 +1007,7 @@ const (
 
 // Defines values for IdentityV1Roles.
 const (
+	IdentityV1RolesActOnBehalfOfUsers        IdentityV1Roles = "act_on_behalf_of_users"
 	IdentityV1RolesApiKeysManage             IdentityV1Roles = "api_keys_manage"
 	IdentityV1RolesCatalogEditor             IdentityV1Roles = "catalog_editor"
 	IdentityV1RolesCatalogViewer             IdentityV1Roles = "catalog_viewer"
@@ -7028,8 +7032,7 @@ type ScheduleSyncRuleV2 struct {
 	CreatedAt time.Time `json:"created_at"`
 
 	// Id Unique identifier of the sync rule
-	Id             string            `json:"id"`
-	ManagementMeta *ManagementMetaV2 `json:"management_meta,omitempty"`
+	Id string `json:"id"`
 
 	// ScheduleId The schedule this rule belongs to
 	ScheduleId         string                       `json:"schedule_id"`
@@ -7070,7 +7073,6 @@ type ScheduleSyncTargetResourceV2 struct {
 
 	// LinkedSchedules Schedules with an active sync rule pointing at this target
 	LinkedSchedules []LinkedScheduleV2 `json:"linked_schedules"`
-	ManagementMeta  *ManagementMetaV2  `json:"management_meta,omitempty"`
 
 	// SlackTeamId Slack team ID for the user group
 	SlackTeamId string `json:"slack_team_id"`

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -7272,6 +7272,9 @@ type SchedulesUpdateResultV2 struct {
 
 // SchedulesUpdateScheduleSyncRulePayloadV2 defines model for SchedulesUpdateScheduleSyncRulePayloadV2.
 type SchedulesUpdateScheduleSyncRulePayloadV2 struct {
+	// Annotations Annotations that track metadata about this resource
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
 	// SyncType Which schedule members sync to the user group
 	SyncType SchedulesUpdateScheduleSyncRulePayloadV2SyncType `json:"sync_type"`
 }

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -1216,20 +1216,24 @@ const (
 
 // Defines values for ManagedResourceV2ResourceType.
 const (
-	ManagedResourceV2ResourceTypeAlertRoute     ManagedResourceV2ResourceType = "alert_route"
-	ManagedResourceV2ResourceTypeAlertSource    ManagedResourceV2ResourceType = "alert_source"
-	ManagedResourceV2ResourceTypeEscalationPath ManagedResourceV2ResourceType = "escalation_path"
-	ManagedResourceV2ResourceTypeSchedule       ManagedResourceV2ResourceType = "schedule"
-	ManagedResourceV2ResourceTypeWorkflow       ManagedResourceV2ResourceType = "workflow"
+	ManagedResourceV2ResourceTypeAlertRoute         ManagedResourceV2ResourceType = "alert_route"
+	ManagedResourceV2ResourceTypeAlertSource        ManagedResourceV2ResourceType = "alert_source"
+	ManagedResourceV2ResourceTypeEscalationPath     ManagedResourceV2ResourceType = "escalation_path"
+	ManagedResourceV2ResourceTypeSchedule           ManagedResourceV2ResourceType = "schedule"
+	ManagedResourceV2ResourceTypeScheduleSyncRule   ManagedResourceV2ResourceType = "schedule_sync_rule"
+	ManagedResourceV2ResourceTypeScheduleSyncTarget ManagedResourceV2ResourceType = "schedule_sync_target"
+	ManagedResourceV2ResourceTypeWorkflow           ManagedResourceV2ResourceType = "workflow"
 )
 
 // Defines values for ManagedResourcesCreateManagedResourcePayloadV2ResourceType.
 const (
-	AlertRoute     ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "alert_route"
-	AlertSource    ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "alert_source"
-	EscalationPath ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "escalation_path"
-	Schedule       ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "schedule"
-	Workflow       ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "workflow"
+	AlertRoute         ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "alert_route"
+	AlertSource        ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "alert_source"
+	EscalationPath     ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "escalation_path"
+	Schedule           ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "schedule"
+	ScheduleSyncRule   ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "schedule_sync_rule"
+	ScheduleSyncTarget ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "schedule_sync_target"
+	Workflow           ManagedResourcesCreateManagedResourcePayloadV2ResourceType = "workflow"
 )
 
 // Defines values for ManagementMetaV2ManagedBy.
@@ -2806,6 +2810,11 @@ type AlertsListIncidentAlertsResultV2 struct {
 type AlertsListResultV2 struct {
 	Alerts         []AlertV2              `json:"alerts"`
 	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
+}
+
+// AlertsResolveResultV2 defines model for AlertsResolveResultV2.
+type AlertsResolveResultV2 struct {
+	Alert AlertV2 `json:"alert"`
 }
 
 // AlertsShowResultV2 defines model for AlertsShowResultV2.
@@ -6899,10 +6908,10 @@ type ScheduleRotationCreatePayloadV2SchedulingMode string
 
 // ScheduleRotationHandoverV2 defines model for ScheduleRotationHandoverV2.
 type ScheduleRotationHandoverV2 struct {
-	Interval *int64 `json:"interval,omitempty"`
+	Interval int64 `json:"interval"`
 
 	// IntervalType How often a handover occurs
-	IntervalType *ScheduleRotationHandoverV2IntervalType `json:"interval_type,omitempty"`
+	IntervalType ScheduleRotationHandoverV2IntervalType `json:"interval_type"`
 }
 
 // ScheduleRotationHandoverV2IntervalType How often a handover occurs
@@ -7001,6 +7010,9 @@ type ScheduleRotationWorkingIntervalV2Weekday string
 
 // ScheduleSyncRuleCreatePayloadV2 defines model for ScheduleSyncRuleCreatePayloadV2.
 type ScheduleSyncRuleCreatePayloadV2 struct {
+	// Annotations Annotations that track metadata about this resource
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
 	// ScheduleSyncTargetId The sync target to link to
 	ScheduleSyncTargetId string `json:"schedule_sync_target_id"`
 
@@ -7016,7 +7028,8 @@ type ScheduleSyncRuleV2 struct {
 	CreatedAt time.Time `json:"created_at"`
 
 	// Id Unique identifier of the sync rule
-	Id string `json:"id"`
+	Id             string            `json:"id"`
+	ManagementMeta *ManagementMetaV2 `json:"management_meta,omitempty"`
 
 	// ScheduleId The schedule this rule belongs to
 	ScheduleId         string                       `json:"schedule_id"`
@@ -7036,7 +7049,10 @@ type ScheduleSyncRuleV2SyncType string
 // ScheduleSyncTargetCreatePayloadV2 defines model for ScheduleSyncTargetCreatePayloadV2.
 type ScheduleSyncTargetCreatePayloadV2 struct {
 	// AddBotToGroup Whether the incident.io bot should be added to the group
-	AddBotToGroup     bool                        `json:"add_bot_to_group"`
+	AddBotToGroup bool `json:"add_bot_to_group"`
+
+	// Annotations Annotations that track metadata about this resource
+	Annotations       *map[string]string          `json:"annotations,omitempty"`
 	NewSlackUserGroup *NewSlackUserGroupPayloadV2 `json:"new_slack_user_group,omitempty"`
 
 	// SlackUserGroupId Slack ID of an existing user group to sync to. Mutually exclusive with new_slack_user_group; exactly one must be set.
@@ -7054,6 +7070,7 @@ type ScheduleSyncTargetResourceV2 struct {
 
 	// LinkedSchedules Schedules with an active sync rule pointing at this target
 	LinkedSchedules []LinkedScheduleV2 `json:"linked_schedules"`
+	ManagementMeta  *ManagementMetaV2  `json:"management_meta,omitempty"`
 
 	// SlackTeamId Slack team ID for the user group
 	SlackTeamId string `json:"slack_team_id"`
@@ -7088,6 +7105,9 @@ type ScheduleSyncTargetsShowResultV2 struct {
 type ScheduleSyncTargetsUpdatePayloadV2 struct {
 	// AddBotToGroup Whether the incident.io bot should be added to the group
 	AddBotToGroup bool `json:"add_bot_to_group"`
+
+	// Annotations Annotations that track metadata about this resource
+	Annotations *map[string]string `json:"annotations,omitempty"`
 }
 
 // ScheduleSyncTargetsUpdateResultV2 defines model for ScheduleSyncTargetsUpdateResultV2.
@@ -9406,6 +9426,9 @@ type ClientInterface interface {
 	// AlertsV2Show request
 	AlertsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// AlertsV2Resolve request
+	AlertsV2Resolve(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// CatalogV2ListEntries request
 	CatalogV2ListEntries(ctx context.Context, params *CatalogV2ListEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -11079,6 +11102,18 @@ func (c *Client) AlertsV2List(ctx context.Context, params *AlertsV2ListParams, r
 
 func (c *Client) AlertsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewAlertsV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AlertsV2Resolve(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertsV2ResolveRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -16264,6 +16299,40 @@ func NewAlertsV2ShowRequest(server string, id string) (*http.Request, error) {
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAlertsV2ResolveRequest generates requests for AlertsV2Resolve
+func NewAlertsV2ResolveRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/alerts/%s/actions/resolve", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -21858,6 +21927,9 @@ type ClientWithResponsesInterface interface {
 	// AlertsV2ShowWithResponse request
 	AlertsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*AlertsV2ShowResponse, error)
 
+	// AlertsV2ResolveWithResponse request
+	AlertsV2ResolveWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*AlertsV2ResolveResponse, error)
+
 	// CatalogV2ListEntriesWithResponse request
 	CatalogV2ListEntriesWithResponse(ctx context.Context, params *CatalogV2ListEntriesParams, reqEditors ...RequestEditorFn) (*CatalogV2ListEntriesResponse, error)
 
@@ -23977,6 +24049,28 @@ func (r AlertsV2ShowResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r AlertsV2ShowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AlertsV2ResolveResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AlertsResolveResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r AlertsV2ResolveResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AlertsV2ResolveResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -27234,6 +27328,15 @@ func (c *ClientWithResponses) AlertsV2ShowWithResponse(ctx context.Context, id s
 	return ParseAlertsV2ShowResponse(rsp)
 }
 
+// AlertsV2ResolveWithResponse request returning *AlertsV2ResolveResponse
+func (c *ClientWithResponses) AlertsV2ResolveWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*AlertsV2ResolveResponse, error) {
+	rsp, err := c.AlertsV2Resolve(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertsV2ResolveResponse(rsp)
+}
+
 // CatalogV2ListEntriesWithResponse request returning *CatalogV2ListEntriesResponse
 func (c *ClientWithResponses) CatalogV2ListEntriesWithResponse(ctx context.Context, params *CatalogV2ListEntriesParams, reqEditors ...RequestEditorFn) (*CatalogV2ListEntriesResponse, error) {
 	rsp, err := c.CatalogV2ListEntries(ctx, params, reqEditors...)
@@ -30432,6 +30535,32 @@ func ParseAlertsV2ShowResponse(rsp *http.Response) (*AlertsV2ShowResponse, error
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AlertsShowResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAlertsV2ResolveResponse parses an HTTP response from a AlertsV2ResolveWithResponse call
+func ParseAlertsV2ResolveResponse(rsp *http.Response) (*AlertsV2ResolveResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AlertsV2ResolveResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AlertsResolveResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -361,7 +361,7 @@ func (r *IncidentAlertRouteResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	claimResource(ctx, r.client, result.JSON201.AlertRoute.Id, resp.Diagnostics, client.AlertRoute, r.terraformVersion)
+	claimResource(ctx, r.client, result.JSON201.AlertRoute.Id, &resp.Diagnostics, client.AlertRoute, r.terraformVersion)
 
 	tflog.Trace(ctx, fmt.Sprintf("Created an alert route with id=%s", result.JSON201.AlertRoute.Id))
 
@@ -431,7 +431,7 @@ func (r *IncidentAlertRouteResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	claimResource(ctx, r.client, result.JSON200.AlertRoute.Id, resp.Diagnostics, client.AlertRoute, r.terraformVersion)
+	claimResource(ctx, r.client, result.JSON200.AlertRoute.Id, &resp.Diagnostics, client.AlertRoute, r.terraformVersion)
 
 	data = models.AlertRouteResourceModel{}.FromAPIWithPlan(updateResult.JSON200.AlertRoute, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -452,6 +452,6 @@ func (r *IncidentAlertRouteResource) Delete(ctx context.Context, req resource.De
 }
 
 func (r *IncidentAlertRouteResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.AlertRoute, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, &resp.Diagnostics, client.AlertRoute, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -506,7 +506,7 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	claimResource(ctx, r.client, result.JSON200.AlertSource.Id, resp.Diagnostics, client.AlertSource, r.terraformVersion)
+	claimResource(ctx, r.client, result.JSON200.AlertSource.Id, &resp.Diagnostics, client.AlertSource, r.terraformVersion)
 
 	tflog.Trace(ctx, fmt.Sprintf("created an alert source with id=%s", result.JSON200.AlertSource.Id))
 
@@ -631,7 +631,7 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	claimResource(ctx, r.client, result.JSON200.AlertSource.Id, resp.Diagnostics, client.AlertSource, r.terraformVersion)
+	claimResource(ctx, r.client, result.JSON200.AlertSource.Id, &resp.Diagnostics, client.AlertSource, r.terraformVersion)
 
 	// Save the planned values before overwriting with API response.
 	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
@@ -679,6 +679,6 @@ func (r *IncidentAlertSourceResource) Delete(ctx context.Context, req resource.D
 }
 
 func (r *IncidentAlertSourceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.AlertSource, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, &resp.Diagnostics, client.AlertSource, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -502,7 +502,7 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 		return
 	}
 
-	claimResource(ctx, r.client, result.JSON201.EscalationPath.Id, resp.Diagnostics, client.EscalationPath, r.terraformVersion)
+	claimResource(ctx, r.client, result.JSON201.EscalationPath.Id, &resp.Diagnostics, client.EscalationPath, r.terraformVersion)
 
 	tflog.Trace(ctx, fmt.Sprintf("created an escalation path resource with id=%s", result.JSON201.EscalationPath.Id))
 	data = r.buildModel(result.JSON201.EscalationPath)
@@ -584,7 +584,7 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 		return
 	}
 
-	claimResource(ctx, r.client, result.JSON200.EscalationPath.Id, resp.Diagnostics, client.EscalationPath, r.terraformVersion)
+	claimResource(ctx, r.client, result.JSON200.EscalationPath.Id, &resp.Diagnostics, client.EscalationPath, r.terraformVersion)
 
 	data = r.buildModel(result.JSON200.EscalationPath)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -605,7 +605,7 @@ func (r *IncidentEscalationPathResource) Delete(ctx context.Context, req resourc
 }
 
 func (r *IncidentEscalationPathResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.EscalationPath, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, &resp.Diagnostics, client.EscalationPath, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -338,7 +338,7 @@ func (r *IncidentScheduleResource) Delete(ctx context.Context, req resource.Dele
 }
 
 func (r *IncidentScheduleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.Schedule, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, &resp.Diagnostics, client.Schedule, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/provider/incident_schedule_resource.go
+++ b/internal/provider/incident_schedule_resource.go
@@ -447,10 +447,9 @@ func buildUsersArray(users []types.String) []client.UserReferencePayloadV2 {
 // buildHandoversArray converts a list of handovers to a list of handover references.
 func buildHandoversArray(handovers []models.HandoverV2) []client.ScheduleRotationHandoverV2 {
 	clientHandovers := lo.Map(handovers, func(handover models.HandoverV2, _ int) client.ScheduleRotationHandoverV2 {
-		intervalType := client.ScheduleRotationHandoverV2IntervalType(handover.IntervalType.ValueString())
 		return client.ScheduleRotationHandoverV2{
-			Interval:     handover.Interval.ValueInt64Pointer(),
-			IntervalType: &intervalType,
+			Interval:     handover.Interval.ValueInt64(),
+			IntervalType: client.ScheduleRotationHandoverV2IntervalType(handover.IntervalType.ValueString()),
 		}
 	})
 	return clientHandovers
@@ -553,10 +552,9 @@ func (r *IncidentScheduleResource) buildModel(schedule client.ScheduleV2, plan *
 					})
 
 					handovers := lo.Map(rotation.Handovers, func(handover client.ScheduleRotationHandoverV2, _ int) models.HandoverV2 {
-						intervalTypeString := string(*handover.IntervalType)
 						return models.HandoverV2{
-							Interval:     types.Int64Value(lo.FromPtr(handover.Interval)),
-							IntervalType: types.StringValue(intervalTypeString),
+							Interval:     types.Int64Value(handover.Interval),
+							IntervalType: types.StringValue(string(handover.IntervalType)),
 						}
 					})
 

--- a/internal/provider/incident_schedule_resource_test.go
+++ b/internal/provider/incident_schedule_resource_test.go
@@ -34,8 +34,8 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 								Name:            "Rota",
 								Handovers: []client.ScheduleRotationHandoverV2{
 									{
-										IntervalType: lo.ToPtr(client.ScheduleRotationHandoverV2IntervalType("weekly")),
-										Interval:     lo.ToPtr(int64(1)),
+										IntervalType: client.ScheduleRotationHandoverV2IntervalType("weekly"),
+										Interval:     1,
 									},
 								},
 								Layers: []client.ScheduleLayerV2{
@@ -52,8 +52,8 @@ func TestAccIncidentScheduleResource(t *testing.T) {
 								Name:            "Rota",
 								Handovers: []client.ScheduleRotationHandoverV2{
 									{
-										IntervalType: lo.ToPtr(client.ScheduleRotationHandoverV2IntervalType("weekly")),
-										Interval:     lo.ToPtr(int64(1)),
+										IntervalType: client.ScheduleRotationHandoverV2IntervalType("weekly"),
+										Interval:     1,
 									},
 								},
 								Layers: []client.ScheduleLayerV2{
@@ -167,8 +167,8 @@ func TestAccIncidentScheduleResourceRotationUpdates(t *testing.T) {
 								HandoverStartAt: handoverStartAt,
 								Handovers: []client.ScheduleRotationHandoverV2{
 									{
-										Interval:     lo.ToPtr(int64(1)),
-										IntervalType: lo.ToPtr(client.Weekly),
+										Interval:     1,
+										IntervalType: client.Weekly,
 									},
 								},
 								Layers: []client.ScheduleLayerV2{
@@ -203,8 +203,8 @@ func TestAccIncidentScheduleResourceRotationUpdates(t *testing.T) {
 								HandoverStartAt: handoverStartAt,
 								Handovers: []client.ScheduleRotationHandoverV2{
 									{
-										Interval:     lo.ToPtr(int64(1)),
-										IntervalType: lo.ToPtr(client.Daily),
+										Interval:     1,
+										IntervalType: client.Daily,
 									},
 								},
 								Layers: []client.ScheduleLayerV2{
@@ -220,8 +220,8 @@ func TestAccIncidentScheduleResourceRotationUpdates(t *testing.T) {
 								HandoverStartAt: handoverStartAt,
 								Handovers: []client.ScheduleRotationHandoverV2{
 									{
-										Interval:     lo.ToPtr(int64(1)),
-										IntervalType: lo.ToPtr(client.Daily),
+										Interval:     1,
+										IntervalType: client.Daily,
 									},
 								},
 								EffectiveFrom: &effectiveFrom,
@@ -441,8 +441,8 @@ func incidentScheduleDefault(name string) client.ScheduleV2 {
 					HandoverStartAt: handoverStartAt1,
 					Handovers: []client.ScheduleRotationHandoverV2{
 						{
-							IntervalType: lo.ToPtr(client.ScheduleRotationHandoverV2IntervalType("weekly")),
-							Interval:     lo.ToPtr(int64(1)),
+							IntervalType: client.ScheduleRotationHandoverV2IntervalType("weekly"),
+							Interval:     1,
 						},
 					},
 					Layers: []client.ScheduleLayerV2{
@@ -535,8 +535,8 @@ func generateHandoversArray(handovers []client.ScheduleRotationHandoverV2) strin
 	result += "[\n"
 	for _, handover := range handovers {
 		result += "  {\n"
-		result += "    interval_type = " + quote(string(*handover.IntervalType)) + "\n"
-		result += "    interval      = " + quote(strconv.FormatInt(*handover.Interval, 10)) + "\n"
+		result += "    interval_type = " + quote(string(handover.IntervalType)) + "\n"
+		result += "    interval      = " + quote(strconv.FormatInt(handover.Interval, 10)) + "\n"
 		result += "  },\n"
 	}
 	result += "]\n"

--- a/internal/provider/incident_schedule_sync_rule_resource.go
+++ b/internal/provider/incident_schedule_sync_rule_resource.go
@@ -193,7 +193,7 @@ func (r *IncidentScheduleSyncRuleResource) ImportState(ctx context.Context, req 
 
 	tflog.Info(ctx, fmt.Sprintf("Importing schedule sync rule with schedule_id=%s and rule_id=%s", scheduleID, ruleID))
 
-	claimResource(ctx, r.client, ruleID, resp.Diagnostics, client.ScheduleSyncRule, r.terraformVersion)
+	claimResource(ctx, r.client, ruleID, &resp.Diagnostics, client.ScheduleSyncRule, r.terraformVersion)
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), ruleID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("schedule_id"), scheduleID)...)

--- a/internal/provider/incident_schedule_sync_rule_resource.go
+++ b/internal/provider/incident_schedule_sync_rule_resource.go
@@ -25,7 +25,8 @@ var (
 )
 
 type IncidentScheduleSyncRuleResource struct {
-	client *client.ClientWithResponses
+	client           *client.ClientWithResponses
+	terraformVersion string
 }
 
 func NewIncidentScheduleSyncRuleResource() resource.Resource {
@@ -84,6 +85,7 @@ func (r *IncidentScheduleSyncRuleResource) Configure(ctx context.Context, req re
 	}
 
 	r.client = client.Client
+	r.terraformVersion = client.TerraformVersion
 }
 
 func (r *IncidentScheduleSyncRuleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -97,6 +99,9 @@ func (r *IncidentScheduleSyncRuleResource) Create(ctx context.Context, req resou
 		ScheduleSyncRule: client.ScheduleSyncRuleCreatePayloadV2{
 			ScheduleSyncTargetId: data.ScheduleSyncTargetID.ValueString(),
 			SyncType:             client.ScheduleSyncRuleCreatePayloadV2SyncType(data.SyncType.ValueString()),
+			Annotations: &map[string]string{
+				"incident.io/terraform/version": r.terraformVersion,
+			},
 		},
 	})
 	if err != nil {
@@ -184,6 +189,8 @@ func (r *IncidentScheduleSyncRuleResource) ImportState(ctx context.Context, req 
 	ruleID := idParts[1]
 
 	tflog.Info(ctx, fmt.Sprintf("Importing schedule sync rule with schedule_id=%s and rule_id=%s", scheduleID, ruleID))
+
+	claimResource(ctx, r.client, ruleID, resp.Diagnostics, client.ScheduleSyncRule, r.terraformVersion)
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), ruleID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("schedule_id"), scheduleID)...)

--- a/internal/provider/incident_schedule_sync_rule_resource.go
+++ b/internal/provider/incident_schedule_sync_rule_resource.go
@@ -149,6 +149,9 @@ func (r *IncidentScheduleSyncRuleResource) Update(ctx context.Context, req resou
 
 	result, err := r.client.SchedulesV2UpdateScheduleSyncRuleWithResponse(ctx, data.ScheduleID.ValueString(), data.ID.ValueString(), client.SchedulesUpdateScheduleSyncRulePayloadV2{
 		SyncType: client.SchedulesUpdateScheduleSyncRulePayloadV2SyncType(data.SyncType.ValueString()),
+		Annotations: &map[string]string{
+			"incident.io/terraform/version": r.terraformVersion,
+		},
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update schedule sync rule, got error: %s", err))

--- a/internal/provider/incident_schedule_sync_target_resource.go
+++ b/internal/provider/incident_schedule_sync_target_resource.go
@@ -26,7 +26,8 @@ var (
 )
 
 type IncidentScheduleSyncTargetResource struct {
-	client *client.ClientWithResponses
+	client           *client.ClientWithResponses
+	terraformVersion string
 }
 
 func NewIncidentScheduleSyncTargetResource() resource.Resource {
@@ -150,6 +151,7 @@ func (r *IncidentScheduleSyncTargetResource) Configure(ctx context.Context, req 
 	}
 
 	r.client = client.Client
+	r.terraformVersion = client.TerraformVersion
 }
 
 func (r *IncidentScheduleSyncTargetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -159,8 +161,12 @@ func (r *IncidentScheduleSyncTargetResource) Create(ctx context.Context, req res
 		return
 	}
 
+	payload := data.ToPayload()
+	payload.Annotations = &map[string]string{
+		"incident.io/terraform/version": r.terraformVersion,
+	}
 	result, err := r.client.ScheduleSyncTargetsV2CreateWithResponse(ctx, client.ScheduleSyncTargetsCreatePayloadV2{
-		ScheduleSyncTarget: data.ToPayload(),
+		ScheduleSyncTarget: payload,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create schedule sync target, got error: %s", err))
@@ -245,5 +251,6 @@ func (r *IncidentScheduleSyncTargetResource) Delete(ctx context.Context, req res
 }
 
 func (r *IncidentScheduleSyncTargetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.ScheduleSyncTarget, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/incident_schedule_sync_target_resource.go
+++ b/internal/provider/incident_schedule_sync_target_resource.go
@@ -221,6 +221,9 @@ func (r *IncidentScheduleSyncTargetResource) Update(ctx context.Context, req res
 
 	result, err := r.client.ScheduleSyncTargetsV2UpdateWithResponse(ctx, data.ID.ValueString(), client.ScheduleSyncTargetsUpdatePayloadV2{
 		AddBotToGroup: data.AddBotToGroup.ValueBool(),
+		Annotations: &map[string]string{
+			"incident.io/terraform/version": r.terraformVersion,
+		},
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update schedule sync target, got error: %s", err))

--- a/internal/provider/incident_schedule_sync_target_resource.go
+++ b/internal/provider/incident_schedule_sync_target_resource.go
@@ -254,6 +254,6 @@ func (r *IncidentScheduleSyncTargetResource) Delete(ctx context.Context, req res
 }
 
 func (r *IncidentScheduleSyncTargetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.ScheduleSyncTarget, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, &resp.Diagnostics, client.ScheduleSyncTarget, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -335,7 +335,7 @@ func (r *IncidentWorkflowResource) Delete(ctx context.Context, req resource.Dele
 }
 
 func (r *IncidentWorkflowResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, resp.Diagnostics, client.Workflow, r.terraformVersion)
+	claimResource(ctx, r.client, req.ID, &resp.Diagnostics, client.Workflow, r.terraformVersion)
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/provider/managed_resources.go
+++ b/internal/provider/managed_resources.go
@@ -12,7 +12,7 @@ func claimResource(
 	ctx context.Context,
 	apiClient *client.ClientWithResponses,
 	resourceID string,
-	diagnostics diag.Diagnostics,
+	diagnostics *diag.Diagnostics,
 	resourceType client.ManagedResourcesCreateManagedResourcePayloadV2ResourceType,
 	terraformVersion string,
 ) {


### PR DESCRIPTION
## Summary

- Pass terraform version annotations when creating and updating sync targets and sync rules, marking them as managed by Terraform
- Use `claimResource` on import to mark imported resources as terraform-managed
- Update API schema from core master
- Also adds a bug fix to ensure that diagnostics are passed correctly to `claimResource` - this was an existing bug found by bugbot

## Test plan

- [x] Run acceptance tests for sync target and sync rule resources
- [x] Verify resources show as terraform-managed in dashboard after create/update/import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates resource create/update/import flows and generated API client/schema, including making schedule handover fields required and adding new API surface; these could affect Terraform state consistency and downstream client usage if any assumptions about optional fields or endpoints change.
> 
> **Overview**
> Marks `incident_schedule_sync_target` and `incident_schedule_sync_rule` as Terraform-managed by sending Terraform version *annotations* on create/update and calling `claimResource` during import so imported resources become dashboard-locked.
> 
> Updates the managed-resources helper to take diagnostics by pointer and adjusts existing resources to use it consistently. Regenerates the public API schema/client: adds `POST /v2/alerts/{id}/actions/resolve` and response types, introduces the `act_on_behalf_of_users` API key role, extends managed resource types to include `schedule_sync_target`/`schedule_sync_rule`, and makes schedule rotation handover `interval`/`interval_type` required (non-pointer), updating schedule resource code/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3940bd9f7fa34d993206baac8b69cdefbd4000e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->