### PR TITLE
ONC-11917: Fix escalation path crash on unknown path/working_hours values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix `incident_escalation_path` crashing at plan time with a "cannot handle unknown values" error when `path` or `working_hours` contain values that are unknown until apply (e.g. `path = local.path_templates[var.path_template]`)
+
 ## v5.38.1
 
 - Mark `incident_schedule_sync_target` and `incident_schedule_sync_rule` resources as managed by Terraform

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -389,13 +389,26 @@ func (r *IncidentEscalationPathResource) Configure(ctx context.Context, req reso
 }
 
 func (r *IncidentEscalationPathResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var data *IncidentEscalationPathResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() || data == nil {
+	// We deliberately avoid decoding the whole config into our model here.
+	//
+	// IncidentEscalationPathResourceModel uses plain Go slices (e.g.
+	// []IncidentEscalationPathNode, []models.IncidentWeekdayIntervalConfig)
+	// which cannot represent unknown values. Calling req.Config.Get with a
+	// config that contains any unknown list or element - for example a `path`
+	// derived from a variable-indexed local, or a value that's "known after
+	// apply" - fails with a "cannot handle unknown values" conversion error.
+	//
+	// Instead we pull just the `path` attribute as a types.List and walk it
+	// element-by-element, descending only into values that are known. This
+	// keeps validation working for fully-known configs while tolerating
+	// unknowns anywhere in the tree.
+	var pathVal types.List
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("path"), &pathVal)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	validateEscalationPathTargets(data.Path, &resp.Diagnostics)
+	validateEscalationPathNodeList(pathVal, &resp.Diagnostics)
 }
 
 // rotaRequiredScheduleModes is the set of schedule_mode values that require a
@@ -406,32 +419,81 @@ var rotaRequiredScheduleModes = map[string]bool{
 	string(client.EscalationPathTargetV2ScheduleModeNextOnCallForRota):      true,
 }
 
