### PR TITLE
Validate http_custom_options against source_type at plan time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Validate at plan time that `http_custom_options` is only set when `source_type = "http_custom"` (and is required for it). Previously these options were accepted but silently dropped by the API for other source types — including the legacy `http` source — which surfaced as a `Provider produced inconsistent result after apply` error.
+
 ## v5.39.0
 
 - Fix `Provider produced inconsistent result after apply` and perpetual diffs on engine param-binding `literal` fields when JSON containing HTML characters (`>`, `<`, `&`) is supplied by an encoder that does not HTML-escape (e.g. CDKTF `JSON.stringify`, `file()`, heredocs). The `literal` field now uses a semantic-equality string type that treats byte-different-but-equivalent JSON as equal.

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -86,6 +86,31 @@ func (r *IncidentAlertSourceResource) ValidateConfig(ctx context.Context, req re
 		return
 	}
 
+	// Read http_custom_options as an Object rather than the model pointer so we
+	// can tell "unknown" (computed at plan time) apart from "null" (not set).
+	// We only validate it against source_type once both are known: if either is
+	// computed from another resource, Terraform re-runs validation at apply.
+	var httpCustomOptions types.Object
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("http_custom_options"), &httpCustomOptions)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !data.SourceType.IsUnknown() && !httpCustomOptions.IsUnknown() {
+		httpCustomOptionsSet := !httpCustomOptions.IsNull()
+		if httpCustomOptionsSet && data.SourceType.ValueString() != "http_custom" {
+			resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+				"http_custom_options can only be set when source_type is http_custom",
+				"These options only apply to the 'http_custom' source type. The 'http' source type does not support a transform expression or deduplication key path."))
+			return
+		}
+		if !httpCustomOptionsSet && data.SourceType.ValueString() == "http_custom" {
+			resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+				"http_custom_options must be set when source_type is http_custom",
+				"These options are required for the 'http_custom' source type, to specify the transform expression and deduplication key path."))
+			return
+		}
+	}
+
 	// Validate that heartbeat sources don't set template title or description,
 	// as the API normalizes these fields and the provider ignores the returned values.
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -362,6 +362,61 @@ resource "incident_alert_source" "test" {
 				ExpectError: regexp.MustCompile("email_options can only be set when source_type is email"),
 			},
 			{
+				// Test http_custom_options with wrong source_type
+				Config: testRunTemplate("incident_alert_source_invalid_http_custom", `
+resource "incident_alert_source" "test" {
+  name = "Not http_custom, but with http_custom options"
+  source_type = "datadog"
+
+  template = {
+    expressions = [],
+    title = {
+      literal = {{ quote .Title }}
+    },
+    description = {
+      literal = {{ quote .Description }}
+    },
+    attributes = []
+  }
+
+  http_custom_options = {
+    transform_expression   = "return { title: $.title }"
+    deduplication_key_path = "$.alert_id"
+  }
+}
+`, struct{ Title, Description string }{
+					Title:       testAlertSourceTitle,
+					Description: testAlertSourceDescription,
+				}),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("http_custom_options can only be set when source_type is http_custom"),
+			},
+			{
+				// Test http_custom source_type without the required http_custom_options
+				Config: testRunTemplate("incident_alert_source_missing_http_custom", `
+resource "incident_alert_source" "test" {
+  name = "http_custom without options"
+  source_type = "http_custom"
+
+  template = {
+    expressions = [],
+    title = {
+      literal = {{ quote .Title }}
+    },
+    description = {
+      literal = {{ quote .Description }}
+    },
+    attributes = []
+  }
+}
+`, struct{ Title, Description string }{
+					Title:       testAlertSourceTitle,
+					Description: testAlertSourceDescription,
+				}),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("http_custom_options must be set when source_type is http_custom"),
+			},
+			{
 				// Test missing required template fields
 				Config: testRunTemplate("incident_alert_source_invalid", `
 resource "incident_alert_source" "test" {
@@ -1148,6 +1203,133 @@ resource "incident_alert_source" "test" {
   email_options = {
     redactions           = ["credit_card_numbers", "phone_numbers"]
     transform_expression = "payload.subject"
+  }
+}
+`, struct {
+		Name, Title, Description string
+	}{
+		Name:        name,
+		Title:       testAlertSourceTitle,
+		Description: testAlertSourceDescription,
+	})
+}
+
+// Regression test: an http_custom alert source with http_custom_options must
+// round-trip cleanly through create, apply and re-read with no "Provider
+// produced inconsistent result after apply" error and no perpetual diff. The
+// public API returns http_custom_options on read for the http_custom source
+// type, so the planned value matches the post-apply state without any
+// provider-side workaround.
+//
+// (http_custom_options only apply to the http_custom source type. The API
+// rejects them on other source types, including the legacy "http" source —
+// see incident-io/terraform-provider-incident#352.)
+func TestAccAlertSourceResource_HTTPCustomOptions(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertSourceResourceConfigWithHTTPCustom("http-custom-source"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_alert_source.test", "name", "http-custom-source"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "source_type", "http_custom"),
+					resource.TestCheckResourceAttrSet("incident_alert_source.test", "alert_events_url"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "http_custom_options.deduplication_key_path", "$.alert_id"),
+					resource.TestCheckResourceAttr("incident_alert_source.test", "http_custom_options.transform_expression", "return { title: $.title }"),
+				),
+			},
+			// ImportState testing. The API returns http_custom_options on read
+			// for http_custom sources, so they round-trip on import too.
+			{
+				ResourceName:      "incident_alert_source.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Regression test: http_custom_options whose values are computed at plan time
+// (e.g. derived from another resource) must not trip up ValidateConfig. The
+// source_type↔http_custom_options validation only runs once both are known, so
+// the plan should not raise a spurious validation error and the apply should
+// succeed. Guards against the validation choking on unknown values.
+func TestAccAlertSourceResource_HTTPCustomOptionsComputed(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertSourceResourceConfigHTTPCustomComputed("http-custom-computed"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_alert_source.test", "source_type", "http_custom"),
+					resource.TestCheckResourceAttrSet("incident_alert_source.test", "http_custom_options.deduplication_key_path"),
+				),
+			},
+		},
+	})
+}
+
+// The deduplication_key_path interpolates a computed attribute id, so the value
+// inside http_custom_options is unknown at plan time.
+func testAccAlertSourceResourceConfigHTTPCustomComputed(name string) string {
+	return testRunTemplate("incident_alert_source_http_custom_computed", `
+resource "incident_alert_attribute" "dedup" {
+  name  = "dedup-tf-attr"
+  type  = "String"
+  array = false
+}
+
+resource "incident_alert_source" "test" {
+  name        = {{ quote .Name }}
+  source_type = "http_custom"
+
+  template = {
+    expressions = [],
+    title = {
+      literal = {{ quote .Title }}
+    },
+    description = {
+      literal = {{ quote .Description }}
+    },
+    attributes = []
+  }
+
+  http_custom_options = {
+    transform_expression   = "return { title: $.title }"
+    deduplication_key_path = "$.${incident_alert_attribute.dedup.id}"
+  }
+}
+`, struct {
+		Name, Title, Description string
+	}{
+		Name:        name,
+		Title:       testAlertSourceTitle,
+		Description: testAlertSourceDescription,
+	})
+}
+
+func testAccAlertSourceResourceConfigWithHTTPCustom(name string) string {
+	return testRunTemplate("incident_alert_source_http_custom", `
+resource "incident_alert_source" "test" {
+  name        = {{ quote .Name }}
+  source_type = "http_custom"
+
+  template = {
+    expressions = [],
+    title = {
+      literal = {{ quote .Title }}
+    },
+    description = {
+      literal = {{ quote .Description }}
+    },
+    attributes = []
+  }
+
+  http_custom_options = {
+    transform_expression   = "return { title: $.title }"
+    deduplication_key_path = "$.alert_id"
   }
 }
 `, struct {


### PR DESCRIPTION
Creating an `incident_alert_source` with `source_type = "http"` and `http_custom_options` failed on apply with `Provider produced inconsistent result after apply` ([#352](https://github.com/incident-io/terraform-provider-incident/issues/352)). The root cause was on the API side: `http_custom_options` (the JS transform expression and deduplication key path) only apply to the `http_custom` source type, but the API silently accepted and dropped them for other types — so the provider planned a non-null value, applied it, read back `null`, and the framework rejected the inconsistent result.

The real fix is in the API ([incident-io/core#58859](https://github.com/incident-io/core/pull/58859)), which now rejects mismatched source options instead of dropping them, and continues to return them on read for the correct type (so they round-trip cleanly with no provider-side workaround). This PR adds the matching plan-time validation in `ValidateConfig`, mirroring the existing jira/email/heartbeat checks, so users get a clear error before apply rather than a 422 — in both directions, since the options are also required for `http_custom`.

The validation only runs once both `source_type` and `http_custom_options` are known. When either is computed from another resource it stays unknown at plan time, so the options are read as an `Object` (to tell unknown from null) and the comparison is skipped until Terraform re-validates at apply — avoiding a spurious plan-time error when the options are computed.

This supersedes the state-preservation workaround proposed in #353: with the correct source type the options are returned on read, so nothing needs preserving. Tests cover an `http_custom` source applying and round-tripping (including on import with no `ImportStateVerifyIgnore`), both plan-time validation errors, and an `http_custom` source with a computed option value. Closes #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)