### PR TITLE
Guard nil JSON responses in escalation path resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix panic when importing or refreshing an `incident_escalation_path` if the API returns an unexpected successful response (e.g. a 2xx without the expected JSON body). The provider now returns a diagnostic with the response status instead of crashing on a nil pointer dereference.
+
 ## v5.40.0
 
 - Add an optional `rotation_id` to `incident_schedule_sync_rule`, scoping a sync rule to a single rotation on the schedule. Omit it to sync all rotations (the previous behaviour); to feed a Slack user group from several rotations, create one rule per rotation pointing at the same target.

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -687,6 +687,14 @@ func (r *IncidentEscalationPathResource) Create(ctx context.Context, req resourc
 		return
 	}
 
+	if result.JSON201 == nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to create escalation path: unexpected response from API (status %s)", result.Status()),
+		)
+		return
+	}
+
 	claimResource(ctx, r.client, result.JSON201.EscalationPath.Id, &resp.Diagnostics, client.EscalationPath, r.terraformVersion)
 
 	tflog.Trace(ctx, fmt.Sprintf("created an escalation path resource with id=%s", result.JSON201.EscalationPath.Id))
@@ -711,6 +719,14 @@ func (r *IncidentEscalationPathResource) Read(ctx context.Context, req resource.
 			return
 		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read escalation path, got error: %s", err))
+		return
+	}
+
+	if result.JSON200 == nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to read escalation path: unexpected response from API (status %s)", result.Status()),
+		)
 		return
 	}
 
@@ -778,6 +794,14 @@ func (r *IncidentEscalationPathResource) Update(ctx context.Context, req resourc
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update escalation path, got error: %s", err))
+		return
+	}
+
+	if result.JSON200 == nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to update escalation path: unexpected response from API (status %s)", result.Status()),
+		)
 		return
 	}
 


### PR DESCRIPTION
Fixes a panic when importing/refreshing an `incident_escalation_path`.

`Read` dereferenced `result.JSON200.EscalationPath` without checking whether `result.JSON200` was nil. The generated client only populates `JSON200`/`JSON201` on an exact HTTP 200/201 with a JSON content type, so an unexpected successful response (a different 2xx, or a 200 without the expected content type) leaves the field nil while `err` stays nil — causing a nil pointer dereference and crashing the provider during `terraform import`.

Guarded the dereference in `Read`, and swept `Create` (`JSON201`) and `Update` (`JSON200`) for the same pattern. Each now returns a diagnostic carrying the response status instead of panicking.