### PR TITLE
Source alert route resource description from the v3 schema tag

### DIFF
--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -3,13 +3,16 @@
 page_title: "incident_alert_route Resource - terraform-provider-incident"
 subcategory: ""
 description: |-
-  Alert routes define how alerts are processed: how they're grouped, which channels they post to, who is escalated, and whether they open incidents.
+  Configure your alert routes in incident.io.
+  Alert routes define how alerts from different sources are processed, grouped, and routed to the right teams and people.
   We'd generally recommend building alert routes in our web dashboard https://app.incident.io/~/alerts/configuration, and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.
 ---
 
 # incident_alert_route (Resource)
 
-Alert routes define how alerts are processed: how they're grouped, which channels they post to, who is escalated, and whether they open incidents.
+Configure your alert routes in incident.io.
+
+Alert routes define how alerts from different sources are processed, grouped, and routed to the right teams and people.
 
 We'd generally recommend building alert routes in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.
 

--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -62,9 +62,7 @@ func (r *IncidentAlertRouteResource) Metadata(ctx context.Context, req resource.
 
 func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: `Alert routes define how alerts are processed: how they're grouped, which channels they post to, who is escalated, and whether they open incidents.
-
-We'd generally recommend building alert routes in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.`,
+		MarkdownDescription: fmt.Sprintf("%s\n\n%s", apischema.TagDocstring("Alert Routes V3"), `We'd generally recommend building alert routes in our [web dashboard](https://app.incident.io/~/alerts/configuration), and using the 'Export' flow to generate your Terraform, as it's easier to see what you've configured. You can also make changes to an existing alert route and copy the resulting Terraform without persisting it.`),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,


### PR DESCRIPTION
A little housekeeping following #375 - that PR unnecessarily changed the alert route resource description. This PR restores it to being based on the API spec plus the export guidance.

## What

Restores the `incident_alert_route` resource description to being sourced from the API schema tag, rather than a hand-written string.

Before the v3 work, the description came from `apischema.TagDocstring("Alert Routes V2")`. During #375 it was replaced with a hardcoded paragraph. This switches it back to the tag docstring — now `"Alert Routes V3"`, since the resource targets the v3 API — while keeping the existing "Export flow" recommendation blurb.

Docs regenerated via `tfplugindocs`.

## Why

Keeps the resource description in sync with the API schema tag automatically, matching how the other resources in the provider derive their descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and schema description text only; no Terraform resource behavior or API client logic changes.
> 
> **Overview**
> **`incident_alert_route`** resource docs again pull the top-level description from **`apischema.TagDocstring("Alert Routes V3")`**, matching other provider resources, instead of the hand-written paragraph introduced during v3 work.
> 
> The existing recommendation to use the web dashboard **Export** flow is still appended in **`incident_alert_route_resource.go`**. **`docs/resources/alert_route.md`** was regenerated with **`tfplugindocs`**, so the page intro now reflects the v3 tag wording (configure alert routes; how sources are processed, grouped, and routed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51754c929293f8c2bdd0e6c7ed6c17163c43168b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->