### PR TITLE
Reject explicit empty deprecated sets in v3 alert-route validation

### DIFF
--- a/internal/provider/incident_alert_route_validate.go
+++ b/internal/provider/incident_alert_route_validate.go
@@ -48,12 +48,18 @@ func (r *IncidentAlertRouteResource) ValidateConfig(ctx context.Context, req res
 		}
 		return !v.IsNull() && !v.IsUnknown()
 	}
-	setNonEmpty := func(p path.Path) bool {
+	// setPresent reports that a set attribute is configured: non-null and known,
+	// regardless of how many elements it holds. Mutual-exclusion checks use this
+	// (rather than a non-empty check) so an explicit empty set — e.g.
+	// `channel_config = []` — still counts as using the attribute. Otherwise
+	// validation would pass, apply would ignore it, and the config/state
+	// mismatch would produce a perpetual diff.
+	setPresent := func(p path.Path) bool {
 		var v types.Set
 		if d := req.Config.GetAttribute(ctx, p, &v); d.HasError() {
 			return false
 		}
-		return !v.IsNull() && !v.IsUnknown() && len(v.Elements()) > 0
+		return !v.IsNull() && !v.IsUnknown()
 	}
 	// The *Missing helpers report that an attribute is definitively absent: known
 	// to be null (not merely unknown). Required-attribute checks use these so we
@@ -98,7 +104,7 @@ func (r *IncidentAlertRouteResource) ValidateConfig(ctx context.Context, req res
 
 	if isV3 {
 		// v2-only attributes must not be set in v3 mode.
-		if setNonEmpty(path.Root("channel_config")) {
+		if setPresent(path.Root("channel_config")) {
 			addErr(path.Root("channel_config"), "Invalid attribute combination",
 				"`channel_config` can't be used together with `grouping_config`. Use `message_config.destinations` instead.")
 		}
@@ -110,7 +116,7 @@ func (r *IncidentAlertRouteResource) ValidateConfig(ctx context.Context, req res
 			addErr(path.Root("incident_template"), "Invalid attribute combination",
 				"`incident_template` can't be used together with `grouping_config`. Use `incident_config.template` instead.")
 		}
-		if setNonEmpty(incidentBase.AtName("grouping_keys")) {
+		if setPresent(incidentBase.AtName("grouping_keys")) {
 			addErr(incidentBase.AtName("grouping_keys"), "Invalid attribute combination",
 				"`incident_config.grouping_keys` can't be used together with `grouping_config`. Use `grouping_config.default.grouping_keys` instead.")
 		}
@@ -133,7 +139,7 @@ func (r *IncidentAlertRouteResource) ValidateConfig(ctx context.Context, req res
 				"`message_config` is required when `grouping_config` is set.")
 		}
 
-		r.validateV3Gating(ctx, req, resp, boolValue, boolSet, boolMissing, setNonEmpty, objectSet, int64Set, int64Missing)
+		r.validateV3Gating(ctx, req, resp, boolValue, boolSet, boolMissing, setPresent, objectSet, int64Set, int64Missing)
 	} else {
 		// v3-only attributes must not be set in v2 mode.
 		if objectSet(path.Root("message_config")) {
@@ -185,7 +191,7 @@ func (r *IncidentAlertRouteResource) validateV3Gating(
 	boolValue func(path.Path) (bool, bool),
 	boolSet func(path.Path) bool,
 	boolMissing func(path.Path) bool,
-	setNonEmpty func(path.Path) bool,
+	setPresent func(path.Path) bool,
 	objectSet func(path.Path) bool,
 	int64Set func(path.Path) bool,
 	int64Missing func(path.Path) bool,
@@ -244,7 +250,7 @@ func (r *IncidentAlertRouteResource) validateV3Gating(
 				addErr(groupingBase.AtName("window_type"), "Invalid attribute combination",
 					"`window_type` must not be set when `grouping_config.default.enabled` is false.")
 			}
-			if setNonEmpty(groupingBase.AtName("grouping_keys")) {
+			if setPresent(groupingBase.AtName("grouping_keys")) {
 				addErr(groupingBase.AtName("grouping_keys"), "Invalid attribute combination",
 					"`grouping_keys` must not be set when `grouping_config.default.enabled` is false.")
 			}

--- a/internal/provider/incident_alert_route_validate_test.go
+++ b/internal/provider/incident_alert_route_validate_test.go
@@ -99,6 +99,20 @@ const (
       }
     }
   ]`
+	// arChannelConfigEmpty is an explicit empty channel_config. It must still be
+	// rejected in v3 mode: an empty set is not "unset", and letting it through
+	// causes a perpetual diff.
+	arChannelConfigEmpty = `
+  channel_config = []`
+	// arGroupingDisabledWithEmptyKeys disables grouping but sets an empty
+	// grouping_keys, which must not be set when grouping is disabled.
+	arGroupingDisabledWithEmptyKeys = `
+  grouping_config = {
+    default = {
+      enabled       = false
+      grouping_keys = []
+    }
+  }`
 )
 
 // arIncidentEnabled is a valid v3 incident_config with the template nested.
@@ -108,6 +122,20 @@ func arIncidentEnabled() string {
     auto_decline_enabled = true
     enabled              = true
     condition_groups     = []
+` + alertRouteV3IncidentTemplateBlock + `
+  }`
+}
+
+// arIncidentEnabledWithEmptyGroupingKeys is a valid v3 incident_config that
+// additionally sets the deprecated grouping_keys to an explicit empty set,
+// which must not be combined with grouping_config.
+func arIncidentEnabledWithEmptyGroupingKeys() string {
+	return `
+  incident_config = {
+    auto_decline_enabled = true
+    enabled              = true
+    condition_groups     = []
+    grouping_keys        = []
 ` + alertRouteV3IncidentTemplateBlock + `
   }`
 }
@@ -255,6 +283,21 @@ func TestIncidentAlertRouteResource_ValidateConfig(t *testing.T) {
 			name:   "v3 forbids channel_config",
 			config: arValidateConfig(arGroupingDisabled + arMessageValid + arEscalationValid + arIncidentEnabled() + arChannelConfig),
 			errRe:  "channel_config` can't be used together with `grouping_config",
+		},
+		{
+			name:   "v3 forbids empty channel_config",
+			config: arValidateConfig(arGroupingDisabled + arMessageValid + arEscalationValid + arIncidentEnabled() + arChannelConfigEmpty),
+			errRe:  "channel_config` can't be used together with `grouping_config",
+		},
+		{
+			name:   "v3 forbids empty incident_config.grouping_keys",
+			config: arValidateConfig(arGroupingDisabled + arMessageValid + arEscalationValid + arIncidentEnabledWithEmptyGroupingKeys()),
+			errRe:  "`incident_config.grouping_keys` can't be used together with `grouping_config",
+		},
+		{
+			name:   "v3 grouping disabled forbids empty grouping_keys",
+			config: arValidateConfig(arGroupingDisabledWithEmptyKeys + arMessageValid + arEscalationValid + arIncidentEnabled()),
+			errRe:  "`grouping_keys` must not be set when `grouping_config.default.enabled` is false",
 		},
 		{
 			name:   "v3 grouping enabled requires window_seconds",


### PR DESCRIPTION
Addresses the Cursor Bugbot finding on #375: [Empty deprecated sets bypass exclusion](https://github.com/incident-io/terraform-provider-incident/pull/375#discussion_r3513668639).

## Problem

In v3 mode (when `grouping_config` is set), the mutual-exclusion checks for the deprecated v2 attributes used a **non-empty** helper (`setNonEmpty`, `len(v.Elements()) > 0`). An explicit empty set is non-null but has zero elements, so:

```hcl
channel_config = []          # alongside grouping_config
incident_config = { grouping_keys = [] }
```

passed validation. Apply builds the v3 payload and ignores these attributes; read maps the API response back to `null`; config keeps `[]` → **perpetual diff**, with no plan-time error.

Both attributes are `Optional` with no `Default`/`Computed`, so an empty set only ever comes from explicit user input — there was no default-empty-set case justifying the length guard.

## Fix

Replace the non-empty check with a presence check (non-null and known, regardless of element count), renamed to `setPresent`. This covers all three "must not be set / can't be used together" exclusion checks in one place:

- `channel_config` (flagged)
- `incident_config.grouping_keys` (flagged)
- `grouping_config.default.grouping_keys` when grouping is disabled (same root cause)

The nearby `condition_groups` check keeps its inline `len > 0` — its rule is "must be *empty*", where an empty set is valid.

## Tests

Added three regression cases to `TestIncidentAlertRouteResource_ValidateConfig`:

- `v3 forbids empty channel_config`
- `v3 forbids empty incident_config.grouping_keys`
- `v3 grouping disabled forbids empty grouping_keys`

All existing and new validation tests pass; `go build`, `go vet`, and `gofmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Terraform provider validation logic with regression tests; no runtime API or auth behavior changes.
> 
> **Overview**
> **v3 alert-route `ValidateConfig` now treats explicit empty sets as “present”** for mutual-exclusion and gating rules, instead of only flagging non-empty sets.
> 
> The helper is renamed from `setNonEmpty` to `setPresent` and no longer requires `len(elements) > 0`. That affects v3 checks for deprecated `channel_config`, `incident_config.grouping_keys` alongside `grouping_config`, and `grouping_config.default.grouping_keys` when grouping is disabled—so values like `channel_config = []` fail at plan time instead of slipping through and causing a perpetual diff after apply.
> 
> Three unit tests cover empty `channel_config`, empty `incident_config.grouping_keys`, and empty `grouping_keys` with grouping disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8e99fc93b79cdd1b3387323d13c8e595b32f27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->