### PR TITLE
Update release instructions to open a PR for the CHANGELOG

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,10 +4,11 @@ When you want to cut a new release, you can:
 
 1. Merge any of the changes you want in the release to master.
 2. Ensure that Terraform acceptance tests have passed.
-3. Create a new commit on master that adjusts the CHANGELOG so all unreleased
-   changes appear under the new version.
-4. Push this commit to master
-5. Tag that commit with whatever your release version should be, and push with the tags flag set.
+3. Create a new branch that adjusts the CHANGELOG so all unreleased changes
+   appear under the new version.
+4. Open a pull request with this change, get it reviewed, and merge it to master.
+5. Once merged, tag the resulting master commit with whatever your release
+   version should be, and push with the tags flag set.
 
 That will trigger the CI pipeline that will publish your provider version to the
 Terraform registry.
@@ -15,8 +16,12 @@ Terraform registry.
 That ends up looking like this:
 
 ```
+git checkout -b changelog-v1.2.3
 git commit -m "Changelog for v1.2.3"
-git push
+git push -u origin changelog-v1.2.3
+# open a PR for the branch, get it reviewed and merged, then:
+git checkout master
+git pull
 git tag v1.2.3
 git push --tags
 ```


### PR DESCRIPTION
## What

Updates `RELEASE.md` so the release process routes the CHANGELOG version bump through a reviewed pull request, rather than committing it directly to `master` and pushing.

## Why

The previous instructions had you commit the "Changelog for vX.Y.Z" change straight onto `master` and push it. Routing that change through a PR gets it reviewed like any other change before it lands on `master`. Once merged, you tag the resulting `master` commit to trigger the release pipeline as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to internal release steps; no runtime or provider behavior is affected.
> 
> **Overview**
> **Release workflow** now requires a reviewed PR for the CHANGELOG version bump instead of committing directly to `master`.
> 
> Steps 3–5 in `RELEASE.md` are reordered: create a branch, open and merge a PR with the changelog update, then tag the merged `master` commit and push tags. The example shell block matches that flow (`changelog-v1.2.3` branch, push with upstream, PR merge, `git pull` on `master`, then `git tag` / `git push --tags`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb3fb80d2921f7c32552197be0a9f6c0d26cd41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->