### PR TITLE
Fix expressions `terraform validate` failure when some expressions omit `else_branch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix `terraform validate` failing with `element types must all match for conversion to set` when the `expressions` attribute (on `incident_alert_source`, `incident_alert_route` and `incident_workflow`) contains a mix of expressions with and without an `else_branch`. This is the shape the dashboard's "Export to Terraform" feature produces. `expressions` is now a list rather than a set, which tolerates the heterogeneous elements without needing placeholder `else_branch` workarounds or `ignore_changes`.
+
 ## v5.40.0
 
 - Add an optional `rotation_id` to `incident_schedule_sync_rule`, scoping a sync rule to a single rotation on the schedule. Omit it to sync all rotations (the previous behaviour); to feed a Slack user group from several rotations, create one rule per rotation pointing at the same target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Fix `terraform validate` failing with `element types must all match for conversion to set` when the `expressions` attribute (on `incident_alert_source`, `incident_alert_route` and `incident_workflow`) contains a mix of expressions with and without an `else_branch`. This is the shape the dashboard's "Export to Terraform" feature produces. `expressions` is now a list rather than a set, which tolerates the heterogeneous elements without needing placeholder `else_branch` workarounds or `ignore_changes`.
+- Fix `terraform validate` failing with `element types must all match for conversion to set` when the `expressions` attribute (on `incident_alert_source`, `incident_alert_route` and `incident_workflow`) contains a mix of expressions with and without an `else_branch`. This is the shape the dashboard's "Export to Terraform" feature produces. `expressions` is now a list rather than a set, which tolerates the heterogeneous elements without needing placeholder `else_branch` workarounds or `ignore_changes`. To avoid the ordering drift that previously forced this back to a set (v5.21.1), the provider now realigns the API's expression response to the planned/prior order by reference, so there's no spurious diff or "inconsistent result after apply". Existing resources may see a one-time reordering of `expressions` in the first plan after upgrading, which is expected and resolves on apply.
 
 ## v5.40.0
 

--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -246,7 +246,7 @@ resource "incident_alert_route" "service_alerts" {
 - `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
 - `enabled` (Boolean) Whether this alert route is enabled or not
 - `escalation_config` (Attributes) (see [below for nested schema](#nestedatt--escalation_config))
-- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
+- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `incident_config` (Attributes) (see [below for nested schema](#nestedatt--incident_config))
 - `incident_template` (Attributes) (see [below for nested schema](#nestedatt--incident_template))
 - `is_private` (Boolean) Whether this alert route is private. Private alert routes will only create private incidents from alerts.

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -160,7 +160,7 @@ Required:
 
 - `attributes` (Attributes Set) Attributes to set on alerts coming from this source, with a binding describing how to set them. (see [below for nested schema](#nestedatt--template--attributes))
 - `description` (Attributes) (see [below for nested schema](#nestedatt--template--description))
-- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--template--expressions))
+- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--template--expressions))
 - `title` (Attributes) (see [below for nested schema](#nestedatt--template--title))
 
 Optional:

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -83,7 +83,7 @@ resource "incident_workflow" "autoassign_incident_lead" {
 
 - `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
 - `continue_on_step_error` (Boolean) Whether to continue executing the workflow if a step fails
-- `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
+- `expressions` (Attributes List) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
 - `include_private_incidents` (Boolean) Whether to include private incidents
 - `name` (String) Name provided by the user when creating the workflow
 - `once_for` (List of String) This workflow will run 'once for' a list of references

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -538,6 +538,7 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 	// Save the planned values before overwriting with API response.
 	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
 	planEmailOptions := data.EmailOptions
+	planExpressions := planExpressionsOf(data.Template)
 
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
 
@@ -556,12 +557,36 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 		data.EmailOptions = planEmailOptions
 	}
 
+	// The API doesn't preserve expression order; realign to the planned order
+	// so the (list-typed) expressions match what Terraform planned.
+	reorderTemplateExpressions(data.Template, planExpressions)
+
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
 		data.Template.Title = models.IncidentEngineParamBindingValue{}
 		data.Template.Description = models.IncidentEngineParamBindingValue{}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// planExpressionsOf returns the expressions from a template model, tolerating a
+// nil template.
+func planExpressionsOf(template *models.AlertTemplateModel) models.IncidentEngineExpressions {
+	if template == nil {
+		return nil
+	}
+	return template.Expressions
+}
+
+// reorderTemplateExpressions realigns the template's expressions to follow the
+// order of `desired`, keyed by reference. The API does not preserve expression
+// order, so without this the list-typed expressions would drift from the
+// planned/prior order.
+func reorderTemplateExpressions(template *models.AlertTemplateModel, desired models.IncidentEngineExpressions) {
+	if template == nil {
+		return
+	}
+	template.Expressions = template.Expressions.ReorderToMatch(desired)
 }
 
 func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -587,6 +612,7 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 	// Save the prior state values before overwriting with API response.
 	stateAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
 	stateEmailOptions := data.EmailOptions
+	stateExpressions := planExpressionsOf(data.Template)
 
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
 
@@ -602,6 +628,10 @@ func (r *IncidentAlertSourceResource) Read(ctx context.Context, req resource.Rea
 	if stateEmailOptions != nil && data.EmailOptions == nil {
 		data.EmailOptions = stateEmailOptions
 	}
+
+	// The API doesn't preserve expression order; realign to the prior state
+	// order so the (list-typed) expressions don't show a perpetual diff.
+	reorderTemplateExpressions(data.Template, stateExpressions)
 
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
 		data.Template.Title = models.IncidentEngineParamBindingValue{}
@@ -661,6 +691,7 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 	// Save the planned values before overwriting with API response.
 	planAutoResolveIncidentAlerts := data.AutoResolveIncidentAlerts
 	planEmailOptions := data.EmailOptions
+	planExpressions := planExpressionsOf(data.Template)
 
 	data = models.AlertSourceResourceModel{}.FromAPI(result.JSON200.AlertSource)
 
@@ -678,6 +709,10 @@ func (r *IncidentAlertSourceResource) Update(ctx context.Context, req resource.U
 	if planEmailOptions != nil && data.EmailOptions == nil {
 		data.EmailOptions = planEmailOptions
 	}
+
+	// The API doesn't preserve expression order; realign to the planned order
+	// so the (list-typed) expressions match what Terraform planned.
+	reorderTemplateExpressions(data.Template, planExpressions)
 
 	if data.SourceType.ValueString() == "heartbeat" && data.Template != nil {
 		data.Template.Title = models.IncidentEngineParamBindingValue{}

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -490,6 +490,113 @@ func TestAccAlertSourceResource_MixedElseBranchExpressions(t *testing.T) {
 	})
 }
 
+// TestAccAlertSourceResource_ExpressionOrderingStable guards the ordering
+// concern that previously forced `expressions` back from a list to a set in
+// v5.21.1: the API does not return expressions in a stable order, so a naive
+// list representation produces "Provider produced inconsistent result after
+// apply" on create and perpetual diffs thereafter.
+//
+// The provider now realigns the API's expression response to the
+// planned/prior order (models.IncidentEngineExpressions.ReorderToMatch). This
+// test creates an alert source with several expressions and then re-plans the
+// identical config, asserting an empty plan — which fails if the API's ordering
+// leaks through into state. Unlike the validate-only test above, this exercises
+// the create + read round-trip, so it requires API credentials.
+func TestAccAlertSourceResource_ExpressionOrderingStable(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlertSourceResourceConfigManyExpressions(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_alert_source.ordering", "template.expressions.#", "4"),
+				),
+			},
+			// Re-applying the identical config must produce no diff. If the
+			// API's expression ordering were leaking into state, this PlanOnly
+			// step would fail with a non-empty plan.
+			{
+				Config:   testAccAlertSourceResourceConfigManyExpressions(),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// testAccAlertSourceResourceConfigManyExpressions defines an alert source with
+// several parse expressions plus a branches expression carrying an else_branch,
+// so the API has multiple expressions it may reorder.
+func testAccAlertSourceResourceConfigManyExpressions() string {
+	return fmt.Sprintf(`
+resource "incident_alert_source" "ordering" {
+  name        = "expression-ordering-test"
+  source_type = "http"
+
+  template = {
+    title = {
+      literal = %[1]q
+    }
+    description = {
+      literal = %[2]q
+    }
+    attributes = []
+
+    expressions = [
+      {
+        label          = "Alpha"
+        reference      = "alpha"
+        root_reference = "payload"
+        operations = [
+          { operation_type = "parse", parse = { source = "$.alpha", returns = { type = "String", array = false } } }
+        ]
+      },
+      {
+        label          = "Bravo"
+        reference      = "bravo"
+        root_reference = "payload"
+        operations = [
+          { operation_type = "parse", parse = { source = "$.bravo", returns = { type = "String", array = false } } }
+        ]
+      },
+      {
+        label          = "Charlie"
+        reference      = "charlie"
+        root_reference = "payload"
+        operations = [
+          { operation_type = "parse", parse = { source = "$.charlie", returns = { type = "String", array = false } } }
+        ]
+      },
+      {
+        label          = "Delta"
+        reference      = "delta"
+        root_reference = "."
+        else_branch = {
+          result = { value = { literal = "fallback" } }
+        }
+        operations = [
+          {
+            operation_type = "branches"
+            branches = {
+              returns = { type = "String", array = false }
+              branches = [
+                {
+                  condition_groups = [
+                    { conditions = [{ subject = "payload.title", operation = "is_set", param_bindings = [] }] }
+                  ]
+                  result = { value = { literal = "set" } }
+                }
+              ]
+            }
+          }
+        ]
+      },
+    ]
+  }
+}
+`, testAlertSourceTitle, testAlertSourceDescription)
+}
+
 // testAccAlertSourceResourceConfigMixedElseBranch mirrors the dashboard's
 // "Export to Terraform" output: a parse expression with no else_branch
 // alongside a branches expression that carries one.

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -455,6 +455,128 @@ resource "incident_alert_source" "test" {
 	})
 }
 
+// TestAccAlertSourceResource_MixedElseBranchExpressions is a regression test
+// for RESP-17992.
+//
+// The shared `expressions` attribute (on incident_alert_source,
+// incident_alert_route and incident_workflow) used to be a SetNestedAttribute
+// whose element object has an optional `else_branch`. When a config contained a
+// mix of expressions — some with `else_branch` and some without — Terraform
+// failed at validate time, before any API call, with:
+//
+//	Inappropriate value for attribute "template": element types must all match
+//	for conversion to set.
+//
+// This is exactly the shape the dashboard's "Export to Terraform" feature
+// produces (parse expressions have no `else_branch`; a branches expression has
+// one). On Terraform 1.2.x (the version this provider targets) the tuple→set
+// conversion does not honour the optional attribute, so the heterogeneous
+// elements are rejected. Modelling `expressions` as a ListNestedAttribute
+// avoids the lossy set conversion and lets the mixed config validate.
+//
+// This step is PlanOnly: the failure happens during config validation, so it
+// reproduces without any API credentials or network access (a create plan does
+// not call the API). It does still require TF_ACC=1 to drive Terraform.
+func TestAccAlertSourceResource_MixedElseBranchExpressions(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccAlertSourceResourceConfigMixedElseBranch(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// testAccAlertSourceResourceConfigMixedElseBranch mirrors the dashboard's
+// "Export to Terraform" output: a parse expression with no else_branch
+// alongside a branches expression that carries one.
+func testAccAlertSourceResourceConfigMixedElseBranch() string {
+	return fmt.Sprintf(`
+resource "incident_alert_source" "mixed_else_branch" {
+  name        = "mixed-else-branch-test"
+  source_type = "http"
+
+  template = {
+    title = {
+      literal = %[1]q
+    }
+    description = {
+      literal = %[2]q
+    }
+    attributes = []
+
+    expressions = [
+      # Parse expression — NO else_branch.
+      {
+        label          = "Environment"
+        reference      = "environment"
+        root_reference = "payload"
+        operations = [
+          {
+            operation_type = "parse"
+            parse = {
+              source = "$.environment"
+              returns = {
+                type  = "String"
+                array = false
+              }
+            }
+          }
+        ]
+      },
+      # Branches expression — HAS else_branch.
+      {
+        label          = "Priority"
+        reference      = "priority"
+        root_reference = "."
+        else_branch = {
+          result = {
+            value = {
+              literal = "default-priority"
+            }
+          }
+        }
+        operations = [
+          {
+            operation_type = "branches"
+            branches = {
+              returns = {
+                type  = "String"
+                array = false
+              }
+              branches = [
+                {
+                  condition_groups = [
+                    {
+                      conditions = [
+                        {
+                          subject   = "payload.title"
+                          operation = "is_set"
+                          param_bindings = []
+                        }
+                      ]
+                    }
+                  ]
+                  result = {
+                    value = {
+                      literal = "high-priority"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+    ]
+  }
+}
+`, testAlertSourceTitle, testAlertSourceDescription)
+}
+
 func testAccAlertSourceResourceConfigInvalidBranches() string {
 	return fmt.Sprintf(`
 resource "incident_alert_source" "invalid_branches" {

--- a/internal/provider/incident_alert_source_resource_test.go
+++ b/internal/provider/incident_alert_source_resource_test.go
@@ -525,8 +525,11 @@ func TestAccAlertSourceResource_ExpressionOrderingStable(t *testing.T) {
 }
 
 // testAccAlertSourceResourceConfigManyExpressions defines an alert source with
-// several parse expressions plus a branches expression carrying an else_branch,
-// so the API has multiple expressions it may reorder.
+// several parse expressions, so the API has multiple expressions it may
+// reorder. Ordering reconciliation is independent of else_branch/branches, so
+// we use the simple parse shape that the API accepts on apply (mirroring the
+// Issue342 test); the else_branch validate path is covered separately by the
+// PlanOnly TestAccAlertSourceResource_MixedElseBranchExpressions.
 func testAccAlertSourceResourceConfigManyExpressions() string {
 	return fmt.Sprintf(`
 resource "incident_alert_source" "ordering" {
@@ -570,25 +573,9 @@ resource "incident_alert_source" "ordering" {
       {
         label          = "Delta"
         reference      = "delta"
-        root_reference = "."
-        else_branch = {
-          result = { value = { literal = "fallback" } }
-        }
+        root_reference = "payload"
         operations = [
-          {
-            operation_type = "branches"
-            branches = {
-              returns = { type = "String", array = false }
-              branches = [
-                {
-                  condition_groups = [
-                    { conditions = [{ subject = "payload.title", operation = "is_set", param_bindings = [] }] }
-                  ]
-                  result = { value = { literal = "set" } }
-                }
-              ]
-            }
-          }
+          { operation_type = "parse", parse = { source = "$.delta", returns = { type = "String", array = false } } }
         ]
       },
     ]

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -225,7 +225,12 @@ func (r *IncidentWorkflowResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	tflog.Trace(ctx, fmt.Sprintf("created a workflow resource with id=%s", result.JSON201.Workflow.Id))
+
+	// The API doesn't preserve expression order; realign to the planned order
+	// so the (list-typed) expressions match what Terraform planned.
+	planExpressions := data.Expressions
 	data = r.buildModel(ctx, result.JSON201.Workflow)
+	data.Expressions = data.Expressions.ReorderToMatch(planExpressions)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -290,7 +295,11 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
+	// The API doesn't preserve expression order; realign to the planned order
+	// so the (list-typed) expressions match what Terraform planned.
+	planExpressions := data.Expressions
 	data = r.buildModel(ctx, result.JSON200.Workflow)
+	data.Expressions = data.Expressions.ReorderToMatch(planExpressions)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -316,7 +325,11 @@ func (r *IncidentWorkflowResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	// The API doesn't preserve expression order; realign to the prior state
+	// order so the (list-typed) expressions don't show a perpetual diff.
+	stateExpressions := data.Expressions
 	data = r.buildModel(ctx, result.JSON200.Workflow)
+	data.Expressions = data.Expressions.ReorderToMatch(stateExpressions)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/models/alert_route_v1_model.go
+++ b/internal/provider/models/alert_route_v1_model.go
@@ -425,6 +425,11 @@ func (AlertRouteResourceModel) FromAPIWithPlan(apiModel client.AlertRouteV2, pla
 	result.Expressions = IncidentEngineExpressions{}
 	if len(apiModel.Expressions) > 0 {
 		result.Expressions = IncidentEngineExpressions{}.FromAPI(apiModel.Expressions)
+		// The API doesn't preserve expression order; realign to the
+		// planned/prior order so the (list-typed) expressions stay stable.
+		if plan != nil {
+			result.Expressions = result.Expressions.ReorderToMatch(plan.Expressions)
+		}
 	}
 
 	result.EscalationConfig = &AlertRouteEscalationConfigModel{

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -361,8 +361,16 @@ func ReturnsAttribute() schema.SingleNestedAttribute {
 	}
 }
 
-func ExpressionsAttribute() schema.SetNestedAttribute {
-	return schema.SetNestedAttribute{
+// ExpressionsAttribute is deliberately a ListNestedAttribute rather than a
+// SetNestedAttribute. The element object has an optional `else_branch`, and on
+// the Terraform versions this provider targets (1.2.x) a config with a mix of
+// expressions — some with `else_branch`, some without — fails at validate time
+// with "element types must all match for conversion to set", because the
+// tuple→set conversion does not honour optional attributes. This is the exact
+// shape the dashboard's "Export to Terraform" feature emits. Lists are decoded
+// element-by-element and so tolerate the heterogeneous objects (RESP-17992).
+func ExpressionsAttribute() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
 		MarkdownDescription: "The expressions to be prepared for use by steps and conditions",
 		Required:            true,
 		NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -179,31 +179,31 @@ func (IncidentEngineExpressions) FromAPI(expressions []client.ExpressionV2) Inci
 // planned/prior order, the API's reordered result triggers "Provider produced
 // inconsistent result after apply" and perpetual plan diffs. Reordering by the
 // stable reference key keeps the list consistent regardless of API ordering.
-func (exprs IncidentEngineExpressions) ReorderToMatch(desired IncidentEngineExpressions) IncidentEngineExpressions {
-	if len(desired) == 0 || len(exprs) == 0 {
-		return exprs
+func (expressions IncidentEngineExpressions) ReorderToMatch(desired IncidentEngineExpressions) IncidentEngineExpressions {
+	if len(desired) == 0 || len(expressions) == 0 {
+		return expressions
 	}
 
-	used := make([]bool, len(exprs))
-	out := make(IncidentEngineExpressions, 0, len(exprs))
+	used := make([]bool, len(expressions))
+	out := make(IncidentEngineExpressions, 0, len(expressions))
 
 	for _, d := range desired {
 		key := d.Reference.ValueString()
-		for i := range exprs {
+		for i := range expressions {
 			if used[i] {
 				continue
 			}
-			if exprs[i].Reference.ValueString() == key {
-				out = append(out, exprs[i])
+			if expressions[i].Reference.ValueString() == key {
+				out = append(out, expressions[i])
 				used[i] = true
 				break
 			}
 		}
 	}
 
-	for i := range exprs {
+	for i := range expressions {
 		if !used[i] {
-			out = append(out, exprs[i])
+			out = append(out, expressions[i])
 		}
 	}
 

--- a/internal/provider/models/engine.go
+++ b/internal/provider/models/engine.go
@@ -165,6 +165,51 @@ func (IncidentEngineExpressions) FromAPI(expressions []client.ExpressionV2) Inci
 	return out
 }
 
+// ReorderToMatch returns the receiver's expressions reordered so their order
+// follows `desired`, matched by the unique `reference` field. Any expressions
+// present in the receiver but absent from `desired` are appended in their
+// original order.
+//
+// The incident.io API does not preserve the order of expressions in its
+// responses (this is why a previous list-based representation was reverted to a
+// set in v5.21.1). Now that `expressions` is modelled as a list again — a set
+// cannot represent a mix of expressions with and without the optional
+// else_branch on the Terraform versions we target (RESP-17992) — the element
+// order is significant to Terraform. Without realigning the response to the
+// planned/prior order, the API's reordered result triggers "Provider produced
+// inconsistent result after apply" and perpetual plan diffs. Reordering by the
+// stable reference key keeps the list consistent regardless of API ordering.
+func (exprs IncidentEngineExpressions) ReorderToMatch(desired IncidentEngineExpressions) IncidentEngineExpressions {
+	if len(desired) == 0 || len(exprs) == 0 {
+		return exprs
+	}
+
+	used := make([]bool, len(exprs))
+	out := make(IncidentEngineExpressions, 0, len(exprs))
+
+	for _, d := range desired {
+		key := d.Reference.ValueString()
+		for i := range exprs {
+			if used[i] {
+				continue
+			}
+			if exprs[i].Reference.ValueString() == key {
+				out = append(out, exprs[i])
+				used[i] = true
+				break
+			}
+		}
+	}
+
+	for i := range exprs {
+		if !used[i] {
+			out = append(out, exprs[i])
+		}
+	}
+
+	return out
+}
+
 type IncidentEngineExpression struct {
 	ElseBranch    *IncidentEngineElseBranch          `tfsdk:"else_branch"`
 	Label         types.String                       `tfsdk:"label"`

--- a/internal/provider/models/engine_test.go
+++ b/internal/provider/models/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -76,4 +77,60 @@ func TestIncidentEngineParamBindingValue_SemanticEquality(t *testing.T) {
 	equal, diags = escaped.StringSemanticEquals(ctx, raw)
 	require.False(t, diags.HasError())
 	assert.True(t, equal, "HTML-escaped and raw literals should be semantically equal")
+}
+
+// TestIncidentEngineExpressions_ReorderToMatch covers the realignment that
+// keeps the list-typed `expressions` attribute stable even though the API does
+// not preserve the order of expressions in its responses. Without it, switching
+// `expressions` from a set to a list (needed so a mix of expressions with and
+// without an optional else_branch passes `terraform validate` — RESP-17992)
+// would resurface the ordering drift that caused the v5.21.1 revert.
+func TestIncidentEngineExpressions_ReorderToMatch(t *testing.T) {
+	expr := func(reference string) IncidentEngineExpression {
+		return IncidentEngineExpression{
+			Reference: types.StringValue(reference),
+			Label:     types.StringValue(reference),
+		}
+	}
+
+	references := func(exprs IncidentEngineExpressions) []string {
+		out := make([]string, 0, len(exprs))
+		for _, e := range exprs {
+			out = append(out, e.Reference.ValueString())
+		}
+		return out
+	}
+
+	t.Run("reorders API response to match desired order", func(t *testing.T) {
+		// Desired (planned/prior) order.
+		desired := IncidentEngineExpressions{expr("a"), expr("b"), expr("c")}
+		// API returns the same expressions in a different order.
+		api := IncidentEngineExpressions{expr("c"), expr("a"), expr("b")}
+
+		got := api.ReorderToMatch(desired)
+		assert.Equal(t, []string{"a", "b", "c"}, references(got))
+	})
+
+	t.Run("appends expressions missing from desired in API order", func(t *testing.T) {
+		desired := IncidentEngineExpressions{expr("a")}
+		api := IncidentEngineExpressions{expr("b"), expr("a"), expr("c")}
+
+		got := api.ReorderToMatch(desired)
+		// "a" first (matched), then the unmatched ones in their API order.
+		assert.Equal(t, []string{"a", "b", "c"}, references(got))
+	})
+
+	t.Run("empty desired returns API order unchanged", func(t *testing.T) {
+		api := IncidentEngineExpressions{expr("b"), expr("a")}
+
+		got := api.ReorderToMatch(IncidentEngineExpressions{})
+		assert.Equal(t, []string{"b", "a"}, references(got))
+	})
+
+	t.Run("empty API returns empty", func(t *testing.T) {
+		desired := IncidentEngineExpressions{expr("a"), expr("b")}
+
+		got := IncidentEngineExpressions{}.ReorderToMatch(desired)
+		assert.Empty(t, got)
+	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes RESP-17992. The shared `expressions` attribute on `incident_alert_source` (`template.expressions`), `incident_alert_route` and `incident_workflow` was modelled as a `SetNestedAttribute` whose element object has an **optional** `else_branch`.

On the Terraform 1.2.x versions this provider targets (see the CI matrix), a config containing a mix of expressions — some with `else_branch`, some without — fails at **validate time, before any API call**, with:

```
Inappropriate value for attribute "template": element types must all match
for conversion to set.
```

This is exactly the shape the dashboard's **Export to Terraform** feature emits (parse expressions have no `else_branch`; a `branches` expression carries one), so the exported HCL doesn't pass `terraform validate` as-is. The previous workaround was to add a placeholder `else_branch` to expressions that lack one and then silence the resulting drift with `ignore_changes`.

## Root cause

Terraform core decodes the config tuple and converts it to the attribute's type. For a **set**, this goes through a tuple→set conversion that does not honour optional attributes on Terraform 1.2.x, so two elements with structurally different object shapes (one with `else_branch`, one without) are rejected. Confirmed against real Terraform binaries: it reproduces on **1.2.8** and is fixed in core by **1.9.8**. Since the provider still targets 1.2.x, the fix must live in the provider.

## Fix

Model `expressions` as a `ListNestedAttribute` instead of a `SetNestedAttribute`. Lists are decoded element-by-element and tolerate the heterogeneous objects, so the mixed config validates on all Terraform versions.

### Keeping ordering stable (the reason for the v5.21.1 revert)

A previous list→set change was reverted in **v5.21.1** because the API does not return `expressions` in a stable order; a plain list resurfaced as `Provider produced inconsistent result after apply` and perpetual diffs (this is exactly what Bugbot flagged, and it showed up as a CI failure in `TestAccAlertSourceResource_Issue342_SpuriousMergeStrategy`).

To keep the list but avoid that drift, this PR adds `IncidentEngineExpressions.ReorderToMatch`, which realigns the API response to the planned/prior order keyed by the unique `reference` field (any extras are appended in API order). It's wired into:

- `incident_alert_source` — Create/Read/Update (reorder against plan on create/update, against prior state on read).
- `incident_alert_route` — inside the existing `FromAPIWithPlan` (reorder against the threaded plan/state).
- `incident_workflow` — Create/Read/Update (reorder against plan/state around `buildModel`).

The data source (`incident_alert_sources`) is left as a set: it's read-only and populated from the API, so neither the config-conversion nor the ordering path applies.

## Testing

- `TestAccAlertSourceResource_MixedElseBranchExpressions` — a `PlanOnly` regression test mirroring the Export-to-Terraform output. Verified against Terraform 1.2.8: fails with the `element types must all match for conversion to set` error on the old `Set` schema; passes with the `List` fix. The failure is at config-validation time, so it needs no API credentials.
- `TestIncidentEngineExpressions_ReorderToMatch` — unit test covering reordering, appending unmatched expressions, and the empty cases.

Also updated the generated docs (`expressions` now reads `(Attributes List)`) and added a CHANGELOG entry noting the possible one-time reorder on upgrade.

## Notes / risk

Changing an attribute from set to list is a schema type change. Stored state and config both serialise the value as a JSON array, so re-reading existing state as a list works structurally. Existing resources may see a one-time reordering of `expressions` in the first plan after upgrade (expected, resolves on apply); thereafter the `ReorderToMatch` realignment keeps the list stable against API reordering.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [RESP-17992](https://linear.app/incident-io/issue/RESP-17992/alert-sourcerouteworkflow-expressions-setnestedattribute-fails)

<div><a href="https://cursor.com/agents/bc-376a1e09-1d87-42a2-9837-9b7ea90d13d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-376a1e09-1d87-42a2-9837-9b7ea90d13d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

