### PR TITLE
Sync alert routes v3 public API schema + regenerate client

### DIFF
--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -1929,7 +1929,7 @@
         "example": {
           "default": {
             "enabled": true,
-            "group_keys": [
+            "grouping_keys": [
               {
                 "reference": "alert.title"
               }
@@ -2008,7 +2008,7 @@
               }
             }
           ],
-          "message_template": {
+          "template": {
             "array_value": [
               {
                 "literal": "SEV123",
@@ -2087,7 +2087,7 @@
             },
             "type": "array"
           },
-          "message_template": {
+          "template": {
             "$ref": "#/components/schemas/EngineParamBindingPayloadV3"
           }
         },
@@ -2162,7 +2162,7 @@
               }
             }
           ],
-          "message_template": {
+          "template": {
             "array_value": [
               {
                 "literal": "SEV123",
@@ -2247,7 +2247,7 @@
             },
             "type": "array"
           },
-          "message_template": {
+          "template": {
             "$ref": "#/components/schemas/EngineParamBindingV3"
           }
         },
@@ -2786,62 +2786,6 @@
         },
         "required": [
           "alert_note"
-        ],
-        "type": "object"
-      },
-      "AlertRouteAlertJoinsGroupPayloadV3": {
-        "example": {
-          "grace_period_seconds": 60,
-          "mode": "on_each_new_alert"
-        },
-        "properties": {
-          "grace_period_seconds": {
-            "description": "How long to wait before escalating once an alert joins the group, in seconds. Must be between 0 and 3600 (1 hour).",
-            "example": 60,
-            "format": "int32",
-            "maximum": 3600,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "mode": {
-            "description": "When a subsequent alert joins an existing group, when should we escalate again?",
-            "enum": [
-              "on_priority_increase",
-              "on_each_new_alert"
-            ],
-            "example": "on_each_new_alert",
-            "type": "string"
-          }
-        },
-        "required": [
-          "mode"
-        ],
-        "type": "object"
-      },
-      "AlertRouteAlertJoinsGroupV3": {
-        "example": {
-          "grace_period_seconds": 60,
-          "mode": "on_each_new_alert"
-        },
-        "properties": {
-          "grace_period_seconds": {
-            "description": "How long to wait before escalating once an alert joins the group",
-            "example": 60,
-            "format": "int32",
-            "type": "integer"
-          },
-          "mode": {
-            "description": "When a subsequent alert joins an existing group, when should we escalate again?",
-            "enum": [
-              "on_priority_increase",
-              "on_each_new_alert"
-            ],
-            "example": "on_each_new_alert",
-            "type": "string"
-          }
-        },
-        "required": [
-          "mode"
         ],
         "type": "object"
       },
@@ -3976,7 +3920,7 @@
             "type": "array"
           },
           "when_alert_joins_group": {
-            "$ref": "#/components/schemas/AlertRouteAlertJoinsGroupPayloadV3"
+            "$ref": "#/components/schemas/AlertRouteWhenAlertJoinsGroupPayloadV3"
           }
         },
         "required": [
@@ -4151,7 +4095,7 @@
             "type": "array"
           },
           "when_alert_joins_group": {
-            "$ref": "#/components/schemas/AlertRouteAlertJoinsGroupV3"
+            "$ref": "#/components/schemas/AlertRouteWhenAlertJoinsGroupV3"
           }
         },
         "required": [
@@ -7067,7 +7011,7 @@
           "grouping_config": {
             "default": {
               "enabled": true,
-              "group_keys": [
+              "grouping_keys": [
                 {
                   "reference": "alert.title"
                 }
@@ -7284,7 +7228,7 @@
                 }
               }
             ],
-            "message_template": {
+            "template": {
               "array_value": [
                 {
                   "literal": "SEV123",
@@ -7598,6 +7542,62 @@
         ],
         "type": "object"
       },
+      "AlertRouteWhenAlertJoinsGroupPayloadV3": {
+        "example": {
+          "grace_period_seconds": 60,
+          "mode": "on_each_new_alert"
+        },
+        "properties": {
+          "grace_period_seconds": {
+            "description": "How long to wait before escalating once an alert joins the group, in seconds. Only applies when mode is 'on_each_new_alert', and must be unset when mode is 'on_priority_increase'. Must be between 0 and 3600 (1 hour).",
+            "example": 60,
+            "format": "int32",
+            "maximum": 3600,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mode": {
+            "description": "When a subsequent alert joins an existing group, when should we escalate again?",
+            "enum": [
+              "on_priority_increase",
+              "on_each_new_alert"
+            ],
+            "example": "on_each_new_alert",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "AlertRouteWhenAlertJoinsGroupV3": {
+        "example": {
+          "grace_period_seconds": 60,
+          "mode": "on_each_new_alert"
+        },
+        "properties": {
+          "grace_period_seconds": {
+            "description": "How long to wait before escalating once an alert joins the group, in seconds. Only applies when mode is 'on_each_new_alert'.",
+            "example": 60,
+            "format": "int32",
+            "type": "integer"
+          },
+          "mode": {
+            "description": "When a subsequent alert joins an existing group, when should we escalate again?",
+            "enum": [
+              "on_priority_increase",
+              "on_each_new_alert"
+            ],
+            "example": "on_each_new_alert",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
       "AlertRoutesCreatePayloadV2": {
         "example": {
           "alert_sources": [
@@ -7804,6 +7804,12 @@
                         }
                       }
                     ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "cast": {
                     "returns": {
                       "array": true,
                       "type": "IncidentStatus"
@@ -8245,6 +8251,12 @@
                         "type": "IncidentStatus"
                       }
                     },
+                    "cast": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
                     "concatenate": {
                       "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                     },
@@ -8503,6 +8515,12 @@
                       "type": "IncidentStatus"
                     }
                   },
+                  "cast": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
                   "concatenate": {
                     "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                   },
@@ -8552,7 +8570,7 @@
           "grouping_config": {
             "default": {
               "enabled": true,
-              "group_keys": [
+              "grouping_keys": [
                 {
                   "reference": "alert.title"
                 }
@@ -8756,7 +8774,7 @@
                 }
               }
             ],
-            "message_template": {
+            "template": {
               "array_value": [
                 {
                   "literal": "SEV123",
@@ -8912,6 +8930,12 @@
                           }
                         }
                       ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "cast": {
                       "returns": {
                         "array": true,
                         "type": "IncidentStatus"
@@ -9781,7 +9805,7 @@
             "grouping_config": {
               "default": {
                 "enabled": true,
-                "group_keys": [
+                "grouping_keys": [
                   {
                     "reference": "alert.title"
                   }
@@ -9998,7 +10022,7 @@
                   }
                 }
               ],
-              "message_template": {
+              "template": {
                 "array_value": [
                   {
                     "literal": "SEV123",
@@ -10873,7 +10897,7 @@
             "grouping_config": {
               "default": {
                 "enabled": true,
-                "group_keys": [
+                "grouping_keys": [
                   {
                     "reference": "alert.title"
                   }
@@ -11090,7 +11114,7 @@
                   }
                 }
               ],
-              "message_template": {
+              "template": {
                 "array_value": [
                   {
                     "literal": "SEV123",
@@ -11327,6 +11351,12 @@
                         }
                       }
                     ],
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
+                  "cast": {
                     "returns": {
                       "array": true,
                       "type": "IncidentStatus"
@@ -11769,6 +11799,12 @@
                         "type": "IncidentStatus"
                       }
                     },
+                    "cast": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
                     "concatenate": {
                       "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                     },
@@ -12034,6 +12070,12 @@
                       "type": "IncidentStatus"
                     }
                   },
+                  "cast": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
                   "concatenate": {
                     "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                   },
@@ -12083,7 +12125,7 @@
           "grouping_config": {
             "default": {
               "enabled": true,
-              "group_keys": [
+              "grouping_keys": [
                 {
                   "reference": "alert.title"
                 }
@@ -12287,7 +12329,7 @@
                 }
               }
             ],
-            "message_template": {
+            "template": {
               "array_value": [
                 {
                   "literal": "SEV123",
@@ -12444,6 +12486,12 @@
                           }
                         }
                       ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "cast": {
                       "returns": {
                         "array": true,
                         "type": "IncidentStatus"
@@ -13320,7 +13368,7 @@
             "grouping_config": {
               "default": {
                 "enabled": true,
-                "group_keys": [
+                "grouping_keys": [
                   {
                     "reference": "alert.title"
                   }
@@ -13537,7 +13585,7 @@
                   }
                 }
               ],
-              "message_template": {
+              "template": {
                 "array_value": [
                   {
                     "literal": "SEV123",
@@ -14309,6 +14357,12 @@
                           }
                         }
                       ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "cast": {
                       "returns": {
                         "array": true,
                         "type": "IncidentStatus"
@@ -15523,6 +15577,12 @@
                         "type": "IncidentStatus"
                       }
                     },
+                    "cast": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
                     "concatenate": {
                       "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                     },
@@ -16127,6 +16187,12 @@
                       "type": "IncidentStatus"
                     }
                   },
+                  "cast": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
                   "concatenate": {
                     "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                   },
@@ -16282,6 +16348,12 @@
                           }
                         }
                       ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "cast": {
                       "returns": {
                         "array": true,
                         "type": "IncidentStatus"
@@ -26845,91 +26917,6 @@
         ],
         "type": "object"
       },
-      "AuditLogsPrivateIncidentMembershipRemovedFromChannelV1": {
-        "example": {
-          "action": "private_incident_membership.removed_from_channel",
-          "actor": {
-            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-            "metadata": {
-              "user_base_role_slug": "admin",
-              "user_custom_role_slugs": "engineering,security"
-            },
-            "name": "John Doe",
-            "type": "user"
-          },
-          "context": {
-            "location": "1.2.3.4",
-            "user_agent": "Chrome/91.0.4472.114"
-          },
-          "occurred_at": "2021-08-17T13:28:57.801578Z",
-          "targets": [
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "Bob the builder",
-              "type": "user"
-            },
-            {
-              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-              "name": "#INC-123 The website is slow",
-              "type": "incident"
-            }
-          ],
-          "version": 1
-        },
-        "properties": {
-          "action": {
-            "description": "The type of log entry that this is",
-            "example": "private_incident_membership.removed_from_channel",
-            "type": "string"
-          },
-          "actor": {
-            "$ref": "#/components/schemas/AuditLogActorV2"
-          },
-          "context": {
-            "$ref": "#/components/schemas/AuditLogEntryContextV2"
-          },
-          "occurred_at": {
-            "description": "When the entry occurred",
-            "example": "2021-08-17T13:28:57.801578Z",
-            "format": "date-time",
-            "type": "string"
-          },
-          "targets": {
-            "description": "The custom field that was created",
-            "example": [
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "Bob the builder",
-                "type": "user"
-              },
-              {
-                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                "name": "#INC-123 The website is slow",
-                "type": "incident"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/AuditLogTargetV2"
-            },
-            "type": "array"
-          },
-          "version": {
-            "description": "Which version the event is",
-            "example": 1,
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "action",
-          "occurred_at",
-          "version",
-          "actor",
-          "targets",
-          "context"
-        ],
-        "type": "object"
-      },
       "AuditLogsPrivateIncidentMembershipRevokedV1": {
         "example": {
           "action": "private_incident_membership.revoked",
@@ -32346,10 +32333,16 @@
       },
       "CatalogEntrySlimV3V3": {
         "example": {
+          "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "name": "Primary On-call"
         },
         "properties": {
+          "external_id": {
+            "description": "An optional alternative ID for this entry, which is ensured to be unique for the type",
+            "example": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
+            "type": "string"
+          },
           "id": {
             "description": "ID of this catalog entry",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -43156,6 +43149,40 @@
         ],
         "type": "object"
       },
+      "ExpressionCastOptsPayloadV2": {
+        "example": {
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "properties": {
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV2"
+          }
+        },
+        "required": [
+          "returns"
+        ],
+        "type": "object"
+      },
+      "ExpressionCastOptsPayloadV3": {
+        "example": {
+          "returns": {
+            "array": true,
+            "type": "IncidentStatus"
+          }
+        },
+        "properties": {
+          "returns": {
+            "$ref": "#/components/schemas/ReturnsMetaV3"
+          }
+        },
+        "required": [
+          "returns"
+        ],
+        "type": "object"
+      },
       "ExpressionConcatenateOptsPayloadV2": {
         "example": {
           "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
@@ -43704,6 +43731,12 @@
               "type": "IncidentStatus"
             }
           },
+          "cast": {
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            }
+          },
           "concatenate": {
             "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
           },
@@ -43749,6 +43782,9 @@
           "branches": {
             "$ref": "#/components/schemas/ExpressionBranchesOptsPayloadV2"
           },
+          "cast": {
+            "$ref": "#/components/schemas/ExpressionCastOptsPayloadV2"
+          },
           "concatenate": {
             "$ref": "#/components/schemas/ExpressionConcatenateOptsPayloadV2"
           },
@@ -43771,7 +43807,8 @@
               "random",
               "first",
               "parse",
-              "branches"
+              "branches",
+              "cast"
             ],
             "example": "navigate",
             "type": "string"
@@ -43833,6 +43870,12 @@
               "type": "IncidentStatus"
             }
           },
+          "cast": {
+            "returns": {
+              "array": true,
+              "type": "IncidentStatus"
+            }
+          },
           "concatenate": {
             "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
           },
@@ -43878,6 +43921,9 @@
           "branches": {
             "$ref": "#/components/schemas/ExpressionBranchesOptsPayloadV3"
           },
+          "cast": {
+            "$ref": "#/components/schemas/ExpressionCastOptsPayloadV3"
+          },
           "concatenate": {
             "$ref": "#/components/schemas/ExpressionConcatenateOptsPayloadV3"
           },
@@ -43900,7 +43946,8 @@
               "random",
               "first",
               "parse",
-              "branches"
+              "branches",
+              "cast"
             ],
             "example": "navigate",
             "type": "string"
@@ -44046,7 +44093,8 @@
               "random",
               "first",
               "parse",
-              "branches"
+              "branches",
+              "cast"
             ],
             "example": "navigate",
             "type": "string"
@@ -44190,7 +44238,8 @@
               "random",
               "first",
               "parse",
-              "branches"
+              "branches",
+              "cast"
             ],
             "example": "navigate",
             "type": "string"
@@ -44369,6 +44418,12 @@
                   "type": "IncidentStatus"
                 }
               },
+              "cast": {
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              },
               "concatenate": {
                 "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
               },
@@ -44467,6 +44522,12 @@
                       }
                     }
                   ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "cast": {
                   "returns": {
                     "array": true,
                     "type": "IncidentStatus"
@@ -44603,6 +44664,12 @@
                   "type": "IncidentStatus"
                 }
               },
+              "cast": {
+                "returns": {
+                  "array": true,
+                  "type": "IncidentStatus"
+                }
+              },
               "concatenate": {
                 "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
               },
@@ -44701,6 +44768,12 @@
                       }
                     }
                   ],
+                  "returns": {
+                    "array": true,
+                    "type": "IncidentStatus"
+                  }
+                },
+                "cast": {
                   "returns": {
                     "array": true,
                     "type": "IncidentStatus"
@@ -46359,7 +46432,7 @@
       "GroupingSettingsV3": {
         "example": {
           "enabled": true,
-          "group_keys": [
+          "grouping_keys": [
             {
               "reference": "alert.title"
             }
@@ -46373,7 +46446,7 @@
             "example": true,
             "type": "boolean"
           },
-          "group_keys": {
+          "grouping_keys": {
             "description": "Which attributes should this alert route use to group alerts? Only set when grouping is enabled.",
             "example": [
               {
@@ -48943,6 +49016,9 @@
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "is_default": false,
           "name": "Production Outage",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "private_incidents_only": false,
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
@@ -48981,6 +49057,17 @@
             "description": "The name of this Incident Type",
             "example": "Production Outage",
             "type": "string"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this incident type",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "type": "string"
+            },
+            "type": "array"
           },
           "private_incidents_only": {
             "description": "Should all incidents created with this Incident Type be private?",
@@ -49087,6 +49174,9 @@
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "is_default": false,
               "name": "Production Outage",
+              "owning_team_ids": [
+                "01G0J1EXE7AXZ2C93K61WBPYEH"
+              ],
               "private_incidents_only": false,
               "updated_at": "2021-08-17T13:28:57.801578Z"
             }
@@ -49102,6 +49192,9 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "is_default": false,
                 "name": "Production Outage",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "private_incidents_only": false,
                 "updated_at": "2021-08-17T13:28:57.801578Z"
               }
@@ -49126,6 +49219,9 @@
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_default": false,
             "name": "Production Outage",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "private_incidents_only": false,
             "updated_at": "2021-08-17T13:28:57.801578Z"
           }
@@ -49436,6 +49532,9 @@
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "is_default": false,
             "name": "Production Outage",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "private_incidents_only": false,
             "updated_at": "2021-08-17T13:28:57.801578Z"
           },
@@ -50731,6 +50830,9 @@
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "is_default": false,
               "name": "Production Outage",
+              "owning_team_ids": [
+                "01G0J1EXE7AXZ2C93K61WBPYEH"
+              ],
               "private_incidents_only": false,
               "updated_at": "2021-08-17T13:28:57.801578Z"
             },
@@ -51326,6 +51428,9 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "is_default": false,
                 "name": "Production Outage",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "private_incidents_only": false,
                 "updated_at": "2021-08-17T13:28:57.801578Z"
               },
@@ -51452,6 +51557,9 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "is_default": false,
                   "name": "Production Outage",
+                  "owning_team_ids": [
+                    "01G0J1EXE7AXZ2C93K61WBPYEH"
+                  ],
                   "private_incidents_only": false,
                   "updated_at": "2021-08-17T13:28:57.801578Z"
                 },
@@ -51933,6 +52041,9 @@
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "is_default": false,
               "name": "Production Outage",
+              "owning_team_ids": [
+                "01G0J1EXE7AXZ2C93K61WBPYEH"
+              ],
               "private_incidents_only": false,
               "updated_at": "2021-08-17T13:28:57.801578Z"
             },
@@ -61062,6 +61173,7 @@
       "TeamV3": {
         "example": {
           "catalog_entry": {
+            "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "name": "Primary On-call"
           },
@@ -61123,6 +61235,7 @@
           "teams": [
             {
               "catalog_entry": {
+                "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "name": "Primary On-call"
               },
@@ -61147,6 +61260,7 @@
             "example": [
               {
                 "catalog_entry": {
+                  "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                   "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                   "name": "Primary On-call"
                 },
@@ -61178,6 +61292,7 @@
         "example": {
           "team": {
             "catalog_entry": {
+              "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "name": "Primary On-call"
             },
@@ -68005,6 +68120,12 @@
                       "type": "IncidentStatus"
                     }
                   },
+                  "cast": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
                   "concatenate": {
                     "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                   },
@@ -68202,6 +68323,12 @@
                           }
                         }
                       ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "cast": {
                       "returns": {
                         "array": true,
                         "type": "IncidentStatus"
@@ -69419,6 +69546,12 @@
                       "type": "IncidentStatus"
                     }
                   },
+                  "cast": {
+                    "returns": {
+                      "array": true,
+                      "type": "IncidentStatus"
+                    }
+                  },
                   "concatenate": {
                     "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                   },
@@ -69616,6 +69749,12 @@
                           }
                         }
                       ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "cast": {
                       "returns": {
                         "array": true,
                         "type": "IncidentStatus"
@@ -72630,6 +72769,9 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "is_default": false,
                       "name": "Production Outage",
+                      "owning_team_ids": [
+                        "01G0J1EXE7AXZ2C93K61WBPYEH"
+                      ],
                       "private_incidents_only": false,
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     }
@@ -72682,6 +72824,9 @@
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "is_default": false,
                     "name": "Production Outage",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "private_incidents_only": false,
                     "updated_at": "2021-08-17T13:28:57.801578Z"
                   }
@@ -72854,6 +72999,9 @@
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "is_default": false,
                         "name": "Production Outage",
+                        "owning_team_ids": [
+                          "01G0J1EXE7AXZ2C93K61WBPYEH"
+                        ],
                         "private_incidents_only": false,
                         "updated_at": "2021-08-17T13:28:57.801578Z"
                       },
@@ -73051,6 +73199,9 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "is_default": false,
                       "name": "Production Outage",
+                      "owning_team_ids": [
+                        "01G0J1EXE7AXZ2C93K61WBPYEH"
+                      ],
                       "private_incidents_only": false,
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     },
@@ -73209,6 +73360,9 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "is_default": false,
                       "name": "Production Outage",
+                      "owning_team_ids": [
+                        "01G0J1EXE7AXZ2C93K61WBPYEH"
+                      ],
                       "private_incidents_only": false,
                       "updated_at": "2021-08-17T13:28:57.801578Z"
                     },
@@ -75881,6 +76035,12 @@
                             "type": "IncidentStatus"
                           }
                         },
+                        "cast": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
                         "concatenate": {
                           "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                         },
@@ -77474,6 +77634,12 @@
                             "type": "IncidentStatus"
                           }
                         },
+                        "cast": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
                         "concatenate": {
                           "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                         },
@@ -78615,6 +78781,12 @@
                               "type": "IncidentStatus"
                             }
                           },
+                          "cast": {
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          },
                           "concatenate": {
                             "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                           },
@@ -79350,6 +79522,12 @@
                                 }
                               }
                             ],
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          },
+                          "cast": {
                             "returns": {
                               "array": true,
                               "type": "IncidentStatus"
@@ -84074,7 +84252,7 @@
     },
     "/v2/incident_participant_workloads": {
       "get": {
-        "description": "\u003e **Early preview.** This endpoint is in early access and its behaviour may change.\n\u003e [Contact us](mailto:support@incident.io) to enable it for your account.\n\nList the participants of an incident with their workload.\n\nWe calculate how much time each participant has spent working on the incident, aggregated\nper participant. Each participant is annotated with their participant type and, if they have\nleft the incident, when they were archived.\n\nWorkload is calculated periodically, so values can lag real time and the most recent period\nmay still be filling. The metadata reports the time the figures are calculated up to.\nWorkload is not available for private incidents.",
+        "description": "\u003e **Early preview.** This endpoint is in early access and its behaviour may change.\n\u003e [Contact us](mailto:support@incident.io) to enable it for your account.\n\nList the participants of an incident with their workload.\n\nWe calculate how much time each participant has spent working on the incident, aggregated\nper participant. Each participant is annotated with their participant type and, if they have\nleft the incident, when they were archived.\n\nWorkload is calculated periodically, so values can lag real time and the most recent period\nmay still be filling. The metadata reports the time the figures are calculated up to.\n\nWorkload for private incidents is only returned to API keys with the\n`incident_workloads.view_private` scope.",
         "operationId": "IncidentParticipantWorkloads V2#List",
         "parameters": [
           {
@@ -89972,6 +90150,12 @@
                             "type": "IncidentStatus"
                           }
                         },
+                        "cast": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
                         "concatenate": {
                           "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                         },
@@ -90762,6 +90946,12 @@
                             "type": "IncidentStatus"
                           }
                         },
+                        "cast": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
                         "concatenate": {
                           "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                         },
@@ -91339,6 +91529,12 @@
                             "type": "IncidentStatus"
                           }
                         },
+                        "cast": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
                         "concatenate": {
                           "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                         },
@@ -91388,7 +91584,7 @@
                 "grouping_config": {
                   "default": {
                     "enabled": true,
-                    "group_keys": [
+                    "grouping_keys": [
                       {
                         "reference": "alert.title"
                       }
@@ -91592,7 +91788,7 @@
                       }
                     }
                   ],
-                  "message_template": {
+                  "template": {
                     "array_value": [
                       {
                         "literal": "SEV123",
@@ -91857,7 +92053,7 @@
                     "grouping_config": {
                       "default": {
                         "enabled": true,
-                        "group_keys": [
+                        "grouping_keys": [
                           {
                             "reference": "alert.title"
                           }
@@ -92074,7 +92270,7 @@
                           }
                         }
                       ],
-                      "message_template": {
+                      "template": {
                         "array_value": [
                           {
                             "literal": "SEV123",
@@ -92400,7 +92596,7 @@
                     "grouping_config": {
                       "default": {
                         "enabled": true,
-                        "group_keys": [
+                        "grouping_keys": [
                           {
                             "reference": "alert.title"
                           }
@@ -92617,7 +92813,7 @@
                           }
                         }
                       ],
-                      "message_template": {
+                      "template": {
                         "array_value": [
                           {
                             "literal": "SEV123",
@@ -92829,6 +93025,12 @@
                             "type": "IncidentStatus"
                           }
                         },
+                        "cast": {
+                          "returns": {
+                            "array": true,
+                            "type": "IncidentStatus"
+                          }
+                        },
                         "concatenate": {
                           "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
                         },
@@ -92878,7 +93080,7 @@
                 "grouping_config": {
                   "default": {
                     "enabled": true,
-                    "group_keys": [
+                    "grouping_keys": [
                       {
                         "reference": "alert.title"
                       }
@@ -93082,7 +93284,7 @@
                       }
                     }
                   ],
-                  "message_template": {
+                  "template": {
                     "array_value": [
                       {
                         "literal": "SEV123",
@@ -93348,7 +93550,7 @@
                     "grouping_config": {
                       "default": {
                         "enabled": true,
-                        "group_keys": [
+                        "grouping_keys": [
                           {
                             "reference": "alert.title"
                           }
@@ -93565,7 +93767,7 @@
                           }
                         }
                       ],
-                      "message_template": {
+                      "template": {
                         "array_value": [
                           {
                             "literal": "SEV123",
@@ -94847,6 +95049,7 @@
                   "teams": [
                     {
                       "catalog_entry": {
+                        "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                         "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                         "name": "Primary On-call"
                       },
@@ -94905,6 +95108,7 @@
                 "example": {
                   "team": {
                     "catalog_entry": {
+                      "external_id": "761722cd-d1d7-477b-ac7e-90f9e079dc33",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "name": "Primary On-call"
                     },
@@ -100580,57 +100784,6 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsPrivateIncidentMembershipGrantedV1"
-                }
-              }
-            },
-            "description": "OK response."
-          }
-        },
-        "tags": [
-          "Audit logs"
-        ]
-      }
-    },
-    "/x-audit-logs/private_incident_membership.removed_from_channel.1": {
-      "get": {
-        "description": "This entry is created whenever someone is removed from a private incident's channel while their access is preserved.",
-        "operationId": "PrivateIncidentMembershipRemovedFromChannelV1",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "action": "private_incident_membership.removed_from_channel",
-                  "actor": {
-                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                    "metadata": {
-                      "user_base_role_slug": "admin",
-                      "user_custom_role_slugs": "engineering,security"
-                    },
-                    "name": "John Doe",
-                    "type": "user"
-                  },
-                  "context": {
-                    "location": "1.2.3.4",
-                    "user_agent": "Chrome/91.0.4472.114"
-                  },
-                  "occurred_at": "2021-08-17T13:28:57.801578Z",
-                  "targets": [
-                    {
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "name": "Bob the builder",
-                      "type": "user"
-                    },
-                    {
-                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
-                      "name": "#INC-123 The website is slow",
-                      "type": "incident"
-                    }
-                  ],
-                  "version": 1
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/AuditLogsPrivateIncidentMembershipRemovedFromChannelV1"
                 }
               }
             },

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -168,18 +168,6 @@ const (
 	AlertEventsCreateHTTPPayloadV2StatusResolved AlertEventsCreateHTTPPayloadV2Status = "resolved"
 )
 
-// Defines values for AlertRouteAlertJoinsGroupPayloadV3Mode.
-const (
-	AlertRouteAlertJoinsGroupPayloadV3ModeOnEachNewAlert     AlertRouteAlertJoinsGroupPayloadV3Mode = "on_each_new_alert"
-	AlertRouteAlertJoinsGroupPayloadV3ModeOnPriorityIncrease AlertRouteAlertJoinsGroupPayloadV3Mode = "on_priority_increase"
-)
-
-// Defines values for AlertRouteAlertJoinsGroupV3Mode.
-const (
-	AlertRouteAlertJoinsGroupV3ModeOnEachNewAlert     AlertRouteAlertJoinsGroupV3Mode = "on_each_new_alert"
-	AlertRouteAlertJoinsGroupV3ModeOnPriorityIncrease AlertRouteAlertJoinsGroupV3Mode = "on_priority_increase"
-)
-
 // Defines values for AlertRouteChannelTargetPayloadV3ChannelVisibility.
 const (
 	AlertRouteChannelTargetPayloadV3ChannelVisibilityAssistant AlertRouteChannelTargetPayloadV3ChannelVisibility = "assistant"
@@ -239,6 +227,18 @@ const (
 const (
 	AlertRouteSeverityBindingV3MergeStrategyFirstWins AlertRouteSeverityBindingV3MergeStrategy = "first-wins"
 	AlertRouteSeverityBindingV3MergeStrategyMax       AlertRouteSeverityBindingV3MergeStrategy = "max"
+)
+
+// Defines values for AlertRouteWhenAlertJoinsGroupPayloadV3Mode.
+const (
+	AlertRouteWhenAlertJoinsGroupPayloadV3ModeOnEachNewAlert     AlertRouteWhenAlertJoinsGroupPayloadV3Mode = "on_each_new_alert"
+	AlertRouteWhenAlertJoinsGroupPayloadV3ModeOnPriorityIncrease AlertRouteWhenAlertJoinsGroupPayloadV3Mode = "on_priority_increase"
+)
+
+// Defines values for AlertRouteWhenAlertJoinsGroupV3Mode.
+const (
+	AlertRouteWhenAlertJoinsGroupV3ModeOnEachNewAlert     AlertRouteWhenAlertJoinsGroupV3Mode = "on_each_new_alert"
+	AlertRouteWhenAlertJoinsGroupV3ModeOnPriorityIncrease AlertRouteWhenAlertJoinsGroupV3Mode = "on_priority_increase"
 )
 
 // Defines values for AlertSlimV2Status.
@@ -969,6 +969,7 @@ const (
 // Defines values for ExpressionOperationPayloadV2OperationType.
 const (
 	ExpressionOperationPayloadV2OperationTypeBranches    ExpressionOperationPayloadV2OperationType = "branches"
+	ExpressionOperationPayloadV2OperationTypeCast        ExpressionOperationPayloadV2OperationType = "cast"
 	ExpressionOperationPayloadV2OperationTypeConcatenate ExpressionOperationPayloadV2OperationType = "concatenate"
 	ExpressionOperationPayloadV2OperationTypeCount       ExpressionOperationPayloadV2OperationType = "count"
 	ExpressionOperationPayloadV2OperationTypeFilter      ExpressionOperationPayloadV2OperationType = "filter"
@@ -984,6 +985,7 @@ const (
 // Defines values for ExpressionOperationPayloadV3OperationType.
 const (
 	ExpressionOperationPayloadV3OperationTypeBranches    ExpressionOperationPayloadV3OperationType = "branches"
+	ExpressionOperationPayloadV3OperationTypeCast        ExpressionOperationPayloadV3OperationType = "cast"
 	ExpressionOperationPayloadV3OperationTypeConcatenate ExpressionOperationPayloadV3OperationType = "concatenate"
 	ExpressionOperationPayloadV3OperationTypeCount       ExpressionOperationPayloadV3OperationType = "count"
 	ExpressionOperationPayloadV3OperationTypeFilter      ExpressionOperationPayloadV3OperationType = "filter"
@@ -999,6 +1001,7 @@ const (
 // Defines values for ExpressionOperationV2OperationType.
 const (
 	ExpressionOperationV2OperationTypeBranches    ExpressionOperationV2OperationType = "branches"
+	ExpressionOperationV2OperationTypeCast        ExpressionOperationV2OperationType = "cast"
 	ExpressionOperationV2OperationTypeConcatenate ExpressionOperationV2OperationType = "concatenate"
 	ExpressionOperationV2OperationTypeCount       ExpressionOperationV2OperationType = "count"
 	ExpressionOperationV2OperationTypeFilter      ExpressionOperationV2OperationType = "filter"
@@ -1014,6 +1017,7 @@ const (
 // Defines values for ExpressionOperationV3OperationType.
 const (
 	Branches    ExpressionOperationV3OperationType = "branches"
+	Cast        ExpressionOperationV3OperationType = "cast"
 	Concatenate ExpressionOperationV3OperationType = "concatenate"
 	Count       ExpressionOperationV3OperationType = "count"
 	Filter      ExpressionOperationV3OperationType = "filter"
@@ -2292,15 +2296,15 @@ type AlertGroupingConfigV3 struct {
 // AlertMessageConfigPayloadV3 defines model for AlertMessageConfigPayloadV3.
 type AlertMessageConfigPayloadV3 struct {
 	// Destinations The destinations (Slack/Teams channels) alert messages are sent to
-	Destinations    []AlertMessageDestinationPayloadV3 `json:"destinations"`
-	MessageTemplate *EngineParamBindingPayloadV3       `json:"message_template,omitempty"`
+	Destinations []AlertMessageDestinationPayloadV3 `json:"destinations"`
+	Template     *EngineParamBindingPayloadV3       `json:"template,omitempty"`
 }
 
 // AlertMessageConfigV3 defines model for AlertMessageConfigV3.
 type AlertMessageConfigV3 struct {
 	// Destinations The destinations (Slack/Teams channels) alert messages are sent to
-	Destinations    []AlertMessageDestinationV3 `json:"destinations"`
-	MessageTemplate *EngineParamBindingV3       `json:"message_template,omitempty"`
+	Destinations []AlertMessageDestinationV3 `json:"destinations"`
+	Template     *EngineParamBindingV3       `json:"template,omitempty"`
 }
 
 // AlertMessageDestinationPayloadV3 defines model for AlertMessageDestinationPayloadV3.
@@ -2376,30 +2380,6 @@ type AlertNotesUpdatePayloadV1 struct {
 type AlertNotesUpdateResultV1 struct {
 	AlertNote AlertNoteV1 `json:"alert_note"`
 }
-
-// AlertRouteAlertJoinsGroupPayloadV3 defines model for AlertRouteAlertJoinsGroupPayloadV3.
-type AlertRouteAlertJoinsGroupPayloadV3 struct {
-	// GracePeriodSeconds How long to wait before escalating once an alert joins the group, in seconds. Must be between 0 and 3600 (1 hour).
-	GracePeriodSeconds *int32 `json:"grace_period_seconds,omitempty"`
-
-	// Mode When a subsequent alert joins an existing group, when should we escalate again?
-	Mode AlertRouteAlertJoinsGroupPayloadV3Mode `json:"mode"`
-}
-
-// AlertRouteAlertJoinsGroupPayloadV3Mode When a subsequent alert joins an existing group, when should we escalate again?
-type AlertRouteAlertJoinsGroupPayloadV3Mode string
-
-// AlertRouteAlertJoinsGroupV3 defines model for AlertRouteAlertJoinsGroupV3.
-type AlertRouteAlertJoinsGroupV3 struct {
-	// GracePeriodSeconds How long to wait before escalating once an alert joins the group
-	GracePeriodSeconds *int32 `json:"grace_period_seconds,omitempty"`
-
-	// Mode When a subsequent alert joins an existing group, when should we escalate again?
-	Mode AlertRouteAlertJoinsGroupV3Mode `json:"mode"`
-}
-
-// AlertRouteAlertJoinsGroupV3Mode When a subsequent alert joins an existing group, when should we escalate again?
-type AlertRouteAlertJoinsGroupV3Mode string
 
 // AlertRouteAlertSourcePayloadV2 defines model for AlertRouteAlertSourcePayloadV2.
 type AlertRouteAlertSourcePayloadV2 struct {
@@ -2587,8 +2567,8 @@ type AlertRouteEscalationConfigPayloadV3 struct {
 	AutoCancelEscalations bool `json:"auto_cancel_escalations"`
 
 	// EscalationTargets Targets for escalation
-	EscalationTargets   []AlertRouteEscalationTargetPayloadV3 `json:"escalation_targets"`
-	WhenAlertJoinsGroup *AlertRouteAlertJoinsGroupPayloadV3   `json:"when_alert_joins_group,omitempty"`
+	EscalationTargets   []AlertRouteEscalationTargetPayloadV3   `json:"escalation_targets"`
+	WhenAlertJoinsGroup *AlertRouteWhenAlertJoinsGroupPayloadV3 `json:"when_alert_joins_group,omitempty"`
 }
 
 // AlertRouteEscalationConfigV2 defines model for AlertRouteEscalationConfigV2.
@@ -2606,8 +2586,8 @@ type AlertRouteEscalationConfigV3 struct {
 	AutoCancelEscalations bool `json:"auto_cancel_escalations"`
 
 	// EscalationTargets Targets for escalation
-	EscalationTargets   []AlertRouteEscalationTargetV3 `json:"escalation_targets"`
-	WhenAlertJoinsGroup *AlertRouteAlertJoinsGroupV3   `json:"when_alert_joins_group,omitempty"`
+	EscalationTargets   []AlertRouteEscalationTargetV3   `json:"escalation_targets"`
+	WhenAlertJoinsGroup *AlertRouteWhenAlertJoinsGroupV3 `json:"when_alert_joins_group,omitempty"`
 }
 
 // AlertRouteEscalationTargetPayloadV2 defines model for AlertRouteEscalationTargetPayloadV2.
@@ -2928,6 +2908,30 @@ type AlertRouteV3 struct {
 	// Version The version of this alert route
 	Version int64 `json:"version"`
 }
+
+// AlertRouteWhenAlertJoinsGroupPayloadV3 defines model for AlertRouteWhenAlertJoinsGroupPayloadV3.
+type AlertRouteWhenAlertJoinsGroupPayloadV3 struct {
+	// GracePeriodSeconds How long to wait before escalating once an alert joins the group, in seconds. Only applies when mode is 'on_each_new_alert', and must be unset when mode is 'on_priority_increase'. Must be between 0 and 3600 (1 hour).
+	GracePeriodSeconds *int32 `json:"grace_period_seconds,omitempty"`
+
+	// Mode When a subsequent alert joins an existing group, when should we escalate again?
+	Mode AlertRouteWhenAlertJoinsGroupPayloadV3Mode `json:"mode"`
+}
+
+// AlertRouteWhenAlertJoinsGroupPayloadV3Mode When a subsequent alert joins an existing group, when should we escalate again?
+type AlertRouteWhenAlertJoinsGroupPayloadV3Mode string
+
+// AlertRouteWhenAlertJoinsGroupV3 defines model for AlertRouteWhenAlertJoinsGroupV3.
+type AlertRouteWhenAlertJoinsGroupV3 struct {
+	// GracePeriodSeconds How long to wait before escalating once an alert joins the group, in seconds. Only applies when mode is 'on_each_new_alert'.
+	GracePeriodSeconds *int32 `json:"grace_period_seconds,omitempty"`
+
+	// Mode When a subsequent alert joins an existing group, when should we escalate again?
+	Mode AlertRouteWhenAlertJoinsGroupV3Mode `json:"mode"`
+}
+
+// AlertRouteWhenAlertJoinsGroupV3Mode When a subsequent alert joins an existing group, when should we escalate again?
+type AlertRouteWhenAlertJoinsGroupV3Mode string
 
 // AlertRoutesCreatePayloadV2 defines model for AlertRoutesCreatePayloadV2.
 type AlertRoutesCreatePayloadV2 struct {
@@ -3693,6 +3697,9 @@ type CatalogEntryReferenceV2 struct {
 
 // CatalogEntrySlimV3V3 defines model for CatalogEntrySlimV3V3.
 type CatalogEntrySlimV3V3 struct {
+	// ExternalId An optional alternative ID for this entry, which is ensured to be unique for the type
+	ExternalId *string `json:"external_id,omitempty"`
+
 	// Id ID of this catalog entry
 	Id string `json:"id"`
 
@@ -5538,6 +5545,16 @@ type ExpressionBranchesOptsV3 struct {
 	Returns  ReturnsMetaV3        `json:"returns"`
 }
 
+// ExpressionCastOptsPayloadV2 defines model for ExpressionCastOptsPayloadV2.
+type ExpressionCastOptsPayloadV2 struct {
+	Returns ReturnsMetaV2 `json:"returns"`
+}
+
+// ExpressionCastOptsPayloadV3 defines model for ExpressionCastOptsPayloadV3.
+type ExpressionCastOptsPayloadV3 struct {
+	Returns ReturnsMetaV3 `json:"returns"`
+}
+
 // ExpressionConcatenateOptsPayloadV2 defines model for ExpressionConcatenateOptsPayloadV2.
 type ExpressionConcatenateOptsPayloadV2 struct {
 	// Reference The reference that you want to concatenate with
@@ -5627,6 +5644,7 @@ type ExpressionNavigateOptsV3 struct {
 // ExpressionOperationPayloadV2 defines model for ExpressionOperationPayloadV2.
 type ExpressionOperationPayloadV2 struct {
 	Branches    *ExpressionBranchesOptsPayloadV2    `json:"branches,omitempty"`
+	Cast        *ExpressionCastOptsPayloadV2        `json:"cast,omitempty"`
 	Concatenate *ExpressionConcatenateOptsPayloadV2 `json:"concatenate,omitempty"`
 	Filter      *ExpressionFilterOptsPayloadV2      `json:"filter,omitempty"`
 	Navigate    *ExpressionNavigateOptsPayloadV2    `json:"navigate,omitempty"`
@@ -5642,6 +5660,7 @@ type ExpressionOperationPayloadV2OperationType string
 // ExpressionOperationPayloadV3 defines model for ExpressionOperationPayloadV3.
 type ExpressionOperationPayloadV3 struct {
 	Branches    *ExpressionBranchesOptsPayloadV3    `json:"branches,omitempty"`
+	Cast        *ExpressionCastOptsPayloadV3        `json:"cast,omitempty"`
 	Concatenate *ExpressionConcatenateOptsPayloadV3 `json:"concatenate,omitempty"`
 	Filter      *ExpressionFilterOptsPayloadV3      `json:"filter,omitempty"`
 	Navigate    *ExpressionNavigateOptsPayloadV3    `json:"navigate,omitempty"`
@@ -6031,8 +6050,8 @@ type GroupingSettingsV3 struct {
 	// Enabled Whether grouping is enabled
 	Enabled bool `json:"enabled"`
 
-	// GroupKeys Which attributes should this alert route use to group alerts? Only set when grouping is enabled.
-	GroupKeys *[]GroupingKeyV3 `json:"group_keys,omitempty"`
+	// GroupingKeys Which attributes should this alert route use to group alerts? Only set when grouping is enabled.
+	GroupingKeys *[]GroupingKeyV3 `json:"grouping_keys,omitempty"`
 
 	// WindowSeconds How long the grouping window is, in seconds. Must be between 60 (1 minute) and 172800 (48 hours). Only set when grouping is enabled.
 	WindowSeconds *int32 `json:"window_seconds,omitempty"`
@@ -6779,6 +6798,9 @@ type IncidentTypeV1 struct {
 
 	// Name The name of this Incident Type
 	Name string `json:"name"`
+
+	// OwningTeamIds IDs of the teams that own this incident type
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
 
 	// PrivateIncidentsOnly Should all incidents created with this Incident Type be private?
 	PrivateIncidentsOnly bool `json:"private_incidents_only"`


### PR DESCRIPTION
Splits the generated substrate out of #370 so it can land on its own.

Updates the embedded public OpenAPI schema (`internal/apischema/...`) to core master, which adds the v3 alert routes API surface, and regenerates `internal/client/client.gen.go` from it. No provider behaviour change.

**Part 1 of 2.** The provider changes are stacked on top in a separate PR (based on this branch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large generated diff with breaking JSON field renames and removed audit types; any code importing the client must adopt new names even though the provider is unchanged in this PR.
> 
> **Overview**
> Refreshes the embedded **public OpenAPI v3** schema from core and regenerates **`internal/client/client.gen.go`** via `oapi-codegen`. There is **no Terraform provider logic change** in this PR—it only updates the API substrate ahead of v3 alert routes work.
> 
> Notable **schema deltas** reflected in the generated types:
> 
> - **Alert routes / grouping / messaging:** `group_keys` → **`grouping_keys`**, `message_template` → **`template`**, and alert-joins-group types renamed to **`AlertRouteWhenAlertJoinsGroup*`** with clearer rules for **`grace_period_seconds`** vs mode.
> - **Expressions:** new **`cast`** operation types and enums across V2/V3 expression payloads.
> - **Incident types:** **`owning_team_ids`** on `IncidentTypeV1` (and nested examples).
> - **Catalog / teams:** optional **`external_id`** on slim catalog entries used in team responses.
> - **Audit logs:** removes the **`private_incident_membership.removed_from_channel`** audit schema and its `/x-audit-logs/...` doc path.
> - **Docs:** participant workload endpoint text now states private-incident workload requires the **`incident_workloads.view_private`** API scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b42b1229ab9b05ce9a4123ade7554fe2ea76f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->