### PR TITLE
Model engine `expressions` as ListNestedAttribute (fixes #360)

### DIFF
--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -246,7 +246,7 @@ resource "incident_alert_route" "service_alerts" {
 - `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
 - `enabled` (Boolean) Whether this alert route is enabled or not
 - `escalation_config` (Attributes) (see [below for nested schema](#nestedatt--escalation_config))
-- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
+- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `incident_config` (Attributes) (see [below for nested schema](#nestedatt--incident_config))
 - `incident_template` (Attributes) (see [below for nested schema](#nestedatt--incident_template))
 - `is_private` (Boolean) Whether this alert route is private. Private alert routes will only create private incidents from alerts.

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -160,7 +160,7 @@ Required:
 
 - `attributes` (Attributes Set) Attributes to set on alerts coming from this source, with a binding describing how to set them. (see [below for nested schema](#nestedatt--template--attributes))
 - `description` (Attributes) (see [below for nested schema](#nestedatt--template--description))
-- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--template--expressions))
+- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--template--expressions))
 - `title` (Attributes) (see [below for nested schema](#nestedatt--template--title))
 
 Optional:

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -83,7 +83,7 @@ resource "incident_workflow" "autoassign_incident_lead" {
 
 - `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
 - `continue_on_step_error` (Boolean) Whether to continue executing the workflow if a step fails
-- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
+- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `include_private_incidents` (Boolean) Whether to include private incidents
 - `name` (String) Name provided by the user when creating the workflow
 - `once_for` (List of String) This workflow will run 'once for' a list of references

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -1392,3 +1392,77 @@ resource "incident_alert_source" "test" {
 		TeamTypeName: teamTypeName(),
 	})
 }
+
+// TestAccAlertSourceResource_Issue360_MixedElseBranch is a regression test for
+// #360: expressions that mix present and absent else_branch must plan without
+// "element types must all match for conversion to set".
+func TestAccAlertSourceResource_Issue360_MixedElseBranch(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccAlertSourceResourceConfigMixedElseBranch(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccAlertSourceResourceConfigMixedElseBranch() string {
+	return fmt.Sprintf(`
+resource "incident_alert_source" "mixed_else_branch" {
+  name        = "issue-360-mixed-else-branch"
+  source_type = "http"
+
+  template = {
+    title = {
+      literal = %[1]q
+    }
+    description = {
+      literal = %[2]q
+    }
+    attributes = []
+
+    expressions = [
+      # No else_branch.
+      {
+        label          = "A"
+        reference      = "a"
+        root_reference = "payload"
+        operations = [
+          {
+            operation_type = "parse"
+            parse = {
+              source  = "$.a"
+              returns = { type = "String", array = false }
+            }
+          }
+        ]
+      },
+      # With else_branch — the mix is what broke set conversion.
+      {
+        label          = "B"
+        reference      = "b"
+        root_reference = "payload"
+        else_branch = {
+          result = {
+            value = { literal = "fallback" }
+          }
+        }
+        operations = [
+          {
+            operation_type = "parse"
+            parse = {
+              source  = "$.b"
+              returns = { type = "String", array = false }
+            }
+          }
+        ]
+      },
+    ]
+  }
+}
+`, testAlertSourceTitle, testAlertSourceDescription)
+}

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -361,8 +361,8 @@ func ReturnsAttribute() schema.SingleNestedAttribute {
 	}
 }
 
-func ExpressionsAttribute() schema.SetNestedAttribute {
-	return schema.SetNestedAttribute{
+func ExpressionsAttribute() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
 		MarkdownDescription: "The expressions to be prepared for use by steps and conditions",
 		Required:            true,
 		NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
## Overview

`expressions` (on `incident_alert_source`, `incident_alert_route` and `incident_workflow`) is a `SetNestedAttribute` whose element has an optional `else_branch`. Any config that mixes expressions with and without `else_branch` fails `terraform validate` with `element types must all match for conversion to set` — including the HCL your dashboard's *Export to Terraform* emits. This changes `expressions` to a `ListNestedAttribute` so those configs validate.

Fixes #360.

## Detailed Technical Description of Change

- A Terraform `set` requires a single homogeneous element type. When the config has object literals where the optional `else_branch` is present on some elements and absent on others, the tuple→set conversion can't unify them and fails at decode time, before any API call.
- `ExpressionsAttribute()` in `internal/provider/models/engine.go` is changed from `schema.SetNestedAttribute` to `schema.ListNestedAttribute`. This is shared by all three resources. The sibling `operations` attribute is already a `ListNestedAttribute` and doesn't have the problem; expressions are referenced by their `reference` key rather than by position; and the alert-source resource's existing plan modifier already traverses expressions via `.AtListIndex(...)`.
- Scope is intentionally minimal: only the resource attribute changes. The read-only data-source equivalent (`ExpressionsDataSourceAttribute`) is computed and unaffected, so it's left as-is.
- Tradeoff worth a maintainer eye: a list is order-sensitive, so `Read` should return expressions in a stable order to avoid spurious diffs. In practice import and *Export to Terraform* already emit a consistent order.

## Testing Approach and Results

- **Reproduction (before/after):** the minimal config in #360, and a larger production-shaped config (multiple `parse` expressions without `else_branch` plus a `branches` expression with one), both fail `terraform validate` on the released provider and pass on this build.
- **Regression test:** added `TestAccAlertSourceResource_Issue360_MixedElseBranch`, an acceptance test that plans an alert source whose expressions mix present/absent `else_branch` (runs in CI against the test account).
- **Static checks:** `go vet ./...`, `go build ./...`, and the `internal/provider/models` unit tests all pass.
- **Plan behavior:** validated against a realistic existing configuration — switching the schema to a list produced no spurious reorder/`else_branch` diff on plan.

## Documentation

- Regenerated resource docs via `tfplugindocs` (`expressions`: Attributes Set → List): `docs/resources/alert_source.md`, `docs/resources/alert_route.md`, `docs/resources/workflow.md`.
