### PR TITLE
ONC-11917: Fix escalation path plan-time crash on unknown values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix `Provider produced inconsistent result after apply` and perpetual diffs on engine param-binding `literal` fields when JSON containing HTML characters (`>`, `<`, `&`) is supplied by an encoder that does not HTML-escape (e.g. CDKTF `JSON.stringify`, `file()`, heredocs). The `literal` field now uses a semantic-equality string type that treats byte-different-but-equivalent JSON as equal.
 - Fix plan-time crash on `incident_escalation_path` when `path`, `targets`, or `working_hours` derive from unknown values (e.g. a `local` indexed by a variable, or another resource's computed attribute)
+- Fix crash on `incident_escalation_path` when `if_else` nodes are nested at the maximum supported depth
 
 ## v5.38.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix `Provider produced inconsistent result after apply` and perpetual diffs on engine param-binding `literal` fields when JSON containing HTML characters (`>`, `<`, `&`) is supplied by an encoder that does not HTML-escape (e.g. CDKTF `JSON.stringify`, `file()`, heredocs). The `literal` field now uses a semantic-equality string type that treats byte-different-but-equivalent JSON as equal.
+- Fix plan-time crash on `incident_escalation_path` when `path`, `targets`, or `working_hours` derive from unknown values (e.g. a `local` indexed by a variable, or another resource's computed attribute)
 
 ## v5.38.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Fix `Provider produced inconsistent result after apply` and perpetual diffs on engine param-binding `literal` fields when JSON containing HTML characters (`>`, `<`, `&`) is supplied by an encoder that does not HTML-escape (e.g. CDKTF `JSON.stringify`, `file()`, heredocs). The `literal` field now uses a semantic-equality string type that treats byte-different-but-equivalent JSON as equal.
 - Fix plan-time crash on `incident_escalation_path` when `path`, `targets`, or `working_hours` derive from unknown values (e.g. a `local` indexed by a variable, or another resource's computed attribute)
-- Fix crash on `incident_escalation_path` when `if_else` nodes are nested at the maximum supported depth
+- Fix crash on `incident_escalation_path` when `if_else` nodes are nested at the maximum supported depth, and reject nesting beyond it at plan time with a clear error instead of an opaque API failure
 
 ## v5.38.1
 

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -132,7 +132,7 @@ resource "incident_escalation_path" "urgent_support" {
 - `name` (String) The name of this escalation path, for the user's reference.
 - `path` (Attributes List) The nodes that form the levels and branches of this escalation path.
 
--->**Note** Although the `if_else` block is recursive, currently a maximum of 4 levels are supported. Attempting to configure more than 4 levels of nesting will result in a schema error. (see [below for nested schema](#nestedatt--path))
+-->**Note** Although the `if_else` block is recursive, currently a maximum of 5 levels are supported. Attempting to configure more than 5 levels of nesting will result in a validation error. (see [below for nested schema](#nestedatt--path))
 
 ### Optional
 

--- a/internal/provider/incident_escalation_path_data_source.go
+++ b/internal/provider/incident_escalation_path_data_source.go
@@ -464,7 +464,7 @@ func (d *IncidentEscalationPathDataSource) Read(ctx context.Context, req datasou
 
 	// Reuse the resource's buildModel function for consistency
 	resource := &IncidentEscalationPathResource{}
-	modelResp := resource.buildModel(*escalationPath)
+	modelResp := resource.buildModel(ctx, *escalationPath, &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &modelResp)...)
 }

--- a/internal/provider/incident_escalation_path_data_source.go
+++ b/internal/provider/incident_escalation_path_data_source.go
@@ -96,7 +96,7 @@ func (d *IncidentEscalationPathDataSource) Schema(ctx context.Context, req datas
 			"path": schema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: apischema.Docstring("EscalationPathV2", "path"),
-				NestedObject:        d.getPathSchema(5),
+				NestedObject:        d.getPathSchema(pathSchemaDepth),
 			},
 			"working_hours": schema.ListNestedAttribute{
 				Computed:            true,

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -38,12 +38,12 @@ type IncidentEscalationPathResource struct {
 }
 
 type IncidentEscalationPathResourceModel struct {
-	ID           types.String                           `tfsdk:"id"`
-	Name         types.String                           `tfsdk:"name"`
-	Path         []IncidentEscalationPathNode           `tfsdk:"path"`
-	WorkingHours []models.IncidentWeekdayIntervalConfig `tfsdk:"working_hours"`
-	RepeatConfig types.Object                           `tfsdk:"repeat_config"`
-	TeamIDs      types.Set                              `tfsdk:"team_ids"`
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Path         types.List   `tfsdk:"path"`
+	WorkingHours types.List   `tfsdk:"working_hours"`
+	RepeatConfig types.Object `tfsdk:"repeat_config"`
+	TeamIDs      types.Set    `tfsdk:"team_ids"`
 }
 
 type IncidentEscalationPathNode struct {
@@ -58,12 +58,12 @@ type IncidentEscalationPathNode struct {
 
 type IncidentEscalationPathNodeIfElse struct {
 	Conditions models.IncidentEngineConditions `tfsdk:"conditions"`
-	ElsePath   []IncidentEscalationPathNode    `tfsdk:"else_path"`
-	ThenPath   []IncidentEscalationPathNode    `tfsdk:"then_path"`
+	ElsePath   types.List                      `tfsdk:"else_path"`
+	ThenPath   types.List                      `tfsdk:"then_path"`
 }
 
 type IncidentEscalationPathNodeLevel struct {
-	Targets                          []IncidentEscalationPathTarget      `tfsdk:"targets"`
+	Targets                          types.List                          `tfsdk:"targets"`
 	RoundRobinConfig                 *IncidentEscalationRoundRobinConfig `tfsdk:"round_robin_config"`
 	TimeToAckIntervalCondition       types.String                        `tfsdk:"time_to_ack_interval_condition"`
 	TimeToAckSeconds                 types.Int64                         `tfsdk:"time_to_ack_seconds"`
@@ -73,10 +73,10 @@ type IncidentEscalationPathNodeLevel struct {
 }
 
 type IncidentEscalationPathNodeNotifyChannel struct {
-	Targets                          []IncidentEscalationPathTarget `tfsdk:"targets"`
-	TimeToAckIntervalCondition       types.String                   `tfsdk:"time_to_ack_interval_condition"`
-	TimeToAckSeconds                 types.Int64                    `tfsdk:"time_to_ack_seconds"`
-	TimeToAckWeekdayIntervalConfigID types.String                   `tfsdk:"time_to_ack_weekday_interval_config_id"`
+	Targets                          types.List   `tfsdk:"targets"`
+	TimeToAckIntervalCondition       types.String `tfsdk:"time_to_ack_interval_condition"`
+	TimeToAckSeconds                 types.Int64  `tfsdk:"time_to_ack_seconds"`
+	TimeToAckWeekdayIntervalConfigID types.String `tfsdk:"time_to_ack_weekday_interval_config_id"`
 }
 
 type IncidentEscalationPathNodeDelay struct {
@@ -107,6 +107,82 @@ type IncidentEscalationPathRepeatConfig struct {
 	RepeatAfterSeconds    types.Int64 `tfsdk:"repeat_after_seconds"`
 	DelayRepeatOnActivity types.Bool  `tfsdk:"delay_repeat_on_activity"`
 }
+
+// targetAttrTypes returns the attribute types for an escalation path target
+// object.
+func targetAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":               types.StringType,
+		"type":             types.StringType,
+		"urgency":          types.StringType,
+		"schedule_mode":    types.StringType,
+		"selected_rota_id": types.StringType,
+	}
+}
+
+// targetListType returns the list type of escalation path targets.
+func targetListType() types.ListType {
+	return types.ListType{ElemType: types.ObjectType{AttrTypes: targetAttrTypes()}}
+}
+
+// nodeAttrTypes returns the attribute types for an escalation path node object
+// at the given recursion depth. It MUST mirror getPathSchema exactly: the
+// if_else attribute (which recurses into then_path/else_path) is only present
+// when depth > 0, matching the schema.
+func nodeAttrTypes(depth int) map[string]attr.Type {
+	attrs := map[string]attr.Type{
+		"id":   types.StringType,
+		"type": types.StringType,
+		"level": types.ObjectType{AttrTypes: map[string]attr.Type{
+			"targets": targetListType(),
+			"round_robin_config": types.ObjectType{AttrTypes: map[string]attr.Type{
+				"enabled":              types.BoolType,
+				"rotate_after_seconds": types.Int64Type,
+			}},
+			"time_to_ack_seconds":                    types.Int64Type,
+			"time_to_ack_interval_condition":         types.StringType,
+			"time_to_ack_weekday_interval_config_id": types.StringType,
+			"ack_mode":                               types.StringType,
+		}},
+		"repeat": types.ObjectType{AttrTypes: map[string]attr.Type{
+			"repeat_times": types.Int64Type,
+			"to_node":      types.StringType,
+		}},
+		"notify_channel": types.ObjectType{AttrTypes: map[string]attr.Type{
+			"targets":                                targetListType(),
+			"time_to_ack_seconds":                    types.Int64Type,
+			"time_to_ack_interval_condition":         types.StringType,
+			"time_to_ack_weekday_interval_config_id": types.StringType,
+		}},
+		"delay": types.ObjectType{AttrTypes: map[string]attr.Type{
+			"delay_seconds":                    types.Int64Type,
+			"delay_interval_condition":         types.StringType,
+			"delay_weekday_interval_config_id": types.StringType,
+		}},
+	}
+
+	if depth > 0 {
+		attrs["if_else"] = types.ObjectType{AttrTypes: map[string]attr.Type{
+			"conditions": types.ListType{
+				ElemType: types.ObjectType{AttrTypes: models.ConditionAttrTypes()},
+			},
+			"else_path": nodeListType(depth - 1),
+			"then_path": nodeListType(depth - 1),
+		}}
+	}
+
+	return attrs
+}
+
+// nodeListType returns the list type of escalation path nodes at the given depth.
+func nodeListType(depth int) types.ListType {
+	return types.ListType{ElemType: types.ObjectType{AttrTypes: nodeAttrTypes(depth)}}
+}
+
+// pathSchemaDepth is the maximum if_else nesting depth supported by the schema.
+// The schema is built with this depth (zero-indexed), supporting 4 levels of
+// nesting.
+const pathSchemaDepth = 5
 
 func NewIncidentEscalationPathResource() resource.Resource {
 	return &IncidentEscalationPathResource{}
@@ -395,7 +471,28 @@ func (r *IncidentEscalationPathResource) ValidateConfig(ctx context.Context, req
 		return
 	}
 
-	validateEscalationPathTargets(data.Path, &resp.Diagnostics)
+	validateEscalationPathTargets(ctx, data.Path, &resp.Diagnostics)
+}
+
+// decodeNodes decodes a types.List of escalation path node objects into the
+// Go model structs. It returns nil if the list is null or unknown.
+func decodeNodes(ctx context.Context, list types.List, diags *diag.Diagnostics) []IncidentEscalationPathNode {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+	var nodes []IncidentEscalationPathNode
+	diags.Append(list.ElementsAs(ctx, &nodes, false)...)
+	return nodes
+}
+
+// decodeTargets decodes a types.List of target objects into the Go model structs.
+func decodeTargets(ctx context.Context, list types.List, diags *diag.Diagnostics) []IncidentEscalationPathTarget {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+	var targets []IncidentEscalationPathTarget
+	diags.Append(list.ElementsAs(ctx, &targets, false)...)
+	return targets
 }
 
 // rotaRequiredScheduleModes is the set of schedule_mode values that require a
@@ -406,21 +503,22 @@ var rotaRequiredScheduleModes = map[string]bool{
 	string(client.EscalationPathTargetV2ScheduleModeNextOnCallForRota):      true,
 }
 
-func validateEscalationPathTargets(nodes []IncidentEscalationPathNode, diags *diag.Diagnostics) {
+func validateEscalationPathTargets(ctx context.Context, nodeList types.List, diags *diag.Diagnostics) {
+	nodes := decodeNodes(ctx, nodeList, diags)
 	for _, node := range nodes {
 		if node.Level != nil {
-			for _, target := range node.Level.Targets {
+			for _, target := range decodeTargets(ctx, node.Level.Targets, diags) {
 				validateEscalationPathTarget(target, diags)
 			}
 		}
 		if node.NotifyChannel != nil {
-			for _, target := range node.NotifyChannel.Targets {
+			for _, target := range decodeTargets(ctx, node.NotifyChannel.Targets, diags) {
 				validateEscalationPathTarget(target, diags)
 			}
 		}
 		if node.IfElse != nil {
-			validateEscalationPathTargets(node.IfElse.ThenPath, diags)
-			validateEscalationPathTargets(node.IfElse.ElsePath, diags)
+			validateEscalationPathTargets(ctx, node.IfElse.ThenPath, diags)
+			validateEscalationPathTargets(ctx, node.IfElse.ElsePath, diags)
 		}
 	}
 }
@@ -459,10 +557,17 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 	}
 
 	var workingHours *[]client.WeekdayIntervalConfigV2
-	if len(data.WorkingHours) > 0 {
-		workingHours = &[]client.WeekdayIntervalConfigV2{}
-		for _, wh := range data.WorkingHours {
-			*workingHours = append(*workingHours, wh.ToClientV2())
+	if !data.WorkingHours.IsNull() && !data.WorkingHours.IsUnknown() {
+		var whModels []models.IncidentWeekdayIntervalConfig
+		resp.Diagnostics.Append(data.WorkingHours.ElementsAs(ctx, &whModels, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if len(whModels) > 0 {
+			workingHours = &[]client.WeekdayIntervalConfigV2{}
+			for _, wh := range whModels {
+				*workingHours = append(*workingHours, wh.ToClientV2(ctx))
+			}
 		}
 	}
 
@@ -492,7 +597,7 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 
 	result, err := r.client.EscalationsV2CreatePathWithResponse(ctx, client.EscalationsV2CreatePathJSONRequestBody{
 		Name:         data.Name.ValueString(),
-		Path:         r.toPathPayload(data.Path),
+		Path:         r.toPathPayload(ctx, data.Path, &resp.Diagnostics),
 		WorkingHours: workingHours,
 		TeamIds:      teamIDs,
 		RepeatConfig: repeatConfig,
@@ -505,7 +610,7 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 	claimResource(ctx, r.client, result.JSON201.EscalationPath.Id, &resp.Diagnostics, client.EscalationPath, r.terraformVersion)
 
 	tflog.Trace(ctx, fmt.Sprintf("created an escalation path resource with id=%s", result.JSON201.EscalationPath.Id))
-	data = r.buildModel(result.JSON201.EscalationPath)
+	data = r.buildModel(ctx, result.JSON201.EscalationPath, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -529,7 +634,7 @@ func (r *IncidentEscalationPathResource) Read(ctx context.Context, req resource.
 		return
 	}
 
-	data = r.buildModel(result.JSON200.EscalationPath)
+	data = r.buildModel(ctx, result.JSON200.EscalationPath, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -541,10 +646,17 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 	}
 
 	var workingHours *[]client.WeekdayIntervalConfigV2
-	if len(data.WorkingHours) > 0 {
-		workingHours = &[]client.WeekdayIntervalConfigV2{}
-		for _, wh := range data.WorkingHours {
-			*workingHours = append(*workingHours, wh.ToClientV2())
+	if !data.WorkingHours.IsNull() && !data.WorkingHours.IsUnknown() {
+		var whModels []models.IncidentWeekdayIntervalConfig
+		resp.Diagnostics.Append(data.WorkingHours.ElementsAs(ctx, &whModels, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if len(whModels) > 0 {
+			workingHours = &[]client.WeekdayIntervalConfigV2{}
+			for _, wh := range whModels {
+				*workingHours = append(*workingHours, wh.ToClientV2(ctx))
+			}
 		}
 	}
 
@@ -574,7 +686,7 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 
 	result, err := r.client.EscalationsV2UpdatePathWithResponse(ctx, data.ID.ValueString(), client.EscalationsV2UpdatePathJSONRequestBody{
 		Name:         data.Name.ValueString(),
-		Path:         r.toPathPayload(data.Path),
+		Path:         r.toPathPayload(ctx, data.Path, &resp.Diagnostics),
 		WorkingHours: workingHours,
 		TeamIds:      teamIDs,
 		RepeatConfig: repeatConfig,
@@ -586,7 +698,7 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 
 	claimResource(ctx, r.client, result.JSON200.EscalationPath.Id, &resp.Diagnostics, client.EscalationPath, r.terraformVersion)
 
-	data = r.buildModel(result.JSON200.EscalationPath)
+	data = r.buildModel(ctx, result.JSON200.EscalationPath, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -609,12 +721,16 @@ func (r *IncidentEscalationPathResource) ImportState(ctx context.Context, req re
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *IncidentEscalationPathResource) buildModel(ep client.EscalationPathV2) *IncidentEscalationPathResourceModel {
-	var workingHours []models.IncidentWeekdayIntervalConfig
+func (r *IncidentEscalationPathResource) buildModel(ctx context.Context, ep client.EscalationPathV2, diags *diag.Diagnostics) *IncidentEscalationPathResourceModel {
+	workingHoursType := types.ObjectType{AttrTypes: models.WeekdayIntervalConfigAttrTypes()}
+	workingHours := types.ListNull(workingHoursType)
 	if ep.WorkingHours != nil {
-		workingHours = lo.Map(*ep.WorkingHours, func(wh client.WeekdayIntervalConfigV2, _ int) models.IncidentWeekdayIntervalConfig {
-			return models.IncidentWeekdayIntervalConfig{}.FromClientV2(wh)
+		whModels := lo.Map(*ep.WorkingHours, func(wh client.WeekdayIntervalConfigV2, _ int) models.IncidentWeekdayIntervalConfig {
+			return models.IncidentWeekdayIntervalConfig{}.FromClientV2(ctx, wh)
 		})
+		list, d := types.ListValueFrom(ctx, workingHoursType, whModels)
+		diags.Append(d...)
+		workingHours = list
 	}
 
 	var teamIDsSet types.Set
@@ -649,14 +765,44 @@ func (r *IncidentEscalationPathResource) buildModel(ep client.EscalationPathV2) 
 	return &IncidentEscalationPathResourceModel{
 		ID:           types.StringValue(ep.Id),
 		Name:         types.StringValue(ep.Name),
-		Path:         r.toPathModel(ep.Path),
+		Path:         r.toPathModel(ctx, ep.Path, pathSchemaDepth, diags),
 		WorkingHours: workingHours,
 		RepeatConfig: repeatConfigObj,
 		TeamIDs:      teamIDsSet,
 	}
 }
 
-func (r *IncidentEscalationPathResource) toPathModel(nodes []client.EscalationPathNodeV2) []IncidentEscalationPathNode {
+// targetsFromAPI builds a types.List of escalation path target objects from API
+// targets.
+func targetsFromAPI(ctx context.Context, targets []client.EscalationPathTargetV2, diags *diag.Diagnostics) types.List {
+	models := lo.Map(targets, func(target client.EscalationPathTargetV2, _ int) IncidentEscalationPathTarget {
+		scheduleMode := types.StringNull()
+		if target.ScheduleMode != nil {
+			scheduleMode = types.StringValue(string(*target.ScheduleMode))
+		}
+
+		selectedRotaID := types.StringNull()
+		if target.SelectedRotaId != nil && *target.SelectedRotaId != "" {
+			selectedRotaID = types.StringValue(*target.SelectedRotaId)
+		}
+
+		return IncidentEscalationPathTarget{
+			ID:             types.StringValue(target.Id),
+			Type:           types.StringValue(string(target.Type)),
+			Urgency:        types.StringValue(string(target.Urgency)),
+			ScheduleMode:   scheduleMode,
+			SelectedRotaID: selectedRotaID,
+		}
+	})
+
+	list, d := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: targetAttrTypes()}, models)
+	diags.Append(d...)
+	return list
+}
+
+func (r *IncidentEscalationPathResource) toPathModel(ctx context.Context, nodes []client.EscalationPathNodeV2, depth int, diags *diag.Diagnostics) types.List {
+	elemType := types.ObjectType{AttrTypes: nodeAttrTypes(depth)}
+
 	out := []IncidentEscalationPathNode{}
 	for _, node := range nodes {
 		elem := IncidentEscalationPathNode{
@@ -674,32 +820,13 @@ func (r *IncidentEscalationPathResource) toPathModel(nodes []client.EscalationPa
 						}),
 					}
 				}),
-				ThenPath: r.toPathModel(node.IfElse.ThenPath),
-				ElsePath: r.toPathModel(node.IfElse.ElsePath),
+				ThenPath: r.toPathModel(ctx, node.IfElse.ThenPath, depth-1, diags),
+				ElsePath: r.toPathModel(ctx, node.IfElse.ElsePath, depth-1, diags),
 			}
 		}
 		if node.Level != nil {
 			elem.Level = &IncidentEscalationPathNodeLevel{
-				Targets: lo.Map(node.Level.Targets,
-					func(target client.EscalationPathTargetV2, _ int) IncidentEscalationPathTarget {
-						scheduleMode := types.StringNull()
-						if target.ScheduleMode != nil {
-							scheduleMode = types.StringValue(string(*target.ScheduleMode))
-						}
-
-						selectedRotaID := types.StringNull()
-						if target.SelectedRotaId != nil && *target.SelectedRotaId != "" {
-							selectedRotaID = types.StringValue(*target.SelectedRotaId)
-						}
-
-						return IncidentEscalationPathTarget{
-							ID:             types.StringValue(target.Id),
-							Type:           types.StringValue(string(target.Type)),
-							Urgency:        types.StringValue(string(target.Urgency)),
-							ScheduleMode:   scheduleMode,
-							SelectedRotaID: selectedRotaID,
-						}
-					}),
+				Targets: targetsFromAPI(ctx, node.Level.Targets, diags),
 			}
 			if value := node.Level.RoundRobinConfig; value != nil {
 				var rotateAfterSeconds basetypes.Int64Value
@@ -726,26 +853,7 @@ func (r *IncidentEscalationPathResource) toPathModel(nodes []client.EscalationPa
 		}
 		if node.NotifyChannel != nil {
 			elem.NotifyChannel = &IncidentEscalationPathNodeNotifyChannel{
-				Targets: lo.Map(node.NotifyChannel.Targets,
-					func(target client.EscalationPathTargetV2, _ int) IncidentEscalationPathTarget {
-						scheduleMode := types.StringNull()
-						if target.ScheduleMode != nil {
-							scheduleMode = types.StringValue(string(*target.ScheduleMode))
-						}
-
-						selectedRotaID := types.StringNull()
-						if target.SelectedRotaId != nil && *target.SelectedRotaId != "" {
-							selectedRotaID = types.StringValue(*target.SelectedRotaId)
-						}
-
-						return IncidentEscalationPathTarget{
-							ID:             types.StringValue(target.Id),
-							Type:           types.StringValue(string(target.Type)),
-							Urgency:        types.StringValue(string(target.Urgency)),
-							ScheduleMode:   scheduleMode,
-							SelectedRotaID: selectedRotaID,
-						}
-					}),
+				Targets: targetsFromAPI(ctx, node.NotifyChannel.Targets, diags),
 			}
 			if value := node.NotifyChannel.TimeToAckSeconds; value != nil {
 				elem.NotifyChannel.TimeToAckSeconds = types.Int64Value(*value)
@@ -779,10 +887,35 @@ func (r *IncidentEscalationPathResource) toPathModel(nodes []client.EscalationPa
 		out = append(out, elem)
 	}
 
-	return out
+	list, d := types.ListValueFrom(ctx, elemType, out)
+	diags.Append(d...)
+	return list
 }
 
-func (r *IncidentEscalationPathResource) toPathPayload(path []IncidentEscalationPathNode) []client.EscalationPathNodePayloadV2 {
+// targetsToPayload converts a types.List of target objects to client payloads.
+func targetsToPayload(ctx context.Context, list types.List, diags *diag.Diagnostics) []client.EscalationPathTargetV2 {
+	targets := decodeTargets(ctx, list, diags)
+	return lo.Map(targets, func(target IncidentEscalationPathTarget, _ int) client.EscalationPathTargetV2 {
+		targetPayload := client.EscalationPathTargetV2{
+			Id:      target.ID.ValueString(),
+			Type:    client.EscalationPathTargetV2Type(target.Type.ValueString()),
+			Urgency: client.EscalationPathTargetV2Urgency(target.Urgency.ValueString()),
+		}
+
+		if target.ScheduleMode.ValueString() != "" {
+			targetPayload.ScheduleMode = lo.ToPtr(client.EscalationPathTargetV2ScheduleMode(target.ScheduleMode.ValueString()))
+		}
+
+		if target.SelectedRotaID.ValueString() != "" {
+			targetPayload.SelectedRotaId = lo.ToPtr(target.SelectedRotaID.ValueString())
+		}
+
+		return targetPayload
+	})
+}
+
+func (r *IncidentEscalationPathResource) toPathPayload(ctx context.Context, pathList types.List, diags *diag.Diagnostics) []client.EscalationPathNodePayloadV2 {
+	path := decodeNodes(ctx, pathList, diags)
 	out := []client.EscalationPathNodePayloadV2{}
 	for _, node := range path {
 		nodeID := node.ID.ValueString()
@@ -797,8 +930,8 @@ func (r *IncidentEscalationPathResource) toPathPayload(path []IncidentEscalation
 		if !reflect.ValueOf(node.IfElse).IsZero() {
 			elem.IfElse = &client.EscalationPathNodeIfElsePayloadV2{
 				Conditions: lo.ToPtr(node.IfElse.Conditions.ToPayload()),
-				ThenPath:   r.toPathPayload(node.IfElse.ThenPath),
-				ElsePath:   r.toPathPayload(node.IfElse.ElsePath),
+				ThenPath:   r.toPathPayload(ctx, node.IfElse.ThenPath, diags),
+				ElsePath:   r.toPathPayload(ctx, node.IfElse.ElsePath, diags),
 			}
 		}
 		if !reflect.ValueOf(node.Level).IsZero() {
@@ -808,23 +941,7 @@ func (r *IncidentEscalationPathResource) toPathPayload(path []IncidentEscalation
 			}
 
 			elem.Level = &client.EscalationPathNodeLevelV2{
-				Targets: lo.Map(node.Level.Targets, func(target IncidentEscalationPathTarget, _ int) client.EscalationPathTargetV2 {
-					targetPayload := client.EscalationPathTargetV2{
-						Id:      target.ID.ValueString(),
-						Type:    client.EscalationPathTargetV2Type(target.Type.ValueString()),
-						Urgency: client.EscalationPathTargetV2Urgency(target.Urgency.ValueString()),
-					}
-
-					if target.ScheduleMode.ValueString() != "" {
-						targetPayload.ScheduleMode = lo.ToPtr(client.EscalationPathTargetV2ScheduleMode(target.ScheduleMode.ValueString()))
-					}
-
-					if target.SelectedRotaID.ValueString() != "" {
-						targetPayload.SelectedRotaId = lo.ToPtr(target.SelectedRotaID.ValueString())
-					}
-
-					return targetPayload
-				}),
+				Targets:                    targetsToPayload(ctx, node.Level.Targets, diags),
 				TimeToAckIntervalCondition: intervalCondition,
 				TimeToAckSeconds: node.Level.
 					TimeToAckSeconds.ValueInt64Pointer(),
@@ -853,23 +970,7 @@ func (r *IncidentEscalationPathResource) toPathPayload(path []IncidentEscalation
 			}
 
 			elem.NotifyChannel = &client.EscalationPathNodeNotifyChannelV2{
-				Targets: lo.Map(node.NotifyChannel.Targets, func(target IncidentEscalationPathTarget, _ int) client.EscalationPathTargetV2 {
-					targetPayload := client.EscalationPathTargetV2{
-						Id:      target.ID.ValueString(),
-						Type:    client.EscalationPathTargetV2Type(target.Type.ValueString()),
-						Urgency: client.EscalationPathTargetV2Urgency(target.Urgency.ValueString()),
-					}
-
-					if target.ScheduleMode.ValueString() != "" {
-						targetPayload.ScheduleMode = lo.ToPtr(client.EscalationPathTargetV2ScheduleMode(target.ScheduleMode.ValueString()))
-					}
-
-					if target.SelectedRotaID.ValueString() != "" {
-						targetPayload.SelectedRotaId = lo.ToPtr(target.SelectedRotaID.ValueString())
-					}
-
-					return targetPayload
-				}),
+				Targets:                    targetsToPayload(ctx, node.NotifyChannel.Targets, diags),
 				TimeToAckIntervalCondition: intervalCondition,
 				TimeToAckSeconds: node.NotifyChannel.
 					TimeToAckSeconds.ValueInt64Pointer(),

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -566,7 +566,7 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 		if len(whModels) > 0 {
 			workingHours = &[]client.WeekdayIntervalConfigV2{}
 			for _, wh := range whModels {
-				*workingHours = append(*workingHours, wh.ToClientV2(ctx))
+				*workingHours = append(*workingHours, wh.ToClientV2(ctx, &resp.Diagnostics))
 			}
 		}
 	}
@@ -595,9 +595,14 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 		}
 	}
 
+	pathPayload := r.toPathPayload(ctx, data.Path, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	result, err := r.client.EscalationsV2CreatePathWithResponse(ctx, client.EscalationsV2CreatePathJSONRequestBody{
 		Name:         data.Name.ValueString(),
-		Path:         r.toPathPayload(ctx, data.Path, &resp.Diagnostics),
+		Path:         pathPayload,
 		WorkingHours: workingHours,
 		TeamIds:      teamIDs,
 		RepeatConfig: repeatConfig,
@@ -655,7 +660,7 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 		if len(whModels) > 0 {
 			workingHours = &[]client.WeekdayIntervalConfigV2{}
 			for _, wh := range whModels {
-				*workingHours = append(*workingHours, wh.ToClientV2(ctx))
+				*workingHours = append(*workingHours, wh.ToClientV2(ctx, &resp.Diagnostics))
 			}
 		}
 	}
@@ -684,9 +689,14 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 		}
 	}
 
+	pathPayload := r.toPathPayload(ctx, data.Path, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	result, err := r.client.EscalationsV2UpdatePathWithResponse(ctx, data.ID.ValueString(), client.EscalationsV2UpdatePathJSONRequestBody{
 		Name:         data.Name.ValueString(),
-		Path:         r.toPathPayload(ctx, data.Path, &resp.Diagnostics),
+		Path:         pathPayload,
 		WorkingHours: workingHours,
 		TeamIds:      teamIDs,
 		RepeatConfig: repeatConfig,
@@ -726,7 +736,7 @@ func (r *IncidentEscalationPathResource) buildModel(ctx context.Context, ep clie
 	workingHours := types.ListNull(workingHoursType)
 	if ep.WorkingHours != nil {
 		whModels := lo.Map(*ep.WorkingHours, func(wh client.WeekdayIntervalConfigV2, _ int) models.IncidentWeekdayIntervalConfig {
-			return models.IncidentWeekdayIntervalConfig{}.FromClientV2(ctx, wh)
+			return models.IncidentWeekdayIntervalConfig{}.FromClientV2(ctx, wh, diags)
 		})
 		list, d := types.ListValueFrom(ctx, workingHoursType, whModels)
 		diags.Append(d...)

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -180,8 +180,8 @@ func nodeListType(depth int) types.ListType {
 }
 
 // pathSchemaDepth is the maximum if_else nesting depth supported by the schema.
-// The schema is built with this depth (zero-indexed), supporting 4 levels of
-// nesting.
+// The schema is built with this depth (zero-indexed), supporting 5 levels of
+// if_else nesting.
 const pathSchemaDepth = 5
 
 func NewIncidentEscalationPathResource() resource.Resource {
@@ -210,8 +210,8 @@ func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resourc
 			"path": schema.ListNestedAttribute{
 				MarkdownDescription: fmt.Sprintf("%s\n%s",
 					apischema.Docstring("EscalationPathV2", "path"),
-					"\n-->**Note** Although the `if_else` block is recursive, currently a maximum of 4 levels are supported. "+
-						"Attempting to configure more than 4 levels of nesting will result in a schema error.\n"),
+					"\n-->**Note** Although the `if_else` block is recursive, currently a maximum of 5 levels are supported. "+
+						"Attempting to configure more than 5 levels of nesting will result in a validation error.\n"),
 				Required:     true,
 				NestedObject: r.getPathSchema(5),
 			},
@@ -421,7 +421,7 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 		},
 	}
 
-	// Only include if_else attribute if we haven't reached the maximum nesting depth (4 levels)
+	// Only include if_else attribute if we haven't reached the maximum nesting depth (5 levels)
 	if depth > 0 {
 		result.Attributes["if_else"] = schema.SingleNestedAttribute{
 			MarkdownDescription: apischema.Docstring("EscalationPathNodeV2", "if_else"),
@@ -471,7 +471,7 @@ func (r *IncidentEscalationPathResource) ValidateConfig(ctx context.Context, req
 		return
 	}
 
-	validateEscalationPathTargets(ctx, data.Path, &resp.Diagnostics)
+	validateEscalationPathNodes(ctx, data.Path, pathSchemaDepth, &resp.Diagnostics)
 }
 
 // decodeNodes decodes a types.List of escalation path node objects into the
@@ -562,9 +562,25 @@ var rotaRequiredScheduleModes = map[string]bool{
 	string(client.EscalationPathTargetV2ScheduleModeNextOnCallForRota):      true,
 }
 
-func validateEscalationPathTargets(ctx context.Context, nodeList types.List, diags *diag.Diagnostics) {
+// validateEscalationPathNodes walks the path validating targets, and enforces
+// the maximum if_else nesting depth. depth is the remaining schema depth at this
+// level (pathSchemaDepth at the top, decremented into each if_else branch).
+//
+// The schema only declares if_else down to pathSchemaDepth levels, so a node
+// nested deeper has no if_else attribute to decode into and reaches us with
+// type "if_else" but no if_else block. We reject that at plan time with a clear
+// message rather than letting it through to fail at apply with an opaque API
+// error about a missing if_else payload.
+func validateEscalationPathNodes(ctx context.Context, nodeList types.List, depth int, diags *diag.Diagnostics) {
 	nodes := decodeNodes(ctx, nodeList, diags)
 	for _, node := range nodes {
+		if depth <= 0 && node.Type.ValueString() == string(client.EscalationPathNodeV2TypeIfElse) {
+			diags.Append(diag.NewErrorDiagnostic(
+				"Escalation path nested too deeply",
+				fmt.Sprintf("if_else nodes can be nested at most %d levels deep. Reduce the nesting in your escalation path.", pathSchemaDepth),
+			))
+			continue
+		}
 		if node.Level != nil {
 			for _, target := range decodeTargets(ctx, node.Level.Targets, diags) {
 				validateEscalationPathTarget(target, diags)
@@ -576,8 +592,8 @@ func validateEscalationPathTargets(ctx context.Context, nodeList types.List, dia
 			}
 		}
 		if node.IfElse != nil {
-			validateEscalationPathTargets(ctx, node.IfElse.ThenPath, diags)
-			validateEscalationPathTargets(ctx, node.IfElse.ElsePath, diags)
+			validateEscalationPathNodes(ctx, node.IfElse.ThenPath, depth-1, diags)
+			validateEscalationPathNodes(ctx, node.IfElse.ElsePath, depth-1, diags)
 		}
 	}
 }

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -476,13 +476,72 @@ func (r *IncidentEscalationPathResource) ValidateConfig(ctx context.Context, req
 
 // decodeNodes decodes a types.List of escalation path node objects into the
 // Go model structs. It returns nil if the list is null or unknown.
+//
+// It decodes each element attribute by attribute rather than reflecting the
+// whole struct: at the maximum nesting depth the object type omits if_else
+// (mirroring the finite schema), but the IncidentEscalationPathNode struct
+// always carries an if_else field, so ElementsAs would fail with a struct/object
+// mismatch. Reading attributes explicitly lets us decode if_else only when the
+// object actually carries it.
 func decodeNodes(ctx context.Context, list types.List, diags *diag.Diagnostics) []IncidentEscalationPathNode {
 	if list.IsNull() || list.IsUnknown() {
 		return nil
 	}
-	var nodes []IncidentEscalationPathNode
-	diags.Append(list.ElementsAs(ctx, &nodes, false)...)
+	nodes := make([]IncidentEscalationPathNode, 0, len(list.Elements()))
+	for _, elem := range list.Elements() {
+		obj, ok := elem.(types.Object)
+		if !ok || obj.IsNull() || obj.IsUnknown() {
+			continue
+		}
+		nodes = append(nodes, objectToNode(ctx, obj, diags))
+	}
 	return nodes
+}
+
+// objectToNode decodes a single escalation path node object into the Go model
+// struct. The if_else attribute is only decoded when present and non-null, so
+// it stays safe at the maximum nesting depth where if_else is absent.
+func objectToNode(ctx context.Context, obj types.Object, diags *diag.Diagnostics) IncidentEscalationPathNode {
+	attrs := obj.Attributes()
+	node := IncidentEscalationPathNode{}
+	if v, ok := attrs["id"].(types.String); ok {
+		node.ID = v
+	}
+	if v, ok := attrs["type"].(types.String); ok {
+		node.Type = v
+	}
+
+	decodeObject := func(key string, target any) bool {
+		o, ok := attrs[key].(types.Object)
+		if !ok || o.IsNull() || o.IsUnknown() {
+			return false
+		}
+		diags.Append(o.As(ctx, target, basetypes.ObjectAsOptions{})...)
+		return true
+	}
+
+	var level IncidentEscalationPathNodeLevel
+	if decodeObject("level", &level) {
+		node.Level = &level
+	}
+	var notifyChannel IncidentEscalationPathNodeNotifyChannel
+	if decodeObject("notify_channel", &notifyChannel) {
+		node.NotifyChannel = &notifyChannel
+	}
+	var delay IncidentEscalationPathNodeDelay
+	if decodeObject("delay", &delay) {
+		node.Delay = &delay
+	}
+	var repeat IncidentEscalationPathNodeRepeat
+	if decodeObject("repeat", &repeat) {
+		node.Repeat = &repeat
+	}
+	var ifElse IncidentEscalationPathNodeIfElse
+	if decodeObject("if_else", &ifElse) {
+		node.IfElse = &ifElse
+	}
+
+	return node
 }
 
 // decodeTargets decodes a types.List of target objects into the Go model structs.
@@ -897,9 +956,57 @@ func (r *IncidentEscalationPathResource) toPathModel(ctx context.Context, nodes 
 		out = append(out, elem)
 	}
 
-	list, d := types.ListValueFrom(ctx, elemType, out)
+	// Build the object values explicitly rather than reflecting the whole
+	// struct via ListValueFrom. The IncidentEscalationPathNode struct always
+	// carries an if_else field, but nodeAttrTypes omits if_else at depth 0
+	// (matching the finite schema), so whole-struct reflection would fail at
+	// the maximum nesting depth with a struct/object mismatch.
+	objs := make([]attr.Value, 0, len(out))
+	for _, node := range out {
+		objs = append(objs, nodeToObject(ctx, node, depth, diags))
+	}
+
+	list, d := types.ListValue(elemType, objs)
 	diags.Append(d...)
 	return list
+}
+
+// nodeToObject converts a single escalation path node to a types.Object using
+// the attribute types for the given recursion depth. It only sets the if_else
+// attribute when depth > 0, mirroring nodeAttrTypes/getPathSchema, so it stays
+// safe at the maximum nesting depth where if_else is not part of the schema.
+func nodeToObject(ctx context.Context, node IncidentEscalationPathNode, depth int, diags *diag.Diagnostics) types.Object {
+	attrTypes := nodeAttrTypes(depth)
+	values := map[string]attr.Value{
+		"id":   node.ID,
+		"type": node.Type,
+	}
+
+	setObject := func(key string, isNil bool, from any) {
+		objType, ok := attrTypes[key].(types.ObjectType)
+		if !ok {
+			return
+		}
+		if isNil {
+			values[key] = types.ObjectNull(objType.AttrTypes)
+			return
+		}
+		obj, d := types.ObjectValueFrom(ctx, objType.AttrTypes, from)
+		diags.Append(d...)
+		values[key] = obj
+	}
+
+	setObject("level", node.Level == nil, node.Level)
+	setObject("notify_channel", node.NotifyChannel == nil, node.NotifyChannel)
+	setObject("delay", node.Delay == nil, node.Delay)
+	setObject("repeat", node.Repeat == nil, node.Repeat)
+	if depth > 0 {
+		setObject("if_else", node.IfElse == nil, node.IfElse)
+	}
+
+	obj, d := types.ObjectValue(attrTypes, values)
+	diags.Append(d...)
+	return obj
 }
 
 // targetsToPayload converts a types.List of target objects to client payloads.

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -213,7 +213,7 @@ func (r *IncidentEscalationPathResource) Schema(ctx context.Context, req resourc
 					"\n-->**Note** Although the `if_else` block is recursive, currently a maximum of 5 levels are supported. "+
 						"Attempting to configure more than 5 levels of nesting will result in a validation error.\n"),
 				Required:     true,
-				NestedObject: r.getPathSchema(5),
+				NestedObject: r.getPathSchema(pathSchemaDepth),
 			},
 			"working_hours": schema.ListNestedAttribute{
 				MarkdownDescription: apischema.Docstring("EscalationPathV2", "working_hours"),
@@ -860,7 +860,7 @@ func (r *IncidentEscalationPathResource) buildModel(ctx context.Context, ep clie
 // targetsFromAPI builds a types.List of escalation path target objects from API
 // targets.
 func targetsFromAPI(ctx context.Context, targets []client.EscalationPathTargetV2, diags *diag.Diagnostics) types.List {
-	models := lo.Map(targets, func(target client.EscalationPathTargetV2, _ int) IncidentEscalationPathTarget {
+	targetModels := lo.Map(targets, func(target client.EscalationPathTargetV2, _ int) IncidentEscalationPathTarget {
 		scheduleMode := types.StringNull()
 		if target.ScheduleMode != nil {
 			scheduleMode = types.StringValue(string(*target.ScheduleMode))
@@ -880,7 +880,7 @@ func targetsFromAPI(ctx context.Context, targets []client.EscalationPathTargetV2
 		}
 	})
 
-	list, d := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: targetAttrTypes()}, models)
+	list, d := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: targetAttrTypes()}, targetModels)
 	diags.Append(d...)
 	return list
 }

--- a/internal/provider/incident_escalation_path_resource_test.go
+++ b/internal/provider/incident_escalation_path_resource_test.go
@@ -344,160 +344,113 @@ func teamTypeName() string {
 	return "Team"
 }
 
-func TestAccIncidentEscalationPathResourceValidateMaxDepth(t *testing.T) {
+func TestAccIncidentEscalationPathMaxDepth(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			// A path nested to the maximum supported depth (5 if_else levels)
+			// applies cleanly.
 			{
-				Config: testAccIncidentEscalationPathResourceConfigExceedingMaxDepth(),
-				// Nesting beyond the maximum supported depth is not caught by
-				// schema validation at plan time; the API rejects it at apply
-				// because the deepest if_else node cannot carry an if_else payload.
-				ExpectError: regexp.MustCompile(`If_else type requires an if_else payload`)},
+				Config: testAccIncidentEscalationPathNestedConfig(5),
+				Check: resource.TestCheckResourceAttr(
+					"incident_escalation_path.example", "name", "Deeply Nested Path Test"),
+			},
 		},
 	})
 }
 
-func testAccIncidentEscalationPathResourceConfigExceedingMaxDepth() string {
-	return `
-# This is the primary schedule that receives pages in working hours.
+func TestAccIncidentEscalationPathExceedsMaxDepth(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Nesting one level beyond the maximum (6 if_else levels) is rejected
+			// at plan time with a clear validation error, rather than slipping
+			// through to fail at apply with an opaque API error.
+			{
+				Config:      testAccIncidentEscalationPathNestedConfig(6),
+				ExpectError: regexp.MustCompile(`if_else nodes can be nested at most 5 levels deep`),
+			},
+		},
+	})
+}
+
+// testAccIncidentEscalationPathNestedConfig builds an escalation path whose path
+// is a single chain of ifElseLevels nested if_else nodes terminating in a level
+// node. Used to exercise the maximum supported nesting depth and one level
+// beyond it.
+func testAccIncidentEscalationPathNestedConfig(ifElseLevels int) string {
+	node := `
+                {
+                  type = "level"
+                  level = {
+                    targets = [{
+                      type    = "schedule"
+                      id      = incident_schedule.primary_on_call.id
+                      urgency = "high"
+                    }]
+                    time_to_ack_seconds = 300
+                  }
+                }`
+
+	// Wrap the leaf in (ifElseLevels-1) if_else nodes; the outermost path node
+	// below is the final if_else, giving ifElseLevels in total.
+	for i := 0; i < ifElseLevels-1; i++ {
+		node = fmt.Sprintf(`
+                {
+                  type = "if_else"
+                  if_else = {
+                    conditions = [
+                      {
+                        operation      = "is_active"
+                        param_bindings = []
+                        subject        = "escalation.working_hours[\"UK\"]"
+                      }
+                    ]
+                    then_path = [%s
+                    ]
+                    else_path = []
+                  }
+                }`, node)
+	}
+
+	return fmt.Sprintf(`
 resource "incident_schedule" "primary_on_call" {
-  name = "Deep Nesting Test Schedule"
+  name     = "Deep Nesting Test Schedule"
   timezone = "Europe/London"
   rotations = [{
     id   = "primary"
     name = "Primary"
-
     versions = [
       {
         handover_start_at = "2024-05-01T12:00:00Z"
-        users = []
-        layers = [
-          {
-            id   = "primary"
-            name = "Primary"
-          }
-        ]
-        handovers = [
-          {
-            interval_type = "daily"
-            interval      = 1
-          }
-        ]
+        users             = []
+        layers            = [{ id = "primary", name = "Primary" }]
+        handovers         = [{ interval_type = "daily", interval = 1 }]
       },
     ]
   }]
-
   team_ids = []
 }
 
-# Create a path with if_else nodes nested one level beyond the maximum the
-# schema supports (6 levels deep), which Terraform must reject during config
-# validation because the schema does not define an if_else block at that depth.
 resource "incident_escalation_path" "example" {
   name = "Deeply Nested Path Test"
 
   path = [
     {
-      id = "start"
+      id   = "start"
       type = "if_else"
       if_else = {
         conditions = [
           {
-            operation = "is_active",
+            operation      = "is_active"
             param_bindings = []
-            subject = "escalation.working_hours[\"UK\"]"
+            subject        = "escalation.working_hours[\"UK\"]"
           }
         ]
-        then_path = [
-          {
-            type = "if_else"
-            if_else = {
-              conditions = [
-                {
-                  operation = "is_active",
-                  param_bindings = []
-				  subject = "escalation.working_hours[\"UK\"]"
-                }
-              ]
-              then_path = [
-                {
-                  type = "if_else"
-                  if_else = {
-                    conditions = [
-						{
-						  operation = "is_active",
-						  param_bindings = []
-						  subject = "escalation.working_hours[\"UK\"]"
-						}
-                    ]
-                    then_path = [
-                      {
-                        type = "if_else"
-                        if_else = {
-                          conditions = [
-							{
-							  operation = "is_active",
-							  param_bindings = []
-							  subject = "escalation.working_hours[\"UK\"]"
-							}
-                          ]
-                          then_path = [
-                            {
-                              type = "if_else"
-                              if_else = {
-                                conditions = [
-                                  {
-                                    operation = "is_active",
-                                    param_bindings = []
-                                    subject = "escalation.working_hours[\"UK\"]"
-                                  }
-                                ]
-                                then_path = [
-                                  {
-                                    type = "if_else"
-                                    if_else = {
-                                      conditions = [
-                                        {
-                                          operation = "is_active",
-                                          param_bindings = []
-                                          subject = "escalation.working_hours[\"UK\"]"
-                                        }
-                                      ]
-                                      then_path = [
-                                        {
-                                          type = "level"
-                                          level = {
-                                            targets = [{
-                                              type    = "schedule"
-                                              id      = incident_schedule.primary_on_call.id
-                                              urgency  = "high"
-                                            }]
-                                            time_to_ack_seconds = 300
-                                          }
-                                        }
-                                      ]
-                                      else_path = []
-                                    }
-                                  }
-                                ],
-                                else_path = []
-                              }
-                            }
-                          ],
-                          else_path = []
-                        }
-                      }
-                    ],
-                    else_path = []
-                  }
-                }
-              ],
-              else_path = []
-            }
-          }
-        ],
+        then_path = [%s
+        ]
         else_path = []
       }
     }
@@ -505,8 +458,8 @@ resource "incident_escalation_path" "example" {
 
   working_hours = [
     {
-      id = "UK"
-      name = "UK"
+      id       = "UK"
+      name     = "UK"
       timezone = "Europe/London"
       weekday_intervals = [
         {
@@ -520,7 +473,7 @@ resource "incident_escalation_path" "example" {
 
   team_ids = []
 }
-`
+`, node)
 }
 
 func TestAccIncidentEscalationPathSelectedRotaID(t *testing.T) {

--- a/internal/provider/incident_escalation_path_resource_test.go
+++ b/internal/provider/incident_escalation_path_resource_test.go
@@ -350,8 +350,11 @@ func TestAccIncidentEscalationPathResourceValidateMaxDepth(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccIncidentEscalationPathResourceConfigExceedingMaxDepth(),
-				ExpectError: regexp.MustCompile(`Struct defines fields not found in\nobject: if_else`)},
+				Config: testAccIncidentEscalationPathResourceConfigExceedingMaxDepth(),
+				// Nesting beyond the maximum supported depth is not caught by
+				// schema validation at plan time; the API rejects it at apply
+				// because the deepest if_else node cannot carry an if_else payload.
+				ExpectError: regexp.MustCompile(`If_else type requires an if_else payload`)},
 		},
 	})
 }
@@ -389,7 +392,9 @@ resource "incident_schedule" "primary_on_call" {
   team_ids = []
 }
 
-# Create a path with deeply nested if_else nodes (5 levels deep)
+# Create a path with if_else nodes nested one level beyond the maximum the
+# schema supports (6 levels deep), which Terraform must reject during config
+# validation because the schema does not define an if_else block at that depth.
 resource "incident_escalation_path" "example" {
   name = "Deeply Nested Path Test"
 
@@ -451,14 +456,29 @@ resource "incident_escalation_path" "example" {
                                 ]
                                 then_path = [
                                   {
-                                    type = "level"
-                                    level = {
-                                      targets = [{
-                                        type    = "schedule"
-                                        id      = incident_schedule.primary_on_call.id
-                                        urgency  = "high"
-                                      }]
-                                      time_to_ack_seconds = 300
+                                    type = "if_else"
+                                    if_else = {
+                                      conditions = [
+                                        {
+                                          operation = "is_active",
+                                          param_bindings = []
+                                          subject = "escalation.working_hours[\"UK\"]"
+                                        }
+                                      ]
+                                      then_path = [
+                                        {
+                                          type = "level"
+                                          level = {
+                                            targets = [{
+                                              type    = "schedule"
+                                              id      = incident_schedule.primary_on_call.id
+                                              urgency  = "high"
+                                            }]
+                                            time_to_ack_seconds = 300
+                                          }
+                                        }
+                                      ]
+                                      else_path = []
                                     }
                                   }
                                 ],

--- a/internal/provider/incident_escalation_path_resource_test.go
+++ b/internal/provider/incident_escalation_path_resource_test.go
@@ -665,3 +665,155 @@ resource "incident_escalation_path" "invalid_unexpected_rota" {
   ]
 }`
 }
+
+// TestAccIncidentEscalationPathUnknownValues is a regression test for ONC-11917.
+//
+// It reproduces the two configurations that previously crashed at plan time
+// with "Received unknown value, however the target type cannot handle unknown
+// values ... Target Type: []provider.IncidentEscalationPathNode". The crash
+// happened because the resource model stored path/targets/working_hours as
+// plain Go slices, which cannot represent the unknown values that Terraform
+// produces during planning when those values derive from computed attributes
+// or are constructed via HCL expressions (locals, indexing, etc.).
+//
+// Both steps below force the whole `path` (and a nested target id /
+// working_hours config id) to be unknown at plan time:
+//   - the path is read from a `local` indexed by a variable, mirroring the
+//     customer's `local.path_templates[var.path_template]`, and
+//   - a target id references the computed id of an incident_schedule resource,
+//     so it is "known after apply".
+//
+// With the types.List-based model these plan cleanly and converge.
+func TestAccIncidentEscalationPathUnknownValues(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and read: the whole path is built from a local indexed by a
+			// variable, and the target id is a computed schedule id (known after
+			// apply). Both made the old slice-based model crash at plan time.
+			{
+				Config: testAccIncidentEscalationPathResourceConfigUnknownValues(
+					StableSuffix("EP unknown values"),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.unknown_values", "name", StableSuffix("EP unknown values")),
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.unknown_values", "path.0.type", "level"),
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.unknown_values", "path.0.level.targets.0.type", "schedule"),
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.unknown_values", "path.0.level.targets.0.urgency", "high"),
+					// The target id resolves to the computed schedule id.
+					resource.TestCheckResourceAttrPair(
+						"incident_escalation_path.unknown_values", "path.0.level.targets.0.id",
+						"incident_schedule.unknown_values", "id"),
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.unknown_values", "working_hours.0.id", "UK"),
+				),
+			},
+			// Import/refresh: confirm existing state reads back cleanly. A
+			// ListNestedAttribute already serialises as a list-of-objects in
+			// state, identical to the old []struct encoding, so no schema-version
+			// bump or state upgrader is required.
+			{
+				ResourceName:      "incident_escalation_path.unknown_values",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// testAccIncidentEscalationPathResourceConfigUnknownValues builds a config
+// where the escalation path is assembled from a local indexed by a variable,
+// and where a target id and a working_hours config id reference values that are
+// only known after apply.
+func testAccIncidentEscalationPathResourceConfigUnknownValues(name string) string {
+	return fmt.Sprintf(`
+data "incident_catalog_type" "team" {
+  name = %q
+}
+
+resource "incident_catalog_entry" "terraform_unknown_values" {
+  catalog_type_id    = data.incident_catalog_type.team.id
+  external_id        = "tf-acceptance-test-unknown-values"
+  name               = "Terraform test team unknown values"
+  attribute_values   = []
+  managed_attributes = []
+}
+
+resource "incident_schedule" "unknown_values" {
+  name     = %q
+  timezone = "Europe/London"
+  rotations = [{
+    id   = "primary"
+    name = "Primary"
+    versions = [{
+      handover_start_at = "2024-05-01T12:00:00Z"
+      users             = []
+      layers = [{
+        id   = "primary"
+        name = "Primary"
+      }]
+      handovers = [{
+        interval_type = "daily"
+        interval      = 1
+      }]
+    }]
+  }]
+  team_ids = [incident_catalog_entry.terraform_unknown_values.id]
+}
+
+# Mirrors the customer's local.path_templates[var.path_template]: the path is
+# selected from a map keyed by a variable, so the resource only learns the
+# concrete path during apply. The nested target id and the working_hours config
+# id reference the computed schedule id, making them "known after apply".
+variable "path_template" {
+  type    = string
+  default = "default"
+}
+
+locals {
+  path_templates = {
+    default = [
+      {
+        type = "level"
+        level = {
+          targets = [{
+            type    = "schedule"
+            id      = incident_schedule.unknown_values.id
+            urgency = "high"
+          }]
+          time_to_ack_seconds = 300
+        }
+      },
+    ]
+  }
+}
+
+resource "incident_escalation_path" "unknown_values" {
+  name = %q
+
+  path = local.path_templates[var.path_template]
+
+  working_hours = [
+    {
+      id       = "UK"
+      name     = "UK"
+      timezone = "Europe/London"
+      weekday_intervals = [
+        {
+          weekday    = "monday"
+          start_time = "09:00"
+          end_time   = "17:00"
+        }
+      ]
+    }
+  ]
+
+  team_ids = [incident_catalog_entry.terraform_unknown_values.id]
+}
+`, teamTypeName(), name, name)
+}

--- a/internal/provider/incident_escalation_path_roundtrip_test.go
+++ b/internal/provider/incident_escalation_path_roundtrip_test.go
@@ -1,0 +1,139 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/samber/lo"
+
+	"github.com/incident-io/terraform-provider-incident/internal/client"
+)
+
+// TestEscalationPathRoundTrip exercises the types.List-based model conversions
+// end to end: API -> model (toPathModel via buildModel) -> payload
+// (toPathPayload). It deliberately includes a nested if_else node so we cover
+// the recursive nodeAttrTypes path, including the deepest level where the
+// if_else attribute is absent from the schema.
+func TestEscalationPathRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	r := &IncidentEscalationPathResource{}
+
+	level := func(id string) client.EscalationPathNodeV2 {
+		return client.EscalationPathNodeV2{
+			Id:   id,
+			Type: client.EscalationPathNodeV2TypeLevel,
+			Level: &client.EscalationPathNodeLevelV2{
+				Targets: []client.EscalationPathTargetV2{
+					{
+						Id:      "schedule-1",
+						Type:    client.EscalationPathTargetV2TypeSchedule,
+						Urgency: client.EscalationPathTargetV2UrgencyHigh,
+					},
+				},
+				TimeToAckSeconds: lo.ToPtr(int64(300)),
+			},
+		}
+	}
+
+	// ifElse wraps the given children in an if_else node, letting us build a
+	// deeply nested path to exercise every recursion depth, including the
+	// deepest level (depth 0) where the if_else attribute is absent.
+	ifElse := func(id string, then, els client.EscalationPathNodeV2) client.EscalationPathNodeV2 {
+		return client.EscalationPathNodeV2{
+			Id:   id,
+			Type: client.EscalationPathNodeV2TypeIfElse,
+			IfElse: &client.EscalationPathNodeIfElseV2{
+				Conditions: []client.ConditionV2{
+					{
+						Subject:   client.ConditionSubjectV2{Reference: "incident.severity"},
+						Operation: client.ConditionOperationV2{Value: "is"},
+					},
+				},
+				ThenPath: []client.EscalationPathNodeV2{then},
+				ElsePath: []client.EscalationPathNodeV2{els},
+			},
+		}
+	}
+
+	// Build 4 levels of nesting (the maximum the schema supports), so the
+	// innermost level node sits at recursion depth 1, and its parent if_else
+	// produces then/else lists whose element type is nodeAttrTypes(0) (no
+	// if_else attribute).
+	deeplyNested := ifElse("d1",
+		ifElse("d2",
+			ifElse("d3",
+				ifElse("d4", level("deepest-then"), level("deepest-else")),
+				level("d3-else")),
+			level("d2-else")),
+		level("d1-else"))
+
+	ep := client.EscalationPathV2{
+		Id:   "ep-1",
+		Name: "Test path",
+		Path: []client.EscalationPathNodeV2{
+			level("node-1"),
+			ifElse("node-2", level("node-2-then"), level("node-2-else")),
+			deeplyNested,
+		},
+		WorkingHours: &[]client.WeekdayIntervalConfigV2{
+			{
+				Id:       "wh-1",
+				Name:     "Office hours",
+				Timezone: "Europe/London",
+				WeekdayIntervals: []client.WeekdayIntervalV2{
+					{StartTime: "09:00", EndTime: "17:00", Weekday: client.Monday},
+				},
+			},
+		},
+	}
+
+	var diags diag.Diagnostics
+	model := r.buildModel(ctx, ep, &diags)
+	if diags.HasError() {
+		t.Fatalf("buildModel produced errors: %#v", diags)
+	}
+
+	if model.Path.IsNull() || model.Path.IsUnknown() {
+		t.Fatalf("expected non-null path list")
+	}
+	if l := len(model.Path.Elements()); l != 3 {
+		t.Fatalf("expected 3 path nodes, got %d", l)
+	}
+	if model.WorkingHours.IsNull() {
+		t.Fatalf("expected non-null working hours list")
+	}
+
+	// Now round-trip back to a payload.
+	var payloadDiags diag.Diagnostics
+	payload := r.toPathPayload(ctx, model.Path, &payloadDiags)
+	if payloadDiags.HasError() {
+		t.Fatalf("toPathPayload produced errors: %#v", payloadDiags)
+	}
+	if len(payload) != 3 {
+		t.Fatalf("expected 3 payload nodes, got %d", len(payload))
+	}
+
+	// Walk to the deepest then-path level to confirm full-depth round-trip.
+	deep := payload[2].IfElse
+	for i := 0; i < 3 && deep != nil; i++ {
+		if len(deep.ThenPath) != 1 {
+			t.Fatalf("expected single then-path node at depth %d", i)
+		}
+		deep = deep.ThenPath[0].IfElse
+	}
+	if deep == nil || deep.ThenPath[0].Level == nil {
+		t.Fatalf("expected deepest then-path to terminate in a level node")
+	}
+
+	node2 := payload[1].IfElse
+	if node2 == nil {
+		t.Fatalf("expected second node to have if_else payload")
+	}
+	if len(node2.ThenPath) != 1 || len(node2.ElsePath) != 1 {
+		t.Fatalf("expected then/else paths to round-trip, got then=%d else=%d", len(node2.ThenPath), len(node2.ElsePath))
+	}
+	if node2.ThenPath[0].Level == nil || len(node2.ThenPath[0].Level.Targets) != 1 {
+		t.Fatalf("expected nested then-path level target to round-trip")
+	}
+}

--- a/internal/provider/incident_escalation_path_roundtrip_test.go
+++ b/internal/provider/incident_escalation_path_roundtrip_test.go
@@ -56,14 +56,17 @@ func TestEscalationPathRoundTrip(t *testing.T) {
 		}
 	}
 
-	// Build 4 levels of nesting (the maximum the schema supports), so the
-	// innermost level node sits at recursion depth 1, and its parent if_else
-	// produces then/else lists whose element type is nodeAttrTypes(0) (no
-	// if_else attribute).
+	// Build 5 levels of if_else nesting (the maximum the schema supports), so
+	// the innermost level nodes sit at recursion depth 0 — the level whose
+	// element type (nodeAttrTypes(0)) has no if_else attribute. This is the
+	// case that whole-struct reflection (ListValueFrom) cannot handle, since
+	// the node struct always carries an if_else field.
 	deeplyNested := ifElse("d1",
 		ifElse("d2",
 			ifElse("d3",
-				ifElse("d4", level("deepest-then"), level("deepest-else")),
+				ifElse("d4",
+					ifElse("d5", level("deepest-then"), level("deepest-else")),
+					level("d4-else")),
 				level("d3-else")),
 			level("d2-else")),
 		level("d1-else"))
@@ -114,15 +117,22 @@ func TestEscalationPathRoundTrip(t *testing.T) {
 		t.Fatalf("expected 3 payload nodes, got %d", len(payload))
 	}
 
-	// Walk to the deepest then-path level to confirm full-depth round-trip.
+	// Walk down the then-path chain of the deeply nested node to confirm the
+	// full-depth round-trip terminates in a level node. The deepest level sits
+	// at recursion depth 0, where the if_else attribute is absent.
 	deep := payload[2].IfElse
-	for i := 0; i < 3 && deep != nil; i++ {
-		if len(deep.ThenPath) != 1 {
-			t.Fatalf("expected single then-path node at depth %d", i)
-		}
-		deep = deep.ThenPath[0].IfElse
+	if deep == nil {
+		t.Fatalf("expected deeply nested node to have if_else payload")
 	}
-	if deep == nil || deep.ThenPath[0].Level == nil {
+	depthWalked := 0
+	for deep.ThenPath[0].IfElse != nil {
+		deep = deep.ThenPath[0].IfElse
+		depthWalked++
+	}
+	if depthWalked != 4 {
+		t.Fatalf("expected to walk 4 nested if_else levels, walked %d", depthWalked)
+	}
+	if deep.ThenPath[0].Level == nil {
 		t.Fatalf("expected deepest then-path to terminate in a level node")
 	}
 

--- a/internal/provider/models/common.go
+++ b/internal/provider/models/common.go
@@ -1,6 +1,9 @@
 package models
 
 import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -9,10 +12,35 @@ import (
 )
 
 type IncidentWeekdayIntervalConfig struct {
-	ID               types.String              `tfsdk:"id"`
-	Name             types.String              `tfsdk:"name"`
-	Timezone         types.String              `tfsdk:"timezone"`
-	WeekdayIntervals []IncidentWeekdayInterval `tfsdk:"weekday_intervals"`
+	ID       types.String `tfsdk:"id"`
+	Name     types.String `tfsdk:"name"`
+	Timezone types.String `tfsdk:"timezone"`
+	// WeekdayIntervals is a types.List of IncidentWeekdayInterval objects so the
+	// model can carry unknown values during planning.
+	WeekdayIntervals types.List `tfsdk:"weekday_intervals"`
+}
+
+// WeekdayIntervalAttrTypes returns the attribute types for a single weekday
+// interval object.
+func WeekdayIntervalAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"start_time": types.StringType,
+		"end_time":   types.StringType,
+		"weekday":    types.StringType,
+	}
+}
+
+// WeekdayIntervalConfigAttrTypes returns the attribute types for a single
+// weekday interval config object.
+func WeekdayIntervalConfigAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":       types.StringType,
+		"name":     types.StringType,
+		"timezone": types.StringType,
+		"weekday_intervals": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: WeekdayIntervalAttrTypes()},
+		},
+	}
 }
 
 func (IncidentWeekdayIntervalConfig) Attributes() map[string]schema.Attribute {
@@ -39,23 +67,34 @@ func (IncidentWeekdayIntervalConfig) Attributes() map[string]schema.Attribute {
 	}
 }
 
-func (IncidentWeekdayIntervalConfig) FromClientV2(config client.WeekdayIntervalConfigV2) IncidentWeekdayIntervalConfig {
+func (IncidentWeekdayIntervalConfig) FromClientV2(ctx context.Context, config client.WeekdayIntervalConfigV2) IncidentWeekdayIntervalConfig {
 	intervals := make([]IncidentWeekdayInterval, len(config.WeekdayIntervals))
 	for i, interval := range config.WeekdayIntervals {
 		intervals[i] = IncidentWeekdayInterval{}.FromClientV2(interval)
 	}
 
+	intervalList, _ := types.ListValueFrom(
+		ctx,
+		types.ObjectType{AttrTypes: WeekdayIntervalAttrTypes()},
+		intervals,
+	)
+
 	return IncidentWeekdayIntervalConfig{
 		ID:               types.StringValue(config.Id),
 		Name:             types.StringValue(config.Name),
 		Timezone:         types.StringValue(config.Timezone),
-		WeekdayIntervals: intervals,
+		WeekdayIntervals: intervalList,
 	}
 }
 
-func (c IncidentWeekdayIntervalConfig) ToClientV2() client.WeekdayIntervalConfigV2 {
-	intervals := make([]client.WeekdayIntervalV2, len(c.WeekdayIntervals))
-	for i, interval := range c.WeekdayIntervals {
+func (c IncidentWeekdayIntervalConfig) ToClientV2(ctx context.Context) client.WeekdayIntervalConfigV2 {
+	var modelIntervals []IncidentWeekdayInterval
+	if !c.WeekdayIntervals.IsNull() && !c.WeekdayIntervals.IsUnknown() {
+		_ = c.WeekdayIntervals.ElementsAs(ctx, &modelIntervals, false)
+	}
+
+	intervals := make([]client.WeekdayIntervalV2, len(modelIntervals))
+	for i, interval := range modelIntervals {
 		intervals[i] = client.WeekdayIntervalV2{
 			StartTime: interval.StartTime.ValueString(),
 			EndTime:   interval.EndTime.ValueString(),

--- a/internal/provider/models/common.go
+++ b/internal/provider/models/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -67,17 +68,18 @@ func (IncidentWeekdayIntervalConfig) Attributes() map[string]schema.Attribute {
 	}
 }
 
-func (IncidentWeekdayIntervalConfig) FromClientV2(ctx context.Context, config client.WeekdayIntervalConfigV2) IncidentWeekdayIntervalConfig {
+func (IncidentWeekdayIntervalConfig) FromClientV2(ctx context.Context, config client.WeekdayIntervalConfigV2, diags *diag.Diagnostics) IncidentWeekdayIntervalConfig {
 	intervals := make([]IncidentWeekdayInterval, len(config.WeekdayIntervals))
 	for i, interval := range config.WeekdayIntervals {
 		intervals[i] = IncidentWeekdayInterval{}.FromClientV2(interval)
 	}
 
-	intervalList, _ := types.ListValueFrom(
+	intervalList, d := types.ListValueFrom(
 		ctx,
 		types.ObjectType{AttrTypes: WeekdayIntervalAttrTypes()},
 		intervals,
 	)
+	diags.Append(d...)
 
 	return IncidentWeekdayIntervalConfig{
 		ID:               types.StringValue(config.Id),
@@ -87,10 +89,10 @@ func (IncidentWeekdayIntervalConfig) FromClientV2(ctx context.Context, config cl
 	}
 }
 
-func (c IncidentWeekdayIntervalConfig) ToClientV2(ctx context.Context) client.WeekdayIntervalConfigV2 {
+func (c IncidentWeekdayIntervalConfig) ToClientV2(ctx context.Context, diags *diag.Diagnostics) client.WeekdayIntervalConfigV2 {
 	var modelIntervals []IncidentWeekdayInterval
 	if !c.WeekdayIntervals.IsNull() && !c.WeekdayIntervals.IsUnknown() {
-		_ = c.WeekdayIntervals.ElementsAs(ctx, &modelIntervals, false)
+		diags.Append(c.WeekdayIntervals.ElementsAs(ctx, &modelIntervals, false)...)
 	}
 
 	intervals := make([]client.WeekdayIntervalV2, len(modelIntervals))

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -15,7 +15,7 @@ import (
 // value object.
 func ParamBindingValueAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"literal":   types.StringType,
+		"literal":   jsontypes.NormalizedJSONOrStringType{},
 		"reference": types.StringType,
 	}
 }

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/samber/lo"
@@ -9,6 +10,36 @@ import (
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 	"github.com/incident-io/terraform-provider-incident/internal/provider/jsontypes"
 )
+
+// ParamBindingValueAttrTypes returns the attribute types for a param binding
+// value object.
+func ParamBindingValueAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"literal":   types.StringType,
+		"reference": types.StringType,
+	}
+}
+
+// ParamBindingAttrTypes returns the attribute types for a param binding object.
+func ParamBindingAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"array_value": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: ParamBindingValueAttrTypes()},
+		},
+		"value": types.ObjectType{AttrTypes: ParamBindingValueAttrTypes()},
+	}
+}
+
+// ConditionAttrTypes returns the attribute types for a single condition object.
+func ConditionAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"operation": types.StringType,
+		"param_bindings": types.ListType{
+			ElemType: types.ObjectType{AttrTypes: ParamBindingAttrTypes()},
+		},
+		"subject": types.StringType,
+	}
+}
 
 // Types
 


### PR DESCRIPTION
Customers configuring `incident_escalation_path` dynamically hit a hard plan-time crash: "Received unknown value, however the target type cannot handle unknown values ... Target Type: []provider.IncidentEscalationPathNode". This happened whenever the `path`, target list, or `working_hours` derived from a value Terraform only resolves during apply — for example a path assembled from `local.path_templates[var.path_template]`, or a target whose id references another resource's computed attribute. The resource was effectively unusable in any config that didn't hard-code the entire path inline.

The root cause was that the resource model stored these collections as plain Go slices (`[]IncidentEscalationPathNode`, `[]IncidentEscalationPathTarget`, `[]IncidentWeekdayIntervalConfig`). Plain slices have no representation for "unknown", so the framework cannot decode a plan that contains unknown values into them. Today only `ValidateConfig` surfaced the crash, but the model was fundamentally unable to carry unknowns through any phase. The fix converts these collections to `types.List`, which carries null/unknown end to end. Because the path schema is recursive — `if_else` nodes nest then/else sub-paths down to a fixed depth — the conversion needs object attribute types at each nesting level, so this adds depth-aware `nodeAttrTypes`/`nodeListType` helpers that mirror `getPathSchema` exactly (the `if_else` attribute is only present while `depth > 0`), plus attr-type helpers for targets, weekday intervals, and conditions. The create/read/update/validate paths and the `WeekdayIntervalConfig` conversion methods now thread a `context` and decode the lists via `ElementsAs`.

One deliberate scope decision: `IfElse.Conditions` is left as a plain slice, matching the existing alert-route resource. Making conditions carry unknowns is a separate engine-models refactor and isn't needed to resolve the reported failures. No state-version bump or upgrader is required — a `ListNestedAttribute` already serialises as a list-of-objects in state, identical to the previous `[]struct` encoding. Coverage includes a full-depth round-trip unit test and an acceptance test (gated by `TF_ACC`) reproducing both reported configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)