-func validateEscalationPathTargets(nodes []IncidentEscalationPathNode, diags *diag.Diagnostics) {
-	for _, node := range nodes {
-		if node.Level != nil {
-			for _, target := range node.Level.Targets {
-				validateEscalationPathTarget(target, diags)
-			}
+// validateEscalationPathNodeList walks a list of escalation path nodes,
+// validating the targets on any `level` and `notify_channel` nodes and
+// recursing into the `then_path`/`else_path` of `if_else` nodes.
+//
+// It operates directly on the framework attr.Value types rather than decoding
+// into our Go model, so that unknown values (lists, elements or leaves) can be
+// skipped instead of causing a conversion error.
+func validateEscalationPathNodeList(nodes types.List, diags *diag.Diagnostics) {
+	if nodes.IsNull() || nodes.IsUnknown() {
+		return
+	}
+
+	for _, elem := range nodes.Elements() {
+		node, ok := elem.(types.Object)
+		if !ok || node.IsNull() || node.IsUnknown() {
+			continue
 		}
-		if node.NotifyChannel != nil {
-			for _, target := range node.NotifyChannel.Targets {
-				validateEscalationPathTarget(target, diags)
-			}
+
+		attrs := node.Attributes()
+
+		if level, ok := attrs["level"].(types.Object); ok {
+			validateEscalationPathTargetsAttr(level, diags)
 		}
-		if node.IfElse != nil {
-			validateEscalationPathTargets(node.IfElse.ThenPath, diags)
-			validateEscalationPathTargets(node.IfElse.ElsePath, diags)
+		if notifyChannel, ok := attrs["notify_channel"].(types.Object); ok {
+			validateEscalationPathTargetsAttr(notifyChannel, diags)
+		}
+		if ifElse, ok := attrs["if_else"].(types.Object); ok && !ifElse.IsNull() && !ifElse.IsUnknown() {
+			ifElseAttrs := ifElse.Attributes()
+			if thenPath, ok := ifElseAttrs["then_path"].(types.List); ok {
+				validateEscalationPathNodeList(thenPath, diags)
+			}
+			if elsePath, ok := ifElseAttrs["else_path"].(types.List); ok {
+				validateEscalationPathNodeList(elsePath, diags)
+			}
 		}
 	}
 }
 
-func validateEscalationPathTarget(target IncidentEscalationPathTarget, diags *diag.Diagnostics) {
-	if target.ScheduleMode.IsUnknown() || target.SelectedRotaID.IsUnknown() {
+// validateEscalationPathTargetsAttr validates the `targets` list on a `level`
+// or `notify_channel` node object, skipping anything unknown.
+func validateEscalationPathTargetsAttr(node types.Object, diags *diag.Diagnostics) {
+	if node.IsNull() || node.IsUnknown() {
 		return
 	}
 
-	mode := target.ScheduleMode.ValueString()
-	rotaID := target.SelectedRotaID.ValueString()
+	targets, ok := node.Attributes()["targets"].(types.List)
+	if !ok || targets.IsNull() || targets.IsUnknown() {
+		return
+	}
+
+	for _, elem := range targets.Elements() {
+		target, ok := elem.(types.Object)
+		if !ok || target.IsNull() || target.IsUnknown() {
+			continue
+		}
+
+		validateEscalationPathTarget(target, diags)
+	}
+}
+
+func validateEscalationPathTarget(target types.Object, diags *diag.Diagnostics) {
+	attrs := target.Attributes()
+
+	scheduleMode, _ := attrs["schedule_mode"].(types.String)
+	selectedRotaID, _ := attrs["selected_rota_id"].(types.String)
+
+	// If either field is unknown we can't reliably validate the combination,
+	// so skip - this target will be validated at apply time when values are
+	// known.
+	if scheduleMode.IsUnknown() || selectedRotaID.IsUnknown() {
+		return
+	}
+
+	mode := scheduleMode.ValueString()
+	rotaID := selectedRotaID.ValueString()
 
 	if rotaRequiredScheduleModes[mode] {
 		if rotaID == "" {

--- a/internal/provider/incident_escalation_path_resource_test.go
+++ b/internal/provider/incident_escalation_path_resource_test.go
@@ -665,3 +665,158 @@ resource "incident_escalation_path" "invalid_unexpected_rota" {
   ]
 }`
 }
+
+// TestAccIncidentEscalationPathUnknownValues is a regression test for
+// ONC-11917: ValidateConfig previously decoded the whole config into our model
+// (which uses plain Go slices for `path` and `working_hours`), which crashed
+// with a "cannot handle unknown values" conversion error whenever any part of
+// `path` or `working_hours` was unknown at plan time.
+//
+// Both steps below introduce unknown values into the config in the two ways
+// customers hit this:
+//  1. `path` derived from a local map indexed by a variable.
+//  2. `working_hours` referencing an attribute that is known only after apply.
+//
+// They should plan and apply cleanly rather than erroring during validation.
+func TestAccIncidentEscalationPathUnknownValues(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// 1. path = local.path_templates[var.path_template] - the whole
+			//    `path` list is unknown at plan time.
+			{
+				Config: testAccIncidentEscalationPathResourceConfigUnknownPath(
+					StableSuffix("EP unknown path"),
+				),
+				Check: resource.TestCheckResourceAttr(
+					"incident_escalation_path.unknown_path", "name", StableSuffix("EP unknown path")),
+			},
+			// 2. working_hours referencing a known-after-apply attribute, so a
+			//    nested leaf inside the working_hours list is unknown at plan
+			//    time.
+			{
+				Config: testAccIncidentEscalationPathResourceConfigUnknownWorkingHours(
+					StableSuffix("EP unknown working hours"),
+				),
+				Check: resource.TestCheckResourceAttr(
+					"incident_escalation_path.unknown_working_hours", "name", StableSuffix("EP unknown working hours")),
+			},
+		},
+	})
+}
+
+func testAccIncidentEscalationPathResourceConfigUnknownPath(name string) string {
+	return fmt.Sprintf(`
+resource "incident_schedule" "unknown_path" {
+  name     = %q
+  timezone = "Europe/London"
+  rotations = [{
+    id   = "primary"
+    name = "Primary"
+    versions = [{
+      handover_start_at = "2024-05-01T12:00:00Z"
+      users             = []
+      layers = [{
+        id   = "primary"
+        name = "Primary"
+      }]
+      handovers = [{
+        interval_type = "daily"
+        interval      = 1
+      }]
+    }]
+  }]
+}
+
+variable "path_template" {
+  type    = string
+  default = "default"
+}
+
+# The schedule id is "known after apply", so every node in these template
+# lists - and therefore the selected template itself - is unknown at plan time.
+locals {
+  path_templates = {
+    default = [
+      {
+        type = "level"
+        level = {
+          targets = [{
+            type    = "schedule"
+            id      = incident_schedule.unknown_path.id
+            urgency = "high"
+          }]
+          time_to_ack_seconds = 300
+        }
+      }
+    ]
+  }
+}
+
+resource "incident_escalation_path" "unknown_path" {
+  name = %q
+  path = local.path_templates[var.path_template]
+}
+`, name, name)
+}
+
+func testAccIncidentEscalationPathResourceConfigUnknownWorkingHours(name string) string {
+	return fmt.Sprintf(`
+resource "incident_schedule" "unknown_working_hours" {
+  name     = %q
+  timezone = "Europe/London"
+  rotations = [{
+    id   = "primary"
+    name = "Primary"
+    versions = [{
+      handover_start_at = "2024-05-01T12:00:00Z"
+      users             = []
+      layers = [{
+        id   = "primary"
+        name = "Primary"
+      }]
+      handovers = [{
+        interval_type = "daily"
+        interval      = 1
+      }]
+    }]
+  }]
+}
+
+resource "incident_escalation_path" "unknown_working_hours" {
+  name = %q
+
+  path = [
+    {
+      type = "level"
+      level = {
+        targets = [{
+          type    = "schedule"
+          id      = incident_schedule.unknown_working_hours.id
+          urgency = "high"
+        }]
+        time_to_ack_seconds = 300
+      }
+    }
+  ]
+
+  working_hours = [
+    {
+      # The id references a known-after-apply attribute, so a nested leaf of
+      # the working_hours list is unknown at plan time.
+      id       = incident_schedule.unknown_working_hours.id
+      name     = "UK"
+      timezone = "Europe/London"
+      weekday_intervals = [
+        {
+          weekday    = "monday"
+          start_time = "09:00"
+          end_time   = "17:00"
+        }
+      ]
+    }
+  ]
+}
+`, name, name)
+}


### PR DESCRIPTION
The `incident_escalation_path` resource crashes at plan time with a `Value Conversion Error: Received unknown value, however the target type cannot handle unknown values` whenever any part of `path` or `working_hours` is unknown — for example `path = local.path_templates[var.path_template]`, or a target/working-hours field that references a not-yet-created resource. This regressed in v5.37.0 (the escalation-path schedule modes change) and affects 5.37.0, 5.38.0 and 5.38.1, blocking any plan that builds escalation paths dynamically.

The root cause was in `ValidateConfig`, which called `req.Config.Get` to decode the whole config into `IncidentEscalationPathResourceModel`. That model represents `Path` and `WorkingHours` as plain Go slices (`[]IncidentEscalationPathNode`, `[]models.IncidentWeekdayIntervalConfig`), and plain slices cannot hold an unknown list or element, so the decode errors out before any validation runs. `ValidateConfig` is the only place that decodes config-with-unknowns: Create/Update use `Plan.Get` at apply time when values are known, and Read uses state.

The fix stops decoding the full model in `ValidateConfig`. We now pull just the `path` attribute as a `types.List` via `GetAttribute` and walk it recursively on the framework `attr.Value` types, descending only into elements and nested objects that are known and skipping anything unknown or null. This matters because even when the `path` list itself is known, an individual element or a leaf such as `schedule_mode`/`selected_rota_id` can still be unknown — decoding those into a plain struct would crash. The existing `selected_rota_id`/`schedule_mode` consistency checks are preserved (and still bail out when those leaves are unknown), so validation behaviour is unchanged for fully-known configs. Added acceptance tests cover both failure modes: a `path` sourced from a variable-indexed local, and a `working_hours` entry referencing a known-after-apply attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)