### PR TITLE
Sync alert route V3 resource with renamed public API fields

### DIFF
--- a/docs/resources/alert_route_v3.md
+++ b/docs/resources/alert_route_v3.md
@@ -68,9 +68,9 @@ resource "incident_alert_route_v3" "service_alerts" {
   grouping_config = {
     default = {
       enabled = true
-      // group_keys is an array of { reference = "alert.title" } which specifies
+      // grouping_keys is an array of { reference = "alert.title" } which specifies
       // the keys used to group alerts together
-      group_keys     = []
+      grouping_keys  = []
       window_seconds = 300
       // window_type is one of "rolling" (extends as new alerts attach) or "fixed"
       window_type = "rolling"
@@ -166,7 +166,7 @@ resource "incident_alert_route_v3" "service_alerts" {
     // Optionally control whether (and how) escalations fire again when a
     // subsequent alert joins an existing group.
     when_alert_joins_group = {
-      mode                 = "on_priority_increase"
+      mode                 = "on_each_new_alert"
       grace_period_seconds = 60
     }
   }
@@ -465,7 +465,7 @@ Required:
 
 Optional:
 
-- `grace_period_seconds` (Number) How long to wait before escalating once an alert joins the group
+- `grace_period_seconds` (Number) How long to wait before escalating once an alert joins the group, in seconds. Only applies when mode is 'on_each_new_alert'.
 
 
 
@@ -728,12 +728,12 @@ Required:
 
 Optional:
 
-- `group_keys` (Attributes Set) Which attributes should this alert route use to group alerts? Only set when grouping is enabled. (see [below for nested schema](#nestedatt--grouping_config--default--group_keys))
+- `grouping_keys` (Attributes Set) Which attributes should this alert route use to group alerts? Only set when grouping is enabled. (see [below for nested schema](#nestedatt--grouping_config--default--grouping_keys))
 - `window_seconds` (Number) How long the grouping window is, in seconds. Must be between 60 (1 minute) and 172800 (48 hours). Only set when grouping is enabled.
 - `window_type` (String) Controls how the grouping window behaves. 'rolling' keeps the window open for window_seconds after the most recent alert, so the group stays open as long as alerts keep arriving. 'fixed' opens the window when the first alert arrives and always closes window_seconds later, regardless of any subsequent alerts. Only set when grouping is enabled.. Possible values are: `rolling`, `fixed`.
 
-<a id="nestedatt--grouping_config--default--group_keys"></a>
-### Nested Schema for `grouping_config.default.group_keys`
+<a id="nestedatt--grouping_config--default--grouping_keys"></a>
+### Nested Schema for `grouping_config.default.grouping_keys`
 
 Required:
 

--- a/examples/resources/incident_alert_route_v3/resource.tf
+++ b/examples/resources/incident_alert_route_v3/resource.tf
@@ -44,9 +44,9 @@ resource "incident_alert_route_v3" "service_alerts" {
   grouping_config = {
     default = {
       enabled = true
-      // group_keys is an array of { reference = "alert.title" } which specifies
+      // grouping_keys is an array of { reference = "alert.title" } which specifies
       // the keys used to group alerts together
-      group_keys     = []
+      grouping_keys  = []
       window_seconds = 300
       // window_type is one of "rolling" (extends as new alerts attach) or "fixed"
       window_type = "rolling"
@@ -142,7 +142,7 @@ resource "incident_alert_route_v3" "service_alerts" {
     // Optionally control whether (and how) escalations fire again when a
     // subsequent alert joins an existing group.
     when_alert_joins_group = {
-      mode                 = "on_priority_increase"
+      mode                 = "on_each_new_alert"
       grace_period_seconds = 60
     }
   }

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -1929,7 +1929,7 @@
         "example": {
           "default": {
             "enabled": true,
-            "group_keys": [
+            "grouping_keys": [
               {
                 "reference": "alert.title"
               }
@@ -2786,62 +2786,6 @@
         },
         "required": [
           "alert_note"
-        ],
-        "type": "object"
-      },
-      "AlertRouteAlertJoinsGroupPayloadV3": {
-        "example": {
-          "grace_period_seconds": 60,
-          "mode": "on_each_new_alert"
-        },
-        "properties": {
-          "grace_period_seconds": {
-            "description": "How long to wait before escalating once an alert joins the group, in seconds. Must be between 0 and 3600 (1 hour).",
-            "example": 60,
-            "format": "int32",
-            "maximum": 3600,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "mode": {
-            "description": "When a subsequent alert joins an existing group, when should we escalate again?",
-            "enum": [
-              "on_priority_increase",
-              "on_each_new_alert"
-            ],
-            "example": "on_each_new_alert",
-            "type": "string"
-          }
-        },
-        "required": [
-          "mode"
-        ],
-        "type": "object"
-      },
-      "AlertRouteAlertJoinsGroupV3": {
-        "example": {
-          "grace_period_seconds": 60,
-          "mode": "on_each_new_alert"
-        },
-        "properties": {
-          "grace_period_seconds": {
-            "description": "How long to wait before escalating once an alert joins the group",
-            "example": 60,
-            "format": "int32",
-            "type": "integer"
-          },
-          "mode": {
-            "description": "When a subsequent alert joins an existing group, when should we escalate again?",
-            "enum": [
-              "on_priority_increase",
-              "on_each_new_alert"
-            ],
-            "example": "on_each_new_alert",
-            "type": "string"
-          }
-        },
-        "required": [
-          "mode"
         ],
         "type": "object"
       },
@@ -3976,7 +3920,7 @@
             "type": "array"
           },
           "when_alert_joins_group": {
-            "$ref": "#/components/schemas/AlertRouteAlertJoinsGroupPayloadV3"
+            "$ref": "#/components/schemas/AlertRouteWhenAlertJoinsGroupPayloadV3"
           }
         },
         "required": [
@@ -4151,7 +4095,7 @@
             "type": "array"
           },
           "when_alert_joins_group": {
-            "$ref": "#/components/schemas/AlertRouteAlertJoinsGroupV3"
+            "$ref": "#/components/schemas/AlertRouteWhenAlertJoinsGroupV3"
           }
         },
         "required": [
@@ -7067,7 +7011,7 @@
           "grouping_config": {
             "default": {
               "enabled": true,
-              "group_keys": [
+              "grouping_keys": [
                 {
                   "reference": "alert.title"
                 }
@@ -7595,6 +7539,62 @@
           "message_config",
           "expressions",
           "version"
+        ],
+        "type": "object"
+      },
+      "AlertRouteWhenAlertJoinsGroupPayloadV3": {
+        "example": {
+          "grace_period_seconds": 60,
+          "mode": "on_each_new_alert"
+        },
+        "properties": {
+          "grace_period_seconds": {
+            "description": "How long to wait before escalating once an alert joins the group, in seconds. Only applies when mode is 'on_each_new_alert', and must be unset when mode is 'on_priority_increase'. Must be between 0 and 3600 (1 hour).",
+            "example": 60,
+            "format": "int32",
+            "maximum": 3600,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mode": {
+            "description": "When a subsequent alert joins an existing group, when should we escalate again?",
+            "enum": [
+              "on_priority_increase",
+              "on_each_new_alert"
+            ],
+            "example": "on_each_new_alert",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "AlertRouteWhenAlertJoinsGroupV3": {
+        "example": {
+          "grace_period_seconds": 60,
+          "mode": "on_each_new_alert"
+        },
+        "properties": {
+          "grace_period_seconds": {
+            "description": "How long to wait before escalating once an alert joins the group, in seconds. Only applies when mode is 'on_each_new_alert'.",
+            "example": 60,
+            "format": "int32",
+            "type": "integer"
+          },
+          "mode": {
+            "description": "When a subsequent alert joins an existing group, when should we escalate again?",
+            "enum": [
+              "on_priority_increase",
+              "on_each_new_alert"
+            ],
+            "example": "on_each_new_alert",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mode"
         ],
         "type": "object"
       },
@@ -8552,7 +8552,7 @@
           "grouping_config": {
             "default": {
               "enabled": true,
-              "group_keys": [
+              "grouping_keys": [
                 {
                   "reference": "alert.title"
                 }
@@ -9781,7 +9781,7 @@
             "grouping_config": {
               "default": {
                 "enabled": true,
-                "group_keys": [
+                "grouping_keys": [
                   {
                     "reference": "alert.title"
                   }
@@ -10873,7 +10873,7 @@
             "grouping_config": {
               "default": {
                 "enabled": true,
-                "group_keys": [
+                "grouping_keys": [
                   {
                     "reference": "alert.title"
                   }
@@ -12083,7 +12083,7 @@
           "grouping_config": {
             "default": {
               "enabled": true,
-              "group_keys": [
+              "grouping_keys": [
                 {
                   "reference": "alert.title"
                 }
@@ -13320,7 +13320,7 @@
             "grouping_config": {
               "default": {
                 "enabled": true,
-                "group_keys": [
+                "grouping_keys": [
                   {
                     "reference": "alert.title"
                   }
@@ -46359,7 +46359,7 @@
       "GroupingSettingsV3": {
         "example": {
           "enabled": true,
-          "group_keys": [
+          "grouping_keys": [
             {
               "reference": "alert.title"
             }
@@ -46373,7 +46373,7 @@
             "example": true,
             "type": "boolean"
           },
-          "group_keys": {
+          "grouping_keys": {
             "description": "Which attributes should this alert route use to group alerts? Only set when grouping is enabled.",
             "example": [
               {
@@ -91388,7 +91388,7 @@
                 "grouping_config": {
                   "default": {
                     "enabled": true,
-                    "group_keys": [
+                    "grouping_keys": [
                       {
                         "reference": "alert.title"
                       }
@@ -91857,7 +91857,7 @@
                     "grouping_config": {
                       "default": {
                         "enabled": true,
-                        "group_keys": [
+                        "grouping_keys": [
                           {
                             "reference": "alert.title"
                           }
@@ -92400,7 +92400,7 @@
                     "grouping_config": {
                       "default": {
                         "enabled": true,
-                        "group_keys": [
+                        "grouping_keys": [
                           {
                             "reference": "alert.title"
                           }
@@ -92878,7 +92878,7 @@
                 "grouping_config": {
                   "default": {
                     "enabled": true,
-                    "group_keys": [
+                    "grouping_keys": [
                       {
                         "reference": "alert.title"
                       }
@@ -93348,7 +93348,7 @@
                     "grouping_config": {
                       "default": {
                         "enabled": true,
-                        "group_keys": [
+                        "grouping_keys": [
                           {
                             "reference": "alert.title"
                           }

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -168,18 +168,6 @@ const (
 	AlertEventsCreateHTTPPayloadV2StatusResolved AlertEventsCreateHTTPPayloadV2Status = "resolved"
 )
 
-// Defines values for AlertRouteAlertJoinsGroupPayloadV3Mode.
-const (
-	AlertRouteAlertJoinsGroupPayloadV3ModeOnEachNewAlert     AlertRouteAlertJoinsGroupPayloadV3Mode = "on_each_new_alert"
-	AlertRouteAlertJoinsGroupPayloadV3ModeOnPriorityIncrease AlertRouteAlertJoinsGroupPayloadV3Mode = "on_priority_increase"
-)
-
-// Defines values for AlertRouteAlertJoinsGroupV3Mode.
-const (
-	AlertRouteAlertJoinsGroupV3ModeOnEachNewAlert     AlertRouteAlertJoinsGroupV3Mode = "on_each_new_alert"
-	AlertRouteAlertJoinsGroupV3ModeOnPriorityIncrease AlertRouteAlertJoinsGroupV3Mode = "on_priority_increase"
-)
-
 // Defines values for AlertRouteChannelTargetPayloadV3ChannelVisibility.
 const (
 	AlertRouteChannelTargetPayloadV3ChannelVisibilityAssistant AlertRouteChannelTargetPayloadV3ChannelVisibility = "assistant"
@@ -239,6 +227,18 @@ const (
 const (
 	AlertRouteSeverityBindingV3MergeStrategyFirstWins AlertRouteSeverityBindingV3MergeStrategy = "first-wins"
 	AlertRouteSeverityBindingV3MergeStrategyMax       AlertRouteSeverityBindingV3MergeStrategy = "max"
+)
+
+// Defines values for AlertRouteWhenAlertJoinsGroupPayloadV3Mode.
+const (
+	AlertRouteWhenAlertJoinsGroupPayloadV3ModeOnEachNewAlert     AlertRouteWhenAlertJoinsGroupPayloadV3Mode = "on_each_new_alert"
+	AlertRouteWhenAlertJoinsGroupPayloadV3ModeOnPriorityIncrease AlertRouteWhenAlertJoinsGroupPayloadV3Mode = "on_priority_increase"
+)
+
+// Defines values for AlertRouteWhenAlertJoinsGroupV3Mode.
+const (
+	AlertRouteWhenAlertJoinsGroupV3ModeOnEachNewAlert     AlertRouteWhenAlertJoinsGroupV3Mode = "on_each_new_alert"
+	AlertRouteWhenAlertJoinsGroupV3ModeOnPriorityIncrease AlertRouteWhenAlertJoinsGroupV3Mode = "on_priority_increase"
 )
 
 // Defines values for AlertSlimV2Status.
@@ -2377,30 +2377,6 @@ type AlertNotesUpdateResultV1 struct {
 	AlertNote AlertNoteV1 `json:"alert_note"`
 }
 
-// AlertRouteAlertJoinsGroupPayloadV3 defines model for AlertRouteAlertJoinsGroupPayloadV3.
-type AlertRouteAlertJoinsGroupPayloadV3 struct {
-	// GracePeriodSeconds How long to wait before escalating once an alert joins the group, in seconds. Must be between 0 and 3600 (1 hour).
-	GracePeriodSeconds *int32 `json:"grace_period_seconds,omitempty"`
-
-	// Mode When a subsequent alert joins an existing group, when should we escalate again?
-	Mode AlertRouteAlertJoinsGroupPayloadV3Mode `json:"mode"`
-}
-
-// AlertRouteAlertJoinsGroupPayloadV3Mode When a subsequent alert joins an existing group, when should we escalate again?
-type AlertRouteAlertJoinsGroupPayloadV3Mode string
-
-// AlertRouteAlertJoinsGroupV3 defines model for AlertRouteAlertJoinsGroupV3.
-type AlertRouteAlertJoinsGroupV3 struct {
-	// GracePeriodSeconds How long to wait before escalating once an alert joins the group
-	GracePeriodSeconds *int32 `json:"grace_period_seconds,omitempty"`
-
-	// Mode When a subsequent alert joins an existing group, when should we escalate again?
-	Mode AlertRouteAlertJoinsGroupV3Mode `json:"mode"`
-}
-
-// AlertRouteAlertJoinsGroupV3Mode When a subsequent alert joins an existing group, when should we escalate again?
-type AlertRouteAlertJoinsGroupV3Mode string
-
 // AlertRouteAlertSourcePayloadV2 defines model for AlertRouteAlertSourcePayloadV2.
 type AlertRouteAlertSourcePayloadV2 struct {
 	// AlertSourceId The alert source ID that will match for the route
@@ -2587,8 +2563,8 @@ type AlertRouteEscalationConfigPayloadV3 struct {
 	AutoCancelEscalations bool `json:"auto_cancel_escalations"`
 
 	// EscalationTargets Targets for escalation
-	EscalationTargets   []AlertRouteEscalationTargetPayloadV3 `json:"escalation_targets"`
-	WhenAlertJoinsGroup *AlertRouteAlertJoinsGroupPayloadV3   `json:"when_alert_joins_group,omitempty"`
+	EscalationTargets   []AlertRouteEscalationTargetPayloadV3   `json:"escalation_targets"`
+	WhenAlertJoinsGroup *AlertRouteWhenAlertJoinsGroupPayloadV3 `json:"when_alert_joins_group,omitempty"`
 }
 
 // AlertRouteEscalationConfigV2 defines model for AlertRouteEscalationConfigV2.
@@ -2606,8 +2582,8 @@ type AlertRouteEscalationConfigV3 struct {
 	AutoCancelEscalations bool `json:"auto_cancel_escalations"`
 
 	// EscalationTargets Targets for escalation
-	EscalationTargets   []AlertRouteEscalationTargetV3 `json:"escalation_targets"`
-	WhenAlertJoinsGroup *AlertRouteAlertJoinsGroupV3   `json:"when_alert_joins_group,omitempty"`
+	EscalationTargets   []AlertRouteEscalationTargetV3   `json:"escalation_targets"`
+	WhenAlertJoinsGroup *AlertRouteWhenAlertJoinsGroupV3 `json:"when_alert_joins_group,omitempty"`
 }
 
 // AlertRouteEscalationTargetPayloadV2 defines model for AlertRouteEscalationTargetPayloadV2.
@@ -2928,6 +2904,30 @@ type AlertRouteV3 struct {
 	// Version The version of this alert route
 	Version int64 `json:"version"`
 }
+
+// AlertRouteWhenAlertJoinsGroupPayloadV3 defines model for AlertRouteWhenAlertJoinsGroupPayloadV3.
+type AlertRouteWhenAlertJoinsGroupPayloadV3 struct {
+	// GracePeriodSeconds How long to wait before escalating once an alert joins the group, in seconds. Only applies when mode is 'on_each_new_alert', and must be unset when mode is 'on_priority_increase'. Must be between 0 and 3600 (1 hour).
+	GracePeriodSeconds *int32 `json:"grace_period_seconds,omitempty"`
+
+	// Mode When a subsequent alert joins an existing group, when should we escalate again?
+	Mode AlertRouteWhenAlertJoinsGroupPayloadV3Mode `json:"mode"`
+}
+
+// AlertRouteWhenAlertJoinsGroupPayloadV3Mode When a subsequent alert joins an existing group, when should we escalate again?
+type AlertRouteWhenAlertJoinsGroupPayloadV3Mode string
+
+// AlertRouteWhenAlertJoinsGroupV3 defines model for AlertRouteWhenAlertJoinsGroupV3.
+type AlertRouteWhenAlertJoinsGroupV3 struct {
+	// GracePeriodSeconds How long to wait before escalating once an alert joins the group, in seconds. Only applies when mode is 'on_each_new_alert'.
+	GracePeriodSeconds *int32 `json:"grace_period_seconds,omitempty"`
+
+	// Mode When a subsequent alert joins an existing group, when should we escalate again?
+	Mode AlertRouteWhenAlertJoinsGroupV3Mode `json:"mode"`
+}
+
+// AlertRouteWhenAlertJoinsGroupV3Mode When a subsequent alert joins an existing group, when should we escalate again?
+type AlertRouteWhenAlertJoinsGroupV3Mode string
 
 // AlertRoutesCreatePayloadV2 defines model for AlertRoutesCreatePayloadV2.
 type AlertRoutesCreatePayloadV2 struct {
@@ -6031,8 +6031,8 @@ type GroupingSettingsV3 struct {
 	// Enabled Whether grouping is enabled
 	Enabled bool `json:"enabled"`
 
-	// GroupKeys Which attributes should this alert route use to group alerts? Only set when grouping is enabled.
-	GroupKeys *[]GroupingKeyV3 `json:"group_keys,omitempty"`
+	// GroupingKeys Which attributes should this alert route use to group alerts? Only set when grouping is enabled.
+	GroupingKeys *[]GroupingKeyV3 `json:"grouping_keys,omitempty"`
 
 	// WindowSeconds How long the grouping window is, in seconds. Must be between 60 (1 minute) and 172800 (48 hours). Only set when grouping is enabled.
 	WindowSeconds *int32 `json:"window_seconds,omitempty"`

--- a/internal/provider/incident_alert_route_v3_resource.go
+++ b/internal/provider/incident_alert_route_v3_resource.go
@@ -119,11 +119,11 @@ We'd generally recommend building alert routes in our [web dashboard](https://ap
 						Attributes: map[string]schema.Attribute{
 							"mode": schema.StringAttribute{
 								Required:            true,
-								MarkdownDescription: EnumValuesDescription("AlertRouteAlertJoinsGroupV3", "mode"),
+								MarkdownDescription: EnumValuesDescription("AlertRouteWhenAlertJoinsGroupV3", "mode"),
 							},
 							"grace_period_seconds": schema.Int64Attribute{
 								Optional:            true,
-								MarkdownDescription: apischema.Docstring("AlertRouteAlertJoinsGroupV3", "grace_period_seconds"),
+								MarkdownDescription: apischema.Docstring("AlertRouteWhenAlertJoinsGroupV3", "grace_period_seconds"),
 							},
 						},
 					},
@@ -141,11 +141,11 @@ We'd generally recommend building alert routes in our [web dashboard](https://ap
 								Required:            true,
 								MarkdownDescription: apischema.Docstring("GroupingSettingsV3", "enabled"),
 							},
-							"group_keys": schema.SetNestedAttribute{
+							"grouping_keys": schema.SetNestedAttribute{
 								// Optional: only valid when grouping is enabled. Enforced
 								// conditionally in ValidateConfig.
 								Optional:            true,
-								MarkdownDescription: apischema.Docstring("GroupingSettingsV3", "group_keys"),
+								MarkdownDescription: apischema.Docstring("GroupingSettingsV3", "grouping_keys"),
 								NestedObject: schema.NestedAttributeObject{
 									Attributes: map[string]schema.Attribute{
 										"reference": schema.StringAttribute{
@@ -337,7 +337,7 @@ func (r *IncidentAlertRouteV3Resource) Configure(ctx context.Context, req resour
 }
 
 func (r *IncidentAlertRouteV3Resource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	// The grouping detail fields (window_seconds, window_type, group_keys) are
+	// The grouping detail fields (window_seconds, window_type, grouping_keys) are
 	// optional in the schema because the API only accepts them when grouping is
 	// enabled. Enforce that relationship here: required when enabled, and unset
 	// when disabled (otherwise the value would be silently dropped on apply,
@@ -350,8 +350,8 @@ func (r *IncidentAlertRouteV3Resource) ValidateConfig(ctx context.Context, req r
 		req.Config.GetAttribute(ctx, groupingBase.AtName("window_seconds"), &windowSeconds)
 		var windowType types.String
 		req.Config.GetAttribute(ctx, groupingBase.AtName("window_type"), &windowType)
-		var groupKeys types.Set
-		req.Config.GetAttribute(ctx, groupingBase.AtName("group_keys"), &groupKeys)
+		var groupingKeys types.Set
+		req.Config.GetAttribute(ctx, groupingBase.AtName("grouping_keys"), &groupingKeys)
 
 		if groupingEnabled.ValueBool() {
 			if windowSeconds.IsNull() {
@@ -383,13 +383,32 @@ func (r *IncidentAlertRouteV3Resource) ValidateConfig(ctx context.Context, req r
 					"`window_type` must not be set when `grouping_config.default.enabled` is false.",
 				))
 			}
-			if !groupKeys.IsNull() && !groupKeys.IsUnknown() && len(groupKeys.Elements()) > 0 {
+			if !groupingKeys.IsNull() && !groupingKeys.IsUnknown() && len(groupingKeys.Elements()) > 0 {
 				resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
-					groupingBase.AtName("group_keys"),
+					groupingBase.AtName("grouping_keys"),
 					"Invalid attribute combination",
-					"`group_keys` must not be set when `grouping_config.default.enabled` is false.",
+					"`grouping_keys` must not be set when `grouping_config.default.enabled` is false.",
 				))
 			}
+		}
+	}
+
+	// grace_period_seconds only applies when re-escalating on each new alert: it
+	// gives the grouping window time to attach more alerts before paging. In
+	// on_priority_increase mode we escalate immediately on a higher priority, so
+	// the API rejects a grace period; surface that at plan time.
+	whenAlertJoinsGroupBase := path.Root("escalation_config").AtName("when_alert_joins_group")
+	var mode types.String
+	if d := req.Config.GetAttribute(ctx, whenAlertJoinsGroupBase.AtName("mode"), &mode); !d.HasError() &&
+		!mode.IsNull() && !mode.IsUnknown() && mode.ValueString() == "on_priority_increase" {
+		var gracePeriodSeconds types.Int64
+		if d := req.Config.GetAttribute(ctx, whenAlertJoinsGroupBase.AtName("grace_period_seconds"), &gracePeriodSeconds); !d.HasError() &&
+			!gracePeriodSeconds.IsNull() && !gracePeriodSeconds.IsUnknown() {
+			resp.Diagnostics.Append(diag.NewAttributeErrorDiagnostic(
+				whenAlertJoinsGroupBase.AtName("grace_period_seconds"),
+				"Invalid attribute combination",
+				"`grace_period_seconds` can only be set when `escalation_config.when_alert_joins_group.mode` is `on_each_new_alert`.",
+			))
 		}
 	}
 

--- a/internal/provider/incident_alert_route_v3_resource_test.go
+++ b/internal/provider/incident_alert_route_v3_resource_test.go
@@ -80,7 +80,7 @@ func TestAccIncidentAlertRouteV3ResourceComprehensive(t *testing.T) {
 					resource.TestCheckResourceAttr("incident_alert_route_v3.comprehensive", "message_config.destinations.0.slack_targets.channel_visibility", "public"),
 
 					// Escalation config with when_alert_joins_group.
-					resource.TestCheckResourceAttr("incident_alert_route_v3.comprehensive", "escalation_config.when_alert_joins_group.mode", "on_priority_increase"),
+					resource.TestCheckResourceAttr("incident_alert_route_v3.comprehensive", "escalation_config.when_alert_joins_group.mode", "on_each_new_alert"),
 					resource.TestCheckResourceAttr("incident_alert_route_v3.comprehensive", "escalation_config.when_alert_joins_group.grace_period_seconds", "60"),
 
 					// Incident config and nested template.
@@ -354,7 +354,7 @@ resource "incident_alert_route_v3" "comprehensive" {
   grouping_config = {
     default = {
       enabled        = true
-      group_keys     = []
+      grouping_keys  = []
       window_seconds = 1800
       window_type    = "fixed"
     }
@@ -380,7 +380,7 @@ resource "incident_alert_route_v3" "comprehensive" {
     auto_cancel_escalations = true
     escalation_targets      = []
     when_alert_joins_group = {
-      mode                 = "on_priority_increase"
+      mode                 = "on_each_new_alert"
       grace_period_seconds = 60
     }
   }

--- a/internal/provider/models/alert_route_v3_model.go
+++ b/internal/provider/models/alert_route_v3_model.go
@@ -59,7 +59,7 @@ func whenAlertJoinsGroupAttrTypes() map[string]attr.Type {
 // whenAlertJoinsGroupFromAPI converts the API's optional when_alert_joins_group
 // to a types.Object (null when absent). Modelled as an object, rather than a
 // nested struct, so the Computed attribute can carry an unknown value.
-func whenAlertJoinsGroupFromAPI(in *client.AlertRouteAlertJoinsGroupV3) types.Object {
+func whenAlertJoinsGroupFromAPI(in *client.AlertRouteWhenAlertJoinsGroupV3) types.Object {
 	if in == nil {
 		return types.ObjectNull(whenAlertJoinsGroupAttrTypes())
 	}
@@ -76,7 +76,7 @@ func whenAlertJoinsGroupFromAPI(in *client.AlertRouteAlertJoinsGroupV3) types.Ob
 	return obj
 }
 
-func whenAlertJoinsGroupToPayload(ctx context.Context, obj types.Object) *client.AlertRouteAlertJoinsGroupPayloadV3 {
+func whenAlertJoinsGroupToPayload(ctx context.Context, obj types.Object) *client.AlertRouteWhenAlertJoinsGroupPayloadV3 {
 	if obj.IsNull() || obj.IsUnknown() {
 		return nil
 	}
@@ -84,8 +84,8 @@ func whenAlertJoinsGroupToPayload(ctx context.Context, obj types.Object) *client
 	var m AlertRouteWhenAlertJoinsGroupModel
 	obj.As(ctx, &m, basetypes.ObjectAsOptions{})
 
-	payload := &client.AlertRouteAlertJoinsGroupPayloadV3{
-		Mode: client.AlertRouteAlertJoinsGroupPayloadV3Mode(m.Mode.ValueString()),
+	payload := &client.AlertRouteWhenAlertJoinsGroupPayloadV3{
+		Mode: client.AlertRouteWhenAlertJoinsGroupPayloadV3Mode(m.Mode.ValueString()),
 	}
 	if !m.GracePeriodSeconds.IsNull() && !m.GracePeriodSeconds.IsUnknown() {
 		payload.GracePeriodSeconds = lo32(m.GracePeriodSeconds.ValueInt64())
@@ -99,7 +99,7 @@ type AlertRouteV3GroupingConfigModel struct {
 
 type AlertRouteV3GroupingSettingsModel struct {
 	Enabled       types.Bool              `tfsdk:"enabled"`
-	GroupKeys     []AlertRouteGroupingKey `tfsdk:"group_keys"`
+	GroupingKeys  []AlertRouteGroupingKey `tfsdk:"grouping_keys"`
 	WindowSeconds types.Int64             `tfsdk:"window_seconds"`
 	WindowType    types.String            `tfsdk:"window_type"`
 }
@@ -254,7 +254,7 @@ func (AlertRouteV3ResourceModel) FromAPIWithPlan(apiModel client.AlertRouteV3, p
 
 	result.EscalationConfig.WhenAlertJoinsGroup = whenAlertJoinsGroupFromAPI(apiModel.EscalationConfig.WhenAlertJoinsGroup)
 
-	// Grouping config. The detail fields (group_keys, window_seconds,
+	// Grouping config. The detail fields (grouping_keys, window_seconds,
 	// window_type) are optional in the API and only returned when grouping is
 	// enabled. Mirror the API: use the returned value, otherwise leave the field
 	// null. We deliberately do NOT fall back to prior plan/state when grouping is
@@ -276,18 +276,18 @@ func (AlertRouteV3ResourceModel) FromAPIWithPlan(apiModel client.AlertRouteV3, p
 		groupingDefault.WindowType = types.StringValue(string(*apiModel.GroupingConfig.Default.WindowType))
 	}
 	switch {
-	case apiModel.GroupingConfig.Default.GroupKeys != nil:
-		groupingDefault.GroupKeys = []AlertRouteGroupingKey{}
-		for _, gk := range *apiModel.GroupingConfig.Default.GroupKeys {
-			groupingDefault.GroupKeys = append(groupingDefault.GroupKeys, AlertRouteGroupingKey{
+	case apiModel.GroupingConfig.Default.GroupingKeys != nil:
+		groupingDefault.GroupingKeys = []AlertRouteGroupingKey{}
+		for _, gk := range *apiModel.GroupingConfig.Default.GroupingKeys {
+			groupingDefault.GroupingKeys = append(groupingDefault.GroupingKeys, AlertRouteGroupingKey{
 				Reference: types.StringValue(gk.Reference),
 			})
 		}
 	case apiModel.GroupingConfig.Default.Enabled && planGrouping != nil:
-		// The API omits an empty group_keys (omitempty) even when grouping is
+		// The API omits an empty grouping_keys (omitempty) even when grouping is
 		// enabled, so mirror the planned null-vs-empty shape to avoid a diff.
 		// When grouping is disabled we leave it null (no stale values).
-		groupingDefault.GroupKeys = planGrouping.GroupKeys
+		groupingDefault.GroupingKeys = planGrouping.GroupingKeys
 	}
 	result.GroupingConfig = &AlertRouteV3GroupingConfigModel{Default: groupingDefault}
 
@@ -511,7 +511,7 @@ func (m AlertRouteV3ResourceModel) ToCreatePayload() client.AlertRoutesCreatePay
 		},
 		GroupingConfig: client.AlertGroupingConfigV3{
 			Default: client.GroupingSettingsV3{
-				GroupKeys: &[]client.GroupingKeyV3{},
+				GroupingKeys: &[]client.GroupingKeyV3{},
 			},
 		},
 		MessageConfig: client.AlertMessageConfigPayloadV3{
@@ -565,12 +565,12 @@ func (m AlertRouteV3ResourceModel) ToCreatePayload() client.AlertRoutesCreatePay
 		// rejects them otherwise.
 		if m.GroupingConfig.Default.Enabled.ValueBool() {
 			groupKeys := []client.GroupingKeyV3{}
-			for _, gk := range m.GroupingConfig.Default.GroupKeys {
+			for _, gk := range m.GroupingConfig.Default.GroupingKeys {
 				groupKeys = append(groupKeys, client.GroupingKeyV3{
 					Reference: gk.Reference.ValueString(),
 				})
 			}
-			groupingDefault.GroupKeys = &groupKeys
+			groupingDefault.GroupingKeys = &groupKeys
 			if !m.GroupingConfig.Default.WindowSeconds.IsNull() {
 				groupingDefault.WindowSeconds = lo32(m.GroupingConfig.Default.WindowSeconds.ValueInt64())
 			}

--- a/internal/provider/models/alert_route_v3_model.go
+++ b/internal/provider/models/alert_route_v3_model.go
@@ -87,7 +87,12 @@ func whenAlertJoinsGroupToPayload(ctx context.Context, obj types.Object) *client
 	payload := &client.AlertRouteWhenAlertJoinsGroupPayloadV3{
 		Mode: client.AlertRouteWhenAlertJoinsGroupPayloadV3Mode(m.Mode.ValueString()),
 	}
-	if !m.GracePeriodSeconds.IsNull() && !m.GracePeriodSeconds.IsUnknown() {
+	// The grace period only applies when re-escalating on each new alert; the API
+	// rejects it for on_priority_increase. ValidateConfig surfaces a misconfigured
+	// HCL value at plan time, but guard here too so a value that slips through
+	// (e.g. unknown at validation) is never sent to the API.
+	if m.Mode.ValueString() == string(client.AlertRouteWhenAlertJoinsGroupPayloadV3ModeOnEachNewAlert) &&
+		!m.GracePeriodSeconds.IsNull() && !m.GracePeriodSeconds.IsUnknown() {
 		payload.GracePeriodSeconds = lo32(m.GracePeriodSeconds.ValueInt64())
 	}
 	return payload

--- a/internal/provider/models/alert_route_v3_model_test.go
+++ b/internal/provider/models/alert_route_v3_model_test.go
@@ -42,7 +42,7 @@ func TestAlertRouteV3RoundTrip(t *testing.T) {
 		GroupingConfig: client.AlertGroupingConfigV3{
 			Default: client.GroupingSettingsV3{
 				Enabled:       true,
-				GroupKeys:     &[]client.GroupingKeyV3{{Reference: "alert.title"}},
+				GroupingKeys:  &[]client.GroupingKeyV3{{Reference: "alert.title"}},
 				WindowSeconds: lo.ToPtr(int32(1800)),
 				WindowType:    lo.ToPtr(client.Fixed),
 			},
@@ -63,8 +63,8 @@ func TestAlertRouteV3RoundTrip(t *testing.T) {
 		EscalationConfig: client.AlertRouteEscalationConfigV3{
 			AutoCancelEscalations: true,
 			EscalationTargets:     []client.AlertRouteEscalationTargetV3{},
-			WhenAlertJoinsGroup: &client.AlertRouteAlertJoinsGroupV3{
-				Mode:               client.AlertRouteAlertJoinsGroupV3ModeOnPriorityIncrease,
+			WhenAlertJoinsGroup: &client.AlertRouteWhenAlertJoinsGroupV3{
+				Mode:               client.AlertRouteWhenAlertJoinsGroupV3ModeOnPriorityIncrease,
 				GracePeriodSeconds: lo.ToPtr(int32(60)),
 			},
 		},
@@ -118,8 +118,8 @@ func TestAlertRouteV3RoundTrip(t *testing.T) {
 	if got := model.GroupingConfig.Default.WindowType.ValueString(); got != "fixed" {
 		t.Errorf("window_type: got %q", got)
 	}
-	if got := len(model.GroupingConfig.Default.GroupKeys); got != 1 {
-		t.Errorf("group_keys: got %d", got)
+	if got := len(model.GroupingConfig.Default.GroupingKeys); got != 1 {
+		t.Errorf("grouping_keys: got %d", got)
 	}
 
 	// Message config.
@@ -272,8 +272,8 @@ func TestAlertRouteV3ImportLeavesConditionalFieldsNull(t *testing.T) {
 	if !model.GroupingConfig.Default.WindowType.IsNull() {
 		t.Errorf("window_type: expected null, got %v", model.GroupingConfig.Default.WindowType)
 	}
-	if model.GroupingConfig.Default.GroupKeys != nil {
-		t.Errorf("group_keys: expected nil, got %+v", model.GroupingConfig.Default.GroupKeys)
+	if model.GroupingConfig.Default.GroupingKeys != nil {
+		t.Errorf("grouping_keys: expected nil, got %+v", model.GroupingConfig.Default.GroupingKeys)
 	}
 	if model.IncidentConfig == nil {
 		t.Fatal("incident_config is nil")

--- a/internal/provider/models/alert_route_v3_model_test.go
+++ b/internal/provider/models/alert_route_v3_model_test.go
@@ -64,7 +64,7 @@ func TestAlertRouteV3RoundTrip(t *testing.T) {
 			AutoCancelEscalations: true,
 			EscalationTargets:     []client.AlertRouteEscalationTargetV3{},
 			WhenAlertJoinsGroup: &client.AlertRouteWhenAlertJoinsGroupV3{
-				Mode:               client.AlertRouteWhenAlertJoinsGroupV3ModeOnPriorityIncrease,
+				Mode:               client.AlertRouteWhenAlertJoinsGroupV3ModeOnEachNewAlert,
 				GracePeriodSeconds: lo.ToPtr(int32(60)),
 			},
 		},
@@ -136,7 +136,7 @@ func TestAlertRouteV3RoundTrip(t *testing.T) {
 	}
 	var joinsGroup AlertRouteWhenAlertJoinsGroupModel
 	model.EscalationConfig.WhenAlertJoinsGroup.As(context.Background(), &joinsGroup, basetypes.ObjectAsOptions{})
-	if got := joinsGroup.Mode.ValueString(); got != "on_priority_increase" {
+	if got := joinsGroup.Mode.ValueString(); got != "on_each_new_alert" {
 		t.Errorf("mode: got %q", got)
 	}
 	if got := joinsGroup.GracePeriodSeconds.ValueInt64(); got != 60 {


### PR DESCRIPTION
## What

Updates the `incident_alert_route_v3` resource to match changes made to the v3 alert route API made prior to release.

1. **Regenerated the API client** from the updated `public-schema-v3-including-secret-endpoints.json` (copied from core). This picks up:
   - `AlertRouteAlertJoinsGroup*V3` → `AlertRouteWhenAlertJoinsGroup*V3` type rename.
   - `GroupingSettingsV3.group_keys` → `grouping_keys` field rename.
2. **Renamed the resource attribute** `grouping_config.default.group_keys` → `grouping_keys`.
3. **Added `ValidateConfig` enforcement** so `grace_period_seconds` is only accepted when `when_alert_joins_group.mode` is `on_each_new_alert`. The core API now rejects a grace period for `on_priority_increase` (it escalates immediately on a higher priority, so a grace period is meaningless), and this surfaces that at plan time.
4. Updated the example, acceptance test config, and generated docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Renaming `group_keys` to `grouping_keys` is a breaking Terraform schema change for existing modules; misconfiguration during migration could alter alert grouping and escalation behavior.
> 
> **Overview**
> Aligns **`incident_alert_route_v3`** with the updated V3 alert routes public API (breaking rename for existing Terraform configs).
> 
> **`grouping_config.default.group_keys`** is renamed to **`grouping_keys`** across the resource schema, models, generated client, OpenAPI schema, docs, and examples.
> 
> The generated client now uses **`AlertRouteWhenAlertJoinsGroup*V3`** instead of **`AlertRouteAlertJoinsGroup*V3`**, with updated docs for **`grace_period_seconds`** (only when mode is **`on_each_new_alert`**).
> 
> **Plan-time validation** rejects **`grace_period_seconds`** when **`when_alert_joins_group.mode`** is **`on_priority_increase`**; the model layer also omits grace period on API payloads for that mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc3d1355aea125ba1b5168861f5e08c2bbca160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->