### PR TITLE
add owning_team_ids to workflow resource

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -98,6 +98,7 @@ resource "incident_workflow" "autoassign_incident_lead" {
 - `delay` (Attributes) Configuration controlling workflow delay behaviour (see [below for nested schema](#nestedatt--delay))
 - `folder` (String) Folder to display the workflow in
 - `include_private_escalations` (Boolean) Whether to include private escalations
+- `owning_team_ids` (Set of String) IDs of the teams that own this workflow
 - `shortform` (String) The shortform used to trigger this workflow (only applicable for manual triggers)
 
 ### Read-Only

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -53618,6 +53618,17 @@
             "example": true,
             "type": "boolean"
           },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this workflow",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "include_private_incidents": {
             "description": "Whether to include private incidents",
             "example": true,
@@ -54170,6 +54181,17 @@
             "example": true,
             "type": "boolean"
           },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this workflow",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "include_private_incidents": {
             "description": "Whether to include private incidents",
             "example": true,
@@ -54666,6 +54688,17 @@
             "description": "Whether to include private escalations",
             "example": true,
             "type": "boolean"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this workflow",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
           },
           "include_private_incidents": {
             "description": "Whether to include private incidents",
@@ -56080,6 +56113,17 @@
             "description": "Whether to include private escalations",
             "example": true,
             "type": "boolean"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this workflow",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
           },
           "include_private_incidents": {
             "description": "Whether to include private incidents",

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -7871,6 +7871,9 @@ type WorkflowSlimV2 struct {
 	// OnceFor This workflow will run 'once for' a list of references
 	OnceFor []EngineReferenceV2 `json:"once_for"`
 
+	// OwningTeamIds IDs of the teams that own this workflow
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
 	// RunsFrom The time from which this workflow will run on incidents
 	RunsFrom *time.Time `json:"runs_from,omitempty"`
 
@@ -7933,6 +7936,9 @@ type WorkflowV2 struct {
 	// OnceFor This workflow will run 'once for' a list of references
 	OnceFor []EngineReferenceV2 `json:"once_for"`
 
+	// OwningTeamIds IDs of the teams that own this workflow
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
 	// RunsFrom The time from which this workflow will run on incidents
 	RunsFrom *time.Time `json:"runs_from,omitempty"`
 
@@ -7994,6 +8000,9 @@ type WorkflowsCreateWorkflowPayloadV2 struct {
 
 	// OnceFor This workflow will run 'once for' a list of references
 	OnceFor []string `json:"once_for"`
+
+	// OwningTeamIds IDs of the teams that own this workflow
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
 
 	// RunsOnIncidentModes Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
 	RunsOnIncidentModes []WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes `json:"runs_on_incident_modes"`
@@ -8069,6 +8078,9 @@ type WorkflowsUpdateWorkflowPayloadV2 struct {
 
 	// OnceFor This workflow will run 'once for' a list of references
 	OnceFor []string `json:"once_for"`
+
+	// OwningTeamIds IDs of the teams that own this workflow
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
 
 	// RunsOnIncidentModes Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
 	RunsOnIncidentModes []WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes `json:"runs_on_incident_modes"`

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -45,6 +45,7 @@ type IncidentWorkflowResourceModel struct {
 	OnceFor                   []types.String                       `tfsdk:"once_for"`
 	IncludePrivateIncidents   types.Bool                           `tfsdk:"include_private_incidents"`
 	IncludePrivateEscalations types.Bool                           `tfsdk:"include_private_escalations"`
+	OwningTeamIDs             types.Set                            `tfsdk:"owning_team_ids"`
 	ContinueOnStepError       types.Bool                           `tfsdk:"continue_on_step_error"`
 	Delay                     *IncidentWorkflowDelay               `tfsdk:"delay"`
 	RunsOnIncidents           types.String                         `tfsdk:"runs_on_incidents"`
@@ -134,6 +135,11 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 				Optional:            true,
 				Computed:            true,
 			},
+			"owning_team_ids": schema.SetAttribute{
+				MarkdownDescription: apischema.Docstring("WorkflowV2", "owning_team_ids"),
+				Optional:            true,
+				ElementType:         types.StringType,
+			},
 			"continue_on_step_error": schema.BoolAttribute{
 				MarkdownDescription: apischema.Docstring("WorkflowV2", "continue_on_step_error"),
 				Required:            true,
@@ -200,6 +206,7 @@ func (r *IncidentWorkflowResource) Create(ctx context.Context, req resource.Crea
 		Folder:                  data.Folder.ValueStringPointer(),
 		Shortform:               data.Shortform.ValueStringPointer(),
 		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
+		OwningTeamIds:           toOwningTeamIDs(data.OwningTeamIDs),
 		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
 		State:                   lo.ToPtr(client.WorkflowsCreateWorkflowPayloadV2State(data.State.ValueString())),
 		Annotations: &map[string]string{
@@ -265,6 +272,7 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		Folder:                  data.Folder.ValueStringPointer(),
 		Shortform:               data.Shortform.ValueStringPointer(),
 		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
+		OwningTeamIds:           toOwningTeamIDs(data.OwningTeamIDs),
 		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
 		State:                   lo.ToPtr(client.WorkflowsUpdateWorkflowPayloadV2State(data.State.ValueString())),
 		Annotations: &map[string]string{
@@ -356,6 +364,23 @@ func (r *IncidentWorkflowResource) Configure(ctx context.Context, req resource.C
 
 	r.client = client.Client
 	r.terraformVersion = client.TerraformVersion
+}
+
+// toOwningTeamIDs converts the owning_team_ids set into the optional slice the API
+// expects, returning nil when unset so we don't send an empty list.
+func toOwningTeamIDs(set types.Set) *[]string {
+	if set.IsNull() || set.IsUnknown() {
+		return nil
+	}
+
+	teamIDs := []string{}
+	for _, elem := range set.Elements() {
+		if str, ok := elem.(types.String); ok {
+			teamIDs = append(teamIDs, str.ValueString())
+		}
+	}
+
+	return &teamIDs
 }
 
 func toPayloadSteps(steps []IncidentWorkflowStep) []client.StepConfigPayloadV2 {

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -366,8 +366,6 @@ func (r *IncidentWorkflowResource) Configure(ctx context.Context, req resource.C
 	r.terraformVersion = client.TerraformVersion
 }
 
-// toOwningTeamIDs converts the owning_team_ids set into the optional slice the API
-// expects, returning nil when unset so we don't send an empty list.
 func toOwningTeamIDs(set types.Set) *[]string {
 	if set.IsNull() || set.IsUnknown() {
 		return nil

--- a/internal/provider/incident_workflow_resource_test.go
+++ b/internal/provider/incident_workflow_resource_test.go
@@ -2,12 +2,14 @@ package provider
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/samber/lo"
 )
 
 func TestAccIncidentWorkflowResource(t *testing.T) {
@@ -180,4 +182,120 @@ func testAccIncidentWorkflowResourceConfig(override *workflowTemplateOverrides) 
 	}
 
 	return buf.String()
+}
+
+// TestAccIncidentWorkflowResourceOwningTeamIDs checks that owning_team_ids round-trips:
+// unset reads back as absent, and teams provisioned in-config are applied and re-read.
+// Teams are a catalog type, so the test creates its own Team entries to reference.
+func TestAccIncidentWorkflowResourceOwningTeamIDs(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create without owning_team_ids
+			{
+				Config: testAccIncidentWorkflowResourceConfigOwningTeams(0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("incident_workflow.example", "owning_team_ids"),
+				),
+			},
+			// Update to add a single owning team
+			{
+				Config: testAccIncidentWorkflowResourceConfigOwningTeams(1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_workflow.example", "owning_team_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"incident_workflow.example", "owning_team_ids.0",
+						"incident_catalog_entry.owner_team_0", "id"),
+				),
+			},
+			// Import and verify the owning teams survive a round-trip
+			{
+				ResourceName:      "incident_workflow.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update to two owning teams
+			{
+				Config: testAccIncidentWorkflowResourceConfigOwningTeams(2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_workflow.example", "owning_team_ids.#", "2"),
+				),
+			},
+			// Clear owning teams again
+			{
+				Config: testAccIncidentWorkflowResourceConfigOwningTeams(0),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("incident_workflow.example", "owning_team_ids"),
+				),
+			},
+		},
+	})
+}
+
+// testAccIncidentWorkflowResourceConfigOwningTeams renders a workflow owning teamCount
+// self-provisioned Team catalog entries (0 omits owning_team_ids entirely).
+func testAccIncidentWorkflowResourceConfigOwningTeams(teamCount int) string {
+	teamIDs := make([]string, teamCount)
+	for i := 0; i < teamCount; i++ {
+		teamIDs[i] = fmt.Sprintf("incident_catalog_entry.owner_team_%d.id", i)
+	}
+
+	return testRunTemplate("incident_workflow_with_owning_teams", `
+data "incident_catalog_type" "team" {
+  name = {{ quote .TeamTypeName }}
+}
+
+{{ range $i := .TeamIndices }}
+resource "incident_catalog_entry" "owner_team_{{ $i }}" {
+  catalog_type_id  = data.incident_catalog_type.team.id
+  external_id      = "tf-workflow-owning-team-test-{{ $i }}"
+  name             = "Terraform Workflow Owning Team Test {{ $i }}"
+  attribute_values = []
+}
+{{ end }}
+
+resource "incident_workflow" "example" {
+  name    = "Owning teams workflow"
+  trigger = "incident.updated"
+  condition_groups = [
+    {
+      conditions = [
+        {
+          subject        = "incident.status.category"
+          operation      = "one_of"
+          param_bindings = [{ array_value = [{ literal = "open" }] }]
+        }
+      ]
+    }
+  ]
+  steps = [
+    {
+      id   = "01HXVEA7Y0VWQBJB4F2X8WNRW6"
+      name = "incident.create_follow_ups"
+      param_bindings = [
+        { value = { reference = "incident" } },
+        { array_value = [{ literal = "Write postmortem" }] },
+        {}
+      ]
+    }
+  ]
+  expressions               = []
+  once_for                  = ["incident"]
+  include_private_incidents = false
+  continue_on_step_error    = false
+  runs_on_incidents         = "newly_created"
+  runs_on_incident_modes    = ["standard"]
+  state                     = "draft"
+  {{ if .TeamIDs }}owning_team_ids = [{{ range $i, $ref := .TeamIDs }}{{ if $i }}, {{ end }}{{ $ref }}{{ end }}]{{ end }}
+}
+`, struct {
+		TeamTypeName string
+		TeamIndices  []int
+		TeamIDs      []string
+	}{
+		TeamTypeName: teamTypeName(),
+		TeamIndices:  lo.Range(teamCount),
+		TeamIDs:      teamIDs,
+	})
 }

--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -51,6 +51,7 @@ func (r *IncidentWorkflowResource) buildModel(ctx context.Context, workflow clie
 		RunsOnIncidentModes:       buildRunsOnIncidentModes(workflow.RunsOnIncidentModes),
 		IncludePrivateIncidents:   types.BoolValue(workflow.IncludePrivateIncidents),
 		IncludePrivateEscalations: types.BoolPointerValue(lo.ToPtr(workflow.IncludePrivateEscalations)),
+		OwningTeamIDs:             buildOwningTeamIDs(workflow.OwningTeamIds),
 		ContinueOnStepError:       types.BoolValue(workflow.ContinueOnStepError),
 		RunsOnIncidents:           types.StringValue(string(workflow.RunsOnIncidents)),
 		State:                     types.StringValue(string(workflow.State)),
@@ -78,6 +79,21 @@ func buildOnceFor(onceFor []client.EngineReferenceV2) []basetypes.StringValue {
 	}
 
 	return out
+}
+
+// buildOwningTeamIDs maps the API's optional owning_team_ids into a set, staying null
+// when unset so it round-trips with an unconfigured owning_team_ids attribute.
+func buildOwningTeamIDs(teamIDs *[]string) types.Set {
+	if teamIDs == nil {
+		return types.SetNull(types.StringType)
+	}
+
+	elements := make([]attr.Value, len(*teamIDs))
+	for i, teamID := range *teamIDs {
+		elements[i] = types.StringValue(teamID)
+	}
+
+	return types.SetValueMust(types.StringType, elements)
 }
 
 func buildRunsOnIncidentModes(modes []client.WorkflowV2RunsOnIncidentModes) types.Set {

--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -81,8 +81,6 @@ func buildOnceFor(onceFor []client.EngineReferenceV2) []basetypes.StringValue {
 	return out
 }
 
-// buildOwningTeamIDs maps the API's optional owning_team_ids into a set, staying null
-// when unset so it round-trips with an unconfigured owning_team_ids attribute.
 func buildOwningTeamIDs(teamIDs *[]string) types.Set {
 	if teamIDs == nil {
 		return types.SetNull(types.StringType)


### PR DESCRIPTION
surface workflow team ownership on the incident_workflow resource, mirroring the owning_team_ids support already on incident_alert_source.

the field is optional- unset omits it from the API payload (nil, not empty list) and reads back as null

regenerates the client from a spec patched to carry owning_team_ids on the four workflow schemas.

adds an acceptance test that self-provisions Team catalog entries and asserts owning_team_ids round-trips through create, import and update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional Terraform field and generated client types; no auth or workflow execution logic changes.
> 
> **Overview**
> Adds optional **`owning_team_ids`** on **`incident_workflow`**, aligned with team ownership on other resources (e.g. alert routes).
> 
> The attribute is a set of team ID strings. **Unset** values are omitted from create/update API payloads (`nil`, not an empty list) and **read** back as null; populated sets round-trip through state and import.
> 
> Provider wiring includes schema/docs, API client regeneration for workflow payloads, `toOwningTeamIDs` / `buildOwningTeamIDs` conversion, and an acceptance test that provisions Team catalog entries and exercises create, import, update, and clearing the field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906863198408cba4ebea30b5ac9f381e82578068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->