### PR TITLE
add private_incident_scope to workflow resource

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -84,7 +84,6 @@ resource "incident_workflow" "autoassign_incident_lead" {
 - `condition_groups` (Attributes List) Groups of prerequisite conditions. All conditions in at least one group must be satisfied (see [below for nested schema](#nestedatt--condition_groups))
 - `continue_on_step_error` (Boolean) Whether to continue executing the workflow if a step fails
 - `expressions` (Attributes Set) The expressions to be prepared for use by steps and conditions (see [below for nested schema](#nestedatt--expressions))
-- `include_private_incidents` (Boolean) Whether to include private incidents
 - `name` (String) Name provided by the user when creating the workflow
 - `once_for` (List of String) This workflow will run 'once for' a list of references
 - `runs_on_incident_modes` (Set of String) Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
@@ -98,7 +97,9 @@ resource "incident_workflow" "autoassign_incident_lead" {
 - `delay` (Attributes) Configuration controlling workflow delay behaviour (see [below for nested schema](#nestedatt--delay))
 - `folder` (String) Folder to display the workflow in
 - `include_private_escalations` (Boolean) Whether to include private escalations
+- `include_private_incidents` (Boolean, Deprecated) DEPRECATED: use `private_incident_scope` instead. `true` when the workflow runs on private incidents (a `private_incident_scope` of `all` or `owning_teams`), `false` when the scope is `none`.
 - `owning_team_ids` (Set of String) IDs of the teams that own this workflow
+- `private_incident_scope` (String) Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none. Possible values are: `all`, `owning_teams`, `none`.
 - `shortform` (String) The shortform used to trigger this workflow (only applicable for manual triggers)
 
 ### Read-Only

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -74,7 +74,9 @@
               "schedule_overrides_editor",
               "workflows_editor",
               "private_workflows_editor",
+              "private_escalation_workflows_editor",
               "on_call_editor",
+              "on_call_viewer",
               "escalation_creator",
               "post_incident_flow_opt_out",
               "security_settings_editor",
@@ -84,6 +86,7 @@
               "postmortems_manage",
               "api_keys_manage",
               "notification_methods_manage",
+              "notification_methods_unredacted_viewer",
               "incident_workload_viewer",
               "incident_workload_private_viewer",
               "act_on_behalf_of_users"
@@ -118,7 +121,9 @@
               "schedule_overrides_editor",
               "on_call_editor",
               "escalation_creator",
-              "api_keys_manage"
+              "api_keys_manage",
+              "workflows_editor",
+              "private_workflows_editor"
             ],
             "example": "schedules_editor",
             "type": "string",
@@ -292,7 +297,9 @@
                 "schedule_overrides_editor",
                 "workflows_editor",
                 "private_workflows_editor",
+                "private_escalation_workflows_editor",
                 "on_call_editor",
+                "on_call_viewer",
                 "escalation_creator",
                 "post_incident_flow_opt_out",
                 "security_settings_editor",
@@ -302,6 +309,7 @@
                 "postmortems_manage",
                 "api_keys_manage",
                 "notification_methods_manage",
+                "notification_methods_unredacted_viewer",
                 "incident_workload_viewer",
                 "incident_workload_private_viewer",
                 "act_on_behalf_of_users"
@@ -334,7 +342,9 @@
                 "schedule_overrides_editor",
                 "on_call_editor",
                 "escalation_creator",
-                "api_keys_manage"
+                "api_keys_manage",
+                "workflows_editor",
+                "private_workflows_editor"
               ],
               "example": "schedules_editor",
               "type": "string"
@@ -669,7 +679,9 @@
                 "schedule_overrides_editor",
                 "workflows_editor",
                 "private_workflows_editor",
+                "private_escalation_workflows_editor",
                 "on_call_editor",
+                "on_call_viewer",
                 "escalation_creator",
                 "post_incident_flow_opt_out",
                 "security_settings_editor",
@@ -679,6 +691,7 @@
                 "postmortems_manage",
                 "api_keys_manage",
                 "notification_methods_manage",
+                "notification_methods_unredacted_viewer",
                 "incident_workload_viewer",
                 "incident_workload_private_viewer",
                 "act_on_behalf_of_users"
@@ -711,7 +724,9 @@
                 "schedule_overrides_editor",
                 "on_call_editor",
                 "escalation_creator",
-                "api_keys_manage"
+                "api_keys_manage",
+                "workflows_editor",
+                "private_workflows_editor"
               ],
               "example": "schedules_editor",
               "type": "string"
@@ -2472,6 +2487,8 @@
       },
       "AlertNoteV1": {
         "example": {
+          "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+          "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
           "created_at": "2026-05-28T15:30:00Z",
           "creator": {
@@ -2498,6 +2515,16 @@
           "updated_at": "2026-05-28T15:35:00Z"
         },
         "properties": {
+          "alert_group_id": {
+            "description": "ID of the alert group this note is attached to. Exactly one of alert_id or alert_group_id is set; the other is null.",
+            "example": "01HB9Z8WANK6P870EA6S7TK1DS",
+            "type": "string"
+          },
+          "alert_id": {
+            "description": "ID of the alert this note is attached to. Exactly one of alert_id or alert_group_id is set; the other is null.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
           "content": {
             "description": "Markdown body of the note",
             "example": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
@@ -2555,12 +2582,18 @@
       },
       "AlertNotesCreatePayloadV1": {
         "example": {
+          "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
           "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n"
         },
         "properties": {
+          "alert_group_id": {
+            "description": "ID of the alert group to add the note to. Provide exactly one of alert_id or alert_group_id.",
+            "example": "01HB9Z8WANK6P870EA6S7TK1DS",
+            "type": "string"
+          },
           "alert_id": {
-            "description": "ID of the alert to add the note to",
+            "description": "ID of the alert to add the note to. Provide exactly one of alert_id or alert_group_id.",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
             "type": "string"
           },
@@ -2571,7 +2604,6 @@
           }
         },
         "required": [
-          "alert_id",
           "content"
         ],
         "type": "object"
@@ -2579,6 +2611,8 @@
       "AlertNotesCreateResultV1": {
         "example": {
           "alert_note": {
+            "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+            "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
             "created_at": "2026-05-28T15:30:00Z",
             "creator": {
@@ -2619,6 +2653,8 @@
         "example": {
           "alert_notes": [
             {
+              "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+              "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
               "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
               "created_at": "2026-05-28T15:30:00Z",
               "creator": {
@@ -2654,6 +2690,8 @@
           "alert_notes": {
             "example": [
               {
+                "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+                "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
                 "created_at": "2026-05-28T15:30:00Z",
                 "creator": {
@@ -2698,6 +2736,8 @@
       "AlertNotesShowResultV1": {
         "example": {
           "alert_note": {
+            "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+            "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
             "created_at": "2026-05-28T15:30:00Z",
             "creator": {
@@ -2753,6 +2793,8 @@
       "AlertNotesUpdateResultV1": {
         "example": {
           "alert_note": {
+            "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+            "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
             "created_at": "2026-05-28T15:30:00Z",
             "creator": {
@@ -13618,6 +13660,9 @@
       },
       "AlertSlimV2": {
         "example": {
+          "alert_group_ids": [
+            "01GW2G3V0S59R238FAHPDS1R66"
+          ],
           "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "deduplication_key": "4293868629",
@@ -13630,6 +13675,17 @@
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "properties": {
+          "alert_group_ids": {
+            "description": "The IDs of every alert group this alert belongs to. Empty when the alert is not part of any group.",
+            "example": [
+              "01GW2G3V0S59R238FAHPDS1R66"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "alert_source_id": {
             "description": "The ID of the alert source this alert fired on",
             "example": "01GW2G3V0S59R238FAHPDS1R66",
@@ -14220,6 +14276,7 @@
               "sns",
               "sentry",
               "sentry_metric",
+              "service_now",
               "splunk",
               "status_cake",
               "status_page_views",
@@ -14515,6 +14572,7 @@
               "sns",
               "sentry",
               "sentry_metric",
+              "service_now",
               "splunk",
               "status_cake",
               "status_page_views",
@@ -16813,6 +16871,9 @@
       },
       "AlertV2": {
         "example": {
+          "alert_group_ids": [
+            "01GW2G3V0S59R238FAHPDS1R66"
+          ],
           "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
           "attributes": [
             {
@@ -16857,6 +16918,17 @@
           "updated_at": "2021-08-17T13:28:57.801578Z"
         },
         "properties": {
+          "alert_group_ids": {
+            "description": "The IDs of every alert group this alert belongs to. Empty when the alert is not part of any group.",
+            "example": [
+              "01GW2G3V0S59R238FAHPDS1R66"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "alert_source_id": {
             "description": "The ID of the alert source this alert fired on",
             "example": "01GW2G3V0S59R238FAHPDS1R66",
@@ -16972,6 +17044,9 @@
           "incident_alerts": [
             {
               "alert": {
+                "alert_group_ids": [
+                  "01GW2G3V0S59R238FAHPDS1R66"
+                ],
                 "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "deduplication_key": "4293868629",
@@ -17006,6 +17081,9 @@
             "example": [
               {
                 "alert": {
+                  "alert_group_ids": [
+                    "01GW2G3V0S59R238FAHPDS1R66"
+                  ],
                   "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                   "created_at": "2021-08-17T13:28:57.801578Z",
                   "deduplication_key": "4293868629",
@@ -17049,6 +17127,9 @@
         "example": {
           "alerts": [
             {
+              "alert_group_ids": [
+                "01GW2G3V0S59R238FAHPDS1R66"
+              ],
               "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
               "attributes": [
                 {
@@ -17102,6 +17183,9 @@
           "alerts": {
             "example": [
               {
+                "alert_group_ids": [
+                  "01GW2G3V0S59R238FAHPDS1R66"
+                ],
                 "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                 "attributes": [
                   {
@@ -17164,6 +17248,9 @@
       "AlertsResolveResultV2": {
         "example": {
           "alert": {
+            "alert_group_ids": [
+              "01GW2G3V0S59R238FAHPDS1R66"
+            ],
             "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
             "attributes": [
               {
@@ -17221,6 +17308,9 @@
       "AlertsShowResultV2": {
         "example": {
           "alert": {
+            "alert_group_ids": [
+              "01GW2G3V0S59R238FAHPDS1R66"
+            ],
             "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
             "attributes": [
               {
@@ -17352,6 +17442,29 @@
         "required": [
           "id",
           "type"
+        ],
+        "type": "object"
+      },
+      "AuditLogAnnouncementPostTemplateOwningTeamsMetadataV2": {
+        "example": {
+          "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+          "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1"
+        },
+        "properties": {
+          "after_owning_team_ids": {
+            "description": "Catalog entry IDs of the owning teams after the change, comma separated",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+            "type": "string"
+          },
+          "before_owning_team_ids": {
+            "description": "Catalog entry IDs of the owning teams before the change, comma separated",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1",
+            "type": "string"
+          }
+        },
+        "required": [
+          "before_owning_team_ids",
+          "after_owning_team_ids"
         ],
         "type": "object"
       },
@@ -17851,6 +17964,7 @@
               "alert_source",
               "alert_priority",
               "announcement_rule",
+              "announcement_post_template",
               "catalog_type",
               "catalog_entry",
               "catalog_attribute",
@@ -19495,6 +19609,472 @@
           "actor",
           "targets",
           "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAnnouncementPostTemplateCreatedV1": {
+        "example": {
+          "action": "announcement_post_template.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Major incident",
+              "type": "announcement_post_template"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "announcement_post_template.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Major incident",
+                "type": "announcement_post_template"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAnnouncementPostTemplateCreatedV2": {
+        "example": {
+          "action": "announcement_post_template.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+            "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Major incident",
+              "type": "announcement_post_template"
+            }
+          ],
+          "version": 2
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "announcement_post_template.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogAnnouncementPostTemplateOwningTeamsMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Major incident",
+                "type": "announcement_post_template"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAnnouncementPostTemplateDeletedV1": {
+        "example": {
+          "action": "announcement_post_template.deleted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Major incident",
+              "type": "announcement_post_template"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "announcement_post_template.deleted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Major incident",
+                "type": "announcement_post_template"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAnnouncementPostTemplateSetAsDefaultV1": {
+        "example": {
+          "action": "announcement_post_template.set_as_default",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Major incident",
+              "type": "announcement_post_template"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "announcement_post_template.set_as_default",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Major incident",
+                "type": "announcement_post_template"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAnnouncementPostTemplateUpdatedV1": {
+        "example": {
+          "action": "announcement_post_template.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Major incident",
+              "type": "announcement_post_template"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "announcement_post_template.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Major incident",
+                "type": "announcement_post_template"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAnnouncementPostTemplateUpdatedV2": {
+        "example": {
+          "action": "announcement_post_template.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+            "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Major incident",
+              "type": "announcement_post_template"
+            }
+          ],
+          "version": 2
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "announcement_post_template.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogAnnouncementPostTemplateOwningTeamsMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Major incident",
+                "type": "announcement_post_template"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
         ],
         "type": "object"
       },
@@ -40249,6 +40829,9 @@
           },
           "related_alerts": [
             {
+              "alert_group_ids": [
+                "01GW2G3V0S59R238FAHPDS1R66"
+              ],
               "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
               "created_at": "2021-08-17T13:28:57.801578Z",
               "deduplication_key": "4293868629",
@@ -40335,6 +40918,9 @@
             "description": "Alerts related to this escalation",
             "example": [
               {
+                "alert_group_ids": [
+                  "01GW2G3V0S59R238FAHPDS1R66"
+                ],
                 "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "deduplication_key": "4293868629",
@@ -40486,6 +41072,9 @@
             },
             "related_alerts": [
               {
+                "alert_group_ids": [
+                  "01GW2G3V0S59R238FAHPDS1R66"
+                ],
                 "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "deduplication_key": "4293868629",
@@ -41182,6 +41771,9 @@
             },
             "related_alerts": [
               {
+                "alert_group_ids": [
+                  "01GW2G3V0S59R238FAHPDS1R66"
+                ],
                 "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "deduplication_key": "4293868629",
@@ -41628,6 +42220,9 @@
               },
               "related_alerts": [
                 {
+                  "alert_group_ids": [
+                    "01GW2G3V0S59R238FAHPDS1R66"
+                  ],
                   "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                   "created_at": "2021-08-17T13:28:57.801578Z",
                   "deduplication_key": "4293868629",
@@ -41715,6 +42310,9 @@
                 },
                 "related_alerts": [
                   {
+                    "alert_group_ids": [
+                      "01GW2G3V0S59R238FAHPDS1R66"
+                    ],
                     "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "deduplication_key": "4293868629",
@@ -41942,6 +42540,9 @@
             },
             "related_alerts": [
               {
+                "alert_group_ids": [
+                  "01GW2G3V0S59R238FAHPDS1R66"
+                ],
                 "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "deduplication_key": "4293868629",
@@ -45903,6 +46504,111 @@
         ],
         "type": "object"
       },
+      "FollowUpsConnectExternalIssuePayloadV2": {
+        "example": {
+          "provider": "linear",
+          "url": "https://linear.app/incident/issue/INC-123"
+        },
+        "properties": {
+          "provider": {
+            "description": "The issue tracker provider the issue belongs to",
+            "enum": [
+              "asana",
+              "azure_devops",
+              "click_up",
+              "linear",
+              "jira",
+              "jira_server",
+              "github",
+              "gitlab",
+              "service_now",
+              "shortcut"
+            ],
+            "example": "linear",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the issue in the external provider",
+            "example": "https://linear.app/incident/issue/INC-123",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "url"
+        ],
+        "type": "object"
+      },
+      "FollowUpsConnectExternalIssueResultV2": {
+        "example": {
+          "follow_up": {
+            "assignee": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "owner",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "assignee_team": {
+              "id": "abc123",
+              "name": "abc123"
+            },
+            "completed_at": "2021-08-17T13:28:57.801578Z",
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "creator": {
+              "alert": {
+                "id": "01GW2G3V0S59R238FAHPDS1R66",
+                "title": "*errors.withMessage: PG::Error failed to connect"
+              },
+              "api_key": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My test API key"
+              },
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              },
+              "workflow": {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "My little workflow"
+              }
+            },
+            "description": "Call the fire brigade",
+            "external_issue_reference": {
+              "issue_name": "INC-123",
+              "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+              "provider": "asana"
+            },
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "labels": [
+              "bug",
+              "urgent"
+            ],
+            "priority": {
+              "description": "A follow-up that requires immediate attention.",
+              "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+              "name": "Urgent",
+              "rank": 10
+            },
+            "status": "outstanding",
+            "title": "Cat is stuck in the tree",
+            "updated_at": "2021-08-17T13:28:57.801578Z"
+          }
+        },
+        "properties": {
+          "follow_up": {
+            "$ref": "#/components/schemas/FollowUpV2"
+          }
+        },
+        "required": [
+          "follow_up"
+        ],
+        "type": "object"
+      },
       "FollowUpsCreatePayloadV2": {
         "example": {
           "assignee_id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -46718,7 +47424,9 @@
                 "schedule_overrides_editor",
                 "workflows_editor",
                 "private_workflows_editor",
+                "private_escalation_workflows_editor",
                 "on_call_editor",
+                "on_call_viewer",
                 "escalation_creator",
                 "post_incident_flow_opt_out",
                 "security_settings_editor",
@@ -46728,6 +47436,7 @@
                 "postmortems_manage",
                 "api_keys_manage",
                 "notification_methods_manage",
+                "notification_methods_unredacted_viewer",
                 "incident_workload_viewer",
                 "incident_workload_private_viewer",
                 "act_on_behalf_of_users"
@@ -46751,7 +47460,9 @@
                 "schedule_overrides_editor",
                 "on_call_editor",
                 "escalation_creator",
-                "api_keys_manage"
+                "api_keys_manage",
+                "workflows_editor",
+                "private_workflows_editor"
               ],
               "example": "schedules_editor",
               "type": "string",
@@ -46808,6 +47519,9 @@
       "IncidentAlertV2": {
         "example": {
           "alert": {
+            "alert_group_ids": [
+              "01GW2G3V0S59R238FAHPDS1R66"
+            ],
             "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "deduplication_key": "4293868629",
@@ -62634,6 +63348,9 @@
             "id": "abc123"
           },
           "public_alert.alert_created_v1": {
+            "alert_group_ids": [
+              "01GW2G3V0S59R238FAHPDS1R66"
+            ],
             "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
             "attributes": [
               {
@@ -62678,6 +63395,9 @@
             "updated_at": "2021-08-17T13:28:57.801578Z"
           },
           "public_alert.alert_resolved_v1": {
+            "alert_group_ids": [
+              "01GW2G3V0S59R238FAHPDS1R66"
+            ],
             "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
             "attributes": [
               {
@@ -62772,6 +63492,9 @@
             },
             "related_alerts": [
               {
+                "alert_group_ids": [
+                  "01GW2G3V0S59R238FAHPDS1R66"
+                ],
                 "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "deduplication_key": "4293868629",
@@ -62872,6 +63595,9 @@
               },
               "related_alerts": [
                 {
+                  "alert_group_ids": [
+                    "01GW2G3V0S59R238FAHPDS1R66"
+                  ],
                   "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                   "created_at": "2021-08-17T13:28:57.801578Z",
                   "deduplication_key": "4293868629",
@@ -64725,6 +65451,9 @@
         "example": {
           "event_type": "public_alert.alert_created_v1",
           "public_alert.alert_created_v1": {
+            "alert_group_ids": [
+              "01GW2G3V0S59R238FAHPDS1R66"
+            ],
             "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
             "attributes": [
               {
@@ -64824,6 +65553,9 @@
         "example": {
           "event_type": "public_alert.alert_resolved_v1",
           "public_alert.alert_resolved_v1": {
+            "alert_group_ids": [
+              "01GW2G3V0S59R238FAHPDS1R66"
+            ],
             "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
             "attributes": [
               {
@@ -64973,6 +65705,9 @@
             },
             "related_alerts": [
               {
+                "alert_group_ids": [
+                  "01GW2G3V0S59R238FAHPDS1R66"
+                ],
                 "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "deduplication_key": "4293868629",
@@ -65128,6 +65863,9 @@
               },
               "related_alerts": [
                 {
+                  "alert_group_ids": [
+                    "01GW2G3V0S59R238FAHPDS1R66"
+                  ],
                   "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                   "created_at": "2021-08-17T13:28:57.801578Z",
                   "deduplication_key": "4293868629",
@@ -66917,6 +67655,117 @@
         ],
         "type": "object"
       },
+      "WorkflowFormFieldPayloadV2": {
+        "example": {
+          "array": true,
+          "description": "The customer affected by this incident",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "key": "affected_customer",
+          "required": true,
+          "title": "Affected customer",
+          "type": "User"
+        },
+        "properties": {
+          "array": {
+            "description": "Whether this field holds a list of values rather than a single value",
+            "example": true,
+            "type": "boolean"
+          },
+          "description": {
+            "description": "Optional help text shown beneath the field",
+            "example": "The customer affected by this incident",
+            "type": "string"
+          },
+          "id": {
+            "description": "Stable identifier for this field; omit to create a new field",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key used to reference this field in the workflow scope",
+            "example": "affected_customer",
+            "type": "string"
+          },
+          "required": {
+            "description": "Whether this field must be filled in when running the workflow",
+            "example": true,
+            "type": "boolean"
+          },
+          "title": {
+            "description": "Human readable title shown in the form",
+            "example": "Affected customer",
+            "type": "string"
+          },
+          "type": {
+            "description": "The engine resource type of this field",
+            "example": "User",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "title",
+          "type"
+        ],
+        "type": "object"
+      },
+      "WorkflowFormFieldV2": {
+        "example": {
+          "array": true,
+          "description": "The customer affected by this incident",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "key": "affected_customer",
+          "required": true,
+          "title": "Affected customer",
+          "type": "User"
+        },
+        "properties": {
+          "array": {
+            "description": "Whether this field holds a list of values rather than a single value",
+            "example": true,
+            "type": "boolean"
+          },
+          "description": {
+            "description": "Optional help text shown beneath the field",
+            "example": "The customer affected by this incident",
+            "type": "string"
+          },
+          "id": {
+            "description": "Stable identifier for this form field, preserved across versions",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key used to reference this field in the workflow scope",
+            "example": "affected_customer",
+            "type": "string"
+          },
+          "required": {
+            "description": "Whether this field must be filled in when running the workflow",
+            "example": true,
+            "type": "boolean"
+          },
+          "title": {
+            "description": "Human readable title shown in the form",
+            "example": "Affected customer",
+            "type": "string"
+          },
+          "type": {
+            "description": "The engine resource type of this field",
+            "example": "User",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "key",
+          "title",
+          "type",
+          "array",
+          "required"
+        ],
+        "type": "object"
+      },
       "WorkflowSlimV2": {
         "example": {
           "condition_groups": [
@@ -67106,6 +67955,10 @@
               "type": "IncidentSeverity"
             }
           ],
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
+          "private_incident_scope": "owning_teams",
           "runs_from": "2021-08-17T13:28:57.801578Z",
           "runs_on_incident_modes": [
             "standard",
@@ -67334,31 +68187,10 @@
             "example": true,
             "type": "boolean"
           },
-          "owning_team_ids": {
-            "description": "IDs of the teams that own this workflow",
-            "example": [
-              "01G0J1EXE7AXZ2C93K61WBPYEH"
-            ],
-            "items": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "type": "array"
-          },
           "include_private_incidents": {
             "description": "DEPRECATED: use `private_incident_scope` instead. `true` when the workflow runs on private incidents (a `private_incident_scope` of `all` or `owning_teams`), `false` when the scope is `none`.",
             "example": true,
             "type": "boolean"
-          },
-          "private_incident_scope": {
-            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
-            "enum": [
-              "all",
-              "owning_teams",
-              "none"
-            ],
-            "example": "owning_teams",
-            "type": "string"
           },
           "name": {
             "description": "Name provided by the user when creating the workflow",
@@ -67379,6 +68211,27 @@
               "$ref": "#/components/schemas/EngineReferenceV2"
             },
             "type": "array"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this workflow",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "private_incident_scope": {
+            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
+            "enum": [
+              "all",
+              "owning_teams",
+              "none"
+            ],
+            "example": "owning_teams",
+            "type": "string"
           },
           "runs_from": {
             "description": "The time from which this workflow will run on incidents",
@@ -67464,12 +68317,12 @@
           "condition_groups",
           "steps",
           "include_private_incidents",
+          "private_incident_scope",
           "include_private_escalations",
           "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents",
-          "state",
-          "private_incident_scope"
+          "state"
         ],
         "type": "object"
       },
@@ -67650,6 +68503,17 @@
             }
           ],
           "folder": "My folder 01",
+          "form_fields": [
+            {
+              "array": true,
+              "description": "The customer affected by this incident",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "key": "affected_customer",
+              "required": true,
+              "title": "Affected customer",
+              "type": "User"
+            }
+          ],
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
           "include_private_escalations": true,
           "include_private_incidents": true,
@@ -67662,6 +68526,10 @@
               "type": "IncidentSeverity"
             }
           ],
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
+          "private_incident_scope": "owning_teams",
           "runs_from": "2021-08-17T13:28:57.801578Z",
           "runs_on_incident_modes": [
             "standard",
@@ -67898,6 +68766,24 @@
             "example": "My folder 01",
             "type": "string"
           },
+          "form_fields": {
+            "description": "User-configured form fields available in the workflow scope (manual triggers only)",
+            "example": [
+              {
+                "array": true,
+                "description": "The customer affected by this incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "key": "affected_customer",
+                "required": true,
+                "title": "Affected customer",
+                "type": "User"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/WorkflowFormFieldV2"
+            },
+            "type": "array"
+          },
           "id": {
             "description": "Unique identifier for the workflow",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -67908,31 +68794,10 @@
             "example": true,
             "type": "boolean"
           },
-          "owning_team_ids": {
-            "description": "IDs of the teams that own this workflow",
-            "example": [
-              "01G0J1EXE7AXZ2C93K61WBPYEH"
-            ],
-            "items": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "type": "array"
-          },
           "include_private_incidents": {
             "description": "DEPRECATED: use `private_incident_scope` instead. `true` when the workflow runs on private incidents (a `private_incident_scope` of `all` or `owning_teams`), `false` when the scope is `none`.",
             "example": true,
             "type": "boolean"
-          },
-          "private_incident_scope": {
-            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
-            "enum": [
-              "all",
-              "owning_teams",
-              "none"
-            ],
-            "example": "owning_teams",
-            "type": "string"
           },
           "name": {
             "description": "Name provided by the user when creating the workflow",
@@ -67953,6 +68818,27 @@
               "$ref": "#/components/schemas/EngineReferenceV2"
             },
             "type": "array"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this workflow",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "private_incident_scope": {
+            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
+            "enum": [
+              "all",
+              "owning_teams",
+              "none"
+            ],
+            "example": "owning_teams",
+            "type": "string"
           },
           "runs_from": {
             "description": "The time from which this workflow will run on incidents",
@@ -68056,12 +68942,12 @@
           "condition_groups",
           "steps",
           "include_private_incidents",
+          "private_incident_scope",
           "include_private_escalations",
           "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents",
-          "state",
-          "private_incident_scope"
+          "state"
         ],
         "type": "object"
       },
@@ -68217,12 +69103,27 @@
             }
           ],
           "folder": "My folder 01",
+          "form_fields": [
+            {
+              "array": true,
+              "description": "The customer affected by this incident",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "key": "affected_customer",
+              "required": true,
+              "title": "Affected customer",
+              "type": "User"
+            }
+          ],
           "include_private_escalations": true,
           "include_private_incidents": true,
           "name": "My little workflow",
           "once_for": [
             "incident.url"
           ],
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
+          "private_incident_scope": "owning_teams",
           "runs_on_incident_modes": [
             "standard",
             "test",
@@ -68434,36 +69335,33 @@
             "example": "My folder 01",
             "type": "string"
           },
+          "form_fields": {
+            "description": "User-configured form fields available in the workflow scope (manual triggers only)",
+            "example": [
+              {
+                "array": true,
+                "description": "The customer affected by this incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "key": "affected_customer",
+                "required": true,
+                "title": "Affected customer",
+                "type": "User"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/WorkflowFormFieldPayloadV2"
+            },
+            "type": "array"
+          },
           "include_private_escalations": {
             "description": "Whether to include private escalations",
             "example": true,
             "type": "boolean"
           },
-          "owning_team_ids": {
-            "description": "IDs of the teams that own this workflow",
-            "example": [
-              "01G0J1EXE7AXZ2C93K61WBPYEH"
-            ],
-            "items": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "type": "array"
-          },
           "include_private_incidents": {
-            "description": "DEPRECATED: use `private_incident_scope` instead. Mutually exclusive with `private_incident_scope` — sending both returns a validation error.",
+            "description": "DEPRECATED: use `private_incident_scope` instead. May be sent alongside `private_incident_scope` only if they agree; contradictory values return a validation error.",
             "example": true,
             "type": "boolean"
-          },
-          "private_incident_scope": {
-            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
-            "enum": [
-              "all",
-              "owning_teams",
-              "none"
-            ],
-            "example": "owning_teams",
-            "type": "string"
           },
           "name": {
             "description": "Name provided by the user when creating the workflow",
@@ -68480,6 +69378,27 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this workflow",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "private_incident_scope": {
+            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
+            "enum": [
+              "all",
+              "owning_teams",
+              "none"
+            ],
+            "example": "owning_teams",
+            "type": "string"
           },
           "runs_on_incident_modes": {
             "description": "Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.",
@@ -68756,6 +69675,17 @@
               }
             ],
             "folder": "My folder 01",
+            "form_fields": [
+              {
+                "array": true,
+                "description": "The customer affected by this incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "key": "affected_customer",
+                "required": true,
+                "title": "Affected customer",
+                "type": "User"
+              }
+            ],
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "include_private_escalations": true,
             "include_private_incidents": true,
@@ -68768,6 +69698,10 @@
                 "type": "IncidentSeverity"
               }
             ],
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "private_incident_scope": "owning_teams",
             "runs_from": "2021-08-17T13:28:57.801578Z",
             "runs_on_incident_modes": [
               "standard",
@@ -69013,6 +69947,10 @@
                   "type": "IncidentSeverity"
                 }
               ],
+              "owning_team_ids": [
+                "01G0J1EXE7AXZ2C93K61WBPYEH"
+              ],
+              "private_incident_scope": "owning_teams",
               "runs_from": "2021-08-17T13:28:57.801578Z",
               "runs_on_incident_modes": [
                 "standard",
@@ -69227,6 +70165,10 @@
                     "type": "IncidentSeverity"
                   }
                 ],
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
+                "private_incident_scope": "owning_teams",
                 "runs_from": "2021-08-17T13:28:57.801578Z",
                 "runs_on_incident_modes": [
                   "standard",
@@ -69445,6 +70387,17 @@
               }
             ],
             "folder": "My folder 01",
+            "form_fields": [
+              {
+                "array": true,
+                "description": "The customer affected by this incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "key": "affected_customer",
+                "required": true,
+                "title": "Affected customer",
+                "type": "User"
+              }
+            ],
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "include_private_escalations": true,
             "include_private_incidents": true,
@@ -69457,6 +70410,10 @@
                 "type": "IncidentSeverity"
               }
             ],
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "private_incident_scope": "owning_teams",
             "runs_from": "2021-08-17T13:28:57.801578Z",
             "runs_on_incident_modes": [
               "standard",
@@ -69663,12 +70620,27 @@
             }
           ],
           "folder": "My folder 01",
+          "form_fields": [
+            {
+              "array": true,
+              "description": "The customer affected by this incident",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "key": "affected_customer",
+              "required": true,
+              "title": "Affected customer",
+              "type": "User"
+            }
+          ],
           "include_private_escalations": true,
           "include_private_incidents": true,
           "name": "My little workflow",
           "once_for": [
             "incident.url"
           ],
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
+          "private_incident_scope": "owning_teams",
           "runs_on_incident_modes": [
             "standard",
             "test",
@@ -69880,36 +70852,33 @@
             "example": "My folder 01",
             "type": "string"
           },
+          "form_fields": {
+            "description": "User-configured form fields available in the workflow scope (manual triggers only)",
+            "example": [
+              {
+                "array": true,
+                "description": "The customer affected by this incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "key": "affected_customer",
+                "required": true,
+                "title": "Affected customer",
+                "type": "User"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/WorkflowFormFieldPayloadV2"
+            },
+            "type": "array"
+          },
           "include_private_escalations": {
             "description": "Whether to include private escalations",
             "example": true,
             "type": "boolean"
           },
-          "owning_team_ids": {
-            "description": "IDs of the teams that own this workflow",
-            "example": [
-              "01G0J1EXE7AXZ2C93K61WBPYEH"
-            ],
-            "items": {
-              "example": "abc123",
-              "type": "string"
-            },
-            "type": "array"
-          },
           "include_private_incidents": {
-            "description": "DEPRECATED: use `private_incident_scope` instead. Mutually exclusive with `private_incident_scope` — sending both returns a validation error.",
+            "description": "DEPRECATED: use `private_incident_scope` instead. May be sent alongside `private_incident_scope` only if they agree; contradictory values return a validation error.",
             "example": true,
             "type": "boolean"
-          },
-          "private_incident_scope": {
-            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
-            "enum": [
-              "all",
-              "owning_teams",
-              "none"
-            ],
-            "example": "owning_teams",
-            "type": "string"
           },
           "name": {
             "description": "Name provided by the user when creating the workflow",
@@ -69926,6 +70895,27 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this workflow",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "private_incident_scope": {
+            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
+            "enum": [
+              "all",
+              "owning_teams",
+              "none"
+            ],
+            "example": "owning_teams",
+            "type": "string"
           },
           "runs_on_incident_modes": {
             "description": "Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.",
@@ -70201,6 +71191,17 @@
               }
             ],
             "folder": "My folder 01",
+            "form_fields": [
+              {
+                "array": true,
+                "description": "The customer affected by this incident",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "key": "affected_customer",
+                "required": true,
+                "title": "Affected customer",
+                "type": "User"
+              }
+            ],
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
             "include_private_escalations": true,
             "include_private_incidents": true,
@@ -70213,6 +71214,10 @@
                 "type": "IncidentSeverity"
               }
             ],
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "private_incident_scope": "owning_teams",
             "runs_from": "2021-08-17T13:28:57.801578Z",
             "runs_on_incident_modes": [
               "standard",
@@ -70428,7 +71433,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Actions V1",
-        "x-docs-resource-type": "ActionV1"
+        "x-docs-resource-type": "ActionV1",
+        "x-rbac-scopes": [
+          "actions.view"
+        ]
       }
     },
     "/v1/actions/{id}": {
@@ -70492,7 +71500,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Actions V1",
-        "x-docs-resource-type": "ActionV1"
+        "x-docs-resource-type": "ActionV1",
+        "x-rbac-scopes": [
+          "actions.view"
+        ]
       }
     },
     "/v1/alert_notes": {
@@ -70502,14 +71513,25 @@
         "parameters": [
           {
             "allowEmptyValue": true,
-            "description": "ID of the alert to list notes for",
+            "description": "ID of the alert to list notes for. Provide exactly one of alert_id or alert_group_id.",
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
             "in": "query",
             "name": "alert_id",
-            "required": true,
             "schema": {
-              "description": "ID of the alert to list notes for",
+              "description": "ID of the alert to list notes for. Provide exactly one of alert_id or alert_group_id.",
               "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "ID of the alert group to list notes for. Provide exactly one of alert_id or alert_group_id.",
+            "example": "01HB9Z8WANK6P870EA6S7TK1DS",
+            "in": "query",
+            "name": "alert_group_id",
+            "schema": {
+              "description": "ID of the alert group to list notes for. Provide exactly one of alert_id or alert_group_id.",
+              "example": "01HB9Z8WANK6P870EA6S7TK1DS",
               "type": "string"
             }
           },
@@ -70548,6 +71570,8 @@
                 "example": {
                   "alert_notes": [
                     {
+                      "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+                      "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                       "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
                       "created_at": "2026-05-28T15:30:00Z",
                       "creator": {
@@ -70593,7 +71617,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Alert Notes V1",
-        "x-docs-resource-type": "AlertNoteV1"
+        "x-docs-resource-type": "AlertNoteV1",
+        "x-rbac-scopes": [
+          "alerts.view"
+        ]
       },
       "post": {
         "description": "Add a note to an alert.",
@@ -70602,6 +71629,7 @@
           "content": {
             "application/json": {
               "example": {
+                "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
                 "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n"
               },
@@ -70618,6 +71646,8 @@
               "application/json": {
                 "example": {
                   "alert_note": {
+                    "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+                    "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
                     "created_at": "2026-05-28T15:30:00Z",
                     "creator": {
@@ -70658,7 +71688,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Alert Notes V1",
-        "x-docs-resource-type": "AlertNoteV1"
+        "x-docs-resource-type": "AlertNoteV1",
+        "x-rbac-scopes": [
+          "alerts.edit"
+        ]
       }
     },
     "/v1/alert_notes/{id}": {
@@ -70690,7 +71723,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Alert Notes V1",
-        "x-docs-resource-type": "AlertNoteV1"
+        "x-docs-resource-type": "AlertNoteV1",
+        "x-rbac-scopes": [
+          "alerts.edit"
+        ]
       },
       "get": {
         "description": "Get a single alert note.",
@@ -70715,6 +71751,8 @@
               "application/json": {
                 "example": {
                   "alert_note": {
+                    "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+                    "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
                     "created_at": "2026-05-28T15:30:00Z",
                     "creator": {
@@ -70755,7 +71793,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Alert Notes V1",
-        "x-docs-resource-type": "AlertNoteV1"
+        "x-docs-resource-type": "AlertNoteV1",
+        "x-rbac-scopes": [
+          "alerts.view"
+        ]
       },
       "put": {
         "description": "Replace the content of an alert note.",
@@ -70793,6 +71834,8 @@
               "application/json": {
                 "example": {
                   "alert_note": {
+                    "alert_group_id": "01HB9Z8WANK6P870EA6S7TK1DS",
+                    "alert_id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "content": "Customer reports **checkout 500s** starting ~14:32 UTC. Investigating `payments-api`.\n\n- Error rate: ~12% on `/checkout`\n- Region: `eu-west-1`\n- See [dashboard](https://grafana.example.com/d/abc)\n",
                     "created_at": "2026-05-28T15:30:00Z",
                     "creator": {
@@ -70833,7 +71876,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Alert Notes V1",
-        "x-docs-resource-type": "AlertNoteV1"
+        "x-docs-resource-type": "AlertNoteV1",
+        "x-rbac-scopes": [
+          "alerts.edit"
+        ]
       }
     },
     "/v1/api_keys": {
@@ -70930,7 +71976,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "API Keys V1",
-        "x-docs-resource-type": "APIKeyV1"
+        "x-docs-resource-type": "APIKeyV1",
+        "x-rbac-scopes": [
+          "api_keys.view"
+        ]
       },
       "post": {
         "description": "Create a new API key. The calling API key can only assign roles whose scopes are a subset of its own. The `api_keys_manage` role cannot be assigned via the API. An organization can have a maximum of 5000 active API keys.\n\nThis endpoint requires a valid API key with the `api_keys_manage` role at either the account level or team level.",
@@ -71014,7 +72063,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "API Keys V1",
-        "x-docs-resource-type": "APIKeyV1"
+        "x-docs-resource-type": "APIKeyV1",
+        "x-rbac-scopes": [
+          "api_keys.create"
+        ]
       }
     },
     "/v1/api_keys/{id}": {
@@ -71046,7 +72098,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "API Keys V1",
-        "x-docs-resource-type": "APIKeyV1"
+        "x-docs-resource-type": "APIKeyV1",
+        "x-rbac-scopes": [
+          "api_keys.destroy"
+        ]
       },
       "get": {
         "description": "Show details of a specific API key, including its roles, team assignments and when its token was last issued.\n\nThis endpoint requires a valid API key with the `api_keys_manage` role at either the account level or team level.",
@@ -71120,7 +72175,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "API Keys V1",
-        "x-docs-resource-type": "APIKeyV1"
+        "x-docs-resource-type": "APIKeyV1",
+        "x-rbac-scopes": [
+          "api_keys.view"
+        ]
       },
       "put": {
         "description": "Update an existing API key's name, roles, or team assignments. All fields must be provided (PUT semantics). The calling API key can only assign roles whose scopes are a subset of its own. An API key cannot edit itself, and the `api_keys_manage` role cannot be assigned via the API.\n\nThis endpoint requires a valid API key with the `api_keys_manage` role at either the account level or team level.",
@@ -71217,7 +72275,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "API Keys V1",
-        "x-docs-resource-type": "APIKeyV1"
+        "x-docs-resource-type": "APIKeyV1",
+        "x-rbac-scopes": [
+          "api_keys.update"
+        ]
       }
     },
     "/v1/api_keys/{id}/actions/rotate": {
@@ -71307,7 +72368,10 @@
         ],
         "x-docs-display-name": "Rotate",
         "x-docs-group-name": "API Keys V1",
-        "x-docs-resource-type": "APIKeyV1"
+        "x-docs-resource-type": "APIKeyV1",
+        "x-rbac-scopes": [
+          "api_keys.rotate"
+        ]
       }
     },
     "/v1/custom_field_options": {
@@ -71393,7 +72457,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Custom Field Options V1",
-        "x-docs-resource-type": "CustomFieldOptionV1"
+        "x-docs-resource-type": "CustomFieldOptionV1",
+        "x-rbac-scopes": [
+          "custom_fields.view"
+        ]
       },
       "post": {
         "description": "Create a custom field option. If the sort key is not supplied, it'll default to 1000, so the option appears near the end of the list.",
@@ -71439,7 +72506,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Custom Field Options V1",
-        "x-docs-resource-type": "CustomFieldOptionV1"
+        "x-docs-resource-type": "CustomFieldOptionV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v1/custom_field_options/{id}": {
@@ -71471,7 +72541,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Custom Field Options V1",
-        "x-docs-resource-type": "CustomFieldOptionV1"
+        "x-docs-resource-type": "CustomFieldOptionV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       },
       "get": {
         "description": "Get a single custom field option",
@@ -71516,7 +72589,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Custom Field Options V1",
-        "x-docs-resource-type": "CustomFieldOptionV1"
+        "x-docs-resource-type": "CustomFieldOptionV1",
+        "x-rbac-scopes": [
+          "custom_fields.view"
+        ]
       },
       "put": {
         "description": "Update a custom field option",
@@ -71575,7 +72651,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Custom Field Options V1",
-        "x-docs-resource-type": "CustomFieldOptionV1"
+        "x-docs-resource-type": "CustomFieldOptionV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v1/custom_fields": {
@@ -71628,7 +72707,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Custom Fields V1",
-        "x-docs-resource-type": "CustomFieldV1"
+        "x-docs-resource-type": "CustomFieldV1",
+        "x-rbac-scopes": [
+          "custom_fields.view"
+        ]
       },
       "post": {
         "deprecated": true,
@@ -71698,7 +72780,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Custom Fields V1",
-        "x-docs-resource-type": "CustomFieldV1"
+        "x-docs-resource-type": "CustomFieldV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v1/custom_fields/{id}": {
@@ -71731,7 +72816,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Custom Fields V1",
-        "x-docs-resource-type": "CustomFieldV1"
+        "x-docs-resource-type": "CustomFieldV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       },
       "get": {
         "deprecated": true,
@@ -71794,7 +72882,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Custom Fields V1",
-        "x-docs-resource-type": "CustomFieldV1"
+        "x-docs-resource-type": "CustomFieldV1",
+        "x-rbac-scopes": [
+          "custom_fields.view"
+        ]
       },
       "put": {
         "deprecated": true,
@@ -71877,7 +72968,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Custom Fields V1",
-        "x-docs-resource-type": "CustomFieldV1"
+        "x-docs-resource-type": "CustomFieldV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v1/identity": {
@@ -72019,7 +73113,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Attachments V1",
-        "x-docs-resource-type": "IncidentAttachmentV1"
+        "x-docs-resource-type": "IncidentAttachmentV1",
+        "x-rbac-scopes": [
+          "attachments.view"
+        ]
       },
       "post": {
         "description": "Attaches an external resource to an incident.\n\nYou must provide a resource with resource_type and either external_id or url, but not both.\n\nWhen providing a url, the server will create the attachment from that link for the given resource type if the integration is installed and the link is valid.",
@@ -72072,7 +73169,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Incident Attachments V1",
-        "x-docs-resource-type": "IncidentAttachmentV1"
+        "x-docs-resource-type": "IncidentAttachmentV1",
+        "x-rbac-scopes": [
+          "attachments.create"
+        ]
       }
     },
     "/v1/incident_attachments/{id}": {
@@ -72104,7 +73204,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Incident Attachments V1",
-        "x-docs-resource-type": "IncidentAttachmentV1"
+        "x-docs-resource-type": "IncidentAttachmentV1",
+        "x-rbac-scopes": [
+          "attachments.destroy"
+        ]
       }
     },
     "/v1/incident_memberships": {
@@ -72158,7 +73261,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Incident Memberships V1",
-        "x-docs-resource-type": "IncidentMembershipV1"
+        "x-docs-resource-type": "IncidentMembershipV1",
+        "x-rbac-scopes": [
+          "incident_memberships.grant"
+        ]
       }
     },
     "/v1/incident_memberships/actions/revoke": {
@@ -72190,7 +73296,10 @@
         ],
         "x-docs-display-name": "Revoke",
         "x-docs-group-name": "Incident Memberships V1",
-        "x-docs-resource-type": "IncidentMembershipV1"
+        "x-docs-resource-type": "IncidentMembershipV1",
+        "x-rbac-scopes": [
+          "incident_memberships.revoke"
+        ]
       }
     },
     "/v1/incident_relationships": {
@@ -72273,7 +73382,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Relationships V1",
-        "x-docs-resource-type": "IncidentRelationshipV1"
+        "x-docs-resource-type": "IncidentRelationshipV1",
+        "x-rbac-scopes": [
+          "incidents.view"
+        ]
       }
     },
     "/v1/incident_roles": {
@@ -72314,7 +73426,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Roles V1",
-        "x-docs-resource-type": "IncidentRoleV1"
+        "x-docs-resource-type": "IncidentRoleV1",
+        "x-rbac-scopes": [
+          "incident_roles.view"
+        ]
       },
       "post": {
         "deprecated": true,
@@ -72368,7 +73483,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Incident Roles V1",
-        "x-docs-resource-type": "IncidentRoleV1"
+        "x-docs-resource-type": "IncidentRoleV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v1/incident_roles/{id}": {
@@ -72401,7 +73519,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Incident Roles V1",
-        "x-docs-resource-type": "IncidentRoleV1"
+        "x-docs-resource-type": "IncidentRoleV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       },
       "get": {
         "deprecated": true,
@@ -72452,7 +73573,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Incident Roles V1",
-        "x-docs-resource-type": "IncidentRoleV1"
+        "x-docs-resource-type": "IncidentRoleV1",
+        "x-rbac-scopes": [
+          "incident_roles.view"
+        ]
       },
       "put": {
         "deprecated": true,
@@ -72520,7 +73644,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Incident Roles V1",
-        "x-docs-resource-type": "IncidentRoleV1"
+        "x-docs-resource-type": "IncidentRoleV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v1/incident_statuses": {
@@ -72558,7 +73685,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Statuses V1",
-        "x-docs-resource-type": "IncidentStatusV1"
+        "x-docs-resource-type": "IncidentStatusV1",
+        "x-rbac-scopes": [
+          "incident_statuses.view"
+        ]
       },
       "post": {
         "description": "Create a new incident status",
@@ -72607,7 +73737,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Incident Statuses V1",
-        "x-docs-resource-type": "IncidentStatusV1"
+        "x-docs-resource-type": "IncidentStatusV1",
+        "x-rbac-scopes": [
+          "incident_lifecycles.update"
+        ]
       }
     },
     "/v1/incident_statuses/{id}": {
@@ -72639,7 +73772,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Incident Statuses V1",
-        "x-docs-resource-type": "IncidentStatusV1"
+        "x-docs-resource-type": "IncidentStatusV1",
+        "x-rbac-scopes": [
+          "incident_lifecycles.update"
+        ]
       },
       "get": {
         "description": "Get a single incident status.",
@@ -72687,7 +73823,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Incident Statuses V1",
-        "x-docs-resource-type": "IncidentStatusV1"
+        "x-docs-resource-type": "IncidentStatusV1",
+        "x-rbac-scopes": [
+          "incident_statuses.view"
+        ]
       },
       "put": {
         "description": "Update an existing incident status",
@@ -72749,7 +73888,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Incident Statuses V1",
-        "x-docs-resource-type": "IncidentStatusV1"
+        "x-docs-resource-type": "IncidentStatusV1",
+        "x-rbac-scopes": [
+          "incident_lifecycles.update"
+        ]
       }
     },
     "/v1/incident_team_memberships": {
@@ -72800,7 +73942,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Incident Team Memberships V1",
-        "x-docs-resource-type": "IncidentTeamMembershipV1"
+        "x-docs-resource-type": "IncidentTeamMembershipV1",
+        "x-rbac-scopes": [
+          "incident_team_memberships.grant"
+        ]
       }
     },
     "/v1/incident_team_memberships/actions/revoke": {
@@ -72833,7 +73978,10 @@
         ],
         "x-docs-display-name": "Revoke",
         "x-docs-group-name": "Incident Team Memberships V1",
-        "x-docs-resource-type": "IncidentTeamMembershipV1"
+        "x-docs-resource-type": "IncidentTeamMembershipV1",
+        "x-rbac-scopes": [
+          "incident_team_memberships.revoke"
+        ]
       }
     },
     "/v1/incident_types": {
@@ -72875,7 +74023,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Types V1",
-        "x-docs-resource-type": "IncidentTypeV1"
+        "x-docs-resource-type": "IncidentTypeV1",
+        "x-rbac-scopes": [
+          "incident_types.view"
+        ]
       }
     },
     "/v1/incident_types/{id}": {
@@ -72929,7 +74080,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Incident Types V1",
-        "x-docs-resource-type": "IncidentTypeV1"
+        "x-docs-resource-type": "IncidentTypeV1",
+        "x-rbac-scopes": [
+          "incident_types.view"
+        ]
       }
     },
     "/v1/incidents": {
@@ -73137,7 +74291,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incidents V1",
-        "x-docs-resource-type": "IncidentV1"
+        "x-docs-resource-type": "IncidentV1",
+        "x-rbac-scopes": [
+          "incidents.view"
+        ]
       },
       "post": {
         "deprecated": true,
@@ -73331,7 +74488,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Incidents V1",
-        "x-docs-resource-type": "IncidentV1"
+        "x-docs-resource-type": "IncidentV1",
+        "x-rbac-scopes": [
+          "incidents.create"
+        ]
       }
     },
     "/v1/incidents/{id}": {
@@ -73492,7 +74652,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Incidents V1",
-        "x-docs-resource-type": "IncidentV1"
+        "x-docs-resource-type": "IncidentV1",
+        "x-rbac-scopes": [
+          "incidents.view"
+        ]
       }
     },
     "/v1/ip_allowlists": {
@@ -73586,7 +74749,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "IPAllowlists V1",
-        "x-docs-resource-type": "IPAllowlistV1"
+        "x-docs-resource-type": "IPAllowlistV1",
+        "x-rbac-scopes": [
+          "security_settings.update"
+        ]
       }
     },
     "/v1/maintenance_windows": {
@@ -73780,7 +74946,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "MaintenanceWindows V1",
-        "x-docs-resource-type": "MaintenanceWindowV1"
+        "x-docs-resource-type": "MaintenanceWindowV1",
+        "x-rbac-scopes": [
+          "maintenance_windows.view"
+        ]
       },
       "post": {
         "description": "Create a new maintenance window.",
@@ -74000,7 +75169,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "MaintenanceWindows V1",
-        "x-docs-resource-type": "MaintenanceWindowV1"
+        "x-docs-resource-type": "MaintenanceWindowV1",
+        "x-rbac-scopes": [
+          "maintenance_window.create"
+        ]
       }
     },
     "/v1/maintenance_windows/{id}": {
@@ -74032,7 +75204,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "MaintenanceWindows V1",
-        "x-docs-resource-type": "MaintenanceWindowV1"
+        "x-docs-resource-type": "MaintenanceWindowV1",
+        "x-rbac-scopes": [
+          "maintenance_window.destroy"
+        ]
       },
       "get": {
         "description": "Show a particular maintenance window.",
@@ -74180,7 +75355,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "MaintenanceWindows V1",
-        "x-docs-resource-type": "MaintenanceWindowV1"
+        "x-docs-resource-type": "MaintenanceWindowV1",
+        "x-rbac-scopes": [
+          "maintenance_windows.view"
+        ]
       },
       "put": {
         "description": "Update an existing maintenance window.",
@@ -74419,7 +75597,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "MaintenanceWindows V1",
-        "x-docs-resource-type": "MaintenanceWindowV1"
+        "x-docs-resource-type": "MaintenanceWindowV1",
+        "x-rbac-scopes": [
+          "maintenance_window.update"
+        ]
       }
     },
     "/v1/openapi.json": {
@@ -74589,7 +75770,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "PostmortemDocuments V1",
-        "x-docs-resource-type": "PostmortemDocumentV1"
+        "x-docs-resource-type": "PostmortemDocumentV1",
+        "x-rbac-scopes": [
+          "incidents.view"
+        ]
       }
     },
     "/v1/postmortem_documents/actions/attach": {
@@ -74654,7 +75838,10 @@
         ],
         "x-docs-display-name": "Attach",
         "x-docs-group-name": "PostmortemDocuments V1",
-        "x-docs-resource-type": "PostmortemDocumentV1"
+        "x-docs-resource-type": "PostmortemDocumentV1",
+        "x-rbac-scopes": [
+          "external_postmortems.create"
+        ]
       }
     },
     "/v1/postmortem_documents/{id}": {
@@ -74718,7 +75905,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "PostmortemDocuments V1",
-        "x-docs-resource-type": "PostmortemDocumentV1"
+        "x-docs-resource-type": "PostmortemDocumentV1",
+        "x-rbac-scopes": [
+          "incidents.view"
+        ]
       },
       "put": {
         "description": "Update the status of a post-mortem document.",
@@ -74793,7 +75983,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "PostmortemDocuments V1",
-        "x-docs-resource-type": "PostmortemDocumentV1"
+        "x-docs-resource-type": "PostmortemDocumentV1",
+        "x-rbac-scopes": [
+          "in_app_postmortems.update_status"
+        ]
       }
     },
     "/v1/postmortem_documents/{id}/content": {
@@ -74835,7 +76028,10 @@
         ],
         "x-docs-display-name": "Show Content",
         "x-docs-group-name": "PostmortemDocuments V1",
-        "x-docs-resource-type": "PostmortemDocumentV1"
+        "x-docs-resource-type": "PostmortemDocumentV1",
+        "x-rbac-scopes": [
+          "in_app_postmortems.copy_as_markdown"
+        ]
       }
     },
     "/v1/severities": {
@@ -74872,7 +76068,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Severities V1",
-        "x-docs-resource-type": "SeverityV1"
+        "x-docs-resource-type": "SeverityV1",
+        "x-rbac-scopes": [
+          "severities.view"
+        ]
       },
       "post": {
         "description": "Create a new severity",
@@ -74920,7 +76119,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Severities V1",
-        "x-docs-resource-type": "SeverityV1"
+        "x-docs-resource-type": "SeverityV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v1/severities/{id}": {
@@ -74952,7 +76154,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Severities V1",
-        "x-docs-resource-type": "SeverityV1"
+        "x-docs-resource-type": "SeverityV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       },
       "get": {
         "description": "Get a single incident severity.",
@@ -74999,7 +76204,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Severities V1",
-        "x-docs-resource-type": "SeverityV1"
+        "x-docs-resource-type": "SeverityV1",
+        "x-rbac-scopes": [
+          "severities.view"
+        ]
       },
       "put": {
         "description": "Update an existing severity",
@@ -75061,7 +76269,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Severities V1",
-        "x-docs-resource-type": "SeverityV1"
+        "x-docs-resource-type": "SeverityV1",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v1/status-pages/{id}/incidents/{incident_id}/response-incidents": {
@@ -75225,7 +76436,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Actions V2",
-        "x-docs-resource-type": "ActionV2"
+        "x-docs-resource-type": "ActionV2",
+        "x-rbac-scopes": [
+          "actions.view"
+        ]
       },
       "post": {
         "description": "Create a new incident action.",
@@ -75302,7 +76516,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Actions V2",
-        "x-docs-resource-type": "ActionV2"
+        "x-docs-resource-type": "ActionV2",
+        "x-rbac-scopes": [
+          "actions.create"
+        ]
       }
     },
     "/v2/actions/{id}": {
@@ -75334,7 +76551,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Actions V2",
-        "x-docs-resource-type": "ActionV2"
+        "x-docs-resource-type": "ActionV2",
+        "x-rbac-scopes": [
+          "actions.destroy"
+        ]
       },
       "get": {
         "description": "Get a single incident action.",
@@ -75410,7 +76630,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Actions V2",
-        "x-docs-resource-type": "ActionV2"
+        "x-docs-resource-type": "ActionV2",
+        "x-rbac-scopes": [
+          "actions.view"
+        ]
       },
       "put": {
         "description": "Update an existing incident action.",
@@ -75501,7 +76724,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Actions V2",
-        "x-docs-resource-type": "ActionV2"
+        "x-docs-resource-type": "ActionV2",
+        "x-rbac-scopes": [
+          "actions.update"
+        ]
       }
     },
     "/v2/alert_attributes": {
@@ -75538,7 +76764,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Alert Attributes V2",
-        "x-docs-resource-type": "AlertAttributeV2"
+        "x-docs-resource-type": "AlertAttributeV2",
+        "x-rbac-scopes": [
+          "alert_schema.view"
+        ]
       },
       "post": {
         "description": "Create a new alert attribute.",
@@ -75588,7 +76817,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Alert Attributes V2",
-        "x-docs-resource-type": "AlertAttributeV2"
+        "x-docs-resource-type": "AlertAttributeV2",
+        "x-rbac-scopes": [
+          "alert_schema.update"
+        ]
       }
     },
     "/v2/alert_attributes/{id}": {
@@ -75620,7 +76852,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Alert Attributes V2",
-        "x-docs-resource-type": "AlertAttributeV2"
+        "x-docs-resource-type": "AlertAttributeV2",
+        "x-rbac-scopes": [
+          "alert_schema.update"
+        ]
       },
       "get": {
         "description": "Show an alert attribute.",
@@ -75667,7 +76902,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Alert Attributes V2",
-        "x-docs-resource-type": "AlertAttributeV2"
+        "x-docs-resource-type": "AlertAttributeV2",
+        "x-rbac-scopes": [
+          "alert_schema.view"
+        ]
       },
       "put": {
         "description": "Update an alert attribute.",
@@ -75731,7 +76969,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Alert Attributes V2",
-        "x-docs-resource-type": "AlertAttributeV2"
+        "x-docs-resource-type": "AlertAttributeV2",
+        "x-rbac-scopes": [
+          "alert_schema.update"
+        ]
       }
     },
     "/v2/alert_events/http/{alert_source_config_id}": {
@@ -75901,7 +77142,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Alert Routes V2",
-        "x-docs-resource-type": "AlertRouteV2"
+        "x-docs-resource-type": "AlertRouteV2",
+        "x-rbac-scopes": [
+          "alert_routes.view"
+        ]
       },
       "post": {
         "description": "Create a new alert route in your account.",
@@ -76892,7 +78136,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Alert Routes V2",
-        "x-docs-resource-type": "AlertRouteV2"
+        "x-docs-resource-type": "AlertRouteV2",
+        "x-rbac-scopes": [
+          "alert_route.create"
+        ]
       }
     },
     "/v2/alert_routes/{id}": {
@@ -76924,7 +78171,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Alert Routes V2",
-        "x-docs-resource-type": "AlertRouteV2"
+        "x-docs-resource-type": "AlertRouteV2",
+        "x-rbac-scopes": [
+          "alert_route.destroy"
+        ]
       },
       "get": {
         "description": "Load details about a specific alert route in your account.",
@@ -77481,7 +78731,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Alert Routes V2",
-        "x-docs-resource-type": "AlertRouteV2"
+        "x-docs-resource-type": "AlertRouteV2",
+        "x-rbac-scopes": [
+          "alert_routes.view"
+        ]
       },
       "put": {
         "description": "Update an existing alert route in your account.",
@@ -78492,7 +79745,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Alert Routes V2",
-        "x-docs-resource-type": "AlertRouteV2"
+        "x-docs-resource-type": "AlertRouteV2",
+        "x-rbac-scopes": [
+          "alert_route.update"
+        ]
       }
     },
     "/v2/alert_sources": {
@@ -78740,7 +79996,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Alert Sources V2",
-        "x-docs-resource-type": "AlertSourceV2"
+        "x-docs-resource-type": "AlertSourceV2",
+        "x-rbac-scopes": [
+          "alert_sources.view"
+        ]
       },
       "post": {
         "description": "Create a new alert source in your account.",
@@ -79182,7 +80441,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Alert Sources V2",
-        "x-docs-resource-type": "AlertSourceV2"
+        "x-docs-resource-type": "AlertSourceV2",
+        "x-rbac-scopes": [
+          "alert_source.create"
+        ]
       }
     },
     "/v2/alert_sources/{id}": {
@@ -79214,7 +80476,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Alert Sources V2",
-        "x-docs-resource-type": "AlertSourceV2"
+        "x-docs-resource-type": "AlertSourceV2",
+        "x-rbac-scopes": [
+          "alert_source.destroy"
+        ]
       },
       "get": {
         "description": "Load details about a specific alert source in your account.",
@@ -79472,7 +80737,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Alert Sources V2",
-        "x-docs-resource-type": "AlertSourceV2"
+        "x-docs-resource-type": "AlertSourceV2",
+        "x-rbac-scopes": [
+          "alert_sources.view"
+        ]
       },
       "put": {
         "description": "Update an existing alert source in your account.",
@@ -79928,12 +81196,15 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Alert Sources V2",
-        "x-docs-resource-type": "AlertSourceV2"
+        "x-docs-resource-type": "AlertSourceV2",
+        "x-rbac-scopes": [
+          "alert_source.update"
+        ]
       }
     },
     "/v2/alerts": {
       "get": {
-        "description": "List all alerts for your account.\n\t\t\nThis endpoint supports a number of filters, which can help find alerts matching certain\ncriteria. These filters work similarly to the filters on the incidents endpoint, where \na field is specified alongside a comparison operator in the query string.\n\nNote that:\n- Filters may be used together, and the result will be alerts that match all filters.\n- All query parameters must be URI encoded.\n\n### By deduplication_key\n\nFind all alerts with deduplication_key ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'deduplication_key[is]=ABC'\n\n### By status\n\nFind all alerts in a firing state:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'status[one_of]=firing'\n\n### By alert_source\n\nFind all alerts from a specific alert source (by alert source ID):\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'alert_source[one_of]=01GBSQF3FHF7FWZQNWGHAVQ804'\n\nFind all alerts not from a specific alert source:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'alert_source[not_in]=01GBSQF3FHF7FWZQNWGHAVQ804'\n\n### By created_at\nFind all alerts that follow specified date parameters for created_at field.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and \n\"date_range\" (between two dates). The following example finds all alerts created after \n2025-01-01:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'created_at[gte]=2025-01-01'\n\nTo find alerts created within a specific date range, use the date_range option with \ntilde-separated dates:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'created_at[date_range]=2024-12-02~2024-12-08'\n\n### By has_notes\n\nFind all alerts that have notes attached:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'has_notes[is]=true'\n\nFind all alerts that have no notes attached:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'has_notes[is]=false'\n\n### Maintenance windows\nBy default, all alerts are returned including those held by a maintenance window.\nTo exclude alerts that are held by a maintenance window:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'include_maintenance_window[is]=false'\n\t\t",
+        "description": "List all alerts for your account.\n\t\t\nThis endpoint supports a number of filters, which can help find alerts matching certain\ncriteria. These filters work similarly to the filters on the incidents endpoint, where \na field is specified alongside a comparison operator in the query string.\n\nNote that:\n- Filters may be used together, and the result will be alerts that match all filters.\n- All query parameters must be URI encoded.\n\n### By deduplication_key\n\nFind all alerts with deduplication_key ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'deduplication_key[is]=ABC'\n\n### By status\n\nFind all alerts in a firing state:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'status[one_of]=firing'\n\n### By alert_source\n\nFind all alerts from a specific alert source (by alert source ID):\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'alert_source[one_of]=01GBSQF3FHF7FWZQNWGHAVQ804'\n\nFind all alerts not from a specific alert source:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'alert_source[not_in]=01GBSQF3FHF7FWZQNWGHAVQ804'\n\n### By alert_group_id\n\nFind all alerts in a specific alert group:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'alert_group_id[one_of]=01GBSQF3FHF7FWZQNWGHAVQ804'\n\n### By created_at\nFind all alerts that follow specified date parameters for created_at field.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and \n\"date_range\" (between two dates). The following example finds all alerts created after \n2025-01-01:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'created_at[gte]=2025-01-01'\n\nTo find alerts created within a specific date range, use the date_range option with \ntilde-separated dates:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'created_at[date_range]=2024-12-02~2024-12-08'\n\n### By has_notes\n\nFind all alerts that have notes attached:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'has_notes[is]=true'\n\nFind all alerts that have no notes attached:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'has_notes[is]=false'\n\n### By attributes\n\nAlerts can be filtered by their attribute values. Each filter is keyed by the alert\nattribute ID, followed by an operator and the values to match. The accepted operators\ndepend on the attribute's type.\n\nFind all alerts where attribute 01GBSQF3FHF7FWZQNWGHAVQ804 is one of two catalog entries:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'attributes[01GBSQF3FHF7FWZQNWGHAVQ804][one_of]=01GBSQF3FHF7FWZQNWGHAVQ804' \\\n\t\t\t--data 'attributes[01GBSQF3FHF7FWZQNWGHAVQ804][one_of]=01ET65M7ZARSFZ6TFDFVQDN9AA'\n\nYou can filter on multiple attributes at once, and the result will be alerts that match\nall of them.\n\n### Maintenance windows\nBy default, all alerts are returned including those held by a maintenance window.\nTo exclude alerts that are held by a maintenance window:\n\n\t\tcurl --get 'https://api.incident.io/v2/alerts' \\\n\t\t\t--data 'include_maintenance_window[is]=false'\n\t\t",
         "operationId": "Alerts V2#List",
         "parameters": [
           {
@@ -80057,6 +81328,36 @@
           },
           {
             "allowEmptyValue": true,
+            "description": "Filter on alert group ID. Returns alerts that belong to any of the specified groups. The accepted operator is 'one_of'.",
+            "example": {
+              "one_of": [
+                "01GBSQF3FHF7FWZQNWGHAVQ804"
+              ]
+            },
+            "in": "query",
+            "name": "alert_group_id",
+            "schema": {
+              "additionalProperties": {
+                "example": [
+                  "some_value"
+                ],
+                "items": {
+                  "example": "some_value",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "Filter on alert group ID. Returns alerts that belong to any of the specified groups. The accepted operator is 'one_of'.",
+              "example": {
+                "one_of": [
+                  "01GBSQF3FHF7FWZQNWGHAVQ804"
+                ]
+              },
+              "type": "object"
+            }
+          },
+          {
+            "allowEmptyValue": true,
             "description": "Filter on alert created at timestamp. Accepted operators are 'gte', 'lte' and 'date_range'.",
             "example": {
               "gte": [
@@ -80081,6 +81382,50 @@
                 "gte": [
                   "2025-01-01"
                 ]
+              },
+              "type": "object"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "Filter on an alerts attributes. Alert attribute ID should be sent, followed by the operator and values. Accepted operator will depend on the attribute type.",
+            "example": {
+              "01GBSQF3FHF7FWZQNWGHAVQ804": {
+                "one_of": [
+                  "01GBSQF3FHF7FWZQNWGHAVQ804",
+                  "01ET65M7ZARSFZ6TFDFVQDN9AA"
+                ]
+              }
+            },
+            "in": "query",
+            "name": "attributes",
+            "schema": {
+              "additionalProperties": {
+                "additionalProperties": {
+                  "example": [
+                    "value"
+                  ],
+                  "items": {
+                    "example": "value",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "example": {
+                  "abc123": [
+                    "value"
+                  ]
+                },
+                "type": "object"
+              },
+              "description": "Filter on an alerts attributes. Alert attribute ID should be sent, followed by the operator and values. Accepted operator will depend on the attribute type.",
+              "example": {
+                "01GBSQF3FHF7FWZQNWGHAVQ804": {
+                  "one_of": [
+                    "01GBSQF3FHF7FWZQNWGHAVQ804",
+                    "01ET65M7ZARSFZ6TFDFVQDN9AA"
+                  ]
+                }
               },
               "type": "object"
             }
@@ -80153,6 +81498,9 @@
                 "example": {
                   "alerts": [
                     {
+                      "alert_group_ids": [
+                        "01GW2G3V0S59R238FAHPDS1R66"
+                      ],
                       "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                       "attributes": [
                         {
@@ -80216,7 +81564,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Alerts V2",
-        "x-docs-resource-type": "AlertV2"
+        "x-docs-resource-type": "AlertV2",
+        "x-rbac-scopes": [
+          "alerts.view"
+        ]
       }
     },
     "/v2/alerts/{id}": {
@@ -80243,6 +81594,9 @@
               "application/json": {
                 "example": {
                   "alert": {
+                    "alert_group_ids": [
+                      "01GW2G3V0S59R238FAHPDS1R66"
+                    ],
                     "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                     "attributes": [
                       {
@@ -80301,7 +81655,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Alerts V2",
-        "x-docs-resource-type": "AlertV2"
+        "x-docs-resource-type": "AlertV2",
+        "x-rbac-scopes": [
+          "alerts.view"
+        ]
       }
     },
     "/v2/alerts/{id}/actions/resolve": {
@@ -80328,6 +81685,9 @@
               "application/json": {
                 "example": {
                   "alert": {
+                    "alert_group_ids": [
+                      "01GW2G3V0S59R238FAHPDS1R66"
+                    ],
                     "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                     "attributes": [
                       {
@@ -80386,7 +81746,10 @@
         ],
         "x-docs-display-name": "Resolve",
         "x-docs-group-name": "Alerts V2",
-        "x-docs-resource-type": "AlertV2"
+        "x-docs-resource-type": "AlertV2",
+        "x-rbac-scopes": [
+          "alerts.resolve"
+        ]
       }
     },
     "/v2/catalog_entries": {
@@ -80562,7 +81925,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Catalog Entries V2",
-        "x-docs-resource-type": "CatalogEntryV2"
+        "x-docs-resource-type": "CatalogEntryV2",
+        "x-rbac-scopes": [
+          "catalog_entries.view"
+        ]
       },
       "post": {
         "deprecated": true,
@@ -80676,7 +82042,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Catalog Entries V2",
-        "x-docs-resource-type": "CatalogEntryV2"
+        "x-docs-resource-type": "CatalogEntryV2",
+        "x-rbac-scopes": [
+          "catalog_entries.create"
+        ]
       }
     },
     "/v2/catalog_entries/{id}": {
@@ -80709,7 +82078,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Catalog Entries V2",
-        "x-docs-resource-type": "CatalogEntryV2"
+        "x-docs-resource-type": "CatalogEntryV2",
+        "x-rbac-scopes": [
+          "catalog_entries.destroy"
+        ]
       },
       "get": {
         "deprecated": true,
@@ -80849,7 +82221,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Catalog Entries V2",
-        "x-docs-resource-type": "CatalogEntryV2"
+        "x-docs-resource-type": "CatalogEntryV2",
+        "x-rbac-scopes": [
+          "catalog_entries.view"
+        ]
       },
       "put": {
         "deprecated": true,
@@ -81022,7 +82397,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Catalog Entries V2",
-        "x-docs-resource-type": "CatalogEntryV2"
+        "x-docs-resource-type": "CatalogEntryV2",
+        "x-rbac-scopes": [
+          "catalog_entries.edit"
+        ]
       }
     },
     "/v2/catalog_resources": {
@@ -81059,7 +82437,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Catalog Resources V2",
-        "x-docs-resource-type": "CatalogResourceV2"
+        "x-docs-resource-type": "CatalogResourceV2",
+        "x-rbac-scopes": [
+          "catalog_types.view"
+        ]
       }
     },
     "/v2/catalog_types": {
@@ -81135,7 +82516,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Catalog Types V2",
-        "x-docs-resource-type": "CatalogTypeV2"
+        "x-docs-resource-type": "CatalogTypeV2",
+        "x-rbac-scopes": [
+          "catalog_types.view"
+        ]
       },
       "post": {
         "deprecated": true,
@@ -81232,7 +82616,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Catalog Types V2",
-        "x-docs-resource-type": "CatalogTypeV2"
+        "x-docs-resource-type": "CatalogTypeV2",
+        "x-rbac-scopes": [
+          "catalog_types.create"
+        ]
       }
     },
     "/v2/catalog_types/{id}": {
@@ -81265,7 +82652,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Catalog Types V2",
-        "x-docs-resource-type": "CatalogTypeV2"
+        "x-docs-resource-type": "CatalogTypeV2",
+        "x-rbac-scopes": [
+          "catalog_types.destroy"
+        ]
       },
       "get": {
         "deprecated": true,
@@ -81351,7 +82741,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Catalog Types V2",
-        "x-docs-resource-type": "CatalogTypeV2"
+        "x-docs-resource-type": "CatalogTypeV2",
+        "x-rbac-scopes": [
+          "catalog_types.view"
+        ]
       },
       "put": {
         "deprecated": true,
@@ -81461,7 +82854,10 @@
         ],
         "x-docs-display-name": "Update Type",
         "x-docs-group-name": "Catalog Types V2",
-        "x-docs-resource-type": "CatalogTypeV2"
+        "x-docs-resource-type": "CatalogTypeV2",
+        "x-rbac-scopes": [
+          "catalog_types.edit"
+        ]
       }
     },
     "/v2/catalog_types/{id}/actions/update_schema": {
@@ -81577,7 +82973,10 @@
         ],
         "x-docs-display-name": "Update Type Schema",
         "x-docs-group-name": "Catalog Types V2",
-        "x-docs-resource-type": "CatalogTypeV2"
+        "x-docs-resource-type": "CatalogTypeV2",
+        "x-rbac-scopes": [
+          "catalog_types.edit"
+        ]
       }
     },
     "/v2/custom_fields": {
@@ -81628,7 +83027,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Custom Fields V2",
-        "x-docs-resource-type": "CustomFieldV2"
+        "x-docs-resource-type": "CustomFieldV2",
+        "x-rbac-scopes": [
+          "custom_fields.view"
+        ]
       },
       "post": {
         "description": "Create a new custom field",
@@ -81704,7 +83106,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Custom Fields V2",
-        "x-docs-resource-type": "CustomFieldV2"
+        "x-docs-resource-type": "CustomFieldV2",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v2/custom_fields/{id}": {
@@ -81736,7 +83141,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Custom Fields V2",
-        "x-docs-resource-type": "CustomFieldV2"
+        "x-docs-resource-type": "CustomFieldV2",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       },
       "get": {
         "description": "Get a single custom field.",
@@ -81797,7 +83205,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Custom Fields V2",
-        "x-docs-resource-type": "CustomFieldV2"
+        "x-docs-resource-type": "CustomFieldV2",
+        "x-rbac-scopes": [
+          "custom_fields.view"
+        ]
       },
       "put": {
         "description": "Update the details of a custom field",
@@ -81885,7 +83296,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Custom Fields V2",
-        "x-docs-resource-type": "CustomFieldV2"
+        "x-docs-resource-type": "CustomFieldV2",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v2/escalation_paths": {
@@ -82067,7 +83481,10 @@
         "x-display-name": "List",
         "x-docs-display-name": "List",
         "x-docs-group-name": "Escalation Paths V2",
-        "x-docs-resource-type": "EscalationPathV2"
+        "x-docs-resource-type": "EscalationPathV2",
+        "x-rbac-scopes": [
+          "escalation_paths.view"
+        ]
       },
       "post": {
         "description": "Create an escalation path.\n\nAn escalation path is a series of steps that describe how a page should be escalated,\nrepresented as graph, supporting conditional branches based on alert priority and working\nintervals.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
@@ -82321,7 +83738,10 @@
         "x-display-name": "Create",
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Escalation Paths V2",
-        "x-docs-resource-type": "EscalationPathV2"
+        "x-docs-resource-type": "EscalationPathV2",
+        "x-rbac-scopes": [
+          "escalation_paths.create"
+        ]
       }
     },
     "/v2/escalation_paths/external": {
@@ -82451,7 +83871,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "External Escalation Paths V2",
-        "x-docs-resource-type": "ExternalEscalationPathV2"
+        "x-docs-resource-type": "ExternalEscalationPathV2",
+        "x-rbac-scopes": [
+          "escalation_paths.view"
+        ]
       },
       "post": {
         "description": "Import an external escalation path and its referenced schedules.\n\nTakes the ID of an external escalation path (as returned by the list endpoint) and\nimports it along with any referenced schedules that haven't already been imported.\n",
@@ -82607,7 +84030,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "External Escalation Paths V2",
-        "x-docs-resource-type": "ExternalEscalationPathV2"
+        "x-docs-resource-type": "ExternalEscalationPathV2",
+        "x-rbac-scopes": [
+          "escalation_paths.create"
+        ]
       }
     },
     "/v2/escalation_paths/{id}": {
@@ -82640,7 +84066,10 @@
         "x-display-name": "Destroy",
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Escalation Paths V2",
-        "x-docs-resource-type": "EscalationPathV2"
+        "x-docs-resource-type": "EscalationPathV2",
+        "x-rbac-scopes": [
+          "escalation_paths.destroy"
+        ]
       },
       "get": {
         "description": "Show an escalation path.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
@@ -82798,7 +84227,10 @@
         "x-display-name": "Show",
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Escalation Paths V2",
-        "x-docs-resource-type": "EscalationPathV2"
+        "x-docs-resource-type": "EscalationPathV2",
+        "x-rbac-scopes": [
+          "escalation_paths.view"
+        ]
       },
       "put": {
         "description": "Updates an escalation path.\n\nWe recommend you create escalation paths in the incident.io dashboard where our path\nbuilder makes it easy to use conditions and visualise the path.\n",
@@ -83066,7 +84498,10 @@
         "x-display-name": "Update",
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Escalation Paths V2",
-        "x-docs-resource-type": "EscalationPathV2"
+        "x-docs-resource-type": "EscalationPathV2",
+        "x-rbac-scopes": [
+          "escalation_paths.update"
+        ]
       }
     },
     "/v2/escalations": {
@@ -83340,6 +84775,9 @@
                       },
                       "related_alerts": [
                         {
+                          "alert_group_ids": [
+                            "01GW2G3V0S59R238FAHPDS1R66"
+                          ],
                           "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                           "created_at": "2021-08-17T13:28:57.801578Z",
                           "deduplication_key": "4293868629",
@@ -83387,7 +84825,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Escalations V2",
-        "x-docs-resource-type": "EscalationV2"
+        "x-docs-resource-type": "EscalationV2",
+        "x-rbac-scopes": [
+          "escalations.view"
+        ]
       },
       "post": {
         "description": "Create an escalation.\n\nAn escalation pages people, either according to an escalation path, or directly to\nspecific users. You must provide either an escalation_path_id OR user_ids, but not both.\n\nWhen escalating via an escalation path, the escalation will follow the configured path\nwith its levels and timeouts, using your default [alert\npriority](https://app.incident.io/~/settings/alerts/configuration/priorities).\n\nWhen escalating directly to users, they will receive a high-urgency\nnotification, based on their notification rules.\n\nThis endpoint is rate-limited to 60 requests per minute, since it is intended for\ninteractive use cases (for example someone clicking a \"escalate to team\" button\nin your internal developer platform). To escalate based on automated alerts, we\nrecommend sending events to an alert source instead.\n",
@@ -83469,6 +84910,9 @@
                     },
                     "related_alerts": [
                       {
+                        "alert_group_ids": [
+                          "01GW2G3V0S59R238FAHPDS1R66"
+                        ],
                         "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                         "created_at": "2021-08-17T13:28:57.801578Z",
                         "deduplication_key": "4293868629",
@@ -83511,7 +84955,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Escalations V2",
-        "x-docs-resource-type": "EscalationV2"
+        "x-docs-resource-type": "EscalationV2",
+        "x-rbac-scopes": [
+          "escalations.create"
+        ]
       }
     },
     "/v2/escalations/{id}": {
@@ -83588,6 +85035,9 @@
                     },
                     "related_alerts": [
                       {
+                        "alert_group_ids": [
+                          "01GW2G3V0S59R238FAHPDS1R66"
+                        ],
                         "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                         "created_at": "2021-08-17T13:28:57.801578Z",
                         "deduplication_key": "4293868629",
@@ -83630,7 +85080,45 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Escalations V2",
-        "x-docs-resource-type": "EscalationV2"
+        "x-docs-resource-type": "EscalationV2",
+        "x-rbac-scopes": [
+          "escalations.view"
+        ]
+      }
+    },
+    "/v2/escalations/{id}/actions/cancel": {
+      "post": {
+        "description": "Cancel an escalation.\n\nCancelling an escalation stops any further paging: notifications cease and the\nescalation will not advance to further levels or repeat. This works on escalations\nthat are still paging (for example to silence a page when an incident is resolved\nbefore anyone acknowledges it) as well as snoozed ones. Escalations that have already\nresolved or expired cannot be cancelled, and cancelling an already-cancelled\nescalation is a no-op.\n\nTo use this API, you will need an API key with the \"Create and manage escalations\" permission.",
+        "operationId": "Escalations V2#CancelEscalation",
+        "parameters": [
+          {
+            "description": "Unique ID of the escalation",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Unique ID of the escalation",
+              "example": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK response."
+          }
+        },
+        "summary": "CancelEscalation Escalations V2",
+        "tags": [
+          "Escalations V2"
+        ],
+        "x-docs-display-name": "Cancel",
+        "x-docs-group-name": "Escalations V2",
+        "x-docs-resource-type": "EscalationV2",
+        "x-rbac-scopes": [
+          "escalations.cancel"
+        ]
       }
     },
     "/v2/follow_ups": {
@@ -83761,7 +85249,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Follow-ups V2",
-        "x-docs-resource-type": "FollowUpV2"
+        "x-docs-resource-type": "FollowUpV2",
+        "x-rbac-scopes": [
+          "actions.view"
+        ]
       },
       "post": {
         "description": "Create a new incident follow-up.",
@@ -83867,7 +85358,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Follow-ups V2",
-        "x-docs-resource-type": "FollowUpV2"
+        "x-docs-resource-type": "FollowUpV2",
+        "x-rbac-scopes": [
+          "follow_ups.create"
+        ]
       }
     },
     "/v2/follow_ups/{id}": {
@@ -83899,7 +85393,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Follow-ups V2",
-        "x-docs-resource-type": "FollowUpV2"
+        "x-docs-resource-type": "FollowUpV2",
+        "x-rbac-scopes": [
+          "follow_ups.destroy"
+        ]
       },
       "get": {
         "description": "Get a single incident follow-up.",
@@ -83995,7 +85492,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Follow-ups V2",
-        "x-docs-resource-type": "FollowUpV2"
+        "x-docs-resource-type": "FollowUpV2",
+        "x-rbac-scopes": [
+          "actions.view"
+        ]
       },
       "put": {
         "description": "Update an existing incident follow-up.",
@@ -84114,7 +85614,125 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Follow-ups V2",
-        "x-docs-resource-type": "FollowUpV2"
+        "x-docs-resource-type": "FollowUpV2",
+        "x-rbac-scopes": [
+          "follow_ups.update"
+        ]
+      }
+    },
+    "/v2/follow_ups/{id}/actions/connect_external_issue": {
+      "post": {
+        "description": "Connect a follow-up to an existing issue in an issue tracker, using the URL of the issue.\n\nThis will not work if the follow-up is already connected to an external issue.\n",
+        "operationId": "Follow-ups V2#ConnectExternalIssue",
+        "parameters": [
+          {
+            "description": "Unique identifier for the follow-up",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Unique identifier for the follow-up",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "provider": "linear",
+                "url": "https://linear.app/incident/issue/INC-123"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/FollowUpsConnectExternalIssuePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "follow_up": {
+                    "assignee": {
+                      "email": "lisa@incident.io",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Lisa Karlin Curtis",
+                      "role": "owner",
+                      "slack_user_id": "U02AYNF2XJM"
+                    },
+                    "assignee_team": {
+                      "id": "abc123",
+                      "name": "abc123"
+                    },
+                    "completed_at": "2021-08-17T13:28:57.801578Z",
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "creator": {
+                      "alert": {
+                        "id": "01GW2G3V0S59R238FAHPDS1R66",
+                        "title": "*errors.withMessage: PG::Error failed to connect"
+                      },
+                      "api_key": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My test API key"
+                      },
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "owner",
+                        "slack_user_id": "U02AYNF2XJM"
+                      },
+                      "workflow": {
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "My little workflow"
+                      }
+                    },
+                    "description": "Call the fire brigade",
+                    "external_issue_reference": {
+                      "issue_name": "INC-123",
+                      "issue_permalink": "https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up",
+                      "provider": "asana"
+                    },
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "incident_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "labels": [
+                      "bug",
+                      "urgent"
+                    ],
+                    "priority": {
+                      "description": "A follow-up that requires immediate attention.",
+                      "id": "01GNW4BAQ7XRMFF6FHKNXDFPRW",
+                      "name": "Urgent",
+                      "rank": 10
+                    },
+                    "status": "outstanding",
+                    "title": "Cat is stuck in the tree",
+                    "updated_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/FollowUpsConnectExternalIssueResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ConnectExternalIssue Follow-ups V2",
+        "tags": [
+          "Follow-ups V2"
+        ],
+        "x-docs-display-name": "Connect external issue",
+        "x-docs-group-name": "Follow-ups V2",
+        "x-docs-resource-type": "FollowUpV2",
+        "x-rbac-scopes": [
+          "follow_ups.connect_external_issue"
+        ]
       }
     },
     "/v2/heartbeat/{alert_source_config_id}/ping": {
@@ -84288,6 +85906,9 @@
                   "incident_alerts": [
                     {
                       "alert": {
+                        "alert_group_ids": [
+                          "01GW2G3V0S59R238FAHPDS1R66"
+                        ],
                         "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                         "created_at": "2021-08-17T13:28:57.801578Z",
                         "deduplication_key": "4293868629",
@@ -84331,12 +85952,15 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Alerts V2",
-        "x-docs-resource-type": "IncidentAlertV2"
+        "x-docs-resource-type": "IncidentAlertV2",
+        "x-rbac-scopes": [
+          "alerts.view"
+        ]
       }
     },
     "/v2/incident_participant_workloads": {
       "get": {
-        "description": "\u003e **Early preview.** This endpoint is in early access and its behaviour may change.\n\u003e [Contact us](mailto:support@incident.io) to enable it for your account.\n\nList the participants of an incident with their workload.\n\nWe calculate how much time each participant has spent working on the incident, aggregated\nper participant. Each participant is annotated with their participant type and, if they have\nleft the incident, when they were archived.\n\nWorkload is calculated periodically, so values can lag real time and the most recent period\nmay still be filling. The metadata reports the time the figures are calculated up to.\n\nWorkload for private incidents is only returned to API keys with the\n`incident_workloads.view_private` scope.",
+        "description": "List the participants of an incident with their workload.\n\nWe calculate how much time each participant has spent working on the incident, aggregated\nper participant. Each participant is annotated with their participant type and, if they have\nleft the incident, when they were archived.\n\nWorkload is calculated periodically, so values can lag real time and the most recent period\nmay still be filling. The metadata reports the time the figures are calculated up to.\n\nWorkload for private incidents is only returned to API keys with the\n`incident_workloads.view_private` scope.",
         "operationId": "IncidentParticipantWorkloads V2#List",
         "parameters": [
           {
@@ -84395,7 +86019,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Participant Workloads V2",
-        "x-docs-resource-type": "IncidentParticipantWorkloadV2"
+        "x-docs-resource-type": "IncidentParticipantWorkloadV2",
+        "x-rbac-scopes": [
+          "incident_workloads.view"
+        ]
       }
     },
     "/v2/incident_participants": {
@@ -84463,7 +86090,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Participants V2",
-        "x-docs-resource-type": "IncidentParticipantV2"
+        "x-docs-resource-type": "IncidentParticipantV2",
+        "x-rbac-scopes": [
+          "incidents.view"
+        ]
       }
     },
     "/v2/incident_roles": {
@@ -84502,7 +86132,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Roles V2",
-        "x-docs-resource-type": "IncidentRoleV2"
+        "x-docs-resource-type": "IncidentRoleV2",
+        "x-rbac-scopes": [
+          "incident_roles.view"
+        ]
       },
       "post": {
         "description": "Create a new incident role",
@@ -84553,7 +86186,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Incident Roles V2",
-        "x-docs-resource-type": "IncidentRoleV2"
+        "x-docs-resource-type": "IncidentRoleV2",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v2/incident_roles/{id}": {
@@ -84585,7 +86221,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Incident Roles V2",
-        "x-docs-resource-type": "IncidentRoleV2"
+        "x-docs-resource-type": "IncidentRoleV2",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       },
       "get": {
         "description": "Get a single incident role.",
@@ -84634,7 +86273,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Incident Roles V2",
-        "x-docs-resource-type": "IncidentRoleV2"
+        "x-docs-resource-type": "IncidentRoleV2",
+        "x-rbac-scopes": [
+          "incident_roles.view"
+        ]
       },
       "put": {
         "description": "Update an existing incident role",
@@ -84699,7 +86341,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Incident Roles V2",
-        "x-docs-resource-type": "IncidentRoleV2"
+        "x-docs-resource-type": "IncidentRoleV2",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v2/incident_timestamps": {
@@ -84898,7 +86543,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incident Updates V2",
-        "x-docs-resource-type": "IncidentUpdateV2"
+        "x-docs-resource-type": "IncidentUpdateV2",
+        "x-rbac-scopes": [
+          "incidents.view"
+        ]
       }
     },
     "/v2/incidents": {
@@ -85457,7 +87105,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Incidents V2",
-        "x-docs-resource-type": "IncidentV2"
+        "x-docs-resource-type": "IncidentV2",
+        "x-rbac-scopes": [
+          "incidents.view"
+        ]
       },
       "post": {
         "description": "Create a new incident.\n\nNote that if the incident mode is set to \"retrospective\" then the new incident\nwill not be announced in Slack.\n",
@@ -85701,7 +87352,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Incidents V2",
-        "x-docs-resource-type": "IncidentV2"
+        "x-docs-resource-type": "IncidentV2",
+        "x-rbac-scopes": [
+          "incidents.create"
+        ]
       }
     },
     "/v2/incidents/{id}": {
@@ -85902,7 +87556,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Incidents V2",
-        "x-docs-resource-type": "IncidentV2"
+        "x-docs-resource-type": "IncidentV2",
+        "x-rbac-scopes": [
+          "incidents.view"
+        ]
       }
     },
     "/v2/incidents/{id}/actions/edit": {
@@ -86245,7 +87902,10 @@
         ],
         "x-docs-display-name": "Import postmortem document",
         "x-docs-group-name": "Incidents V2",
-        "x-docs-resource-type": "IncidentV2"
+        "x-docs-resource-type": "IncidentV2",
+        "x-rbac-scopes": [
+          "in_app_postmortems.import"
+        ]
       }
     },
     "/v2/managed_resources": {
@@ -86423,7 +88083,10 @@
         "x-display-name": "List",
         "x-docs-display-name": "List",
         "x-docs-group-name": "Schedule Entries V2",
-        "x-docs-resource-type": "ScheduleEntryV2"
+        "x-docs-resource-type": "ScheduleEntryV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       }
     },
     "/v2/schedule_overrides": {
@@ -86490,7 +88153,10 @@
         "x-display-name": "Create",
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Schedule Overrides V2",
-        "x-docs-resource-type": "ScheduleOverrideV2"
+        "x-docs-resource-type": "ScheduleOverrideV2",
+        "x-rbac-scopes": [
+          "schedule_overrides.create"
+        ]
       }
     },
     "/v2/schedule_sync_targets": {
@@ -86575,7 +88241,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Schedule Sync Targets V2",
-        "x-docs-resource-type": "ScheduleSyncTargetResourceV2"
+        "x-docs-resource-type": "ScheduleSyncTargetResourceV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       },
       "post": {
         "description": "Create a new schedule sync target for a Slack user group.",
@@ -86642,7 +88311,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Schedule Sync Targets V2",
-        "x-docs-resource-type": "ScheduleSyncTargetResourceV2"
+        "x-docs-resource-type": "ScheduleSyncTargetResourceV2",
+        "x-rbac-scopes": [
+          "schedule_sync_targets.create"
+        ]
       }
     },
     "/v2/schedule_sync_targets/{id}": {
@@ -86674,7 +88346,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Schedule Sync Targets V2",
-        "x-docs-resource-type": "ScheduleSyncTargetResourceV2"
+        "x-docs-resource-type": "ScheduleSyncTargetResourceV2",
+        "x-rbac-scopes": [
+          "schedule_sync_targets.destroy"
+        ]
       },
       "get": {
         "description": "Get a single schedule sync target.",
@@ -86730,7 +88405,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Schedule Sync Targets V2",
-        "x-docs-resource-type": "ScheduleSyncTargetResourceV2"
+        "x-docs-resource-type": "ScheduleSyncTargetResourceV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       },
       "put": {
         "description": "Update the add_bot_to_group flag on a sync target. The change propagates to every schedule with an active sync rule pointing at this target; the entire operation aborts if the caller lacks edit permission on any of those schedules.",
@@ -86802,7 +88480,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Schedule Sync Targets V2",
-        "x-docs-resource-type": "ScheduleSyncTargetResourceV2"
+        "x-docs-resource-type": "ScheduleSyncTargetResourceV2",
+        "x-rbac-scopes": [
+          "schedule_sync_targets.update"
+        ]
       }
     },
     "/v2/schedules": {
@@ -86969,7 +88650,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Schedules V2",
-        "x-docs-resource-type": "ScheduleV2"
+        "x-docs-resource-type": "ScheduleV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       },
       "post": {
         "description": "Create a new schedule.",
@@ -87164,7 +88848,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Schedules V2",
-        "x-docs-resource-type": "ScheduleV2"
+        "x-docs-resource-type": "ScheduleV2",
+        "x-rbac-scopes": [
+          "schedules.create"
+        ]
       }
     },
     "/v2/schedules/{id}": {
@@ -87196,7 +88883,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Schedules V2",
-        "x-docs-resource-type": "ScheduleV2"
+        "x-docs-resource-type": "ScheduleV2",
+        "x-rbac-scopes": [
+          "schedules.destroy"
+        ]
       },
       "get": {
         "description": "Get a single schedule.",
@@ -87334,7 +89024,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Schedules V2",
-        "x-docs-resource-type": "ScheduleV2"
+        "x-docs-resource-type": "ScheduleV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       },
       "put": {
         "description": "Update a schedule.\n\nUpdating a schedule replaces its entire configuration with the one you send,\nincluding any scheduled future versions of its rotations — fetch the schedule\nfirst and include every version you want to keep.\n\nTo change who's in a rotation from a future date without affecting shifts\nbefore then, keep the current version unchanged and add another version of the\nsame rotation with `effective_from` set to when the change should land —\nideally an upcoming handover, so nobody is swapped mid-shift. You can check the\neffect of any configuration before saving it with Preview schedule entries.",
@@ -87543,7 +89236,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Schedules V2",
-        "x-docs-resource-type": "ScheduleV2"
+        "x-docs-resource-type": "ScheduleV2",
+        "x-rbac-scopes": [
+          "schedules.update"
+        ]
       }
     },
     "/v2/schedules/{id}/actions/preview_entries": {
@@ -87710,7 +89406,10 @@
         ],
         "x-docs-display-name": "Preview",
         "x-docs-group-name": "Schedule Entries V2",
-        "x-docs-resource-type": "ScheduleEntryV2"
+        "x-docs-resource-type": "ScheduleEntryV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       }
     },
     "/v2/schedules/{schedule_id}/replicas": {
@@ -87778,7 +89477,10 @@
         "x-display-name": "List",
         "x-docs-display-name": "List",
         "x-docs-group-name": "Schedule Replicas V2",
-        "x-docs-resource-type": "ScheduleReplicaV2"
+        "x-docs-resource-type": "ScheduleReplicaV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       },
       "post": {
         "description": "Create a new schedule replica.",
@@ -87866,7 +89568,10 @@
         "x-display-name": "Create",
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Schedule Replicas V2",
-        "x-docs-resource-type": "ScheduleReplicaV2"
+        "x-docs-resource-type": "ScheduleReplicaV2",
+        "x-rbac-scopes": [
+          "schedules.update"
+        ]
       }
     },
     "/v2/schedules/{schedule_id}/replicas/{id}": {
@@ -87911,7 +89616,10 @@
         "x-display-name": "Destroy",
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Schedule Replicas V2",
-        "x-docs-resource-type": "ScheduleReplicaV2"
+        "x-docs-resource-type": "ScheduleReplicaV2",
+        "x-rbac-scopes": [
+          "schedules.update"
+        ]
       },
       "get": {
         "description": "Get a single schedule replica.",
@@ -87987,7 +89695,10 @@
         "x-display-name": "Show",
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Schedule Replicas V2",
-        "x-docs-resource-type": "ScheduleReplicaV2"
+        "x-docs-resource-type": "ScheduleReplicaV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       }
     },
     "/v2/schedules/{schedule_id}/sync_rules": {
@@ -88093,7 +89804,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Schedule Sync Rules V2",
-        "x-docs-resource-type": "ScheduleSyncRuleV2"
+        "x-docs-resource-type": "ScheduleSyncRuleV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       },
       "post": {
         "description": "Create a new sync rule linking a schedule to a sync target.",
@@ -88178,7 +89892,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Schedule Sync Rules V2",
-        "x-docs-resource-type": "ScheduleSyncRuleV2"
+        "x-docs-resource-type": "ScheduleSyncRuleV2",
+        "x-rbac-scopes": [
+          "schedule_sync_rules.create"
+        ]
       }
     },
     "/v2/schedules/{schedule_id}/sync_rules/{id}": {
@@ -88222,7 +89939,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Schedule Sync Rules V2",
-        "x-docs-resource-type": "ScheduleSyncRuleV2"
+        "x-docs-resource-type": "ScheduleSyncRuleV2",
+        "x-rbac-scopes": [
+          "schedule_sync_rules.destroy"
+        ]
       },
       "get": {
         "description": "Get a single sync rule for a schedule.",
@@ -88299,7 +90019,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Schedule Sync Rules V2",
-        "x-docs-resource-type": "ScheduleSyncRuleV2"
+        "x-docs-resource-type": "ScheduleSyncRuleV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
       },
       "put": {
         "description": "Update a sync rule's sync_type in place. If the rule's sync target is shared with other schedules, the change propagates to every linked schedule and the entire operation aborts if the caller lacks edit permission on any of them.",
@@ -88392,7 +90115,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Schedule Sync Rules V2",
-        "x-docs-resource-type": "ScheduleSyncRuleV2"
+        "x-docs-resource-type": "ScheduleSyncRuleV2",
+        "x-rbac-scopes": [
+          "schedule_sync_rules.update"
+        ]
       }
     },
     "/v2/status_page_incident_updates": {
@@ -88455,7 +90181,10 @@
         "x-display-name": "Create",
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Status Page Incident Updates V2",
-        "x-docs-resource-type": "StatusPageIncidentUpdateV2"
+        "x-docs-resource-type": "StatusPageIncidentUpdateV2",
+        "x-rbac-scopes": [
+          "status_pages.publish_updates"
+        ]
       }
     },
     "/v2/status_page_incidents": {
@@ -88703,7 +90432,10 @@
         "x-display-name": "Create",
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Status Page Incidents V2",
-        "x-docs-resource-type": "StatusPageIncidentV2"
+        "x-docs-resource-type": "StatusPageIncidentV2",
+        "x-rbac-scopes": [
+          "status_pages.publish_updates"
+        ]
       }
     },
     "/v2/status_page_incidents/{status_page_incident_id}": {
@@ -88858,7 +90590,10 @@
         "x-display-name": "Update",
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Status Page Incidents V2",
-        "x-docs-resource-type": "StatusPageIncidentV2"
+        "x-docs-resource-type": "StatusPageIncidentV2",
+        "x-rbac-scopes": [
+          "status_pages.publish_updates"
+        ]
       }
     },
     "/v2/status_page_maintenance_updates": {
@@ -88921,7 +90656,10 @@
         "x-display-name": "Create",
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Status Page Maintenance Updates V2",
-        "x-docs-resource-type": "StatusPageMaintenanceUpdateV2"
+        "x-docs-resource-type": "StatusPageMaintenanceUpdateV2",
+        "x-rbac-scopes": [
+          "status_pages.publish_updates"
+        ]
       }
     },
     "/v2/status_page_maintenances": {
@@ -89166,7 +90904,10 @@
         "x-display-name": "Create",
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Status Page Maintenances V2",
-        "x-docs-resource-type": "StatusPageMaintenanceV2"
+        "x-docs-resource-type": "StatusPageMaintenanceV2",
+        "x-rbac-scopes": [
+          "status_pages.publish_updates"
+        ]
       }
     },
     "/v2/status_page_maintenances/{status_page_maintenance_id}": {
@@ -89463,7 +91204,10 @@
         "x-display-name": "Update",
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Telemetry V2",
-        "x-docs-resource-type": "TelemetryDataSourceV2"
+        "x-docs-resource-type": "TelemetryDataSourceV2",
+        "x-rbac-scopes": [
+          "organisation_settings.update"
+        ]
       }
     },
     "/v2/users": {
@@ -89574,7 +91318,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Users V2",
-        "x-docs-resource-type": "UserWithRolesV2"
+        "x-docs-resource-type": "UserWithRolesV2",
+        "x-rbac-scopes": [
+          "users.view"
+        ]
       }
     },
     "/v2/users/{id}": {
@@ -89640,12 +91387,15 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Users V2",
-        "x-docs-resource-type": "UserWithRolesV2"
+        "x-docs-resource-type": "UserWithRolesV2",
+        "x-rbac-scopes": [
+          "users.view"
+        ]
       }
     },
     "/v2/users/{user_id}/notification_methods": {
       "get": {
-        "description": "List notification methods for a user. Phone numbers are always partially redacted.",
+        "description": "List notification methods for a user. Phone numbers are partially redacted unless the API key holds the notification_methods.view_unredacted scope.",
         "operationId": "Users V2#ListNotificationMethods",
         "parameters": [
           {
@@ -89694,7 +91444,10 @@
         "x-display-name": "List",
         "x-docs-display-name": "List",
         "x-docs-group-name": "Notification Methods V2",
-        "x-docs-resource-type": "OnCallNotificationMethodPublicV2"
+        "x-docs-resource-type": "OnCallNotificationMethodPublicV2",
+        "x-rbac-scopes": [
+          "notification_methods.view"
+        ]
       }
     },
     "/v2/users/{user_id}/notification_rules": {
@@ -89757,7 +91510,10 @@
         "x-display-name": "List",
         "x-docs-display-name": "List",
         "x-docs-group-name": "Notification Rules V2",
-        "x-docs-resource-type": "OnCallNotificationRulePublicV2"
+        "x-docs-resource-type": "OnCallNotificationRulePublicV2",
+        "x-rbac-scopes": [
+          "notification_rules.view"
+        ]
       }
     },
     "/v2/users/{user_id}/paging_provider": {
@@ -89797,7 +91553,10 @@
         "tags": [
           "Users V2"
         ],
-        "x-docs-group-name": "Users V2"
+        "x-docs-group-name": "Users V2",
+        "x-rbac-scopes": [
+          "user_preferences.view"
+        ]
       },
       "post": {
         "description": "Update a user's preferred paging provider.",
@@ -89838,7 +91597,10 @@
         "tags": [
           "Users V2"
         ],
-        "x-docs-group-name": "Users V2"
+        "x-docs-group-name": "Users V2",
+        "x-rbac-scopes": [
+          "users.preferred_paging_provider.edit"
+        ]
       }
     },
     "/v2/users/{user_id}/policies/{policy_id}/open": {
@@ -89889,6 +91651,9 @@
         "summary": "HasOpenForUser Policies V2",
         "tags": [
           "Policies V2"
+        ],
+        "x-rbac-scopes": [
+          "users.view"
         ]
       }
     },
@@ -90090,6 +91855,10 @@
                           "type": "IncidentSeverity"
                         }
                       ],
+                      "owning_team_ids": [
+                        "01G0J1EXE7AXZ2C93K61WBPYEH"
+                      ],
+                      "private_incident_scope": "owning_teams",
                       "runs_from": "2021-08-17T13:28:57.801578Z",
                       "runs_on_incident_modes": [
                         "standard",
@@ -90128,7 +91897,10 @@
         "x-display-name": "List",
         "x-docs-display-name": "List",
         "x-docs-group-name": "Workflows V2",
-        "x-docs-resource-type": "WorkflowV2"
+        "x-docs-resource-type": "WorkflowV2",
+        "x-rbac-scopes": [
+          "workflows.view"
+        ]
       },
       "post": {
         "description": "Create a new workflow",
@@ -90287,12 +92059,27 @@
                   }
                 ],
                 "folder": "My folder 01",
+                "form_fields": [
+                  {
+                    "array": true,
+                    "description": "The customer affected by this incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "key": "affected_customer",
+                    "required": true,
+                    "title": "Affected customer",
+                    "type": "User"
+                  }
+                ],
                 "include_private_escalations": true,
                 "include_private_incidents": true,
                 "name": "My little workflow",
                 "once_for": [
                   "incident.url"
                 ],
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
+                "private_incident_scope": "owning_teams",
                 "runs_on_incident_modes": [
                   "standard",
                   "test",
@@ -90519,6 +92306,17 @@
                       }
                     ],
                     "folder": "My folder 01",
+                    "form_fields": [
+                      {
+                        "array": true,
+                        "description": "The customer affected by this incident",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "key": "affected_customer",
+                        "required": true,
+                        "title": "Affected customer",
+                        "type": "User"
+                      }
+                    ],
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "include_private_escalations": true,
                     "include_private_incidents": true,
@@ -90531,6 +92329,10 @@
                         "type": "IncidentSeverity"
                       }
                     ],
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
+                    "private_incident_scope": "owning_teams",
                     "runs_from": "2021-08-17T13:28:57.801578Z",
                     "runs_on_incident_modes": [
                       "standard",
@@ -90586,7 +92388,10 @@
         "x-display-name": "Create",
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Workflows V2",
-        "x-docs-resource-type": "WorkflowV2"
+        "x-docs-resource-type": "WorkflowV2",
+        "x-rbac-scopes": [
+          "workflows.create"
+        ]
       }
     },
     "/v2/workflows/{id}": {
@@ -90619,7 +92424,10 @@
         "x-display-name": "Destroy",
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Workflows V2",
-        "x-docs-resource-type": "WorkflowV2"
+        "x-docs-resource-type": "WorkflowV2",
+        "x-rbac-scopes": [
+          "workflows.destroy"
+        ]
       },
       "get": {
         "description": "Show a workflow by ID",
@@ -90838,6 +92646,17 @@
                       }
                     ],
                     "folder": "My folder 01",
+                    "form_fields": [
+                      {
+                        "array": true,
+                        "description": "The customer affected by this incident",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "key": "affected_customer",
+                        "required": true,
+                        "title": "Affected customer",
+                        "type": "User"
+                      }
+                    ],
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "include_private_escalations": true,
                     "include_private_incidents": true,
@@ -90850,6 +92669,10 @@
                         "type": "IncidentSeverity"
                       }
                     ],
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
+                    "private_incident_scope": "owning_teams",
                     "runs_from": "2021-08-17T13:28:57.801578Z",
                     "runs_on_incident_modes": [
                       "standard",
@@ -90905,7 +92728,10 @@
         "x-display-name": "Show",
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Workflows V2",
-        "x-docs-resource-type": "WorkflowV2"
+        "x-docs-resource-type": "WorkflowV2",
+        "x-rbac-scopes": [
+          "workflows.view"
+        ]
       },
       "put": {
         "description": "Updates a workflow",
@@ -91083,12 +92909,27 @@
                   }
                 ],
                 "folder": "My folder 01",
+                "form_fields": [
+                  {
+                    "array": true,
+                    "description": "The customer affected by this incident",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "key": "affected_customer",
+                    "required": true,
+                    "title": "Affected customer",
+                    "type": "User"
+                  }
+                ],
                 "include_private_escalations": true,
                 "include_private_incidents": true,
                 "name": "My little workflow",
                 "once_for": [
                   "incident.url"
                 ],
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
+                "private_incident_scope": "owning_teams",
                 "runs_on_incident_modes": [
                   "standard",
                   "test",
@@ -91315,6 +93156,17 @@
                       }
                     ],
                     "folder": "My folder 01",
+                    "form_fields": [
+                      {
+                        "array": true,
+                        "description": "The customer affected by this incident",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "key": "affected_customer",
+                        "required": true,
+                        "title": "Affected customer",
+                        "type": "User"
+                      }
+                    ],
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                     "include_private_escalations": true,
                     "include_private_incidents": true,
@@ -91327,6 +93179,10 @@
                         "type": "IncidentSeverity"
                       }
                     ],
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
+                    "private_incident_scope": "owning_teams",
                     "runs_from": "2021-08-17T13:28:57.801578Z",
                     "runs_on_incident_modes": [
                       "standard",
@@ -91382,7 +93238,10 @@
         "x-display-name": "Update",
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Workflows V2",
-        "x-docs-resource-type": "WorkflowV2"
+        "x-docs-resource-type": "WorkflowV2",
+        "x-rbac-scopes": [
+          "workflows.update"
+        ]
       }
     },
     "/v3/alert_routes": {
@@ -91450,7 +93309,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Alert Routes V3",
-        "x-docs-resource-type": "AlertRouteV3"
+        "x-docs-resource-type": "AlertRouteV3",
+        "x-rbac-scopes": [
+          "alert_routes.view"
+        ]
       },
       "post": {
         "description": "Create a new alert route in your account.",
@@ -92389,7 +94251,10 @@
         ],
         "x-docs-display-name": "Create",
         "x-docs-group-name": "Alert Routes V3",
-        "x-docs-resource-type": "AlertRouteV3"
+        "x-docs-resource-type": "AlertRouteV3",
+        "x-rbac-scopes": [
+          "alert_route.create"
+        ]
       }
     },
     "/v3/alert_routes/{id}": {
@@ -92421,7 +94286,10 @@
         ],
         "x-docs-display-name": "Delete",
         "x-docs-group-name": "Alert Routes V3",
-        "x-docs-resource-type": "AlertRouteV3"
+        "x-docs-resource-type": "AlertRouteV3",
+        "x-rbac-scopes": [
+          "alert_route.destroy"
+        ]
       },
       "get": {
         "description": "Load details about a specific alert route in your account.",
@@ -92932,7 +94800,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Alert Routes V3",
-        "x-docs-resource-type": "AlertRouteV3"
+        "x-docs-resource-type": "AlertRouteV3",
+        "x-rbac-scopes": [
+          "alert_routes.view"
+        ]
       },
       "put": {
         "description": "Update an existing alert route in your account.",
@@ -93886,7 +95757,10 @@
         ],
         "x-docs-display-name": "Update",
         "x-docs-group-name": "Alert Routes V3",
-        "x-docs-resource-type": "AlertRouteV3"
+        "x-docs-resource-type": "AlertRouteV3",
+        "x-rbac-scopes": [
+          "alert_route.update"
+        ]
       }
     },
     "/v3/catalog_entries": {
@@ -94060,7 +95934,10 @@
         ],
         "x-docs-display-name": "List Entries",
         "x-docs-group-name": "Catalog Entries V3",
-        "x-docs-resource-type": "CatalogEntryV3"
+        "x-docs-resource-type": "CatalogEntryV3",
+        "x-rbac-scopes": [
+          "catalog_entries.view"
+        ]
       },
       "post": {
         "description": "Create an entry within the catalog. We support a maximum of 50,000 entries per type.\n\nIf you call this API with a payload where the external_id and catalog_type_id match an existing entry, the existing entry will be updated.",
@@ -94145,7 +96022,10 @@
         ],
         "x-docs-display-name": "Create Entry",
         "x-docs-group-name": "Catalog Entries V3",
-        "x-docs-resource-type": "CatalogEntryV3"
+        "x-docs-resource-type": "CatalogEntryV3",
+        "x-rbac-scopes": [
+          "catalog_entries.create"
+        ]
       }
     },
     "/v3/catalog_entries/actions/bulk_update": {
@@ -94224,7 +96104,10 @@
         ],
         "x-docs-display-name": "Bulk Update Entries",
         "x-docs-group-name": "Catalog Entries V3",
-        "x-docs-resource-type": "CatalogEntryV3"
+        "x-docs-resource-type": "CatalogEntryV3",
+        "x-rbac-scopes": [
+          "catalog_entries.edit"
+        ]
       }
     },
     "/v3/catalog_entries/{id}": {
@@ -94256,7 +96139,10 @@
         ],
         "x-docs-display-name": "Delete Entry",
         "x-docs-group-name": "Catalog Entries V3",
-        "x-docs-resource-type": "CatalogEntryV3"
+        "x-docs-resource-type": "CatalogEntryV3",
+        "x-rbac-scopes": [
+          "catalog_entries.destroy"
+        ]
       },
       "get": {
         "description": "Show a single catalog entry.",
@@ -94382,7 +96268,10 @@
         ],
         "x-docs-display-name": "Show Entry",
         "x-docs-group-name": "Catalog Entries V3",
-        "x-docs-resource-type": "CatalogEntryV3"
+        "x-docs-resource-type": "CatalogEntryV3",
+        "x-rbac-scopes": [
+          "catalog_entries.view"
+        ]
       },
       "put": {
         "description": "Updates an existing catalog entry.",
@@ -94530,7 +96419,10 @@
         ],
         "x-docs-display-name": "Update Entry",
         "x-docs-group-name": "Catalog Entries V3",
-        "x-docs-resource-type": "CatalogEntryV3"
+        "x-docs-resource-type": "CatalogEntryV3",
+        "x-rbac-scopes": [
+          "catalog_entries.edit"
+        ]
       }
     },
     "/v3/catalog_resources": {
@@ -94566,7 +96458,10 @@
         ],
         "x-docs-display-name": "List Resources",
         "x-docs-group-name": "Catalog Resources V3",
-        "x-docs-resource-type": "CatalogResourceV3"
+        "x-docs-resource-type": "CatalogResourceV3",
+        "x-rbac-scopes": [
+          "catalog_types.view"
+        ]
       }
     },
     "/v3/catalog_types": {
@@ -94642,7 +96537,10 @@
         ],
         "x-docs-display-name": "List Types",
         "x-docs-group-name": "Catalog Types V3",
-        "x-docs-resource-type": "CatalogTypeV3"
+        "x-docs-resource-type": "CatalogTypeV3",
+        "x-rbac-scopes": [
+          "catalog_types.view"
+        ]
       },
       "post": {
         "description": "Create a catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
@@ -94740,7 +96638,10 @@
         ],
         "x-docs-display-name": "Create Type",
         "x-docs-group-name": "Catalog Types V3",
-        "x-docs-resource-type": "CatalogTypeV3"
+        "x-docs-resource-type": "CatalogTypeV3",
+        "x-rbac-scopes": [
+          "catalog_types.create"
+        ]
       }
     },
     "/v3/catalog_types/{id}": {
@@ -94772,7 +96673,10 @@
         ],
         "x-docs-display-name": "Delete Type",
         "x-docs-group-name": "Catalog Types V3",
-        "x-docs-resource-type": "CatalogTypeV3"
+        "x-docs-resource-type": "CatalogTypeV3",
+        "x-rbac-scopes": [
+          "catalog_types.destroy"
+        ]
       },
       "get": {
         "description": "Show a single catalog type.",
@@ -94858,7 +96762,10 @@
         ],
         "x-docs-display-name": "Show Type",
         "x-docs-group-name": "Catalog Types V3",
-        "x-docs-resource-type": "CatalogTypeV3"
+        "x-docs-resource-type": "CatalogTypeV3",
+        "x-rbac-scopes": [
+          "catalog_types.view"
+        ]
       },
       "put": {
         "description": "Updates an existing catalog type. The schema must be updated using the UpdateTypeSchema endpoint.",
@@ -94969,7 +96876,10 @@
         ],
         "x-docs-display-name": "Update Type",
         "x-docs-group-name": "Catalog Types V3",
-        "x-docs-resource-type": "CatalogTypeV3"
+        "x-docs-resource-type": "CatalogTypeV3",
+        "x-rbac-scopes": [
+          "catalog_types.edit"
+        ]
       }
     },
     "/v3/catalog_types/{id}/actions/update_schema": {
@@ -95085,7 +96995,10 @@
         ],
         "x-docs-display-name": "Update Type Schema",
         "x-docs-group-name": "Catalog Types V3",
-        "x-docs-resource-type": "CatalogTypeV3"
+        "x-docs-resource-type": "CatalogTypeV3",
+        "x-rbac-scopes": [
+          "catalog_types.edit"
+        ]
       }
     },
     "/v3/teams": {
@@ -95164,7 +97077,10 @@
         ],
         "x-docs-display-name": "List",
         "x-docs-group-name": "Teams V3",
-        "x-docs-resource-type": "TeamV3"
+        "x-docs-resource-type": "TeamV3",
+        "x-rbac-scopes": [
+          "catalog_entries.view"
+        ]
       }
     },
     "/v3/teams/{id}": {
@@ -95222,7 +97138,10 @@
         ],
         "x-docs-display-name": "Show",
         "x-docs-group-name": "Teams V3",
-        "x-docs-resource-type": "TeamV3"
+        "x-docs-resource-type": "TeamV3",
+        "x-rbac-scopes": [
+          "catalog_entries.view"
+        ]
       }
     }
   },
@@ -96155,6 +98074,290 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsAlertSourceConfigUpdatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/announcement_post_template.created.1": {
+      "get": {
+        "description": "This entry is created whenever an announcement post template is created",
+        "operationId": "AnnouncementPostTemplateCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "announcement_post_template.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Major incident",
+                      "type": "announcement_post_template"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAnnouncementPostTemplateCreatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/announcement_post_template.created.2": {
+      "get": {
+        "description": "This entry is created whenever an announcement post template is created",
+        "operationId": "AnnouncementPostTemplateCreatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "announcement_post_template.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+                    "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Major incident",
+                      "type": "announcement_post_template"
+                    }
+                  ],
+                  "version": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAnnouncementPostTemplateCreatedV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/announcement_post_template.deleted.1": {
+      "get": {
+        "description": "This entry is created whenever an announcement post template is deleted",
+        "operationId": "AnnouncementPostTemplateDeletedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "announcement_post_template.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Major incident",
+                      "type": "announcement_post_template"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAnnouncementPostTemplateDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/announcement_post_template.set_as_default.1": {
+      "get": {
+        "description": "This entry is created whenever an announcement post template is set as the default",
+        "operationId": "AnnouncementPostTemplateSetAsDefaultV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "announcement_post_template.set_as_default",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Major incident",
+                      "type": "announcement_post_template"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAnnouncementPostTemplateSetAsDefaultV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/announcement_post_template.updated.1": {
+      "get": {
+        "description": "This entry is created whenever an announcement post template is updated",
+        "operationId": "AnnouncementPostTemplateUpdatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "announcement_post_template.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Major incident",
+                      "type": "announcement_post_template"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAnnouncementPostTemplateUpdatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/announcement_post_template.updated.2": {
+      "get": {
+        "description": "This entry is created whenever an announcement post template is updated",
+        "operationId": "AnnouncementPostTemplateUpdatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "announcement_post_template.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+                    "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Major incident",
+                      "type": "announcement_post_template"
+                    }
+                  ],
+                  "version": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAnnouncementPostTemplateUpdatedV2"
                 }
               }
             },
@@ -103953,6 +106156,9 @@
                 "example": {
                   "event_type": "public_alert.alert_created_v1",
                   "public_alert.alert_created_v1": {
+                    "alert_group_ids": [
+                      "01GW2G3V0S59R238FAHPDS1R66"
+                    ],
                     "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                     "attributes": [
                       {
@@ -104021,6 +106227,9 @@
                 "example": {
                   "event_type": "public_alert.alert_resolved_v1",
                   "public_alert.alert_resolved_v1": {
+                    "alert_group_ids": [
+                      "01GW2G3V0S59R238FAHPDS1R66"
+                    ],
                     "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                     "attributes": [
                       {
@@ -104139,6 +106348,9 @@
                     },
                     "related_alerts": [
                       {
+                        "alert_group_ids": [
+                          "01GW2G3V0S59R238FAHPDS1R66"
+                        ],
                         "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                         "created_at": "2021-08-17T13:28:57.801578Z",
                         "deduplication_key": "4293868629",
@@ -104263,6 +106475,9 @@
                       },
                       "related_alerts": [
                         {
+                          "alert_group_ids": [
+                            "01GW2G3V0S59R238FAHPDS1R66"
+                          ],
                           "alert_source_id": "01GW2G3V0S59R238FAHPDS1R66",
                           "created_at": "2021-08-17T13:28:57.801578Z",
                           "deduplication_key": "4293868629",

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -67346,9 +67346,19 @@
             "type": "array"
           },
           "include_private_incidents": {
-            "description": "Whether to include private incidents",
+            "description": "DEPRECATED: use `private_incident_scope` instead. `true` when the workflow runs on private incidents (a `private_incident_scope` of `all` or `owning_teams`), `false` when the scope is `none`.",
             "example": true,
             "type": "boolean"
+          },
+          "private_incident_scope": {
+            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
+            "enum": [
+              "all",
+              "owning_teams",
+              "none"
+            ],
+            "example": "owning_teams",
+            "type": "string"
           },
           "name": {
             "description": "Name provided by the user when creating the workflow",
@@ -67458,7 +67468,8 @@
           "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents",
-          "state"
+          "state",
+          "private_incident_scope"
         ],
         "type": "object"
       },
@@ -67909,9 +67920,19 @@
             "type": "array"
           },
           "include_private_incidents": {
-            "description": "Whether to include private incidents",
+            "description": "DEPRECATED: use `private_incident_scope` instead. `true` when the workflow runs on private incidents (a `private_incident_scope` of `all` or `owning_teams`), `false` when the scope is `none`.",
             "example": true,
             "type": "boolean"
+          },
+          "private_incident_scope": {
+            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
+            "enum": [
+              "all",
+              "owning_teams",
+              "none"
+            ],
+            "example": "owning_teams",
+            "type": "string"
           },
           "name": {
             "description": "Name provided by the user when creating the workflow",
@@ -68039,7 +68060,8 @@
           "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents",
-          "state"
+          "state",
+          "private_incident_scope"
         ],
         "type": "object"
       },
@@ -68429,9 +68451,19 @@
             "type": "array"
           },
           "include_private_incidents": {
-            "description": "Whether to include private incidents",
+            "description": "DEPRECATED: use `private_incident_scope` instead. Mutually exclusive with `private_incident_scope` — sending both returns a validation error.",
             "example": true,
             "type": "boolean"
+          },
+          "private_incident_scope": {
+            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
+            "enum": [
+              "all",
+              "owning_teams",
+              "none"
+            ],
+            "example": "owning_teams",
+            "type": "string"
           },
           "name": {
             "description": "Name provided by the user when creating the workflow",
@@ -68533,7 +68565,6 @@
           "condition_groups",
           "steps",
           "expressions",
-          "include_private_incidents",
           "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents"
@@ -69866,9 +69897,19 @@
             "type": "array"
           },
           "include_private_incidents": {
-            "description": "Whether to include private incidents",
+            "description": "DEPRECATED: use `private_incident_scope` instead. Mutually exclusive with `private_incident_scope` — sending both returns a validation error.",
             "example": true,
             "type": "boolean"
+          },
+          "private_incident_scope": {
+            "description": "Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none",
+            "enum": [
+              "all",
+              "owning_teams",
+              "none"
+            ],
+            "example": "owning_teams",
+            "type": "string"
           },
           "name": {
             "description": "Name provided by the user when creating the workflow",
@@ -69969,7 +70010,6 @@
           "condition_groups",
           "steps",
           "expressions",
-          "include_private_incidents",
           "runs_on_incident_modes",
           "continue_on_step_error",
           "runs_on_incidents"

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -20,32 +20,35 @@ import (
 
 // Defines values for APIKeyRoleV1Name.
 const (
-	APIKeyRoleV1NameActOnBehalfOfUsers            APIKeyRoleV1Name = "act_on_behalf_of_users"
-	APIKeyRoleV1NameApiKeysManage                 APIKeyRoleV1Name = "api_keys_manage"
-	APIKeyRoleV1NameCatalogEditor                 APIKeyRoleV1Name = "catalog_editor"
-	APIKeyRoleV1NameCatalogViewer                 APIKeyRoleV1Name = "catalog_viewer"
-	APIKeyRoleV1NameEscalationCreator             APIKeyRoleV1Name = "escalation_creator"
-	APIKeyRoleV1NameGlobalAccess                  APIKeyRoleV1Name = "global_access"
-	APIKeyRoleV1NameIncidentCreator               APIKeyRoleV1Name = "incident_creator"
-	APIKeyRoleV1NameIncidentEditor                APIKeyRoleV1Name = "incident_editor"
-	APIKeyRoleV1NameIncidentMembershipsEditor     APIKeyRoleV1Name = "incident_memberships_editor"
-	APIKeyRoleV1NameIncidentWorkloadPrivateViewer APIKeyRoleV1Name = "incident_workload_private_viewer"
-	APIKeyRoleV1NameIncidentWorkloadViewer        APIKeyRoleV1Name = "incident_workload_viewer"
-	APIKeyRoleV1NameInvestigationDownload         APIKeyRoleV1Name = "investigation_download"
-	APIKeyRoleV1NameManageSettings                APIKeyRoleV1Name = "manage_settings"
-	APIKeyRoleV1NameNotificationMethodsManage     APIKeyRoleV1Name = "notification_methods_manage"
-	APIKeyRoleV1NameOnCallEditor                  APIKeyRoleV1Name = "on_call_editor"
-	APIKeyRoleV1NamePostIncidentFlowOptOut        APIKeyRoleV1Name = "post_incident_flow_opt_out"
-	APIKeyRoleV1NamePostmortemsManage             APIKeyRoleV1Name = "postmortems_manage"
-	APIKeyRoleV1NamePrivateWorkflowsEditor        APIKeyRoleV1Name = "private_workflows_editor"
-	APIKeyRoleV1NameScheduleOverridesEditor       APIKeyRoleV1Name = "schedule_overrides_editor"
-	APIKeyRoleV1NameSchedulesEditor               APIKeyRoleV1Name = "schedules_editor"
-	APIKeyRoleV1NameSchedulesReader               APIKeyRoleV1Name = "schedules_reader"
-	APIKeyRoleV1NameSecuritySettingsEditor        APIKeyRoleV1Name = "security_settings_editor"
-	APIKeyRoleV1NameStatusPagePublisher           APIKeyRoleV1Name = "status_page_publisher"
-	APIKeyRoleV1NameTeamMembershipsManage         APIKeyRoleV1Name = "team_memberships_manage"
-	APIKeyRoleV1NameViewer                        APIKeyRoleV1Name = "viewer"
-	APIKeyRoleV1NameWorkflowsEditor               APIKeyRoleV1Name = "workflows_editor"
+	APIKeyRoleV1NameActOnBehalfOfUsers                  APIKeyRoleV1Name = "act_on_behalf_of_users"
+	APIKeyRoleV1NameApiKeysManage                       APIKeyRoleV1Name = "api_keys_manage"
+	APIKeyRoleV1NameCatalogEditor                       APIKeyRoleV1Name = "catalog_editor"
+	APIKeyRoleV1NameCatalogViewer                       APIKeyRoleV1Name = "catalog_viewer"
+	APIKeyRoleV1NameEscalationCreator                   APIKeyRoleV1Name = "escalation_creator"
+	APIKeyRoleV1NameGlobalAccess                        APIKeyRoleV1Name = "global_access"
+	APIKeyRoleV1NameIncidentCreator                     APIKeyRoleV1Name = "incident_creator"
+	APIKeyRoleV1NameIncidentEditor                      APIKeyRoleV1Name = "incident_editor"
+	APIKeyRoleV1NameIncidentMembershipsEditor           APIKeyRoleV1Name = "incident_memberships_editor"
+	APIKeyRoleV1NameIncidentWorkloadPrivateViewer       APIKeyRoleV1Name = "incident_workload_private_viewer"
+	APIKeyRoleV1NameIncidentWorkloadViewer              APIKeyRoleV1Name = "incident_workload_viewer"
+	APIKeyRoleV1NameInvestigationDownload               APIKeyRoleV1Name = "investigation_download"
+	APIKeyRoleV1NameManageSettings                      APIKeyRoleV1Name = "manage_settings"
+	APIKeyRoleV1NameNotificationMethodsManage           APIKeyRoleV1Name = "notification_methods_manage"
+	APIKeyRoleV1NameNotificationMethodsUnredactedViewer APIKeyRoleV1Name = "notification_methods_unredacted_viewer"
+	APIKeyRoleV1NameOnCallEditor                        APIKeyRoleV1Name = "on_call_editor"
+	APIKeyRoleV1NameOnCallViewer                        APIKeyRoleV1Name = "on_call_viewer"
+	APIKeyRoleV1NamePostIncidentFlowOptOut              APIKeyRoleV1Name = "post_incident_flow_opt_out"
+	APIKeyRoleV1NamePostmortemsManage                   APIKeyRoleV1Name = "postmortems_manage"
+	APIKeyRoleV1NamePrivateEscalationWorkflowsEditor    APIKeyRoleV1Name = "private_escalation_workflows_editor"
+	APIKeyRoleV1NamePrivateWorkflowsEditor              APIKeyRoleV1Name = "private_workflows_editor"
+	APIKeyRoleV1NameScheduleOverridesEditor             APIKeyRoleV1Name = "schedule_overrides_editor"
+	APIKeyRoleV1NameSchedulesEditor                     APIKeyRoleV1Name = "schedules_editor"
+	APIKeyRoleV1NameSchedulesReader                     APIKeyRoleV1Name = "schedules_reader"
+	APIKeyRoleV1NameSecuritySettingsEditor              APIKeyRoleV1Name = "security_settings_editor"
+	APIKeyRoleV1NameStatusPagePublisher                 APIKeyRoleV1Name = "status_page_publisher"
+	APIKeyRoleV1NameTeamMembershipsManage               APIKeyRoleV1Name = "team_memberships_manage"
+	APIKeyRoleV1NameViewer                              APIKeyRoleV1Name = "viewer"
+	APIKeyRoleV1NameWorkflowsEditor                     APIKeyRoleV1Name = "workflows_editor"
 )
 
 // Defines values for APIKeyTeamRoleV1Name.
@@ -53,39 +56,44 @@ const (
 	APIKeyTeamRoleV1NameApiKeysManage           APIKeyTeamRoleV1Name = "api_keys_manage"
 	APIKeyTeamRoleV1NameEscalationCreator       APIKeyTeamRoleV1Name = "escalation_creator"
 	APIKeyTeamRoleV1NameOnCallEditor            APIKeyTeamRoleV1Name = "on_call_editor"
+	APIKeyTeamRoleV1NamePrivateWorkflowsEditor  APIKeyTeamRoleV1Name = "private_workflows_editor"
 	APIKeyTeamRoleV1NameScheduleOverridesEditor APIKeyTeamRoleV1Name = "schedule_overrides_editor"
 	APIKeyTeamRoleV1NameSchedulesEditor         APIKeyTeamRoleV1Name = "schedules_editor"
 	APIKeyTeamRoleV1NameSchedulesReader         APIKeyTeamRoleV1Name = "schedules_reader"
+	APIKeyTeamRoleV1NameWorkflowsEditor         APIKeyTeamRoleV1Name = "workflows_editor"
 )
 
 // Defines values for APIKeysCreatePayloadV1RoleNames.
 const (
-	APIKeysCreatePayloadV1RoleNamesActOnBehalfOfUsers            APIKeysCreatePayloadV1RoleNames = "act_on_behalf_of_users"
-	APIKeysCreatePayloadV1RoleNamesApiKeysManage                 APIKeysCreatePayloadV1RoleNames = "api_keys_manage"
-	APIKeysCreatePayloadV1RoleNamesCatalogEditor                 APIKeysCreatePayloadV1RoleNames = "catalog_editor"
-	APIKeysCreatePayloadV1RoleNamesCatalogViewer                 APIKeysCreatePayloadV1RoleNames = "catalog_viewer"
-	APIKeysCreatePayloadV1RoleNamesEscalationCreator             APIKeysCreatePayloadV1RoleNames = "escalation_creator"
-	APIKeysCreatePayloadV1RoleNamesGlobalAccess                  APIKeysCreatePayloadV1RoleNames = "global_access"
-	APIKeysCreatePayloadV1RoleNamesIncidentCreator               APIKeysCreatePayloadV1RoleNames = "incident_creator"
-	APIKeysCreatePayloadV1RoleNamesIncidentEditor                APIKeysCreatePayloadV1RoleNames = "incident_editor"
-	APIKeysCreatePayloadV1RoleNamesIncidentMembershipsEditor     APIKeysCreatePayloadV1RoleNames = "incident_memberships_editor"
-	APIKeysCreatePayloadV1RoleNamesIncidentWorkloadPrivateViewer APIKeysCreatePayloadV1RoleNames = "incident_workload_private_viewer"
-	APIKeysCreatePayloadV1RoleNamesIncidentWorkloadViewer        APIKeysCreatePayloadV1RoleNames = "incident_workload_viewer"
-	APIKeysCreatePayloadV1RoleNamesInvestigationDownload         APIKeysCreatePayloadV1RoleNames = "investigation_download"
-	APIKeysCreatePayloadV1RoleNamesManageSettings                APIKeysCreatePayloadV1RoleNames = "manage_settings"
-	APIKeysCreatePayloadV1RoleNamesNotificationMethodsManage     APIKeysCreatePayloadV1RoleNames = "notification_methods_manage"
-	APIKeysCreatePayloadV1RoleNamesOnCallEditor                  APIKeysCreatePayloadV1RoleNames = "on_call_editor"
-	APIKeysCreatePayloadV1RoleNamesPostIncidentFlowOptOut        APIKeysCreatePayloadV1RoleNames = "post_incident_flow_opt_out"
-	APIKeysCreatePayloadV1RoleNamesPostmortemsManage             APIKeysCreatePayloadV1RoleNames = "postmortems_manage"
-	APIKeysCreatePayloadV1RoleNamesPrivateWorkflowsEditor        APIKeysCreatePayloadV1RoleNames = "private_workflows_editor"
-	APIKeysCreatePayloadV1RoleNamesScheduleOverridesEditor       APIKeysCreatePayloadV1RoleNames = "schedule_overrides_editor"
-	APIKeysCreatePayloadV1RoleNamesSchedulesEditor               APIKeysCreatePayloadV1RoleNames = "schedules_editor"
-	APIKeysCreatePayloadV1RoleNamesSchedulesReader               APIKeysCreatePayloadV1RoleNames = "schedules_reader"
-	APIKeysCreatePayloadV1RoleNamesSecuritySettingsEditor        APIKeysCreatePayloadV1RoleNames = "security_settings_editor"
-	APIKeysCreatePayloadV1RoleNamesStatusPagePublisher           APIKeysCreatePayloadV1RoleNames = "status_page_publisher"
-	APIKeysCreatePayloadV1RoleNamesTeamMembershipsManage         APIKeysCreatePayloadV1RoleNames = "team_memberships_manage"
-	APIKeysCreatePayloadV1RoleNamesViewer                        APIKeysCreatePayloadV1RoleNames = "viewer"
-	APIKeysCreatePayloadV1RoleNamesWorkflowsEditor               APIKeysCreatePayloadV1RoleNames = "workflows_editor"
+	APIKeysCreatePayloadV1RoleNamesActOnBehalfOfUsers                  APIKeysCreatePayloadV1RoleNames = "act_on_behalf_of_users"
+	APIKeysCreatePayloadV1RoleNamesApiKeysManage                       APIKeysCreatePayloadV1RoleNames = "api_keys_manage"
+	APIKeysCreatePayloadV1RoleNamesCatalogEditor                       APIKeysCreatePayloadV1RoleNames = "catalog_editor"
+	APIKeysCreatePayloadV1RoleNamesCatalogViewer                       APIKeysCreatePayloadV1RoleNames = "catalog_viewer"
+	APIKeysCreatePayloadV1RoleNamesEscalationCreator                   APIKeysCreatePayloadV1RoleNames = "escalation_creator"
+	APIKeysCreatePayloadV1RoleNamesGlobalAccess                        APIKeysCreatePayloadV1RoleNames = "global_access"
+	APIKeysCreatePayloadV1RoleNamesIncidentCreator                     APIKeysCreatePayloadV1RoleNames = "incident_creator"
+	APIKeysCreatePayloadV1RoleNamesIncidentEditor                      APIKeysCreatePayloadV1RoleNames = "incident_editor"
+	APIKeysCreatePayloadV1RoleNamesIncidentMembershipsEditor           APIKeysCreatePayloadV1RoleNames = "incident_memberships_editor"
+	APIKeysCreatePayloadV1RoleNamesIncidentWorkloadPrivateViewer       APIKeysCreatePayloadV1RoleNames = "incident_workload_private_viewer"
+	APIKeysCreatePayloadV1RoleNamesIncidentWorkloadViewer              APIKeysCreatePayloadV1RoleNames = "incident_workload_viewer"
+	APIKeysCreatePayloadV1RoleNamesInvestigationDownload               APIKeysCreatePayloadV1RoleNames = "investigation_download"
+	APIKeysCreatePayloadV1RoleNamesManageSettings                      APIKeysCreatePayloadV1RoleNames = "manage_settings"
+	APIKeysCreatePayloadV1RoleNamesNotificationMethodsManage           APIKeysCreatePayloadV1RoleNames = "notification_methods_manage"
+	APIKeysCreatePayloadV1RoleNamesNotificationMethodsUnredactedViewer APIKeysCreatePayloadV1RoleNames = "notification_methods_unredacted_viewer"
+	APIKeysCreatePayloadV1RoleNamesOnCallEditor                        APIKeysCreatePayloadV1RoleNames = "on_call_editor"
+	APIKeysCreatePayloadV1RoleNamesOnCallViewer                        APIKeysCreatePayloadV1RoleNames = "on_call_viewer"
+	APIKeysCreatePayloadV1RoleNamesPostIncidentFlowOptOut              APIKeysCreatePayloadV1RoleNames = "post_incident_flow_opt_out"
+	APIKeysCreatePayloadV1RoleNamesPostmortemsManage                   APIKeysCreatePayloadV1RoleNames = "postmortems_manage"
+	APIKeysCreatePayloadV1RoleNamesPrivateEscalationWorkflowsEditor    APIKeysCreatePayloadV1RoleNames = "private_escalation_workflows_editor"
+	APIKeysCreatePayloadV1RoleNamesPrivateWorkflowsEditor              APIKeysCreatePayloadV1RoleNames = "private_workflows_editor"
+	APIKeysCreatePayloadV1RoleNamesScheduleOverridesEditor             APIKeysCreatePayloadV1RoleNames = "schedule_overrides_editor"
+	APIKeysCreatePayloadV1RoleNamesSchedulesEditor                     APIKeysCreatePayloadV1RoleNames = "schedules_editor"
+	APIKeysCreatePayloadV1RoleNamesSchedulesReader                     APIKeysCreatePayloadV1RoleNames = "schedules_reader"
+	APIKeysCreatePayloadV1RoleNamesSecuritySettingsEditor              APIKeysCreatePayloadV1RoleNames = "security_settings_editor"
+	APIKeysCreatePayloadV1RoleNamesStatusPagePublisher                 APIKeysCreatePayloadV1RoleNames = "status_page_publisher"
+	APIKeysCreatePayloadV1RoleNamesTeamMembershipsManage               APIKeysCreatePayloadV1RoleNames = "team_memberships_manage"
+	APIKeysCreatePayloadV1RoleNamesViewer                              APIKeysCreatePayloadV1RoleNames = "viewer"
+	APIKeysCreatePayloadV1RoleNamesWorkflowsEditor                     APIKeysCreatePayloadV1RoleNames = "workflows_editor"
 )
 
 // Defines values for APIKeysCreatePayloadV1TeamRoleNames.
@@ -93,39 +101,44 @@ const (
 	APIKeysCreatePayloadV1TeamRoleNamesApiKeysManage           APIKeysCreatePayloadV1TeamRoleNames = "api_keys_manage"
 	APIKeysCreatePayloadV1TeamRoleNamesEscalationCreator       APIKeysCreatePayloadV1TeamRoleNames = "escalation_creator"
 	APIKeysCreatePayloadV1TeamRoleNamesOnCallEditor            APIKeysCreatePayloadV1TeamRoleNames = "on_call_editor"
+	APIKeysCreatePayloadV1TeamRoleNamesPrivateWorkflowsEditor  APIKeysCreatePayloadV1TeamRoleNames = "private_workflows_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesScheduleOverridesEditor APIKeysCreatePayloadV1TeamRoleNames = "schedule_overrides_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesSchedulesEditor         APIKeysCreatePayloadV1TeamRoleNames = "schedules_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesSchedulesReader         APIKeysCreatePayloadV1TeamRoleNames = "schedules_reader"
+	APIKeysCreatePayloadV1TeamRoleNamesWorkflowsEditor         APIKeysCreatePayloadV1TeamRoleNames = "workflows_editor"
 )
 
 // Defines values for APIKeysUpdatePayloadV1RoleNames.
 const (
-	APIKeysUpdatePayloadV1RoleNamesActOnBehalfOfUsers            APIKeysUpdatePayloadV1RoleNames = "act_on_behalf_of_users"
-	APIKeysUpdatePayloadV1RoleNamesApiKeysManage                 APIKeysUpdatePayloadV1RoleNames = "api_keys_manage"
-	APIKeysUpdatePayloadV1RoleNamesCatalogEditor                 APIKeysUpdatePayloadV1RoleNames = "catalog_editor"
-	APIKeysUpdatePayloadV1RoleNamesCatalogViewer                 APIKeysUpdatePayloadV1RoleNames = "catalog_viewer"
-	APIKeysUpdatePayloadV1RoleNamesEscalationCreator             APIKeysUpdatePayloadV1RoleNames = "escalation_creator"
-	APIKeysUpdatePayloadV1RoleNamesGlobalAccess                  APIKeysUpdatePayloadV1RoleNames = "global_access"
-	APIKeysUpdatePayloadV1RoleNamesIncidentCreator               APIKeysUpdatePayloadV1RoleNames = "incident_creator"
-	APIKeysUpdatePayloadV1RoleNamesIncidentEditor                APIKeysUpdatePayloadV1RoleNames = "incident_editor"
-	APIKeysUpdatePayloadV1RoleNamesIncidentMembershipsEditor     APIKeysUpdatePayloadV1RoleNames = "incident_memberships_editor"
-	APIKeysUpdatePayloadV1RoleNamesIncidentWorkloadPrivateViewer APIKeysUpdatePayloadV1RoleNames = "incident_workload_private_viewer"
-	APIKeysUpdatePayloadV1RoleNamesIncidentWorkloadViewer        APIKeysUpdatePayloadV1RoleNames = "incident_workload_viewer"
-	APIKeysUpdatePayloadV1RoleNamesInvestigationDownload         APIKeysUpdatePayloadV1RoleNames = "investigation_download"
-	APIKeysUpdatePayloadV1RoleNamesManageSettings                APIKeysUpdatePayloadV1RoleNames = "manage_settings"
-	APIKeysUpdatePayloadV1RoleNamesNotificationMethodsManage     APIKeysUpdatePayloadV1RoleNames = "notification_methods_manage"
-	APIKeysUpdatePayloadV1RoleNamesOnCallEditor                  APIKeysUpdatePayloadV1RoleNames = "on_call_editor"
-	APIKeysUpdatePayloadV1RoleNamesPostIncidentFlowOptOut        APIKeysUpdatePayloadV1RoleNames = "post_incident_flow_opt_out"
-	APIKeysUpdatePayloadV1RoleNamesPostmortemsManage             APIKeysUpdatePayloadV1RoleNames = "postmortems_manage"
-	APIKeysUpdatePayloadV1RoleNamesPrivateWorkflowsEditor        APIKeysUpdatePayloadV1RoleNames = "private_workflows_editor"
-	APIKeysUpdatePayloadV1RoleNamesScheduleOverridesEditor       APIKeysUpdatePayloadV1RoleNames = "schedule_overrides_editor"
-	APIKeysUpdatePayloadV1RoleNamesSchedulesEditor               APIKeysUpdatePayloadV1RoleNames = "schedules_editor"
-	APIKeysUpdatePayloadV1RoleNamesSchedulesReader               APIKeysUpdatePayloadV1RoleNames = "schedules_reader"
-	APIKeysUpdatePayloadV1RoleNamesSecuritySettingsEditor        APIKeysUpdatePayloadV1RoleNames = "security_settings_editor"
-	APIKeysUpdatePayloadV1RoleNamesStatusPagePublisher           APIKeysUpdatePayloadV1RoleNames = "status_page_publisher"
-	APIKeysUpdatePayloadV1RoleNamesTeamMembershipsManage         APIKeysUpdatePayloadV1RoleNames = "team_memberships_manage"
-	APIKeysUpdatePayloadV1RoleNamesViewer                        APIKeysUpdatePayloadV1RoleNames = "viewer"
-	APIKeysUpdatePayloadV1RoleNamesWorkflowsEditor               APIKeysUpdatePayloadV1RoleNames = "workflows_editor"
+	APIKeysUpdatePayloadV1RoleNamesActOnBehalfOfUsers                  APIKeysUpdatePayloadV1RoleNames = "act_on_behalf_of_users"
+	APIKeysUpdatePayloadV1RoleNamesApiKeysManage                       APIKeysUpdatePayloadV1RoleNames = "api_keys_manage"
+	APIKeysUpdatePayloadV1RoleNamesCatalogEditor                       APIKeysUpdatePayloadV1RoleNames = "catalog_editor"
+	APIKeysUpdatePayloadV1RoleNamesCatalogViewer                       APIKeysUpdatePayloadV1RoleNames = "catalog_viewer"
+	APIKeysUpdatePayloadV1RoleNamesEscalationCreator                   APIKeysUpdatePayloadV1RoleNames = "escalation_creator"
+	APIKeysUpdatePayloadV1RoleNamesGlobalAccess                        APIKeysUpdatePayloadV1RoleNames = "global_access"
+	APIKeysUpdatePayloadV1RoleNamesIncidentCreator                     APIKeysUpdatePayloadV1RoleNames = "incident_creator"
+	APIKeysUpdatePayloadV1RoleNamesIncidentEditor                      APIKeysUpdatePayloadV1RoleNames = "incident_editor"
+	APIKeysUpdatePayloadV1RoleNamesIncidentMembershipsEditor           APIKeysUpdatePayloadV1RoleNames = "incident_memberships_editor"
+	APIKeysUpdatePayloadV1RoleNamesIncidentWorkloadPrivateViewer       APIKeysUpdatePayloadV1RoleNames = "incident_workload_private_viewer"
+	APIKeysUpdatePayloadV1RoleNamesIncidentWorkloadViewer              APIKeysUpdatePayloadV1RoleNames = "incident_workload_viewer"
+	APIKeysUpdatePayloadV1RoleNamesInvestigationDownload               APIKeysUpdatePayloadV1RoleNames = "investigation_download"
+	APIKeysUpdatePayloadV1RoleNamesManageSettings                      APIKeysUpdatePayloadV1RoleNames = "manage_settings"
+	APIKeysUpdatePayloadV1RoleNamesNotificationMethodsManage           APIKeysUpdatePayloadV1RoleNames = "notification_methods_manage"
+	APIKeysUpdatePayloadV1RoleNamesNotificationMethodsUnredactedViewer APIKeysUpdatePayloadV1RoleNames = "notification_methods_unredacted_viewer"
+	APIKeysUpdatePayloadV1RoleNamesOnCallEditor                        APIKeysUpdatePayloadV1RoleNames = "on_call_editor"
+	APIKeysUpdatePayloadV1RoleNamesOnCallViewer                        APIKeysUpdatePayloadV1RoleNames = "on_call_viewer"
+	APIKeysUpdatePayloadV1RoleNamesPostIncidentFlowOptOut              APIKeysUpdatePayloadV1RoleNames = "post_incident_flow_opt_out"
+	APIKeysUpdatePayloadV1RoleNamesPostmortemsManage                   APIKeysUpdatePayloadV1RoleNames = "postmortems_manage"
+	APIKeysUpdatePayloadV1RoleNamesPrivateEscalationWorkflowsEditor    APIKeysUpdatePayloadV1RoleNames = "private_escalation_workflows_editor"
+	APIKeysUpdatePayloadV1RoleNamesPrivateWorkflowsEditor              APIKeysUpdatePayloadV1RoleNames = "private_workflows_editor"
+	APIKeysUpdatePayloadV1RoleNamesScheduleOverridesEditor             APIKeysUpdatePayloadV1RoleNames = "schedule_overrides_editor"
+	APIKeysUpdatePayloadV1RoleNamesSchedulesEditor                     APIKeysUpdatePayloadV1RoleNames = "schedules_editor"
+	APIKeysUpdatePayloadV1RoleNamesSchedulesReader                     APIKeysUpdatePayloadV1RoleNames = "schedules_reader"
+	APIKeysUpdatePayloadV1RoleNamesSecuritySettingsEditor              APIKeysUpdatePayloadV1RoleNames = "security_settings_editor"
+	APIKeysUpdatePayloadV1RoleNamesStatusPagePublisher                 APIKeysUpdatePayloadV1RoleNames = "status_page_publisher"
+	APIKeysUpdatePayloadV1RoleNamesTeamMembershipsManage               APIKeysUpdatePayloadV1RoleNames = "team_memberships_manage"
+	APIKeysUpdatePayloadV1RoleNamesViewer                              APIKeysUpdatePayloadV1RoleNames = "viewer"
+	APIKeysUpdatePayloadV1RoleNamesWorkflowsEditor                     APIKeysUpdatePayloadV1RoleNames = "workflows_editor"
 )
 
 // Defines values for APIKeysUpdatePayloadV1TeamRoleNames.
@@ -133,9 +146,11 @@ const (
 	APIKeysUpdatePayloadV1TeamRoleNamesApiKeysManage           APIKeysUpdatePayloadV1TeamRoleNames = "api_keys_manage"
 	APIKeysUpdatePayloadV1TeamRoleNamesEscalationCreator       APIKeysUpdatePayloadV1TeamRoleNames = "escalation_creator"
 	APIKeysUpdatePayloadV1TeamRoleNamesOnCallEditor            APIKeysUpdatePayloadV1TeamRoleNames = "on_call_editor"
+	APIKeysUpdatePayloadV1TeamRoleNamesPrivateWorkflowsEditor  APIKeysUpdatePayloadV1TeamRoleNames = "private_workflows_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesScheduleOverridesEditor APIKeysUpdatePayloadV1TeamRoleNames = "schedule_overrides_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesSchedulesEditor         APIKeysUpdatePayloadV1TeamRoleNames = "schedules_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesSchedulesReader         APIKeysUpdatePayloadV1TeamRoleNames = "schedules_reader"
+	APIKeysUpdatePayloadV1TeamRoleNamesWorkflowsEditor         APIKeysUpdatePayloadV1TeamRoleNames = "workflows_editor"
 )
 
 // Defines values for ActionV1Status.
@@ -301,6 +316,7 @@ const (
 	AlertSourceV2SourceTypeRunscope          AlertSourceV2SourceType = "runscope"
 	AlertSourceV2SourceTypeSentry            AlertSourceV2SourceType = "sentry"
 	AlertSourceV2SourceTypeSentryMetric      AlertSourceV2SourceType = "sentry_metric"
+	AlertSourceV2SourceTypeServiceNow        AlertSourceV2SourceType = "service_now"
 	AlertSourceV2SourceTypeSns               AlertSourceV2SourceType = "sns"
 	AlertSourceV2SourceTypeSplunk            AlertSourceV2SourceType = "splunk"
 	AlertSourceV2SourceTypeStatusCake        AlertSourceV2SourceType = "status_cake"
@@ -351,6 +367,7 @@ const (
 	AlertSourcesCreatePayloadV2SourceTypeRunscope          AlertSourcesCreatePayloadV2SourceType = "runscope"
 	AlertSourcesCreatePayloadV2SourceTypeSentry            AlertSourcesCreatePayloadV2SourceType = "sentry"
 	AlertSourcesCreatePayloadV2SourceTypeSentryMetric      AlertSourcesCreatePayloadV2SourceType = "sentry_metric"
+	AlertSourcesCreatePayloadV2SourceTypeServiceNow        AlertSourcesCreatePayloadV2SourceType = "service_now"
 	AlertSourcesCreatePayloadV2SourceTypeSns               AlertSourcesCreatePayloadV2SourceType = "sns"
 	AlertSourcesCreatePayloadV2SourceTypeSplunk            AlertSourcesCreatePayloadV2SourceType = "splunk"
 	AlertSourcesCreatePayloadV2SourceTypeStatusCake        AlertSourcesCreatePayloadV2SourceType = "status_cake"
@@ -1104,6 +1121,20 @@ const (
 	FollowUpV2StatusOutstanding FollowUpV2Status = "outstanding"
 )
 
+// Defines values for FollowUpsConnectExternalIssuePayloadV2Provider.
+const (
+	FollowUpsConnectExternalIssuePayloadV2ProviderAsana       FollowUpsConnectExternalIssuePayloadV2Provider = "asana"
+	FollowUpsConnectExternalIssuePayloadV2ProviderAzureDevops FollowUpsConnectExternalIssuePayloadV2Provider = "azure_devops"
+	FollowUpsConnectExternalIssuePayloadV2ProviderClickUp     FollowUpsConnectExternalIssuePayloadV2Provider = "click_up"
+	FollowUpsConnectExternalIssuePayloadV2ProviderGithub      FollowUpsConnectExternalIssuePayloadV2Provider = "github"
+	FollowUpsConnectExternalIssuePayloadV2ProviderGitlab      FollowUpsConnectExternalIssuePayloadV2Provider = "gitlab"
+	FollowUpsConnectExternalIssuePayloadV2ProviderJira        FollowUpsConnectExternalIssuePayloadV2Provider = "jira"
+	FollowUpsConnectExternalIssuePayloadV2ProviderJiraServer  FollowUpsConnectExternalIssuePayloadV2Provider = "jira_server"
+	FollowUpsConnectExternalIssuePayloadV2ProviderLinear      FollowUpsConnectExternalIssuePayloadV2Provider = "linear"
+	FollowUpsConnectExternalIssuePayloadV2ProviderServiceNow  FollowUpsConnectExternalIssuePayloadV2Provider = "service_now"
+	FollowUpsConnectExternalIssuePayloadV2ProviderShortcut    FollowUpsConnectExternalIssuePayloadV2Provider = "shortcut"
+)
+
 // Defines values for FollowUpsUpdatePayloadV2Status.
 const (
 	FollowUpsUpdatePayloadV2StatusCompleted   FollowUpsUpdatePayloadV2Status = "completed"
@@ -1120,32 +1151,35 @@ const (
 
 // Defines values for IdentityV1Roles.
 const (
-	IdentityV1RolesActOnBehalfOfUsers            IdentityV1Roles = "act_on_behalf_of_users"
-	IdentityV1RolesApiKeysManage                 IdentityV1Roles = "api_keys_manage"
-	IdentityV1RolesCatalogEditor                 IdentityV1Roles = "catalog_editor"
-	IdentityV1RolesCatalogViewer                 IdentityV1Roles = "catalog_viewer"
-	IdentityV1RolesEscalationCreator             IdentityV1Roles = "escalation_creator"
-	IdentityV1RolesGlobalAccess                  IdentityV1Roles = "global_access"
-	IdentityV1RolesIncidentCreator               IdentityV1Roles = "incident_creator"
-	IdentityV1RolesIncidentEditor                IdentityV1Roles = "incident_editor"
-	IdentityV1RolesIncidentMembershipsEditor     IdentityV1Roles = "incident_memberships_editor"
-	IdentityV1RolesIncidentWorkloadPrivateViewer IdentityV1Roles = "incident_workload_private_viewer"
-	IdentityV1RolesIncidentWorkloadViewer        IdentityV1Roles = "incident_workload_viewer"
-	IdentityV1RolesInvestigationDownload         IdentityV1Roles = "investigation_download"
-	IdentityV1RolesManageSettings                IdentityV1Roles = "manage_settings"
-	IdentityV1RolesNotificationMethodsManage     IdentityV1Roles = "notification_methods_manage"
-	IdentityV1RolesOnCallEditor                  IdentityV1Roles = "on_call_editor"
-	IdentityV1RolesPostIncidentFlowOptOut        IdentityV1Roles = "post_incident_flow_opt_out"
-	IdentityV1RolesPostmortemsManage             IdentityV1Roles = "postmortems_manage"
-	IdentityV1RolesPrivateWorkflowsEditor        IdentityV1Roles = "private_workflows_editor"
-	IdentityV1RolesScheduleOverridesEditor       IdentityV1Roles = "schedule_overrides_editor"
-	IdentityV1RolesSchedulesEditor               IdentityV1Roles = "schedules_editor"
-	IdentityV1RolesSchedulesReader               IdentityV1Roles = "schedules_reader"
-	IdentityV1RolesSecuritySettingsEditor        IdentityV1Roles = "security_settings_editor"
-	IdentityV1RolesStatusPagePublisher           IdentityV1Roles = "status_page_publisher"
-	IdentityV1RolesTeamMembershipsManage         IdentityV1Roles = "team_memberships_manage"
-	IdentityV1RolesViewer                        IdentityV1Roles = "viewer"
-	IdentityV1RolesWorkflowsEditor               IdentityV1Roles = "workflows_editor"
+	IdentityV1RolesActOnBehalfOfUsers                  IdentityV1Roles = "act_on_behalf_of_users"
+	IdentityV1RolesApiKeysManage                       IdentityV1Roles = "api_keys_manage"
+	IdentityV1RolesCatalogEditor                       IdentityV1Roles = "catalog_editor"
+	IdentityV1RolesCatalogViewer                       IdentityV1Roles = "catalog_viewer"
+	IdentityV1RolesEscalationCreator                   IdentityV1Roles = "escalation_creator"
+	IdentityV1RolesGlobalAccess                        IdentityV1Roles = "global_access"
+	IdentityV1RolesIncidentCreator                     IdentityV1Roles = "incident_creator"
+	IdentityV1RolesIncidentEditor                      IdentityV1Roles = "incident_editor"
+	IdentityV1RolesIncidentMembershipsEditor           IdentityV1Roles = "incident_memberships_editor"
+	IdentityV1RolesIncidentWorkloadPrivateViewer       IdentityV1Roles = "incident_workload_private_viewer"
+	IdentityV1RolesIncidentWorkloadViewer              IdentityV1Roles = "incident_workload_viewer"
+	IdentityV1RolesInvestigationDownload               IdentityV1Roles = "investigation_download"
+	IdentityV1RolesManageSettings                      IdentityV1Roles = "manage_settings"
+	IdentityV1RolesNotificationMethodsManage           IdentityV1Roles = "notification_methods_manage"
+	IdentityV1RolesNotificationMethodsUnredactedViewer IdentityV1Roles = "notification_methods_unredacted_viewer"
+	IdentityV1RolesOnCallEditor                        IdentityV1Roles = "on_call_editor"
+	IdentityV1RolesOnCallViewer                        IdentityV1Roles = "on_call_viewer"
+	IdentityV1RolesPostIncidentFlowOptOut              IdentityV1Roles = "post_incident_flow_opt_out"
+	IdentityV1RolesPostmortemsManage                   IdentityV1Roles = "postmortems_manage"
+	IdentityV1RolesPrivateEscalationWorkflowsEditor    IdentityV1Roles = "private_escalation_workflows_editor"
+	IdentityV1RolesPrivateWorkflowsEditor              IdentityV1Roles = "private_workflows_editor"
+	IdentityV1RolesScheduleOverridesEditor             IdentityV1Roles = "schedule_overrides_editor"
+	IdentityV1RolesSchedulesEditor                     IdentityV1Roles = "schedules_editor"
+	IdentityV1RolesSchedulesReader                     IdentityV1Roles = "schedules_reader"
+	IdentityV1RolesSecuritySettingsEditor              IdentityV1Roles = "security_settings_editor"
+	IdentityV1RolesStatusPagePublisher                 IdentityV1Roles = "status_page_publisher"
+	IdentityV1RolesTeamMembershipsManage               IdentityV1Roles = "team_memberships_manage"
+	IdentityV1RolesViewer                              IdentityV1Roles = "viewer"
+	IdentityV1RolesWorkflowsEditor                     IdentityV1Roles = "workflows_editor"
 )
 
 // Defines values for IdentityV1TeamRoles.
@@ -1153,9 +1187,11 @@ const (
 	IdentityV1TeamRolesApiKeysManage           IdentityV1TeamRoles = "api_keys_manage"
 	IdentityV1TeamRolesEscalationCreator       IdentityV1TeamRoles = "escalation_creator"
 	IdentityV1TeamRolesOnCallEditor            IdentityV1TeamRoles = "on_call_editor"
+	IdentityV1TeamRolesPrivateWorkflowsEditor  IdentityV1TeamRoles = "private_workflows_editor"
 	IdentityV1TeamRolesScheduleOverridesEditor IdentityV1TeamRoles = "schedule_overrides_editor"
 	IdentityV1TeamRolesSchedulesEditor         IdentityV1TeamRoles = "schedules_editor"
 	IdentityV1TeamRolesSchedulesReader         IdentityV1TeamRoles = "schedules_reader"
+	IdentityV1TeamRolesWorkflowsEditor         IdentityV1TeamRoles = "workflows_editor"
 )
 
 // Defines values for IncidentAttachmentsCreatePayloadV1ResourceResourceType.
@@ -1669,10 +1705,10 @@ const (
 
 // Defines values for UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider.
 const (
-	UsersUpdatePagingProviderPayloadV2PreferredEscalationProviderNative       UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "native"
-	UsersUpdatePagingProviderPayloadV2PreferredEscalationProviderOpsgenie     UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "opsgenie"
-	UsersUpdatePagingProviderPayloadV2PreferredEscalationProviderPagerduty    UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "pagerduty"
-	UsersUpdatePagingProviderPayloadV2PreferredEscalationProviderSplunkOnCall UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "splunk_on_call"
+	Native       UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "native"
+	Opsgenie     UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "opsgenie"
+	Pagerduty    UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "pagerduty"
+	SplunkOnCall UsersUpdatePagingProviderPayloadV2PreferredEscalationProvider = "splunk_on_call"
 )
 
 // Defines values for WeekdayIntervalV2Weekday.
@@ -2353,6 +2389,12 @@ type AlertMessageDestinationV3 struct {
 
 // AlertNoteV1 defines model for AlertNoteV1.
 type AlertNoteV1 struct {
+	// AlertGroupId ID of the alert group this note is attached to. Exactly one of alert_id or alert_group_id is set; the other is null.
+	AlertGroupId *string `json:"alert_group_id,omitempty"`
+
+	// AlertId ID of the alert this note is attached to. Exactly one of alert_id or alert_group_id is set; the other is null.
+	AlertId *string `json:"alert_id,omitempty"`
+
 	// Content Markdown body of the note
 	Content string `json:"content"`
 
@@ -2375,8 +2417,11 @@ type AlertNoteV1 struct {
 
 // AlertNotesCreatePayloadV1 defines model for AlertNotesCreatePayloadV1.
 type AlertNotesCreatePayloadV1 struct {
-	// AlertId ID of the alert to add the note to
-	AlertId string `json:"alert_id"`
+	// AlertGroupId ID of the alert group to add the note to. Provide exactly one of alert_id or alert_group_id.
+	AlertGroupId *string `json:"alert_group_id,omitempty"`
+
+	// AlertId ID of the alert to add the note to. Provide exactly one of alert_id or alert_group_id.
+	AlertId *string `json:"alert_id,omitempty"`
 
 	// Content Markdown body of the note
 	Content string `json:"content"`
@@ -3141,6 +3186,9 @@ type AlertRoutesUpdateResultV3 struct {
 
 // AlertSlimV2 defines model for AlertSlimV2.
 type AlertSlimV2 struct {
+	// AlertGroupIds The IDs of every alert group this alert belongs to. Empty when the alert is not part of any group.
+	AlertGroupIds *[]string `json:"alert_group_ids,omitempty"`
+
 	// AlertSourceId The ID of the alert source this alert fired on
 	AlertSourceId string `json:"alert_source_id"`
 
@@ -3422,6 +3470,9 @@ type AlertTemplateV2 struct {
 
 // AlertV2 defines model for AlertV2.
 type AlertV2 struct {
+	// AlertGroupIds The IDs of every alert group this alert belongs to. Empty when the alert is not part of any group.
+	AlertGroupIds *[]string `json:"alert_group_ids,omitempty"`
+
 	// AlertSourceId The ID of the alert source this alert fired on
 	AlertSourceId string `json:"alert_source_id"`
 
@@ -5980,6 +6031,23 @@ type FollowUpV2 struct {
 
 // FollowUpV2Status Status of the follow-up
 type FollowUpV2Status string
+
+// FollowUpsConnectExternalIssuePayloadV2 defines model for FollowUpsConnectExternalIssuePayloadV2.
+type FollowUpsConnectExternalIssuePayloadV2 struct {
+	// Provider The issue tracker provider the issue belongs to
+	Provider FollowUpsConnectExternalIssuePayloadV2Provider `json:"provider"`
+
+	// Url URL of the issue in the external provider
+	Url string `json:"url"`
+}
+
+// FollowUpsConnectExternalIssuePayloadV2Provider The issue tracker provider the issue belongs to
+type FollowUpsConnectExternalIssuePayloadV2Provider string
+
+// FollowUpsConnectExternalIssueResultV2 defines model for FollowUpsConnectExternalIssueResultV2.
+type FollowUpsConnectExternalIssueResultV2 struct {
+	FollowUp FollowUpV2 `json:"follow_up"`
+}
 
 // FollowUpsCreatePayloadV2 defines model for FollowUpsCreatePayloadV2.
 type FollowUpsCreatePayloadV2 struct {
@@ -9441,6 +9509,54 @@ type WorkflowDelayV2 struct {
 	ForSeconds int64 `json:"for_seconds"`
 }
 
+// WorkflowFormFieldPayloadV2 defines model for WorkflowFormFieldPayloadV2.
+type WorkflowFormFieldPayloadV2 struct {
+	// Array Whether this field holds a list of values rather than a single value
+	Array *bool `json:"array,omitempty"`
+
+	// Description Optional help text shown beneath the field
+	Description *string `json:"description,omitempty"`
+
+	// Id Stable identifier for this field; omit to create a new field
+	Id *string `json:"id,omitempty"`
+
+	// Key The key used to reference this field in the workflow scope
+	Key string `json:"key"`
+
+	// Required Whether this field must be filled in when running the workflow
+	Required *bool `json:"required,omitempty"`
+
+	// Title Human readable title shown in the form
+	Title string `json:"title"`
+
+	// Type The engine resource type of this field
+	Type string `json:"type"`
+}
+
+// WorkflowFormFieldV2 defines model for WorkflowFormFieldV2.
+type WorkflowFormFieldV2 struct {
+	// Array Whether this field holds a list of values rather than a single value
+	Array bool `json:"array"`
+
+	// Description Optional help text shown beneath the field
+	Description *string `json:"description,omitempty"`
+
+	// Id Stable identifier for this form field, preserved across versions
+	Id string `json:"id"`
+
+	// Key The key used to reference this field in the workflow scope
+	Key string `json:"key"`
+
+	// Required Whether this field must be filled in when running the workflow
+	Required bool `json:"required"`
+
+	// Title Human readable title shown in the form
+	Title string `json:"title"`
+
+	// Type The engine resource type of this field
+	Type string `json:"type"`
+}
+
 // WorkflowSlimV2 defines model for WorkflowSlimV2.
 type WorkflowSlimV2 struct {
 	// ConditionGroups Conditions that apply to the workflow trigger
@@ -9527,6 +9643,9 @@ type WorkflowV2 struct {
 	// Folder Folder to display the workflow in
 	Folder *string `json:"folder,omitempty"`
 
+	// FormFields User-configured form fields available in the workflow scope (manual triggers only)
+	FormFields *[]WorkflowFormFieldV2 `json:"form_fields,omitempty"`
+
 	// Id Unique identifier for the workflow
 	Id string `json:"id"`
 
@@ -9601,10 +9720,13 @@ type WorkflowsCreateWorkflowPayloadV2 struct {
 	// Folder Folder to display the workflow in
 	Folder *string `json:"folder,omitempty"`
 
+	// FormFields User-configured form fields available in the workflow scope (manual triggers only)
+	FormFields *[]WorkflowFormFieldPayloadV2 `json:"form_fields,omitempty"`
+
 	// IncludePrivateEscalations Whether to include private escalations
 	IncludePrivateEscalations *bool `json:"include_private_escalations,omitempty"`
 
-	// IncludePrivateIncidents DEPRECATED: use `private_incident_scope` instead. Mutually exclusive with `private_incident_scope` — sending both returns a validation error.
+	// IncludePrivateIncidents DEPRECATED: use `private_incident_scope` instead. May be sent alongside `private_incident_scope` only if they agree; contradictory values return a validation error.
 	IncludePrivateIncidents *bool `json:"include_private_incidents,omitempty"`
 
 	// Name Name provided by the user when creating the workflow
@@ -9685,10 +9807,13 @@ type WorkflowsUpdateWorkflowPayloadV2 struct {
 	// Folder Folder to display the workflow in
 	Folder *string `json:"folder,omitempty"`
 
+	// FormFields User-configured form fields available in the workflow scope (manual triggers only)
+	FormFields *[]WorkflowFormFieldPayloadV2 `json:"form_fields,omitempty"`
+
 	// IncludePrivateEscalations Whether to include private escalations
 	IncludePrivateEscalations *bool `json:"include_private_escalations,omitempty"`
 
-	// IncludePrivateIncidents DEPRECATED: use `private_incident_scope` instead. Mutually exclusive with `private_incident_scope` — sending both returns a validation error.
+	// IncludePrivateIncidents DEPRECATED: use `private_incident_scope` instead. May be sent alongside `private_incident_scope` only if they agree; contradictory values return a validation error.
 	IncludePrivateIncidents *bool `json:"include_private_incidents,omitempty"`
 
 	// Name Name provided by the user when creating the workflow
@@ -9778,8 +9903,11 @@ type ActionsV1ListParamsIncidentMode string
 
 // AlertNotesV1ListParams defines parameters for AlertNotesV1List.
 type AlertNotesV1ListParams struct {
-	// AlertId ID of the alert to list notes for
-	AlertId string `form:"alert_id" json:"alert_id"`
+	// AlertId ID of the alert to list notes for. Provide exactly one of alert_id or alert_group_id.
+	AlertId *string `form:"alert_id,omitempty" json:"alert_id,omitempty"`
+
+	// AlertGroupId ID of the alert group to list notes for. Provide exactly one of alert_id or alert_group_id.
+	AlertGroupId *string `form:"alert_group_id,omitempty" json:"alert_group_id,omitempty"`
 
 	// PageSize Integer number of records to return
 	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
@@ -9928,8 +10056,14 @@ type AlertsV2ListParams struct {
 	// AlertSource Filter on alert source by ID. The accepted operators are 'one_of', or 'not_in'.
 	AlertSource *map[string][]string `form:"alert_source,omitempty" json:"alert_source,omitempty"`
 
+	// AlertGroupId Filter on alert group ID. Returns alerts that belong to any of the specified groups. The accepted operator is 'one_of'.
+	AlertGroupId *map[string][]string `form:"alert_group_id,omitempty" json:"alert_group_id,omitempty"`
+
 	// CreatedAt Filter on alert created at timestamp. Accepted operators are 'gte', 'lte' and 'date_range'.
 	CreatedAt *map[string][]string `form:"created_at,omitempty" json:"created_at,omitempty"`
+
+	// Attributes Filter on an alerts attributes. Alert attribute ID should be sent, followed by the operator and values. Accepted operator will depend on the attribute type.
+	Attributes *map[string]map[string][]string `form:"attributes,omitempty" json:"attributes,omitempty"`
 
 	// HasNotes Filter on whether an alert has notes. The accepted operator is 'is'.
 	HasNotes *map[string][]string `form:"has_notes,omitempty" json:"has_notes,omitempty"`
@@ -10431,6 +10565,9 @@ type FollowUpsV2CreateJSONRequestBody = FollowUpsCreatePayloadV2
 
 // FollowUpsV2UpdateJSONRequestBody defines body for FollowUpsV2Update for application/json ContentType.
 type FollowUpsV2UpdateJSONRequestBody = FollowUpsUpdatePayloadV2
+
+// FollowUpsV2ConnectExternalIssueJSONRequestBody defines body for FollowUpsV2ConnectExternalIssue for application/json ContentType.
+type FollowUpsV2ConnectExternalIssueJSONRequestBody = FollowUpsConnectExternalIssuePayloadV2
 
 // IncidentRolesV2CreateJSONRequestBody defines body for IncidentRolesV2Create for application/json ContentType.
 type IncidentRolesV2CreateJSONRequestBody = IncidentRolesCreatePayloadV2
@@ -11047,6 +11184,9 @@ type ClientInterface interface {
 	// EscalationsV2Show request
 	EscalationsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// EscalationsV2CancelEscalation request
+	EscalationsV2CancelEscalation(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// FollowUpsV2List request
 	FollowUpsV2List(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -11065,6 +11205,11 @@ type ClientInterface interface {
 	FollowUpsV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	FollowUpsV2Update(ctx context.Context, id string, body FollowUpsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// FollowUpsV2ConnectExternalIssueWithBody request with any body
+	FollowUpsV2ConnectExternalIssueWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	FollowUpsV2ConnectExternalIssue(ctx context.Context, id string, body FollowUpsV2ConnectExternalIssueJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// HeartbeatV2Ping1 request
 	HeartbeatV2Ping1(ctx context.Context, alertSourceConfigId string, params *HeartbeatV2Ping1Params, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -13354,6 +13499,18 @@ func (c *Client) EscalationsV2Show(ctx context.Context, id string, reqEditors ..
 	return c.Client.Do(req)
 }
 
+func (c *Client) EscalationsV2CancelEscalation(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEscalationsV2CancelEscalationRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) FollowUpsV2List(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewFollowUpsV2ListRequest(c.Server, params)
 	if err != nil {
@@ -13428,6 +13585,30 @@ func (c *Client) FollowUpsV2UpdateWithBody(ctx context.Context, id string, conte
 
 func (c *Client) FollowUpsV2Update(ctx context.Context, id string, body FollowUpsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewFollowUpsV2UpdateRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FollowUpsV2ConnectExternalIssueWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFollowUpsV2ConnectExternalIssueRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FollowUpsV2ConnectExternalIssue(ctx context.Context, id string, body FollowUpsV2ConnectExternalIssueJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFollowUpsV2ConnectExternalIssueRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -14979,16 +15160,36 @@ func NewAlertNotesV1ListRequest(server string, params *AlertNotesV1ListParams) (
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "alert_id", runtime.ParamLocationQuery, params.AlertId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.AlertId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "alert_id", runtime.ParamLocationQuery, *params.AlertId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
+		}
+
+		if params.AlertGroupId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "alert_group_id", runtime.ParamLocationQuery, *params.AlertGroupId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
 		}
 
 		if params.PageSize != nil {
@@ -18683,9 +18884,41 @@ func NewAlertsV2ListRequest(server string, params *AlertsV2ListParams) (*http.Re
 
 		}
 
+		if params.AlertGroupId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "alert_group_id", runtime.ParamLocationQuery, *params.AlertGroupId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.CreatedAt != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "created_at", runtime.ParamLocationQuery, *params.CreatedAt); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Attributes != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "attributes", runtime.ParamLocationQuery, *params.Attributes); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -20088,6 +20321,40 @@ func NewEscalationsV2ShowRequest(server string, id string) (*http.Request, error
 	return req, nil
 }
 
+// NewEscalationsV2CancelEscalationRequest generates requests for EscalationsV2CancelEscalation
+func NewEscalationsV2CancelEscalationRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/escalations/%s/actions/cancel", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewFollowUpsV2ListRequest generates requests for FollowUpsV2List
 func NewFollowUpsV2ListRequest(server string, params *FollowUpsV2ListParams) (*http.Request, error) {
 	var err error
@@ -20315,6 +20582,53 @@ func NewFollowUpsV2UpdateRequestWithBody(server string, id string, contentType s
 	}
 
 	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewFollowUpsV2ConnectExternalIssueRequest calls the generic FollowUpsV2ConnectExternalIssue builder with application/json body
+func NewFollowUpsV2ConnectExternalIssueRequest(server string, id string, body FollowUpsV2ConnectExternalIssueJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewFollowUpsV2ConnectExternalIssueRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewFollowUpsV2ConnectExternalIssueRequestWithBody generates requests for FollowUpsV2ConnectExternalIssue with any type of body
+func NewFollowUpsV2ConnectExternalIssueRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/follow_ups/%s/actions/connect_external_issue", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -25074,6 +25388,9 @@ type ClientWithResponsesInterface interface {
 	// EscalationsV2ShowWithResponse request
 	EscalationsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EscalationsV2ShowResponse, error)
 
+	// EscalationsV2CancelEscalationWithResponse request
+	EscalationsV2CancelEscalationWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EscalationsV2CancelEscalationResponse, error)
+
 	// FollowUpsV2ListWithResponse request
 	FollowUpsV2ListWithResponse(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*FollowUpsV2ListResponse, error)
 
@@ -25092,6 +25409,11 @@ type ClientWithResponsesInterface interface {
 	FollowUpsV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FollowUpsV2UpdateResponse, error)
 
 	FollowUpsV2UpdateWithResponse(ctx context.Context, id string, body FollowUpsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*FollowUpsV2UpdateResponse, error)
+
+	// FollowUpsV2ConnectExternalIssueWithBodyWithResponse request with any body
+	FollowUpsV2ConnectExternalIssueWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FollowUpsV2ConnectExternalIssueResponse, error)
+
+	FollowUpsV2ConnectExternalIssueWithResponse(ctx context.Context, id string, body FollowUpsV2ConnectExternalIssueJSONRequestBody, reqEditors ...RequestEditorFn) (*FollowUpsV2ConnectExternalIssueResponse, error)
 
 	// HeartbeatV2Ping1WithResponse request
 	HeartbeatV2Ping1WithResponse(ctx context.Context, alertSourceConfigId string, params *HeartbeatV2Ping1Params, reqEditors ...RequestEditorFn) (*HeartbeatV2Ping1Response, error)
@@ -27990,6 +28312,27 @@ func (r EscalationsV2ShowResponse) StatusCode() int {
 	return 0
 }
 
+type EscalationsV2CancelEscalationResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r EscalationsV2CancelEscalationResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EscalationsV2CancelEscalationResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type FollowUpsV2ListResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -28093,6 +28436,28 @@ func (r FollowUpsV2UpdateResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r FollowUpsV2UpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type FollowUpsV2ConnectExternalIssueResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *FollowUpsConnectExternalIssueResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r FollowUpsV2ConnectExternalIssueResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r FollowUpsV2ConnectExternalIssueResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -31386,6 +31751,15 @@ func (c *ClientWithResponses) EscalationsV2ShowWithResponse(ctx context.Context,
 	return ParseEscalationsV2ShowResponse(rsp)
 }
 
+// EscalationsV2CancelEscalationWithResponse request returning *EscalationsV2CancelEscalationResponse
+func (c *ClientWithResponses) EscalationsV2CancelEscalationWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EscalationsV2CancelEscalationResponse, error) {
+	rsp, err := c.EscalationsV2CancelEscalation(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEscalationsV2CancelEscalationResponse(rsp)
+}
+
 // FollowUpsV2ListWithResponse request returning *FollowUpsV2ListResponse
 func (c *ClientWithResponses) FollowUpsV2ListWithResponse(ctx context.Context, params *FollowUpsV2ListParams, reqEditors ...RequestEditorFn) (*FollowUpsV2ListResponse, error) {
 	rsp, err := c.FollowUpsV2List(ctx, params, reqEditors...)
@@ -31445,6 +31819,23 @@ func (c *ClientWithResponses) FollowUpsV2UpdateWithResponse(ctx context.Context,
 		return nil, err
 	}
 	return ParseFollowUpsV2UpdateResponse(rsp)
+}
+
+// FollowUpsV2ConnectExternalIssueWithBodyWithResponse request with arbitrary body returning *FollowUpsV2ConnectExternalIssueResponse
+func (c *ClientWithResponses) FollowUpsV2ConnectExternalIssueWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FollowUpsV2ConnectExternalIssueResponse, error) {
+	rsp, err := c.FollowUpsV2ConnectExternalIssueWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFollowUpsV2ConnectExternalIssueResponse(rsp)
+}
+
+func (c *ClientWithResponses) FollowUpsV2ConnectExternalIssueWithResponse(ctx context.Context, id string, body FollowUpsV2ConnectExternalIssueJSONRequestBody, reqEditors ...RequestEditorFn) (*FollowUpsV2ConnectExternalIssueResponse, error) {
+	rsp, err := c.FollowUpsV2ConnectExternalIssue(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFollowUpsV2ConnectExternalIssueResponse(rsp)
 }
 
 // HeartbeatV2Ping1WithResponse request returning *HeartbeatV2Ping1Response
@@ -35346,6 +35737,22 @@ func ParseEscalationsV2ShowResponse(rsp *http.Response) (*EscalationsV2ShowRespo
 	return response, nil
 }
 
+// ParseEscalationsV2CancelEscalationResponse parses an HTTP response from a EscalationsV2CancelEscalationWithResponse call
+func ParseEscalationsV2CancelEscalationResponse(rsp *http.Response) (*EscalationsV2CancelEscalationResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EscalationsV2CancelEscalationResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
 // ParseFollowUpsV2ListResponse parses an HTTP response from a FollowUpsV2ListWithResponse call
 func ParseFollowUpsV2ListResponse(rsp *http.Response) (*FollowUpsV2ListResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -35456,6 +35863,32 @@ func ParseFollowUpsV2UpdateResponse(rsp *http.Response) (*FollowUpsV2UpdateRespo
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest FollowUpsUpdateResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseFollowUpsV2ConnectExternalIssueResponse parses an HTTP response from a FollowUpsV2ConnectExternalIssueWithResponse call
+func ParseFollowUpsV2ConnectExternalIssueResponse(rsp *http.Response) (*FollowUpsV2ConnectExternalIssueResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &FollowUpsV2ConnectExternalIssueResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest FollowUpsConnectExternalIssueResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -1686,6 +1686,13 @@ const (
 	Wednesday WeekdayIntervalV2Weekday = "wednesday"
 )
 
+// Defines values for WorkflowSlimV2PrivateIncidentScope.
+const (
+	WorkflowSlimV2PrivateIncidentScopeAll         WorkflowSlimV2PrivateIncidentScope = "all"
+	WorkflowSlimV2PrivateIncidentScopeNone        WorkflowSlimV2PrivateIncidentScope = "none"
+	WorkflowSlimV2PrivateIncidentScopeOwningTeams WorkflowSlimV2PrivateIncidentScope = "owning_teams"
+)
+
 // Defines values for WorkflowSlimV2RunsOnIncidentModes.
 const (
 	WorkflowSlimV2RunsOnIncidentModesRetrospective WorkflowSlimV2RunsOnIncidentModes = "retrospective"
@@ -1705,6 +1712,13 @@ const (
 	WorkflowSlimV2StateDisabled WorkflowSlimV2State = "disabled"
 	WorkflowSlimV2StateDraft    WorkflowSlimV2State = "draft"
 	WorkflowSlimV2StateError    WorkflowSlimV2State = "error"
+)
+
+// Defines values for WorkflowV2PrivateIncidentScope.
+const (
+	WorkflowV2PrivateIncidentScopeAll         WorkflowV2PrivateIncidentScope = "all"
+	WorkflowV2PrivateIncidentScopeNone        WorkflowV2PrivateIncidentScope = "none"
+	WorkflowV2PrivateIncidentScopeOwningTeams WorkflowV2PrivateIncidentScope = "owning_teams"
 )
 
 // Defines values for WorkflowV2RunsOnIncidentModes.
@@ -1728,6 +1742,13 @@ const (
 	WorkflowV2StateError    WorkflowV2State = "error"
 )
 
+// Defines values for WorkflowsCreateWorkflowPayloadV2PrivateIncidentScope.
+const (
+	WorkflowsCreateWorkflowPayloadV2PrivateIncidentScopeAll         WorkflowsCreateWorkflowPayloadV2PrivateIncidentScope = "all"
+	WorkflowsCreateWorkflowPayloadV2PrivateIncidentScopeNone        WorkflowsCreateWorkflowPayloadV2PrivateIncidentScope = "none"
+	WorkflowsCreateWorkflowPayloadV2PrivateIncidentScopeOwningTeams WorkflowsCreateWorkflowPayloadV2PrivateIncidentScope = "owning_teams"
+)
+
 // Defines values for WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes.
 const (
 	WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModesRetrospective WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes = "retrospective"
@@ -1747,6 +1768,13 @@ const (
 	WorkflowsCreateWorkflowPayloadV2StateDisabled WorkflowsCreateWorkflowPayloadV2State = "disabled"
 	WorkflowsCreateWorkflowPayloadV2StateDraft    WorkflowsCreateWorkflowPayloadV2State = "draft"
 	WorkflowsCreateWorkflowPayloadV2StateError    WorkflowsCreateWorkflowPayloadV2State = "error"
+)
+
+// Defines values for WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScope.
+const (
+	WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScopeAll         WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScope = "all"
+	WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScopeNone        WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScope = "none"
+	WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScopeOwningTeams WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScope = "owning_teams"
 )
 
 // Defines values for WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes.
@@ -9434,7 +9462,7 @@ type WorkflowSlimV2 struct {
 	// IncludePrivateEscalations Whether to include private escalations
 	IncludePrivateEscalations bool `json:"include_private_escalations"`
 
-	// IncludePrivateIncidents Whether to include private incidents
+	// IncludePrivateIncidents DEPRECATED: use `private_incident_scope` instead. `true` when the workflow runs on private incidents (a `private_incident_scope` of `all` or `owning_teams`), `false` when the scope is `none`.
 	IncludePrivateIncidents bool `json:"include_private_incidents"`
 
 	// Name Name provided by the user when creating the workflow
@@ -9445,6 +9473,9 @@ type WorkflowSlimV2 struct {
 
 	// OwningTeamIds IDs of the teams that own this workflow
 	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
+	// PrivateIncidentScope Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none
+	PrivateIncidentScope WorkflowSlimV2PrivateIncidentScope `json:"private_incident_scope"`
 
 	// RunsFrom The time from which this workflow will run on incidents
 	RunsFrom *time.Time `json:"runs_from,omitempty"`
@@ -9468,6 +9499,9 @@ type WorkflowSlimV2 struct {
 	// Version Revision of the workflow, uniquely identifying it's version
 	Version int64 `json:"version"`
 }
+
+// WorkflowSlimV2PrivateIncidentScope Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none
+type WorkflowSlimV2PrivateIncidentScope string
 
 // WorkflowSlimV2RunsOnIncidentModes Incident mode that workflows can run on
 type WorkflowSlimV2RunsOnIncidentModes string
@@ -9499,7 +9533,7 @@ type WorkflowV2 struct {
 	// IncludePrivateEscalations Whether to include private escalations
 	IncludePrivateEscalations bool `json:"include_private_escalations"`
 
-	// IncludePrivateIncidents Whether to include private incidents
+	// IncludePrivateIncidents DEPRECATED: use `private_incident_scope` instead. `true` when the workflow runs on private incidents (a `private_incident_scope` of `all` or `owning_teams`), `false` when the scope is `none`.
 	IncludePrivateIncidents bool `json:"include_private_incidents"`
 
 	// Name Name provided by the user when creating the workflow
@@ -9510,6 +9544,9 @@ type WorkflowV2 struct {
 
 	// OwningTeamIds IDs of the teams that own this workflow
 	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
+	// PrivateIncidentScope Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none
+	PrivateIncidentScope WorkflowV2PrivateIncidentScope `json:"private_incident_scope"`
 
 	// RunsFrom The time from which this workflow will run on incidents
 	RunsFrom *time.Time `json:"runs_from,omitempty"`
@@ -9533,6 +9570,9 @@ type WorkflowV2 struct {
 	// Version Revision of the workflow, uniquely identifying it's version
 	Version int64 `json:"version"`
 }
+
+// WorkflowV2PrivateIncidentScope Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none
+type WorkflowV2PrivateIncidentScope string
 
 // WorkflowV2RunsOnIncidentModes Incident mode that workflows can run on
 type WorkflowV2RunsOnIncidentModes string
@@ -9564,8 +9604,8 @@ type WorkflowsCreateWorkflowPayloadV2 struct {
 	// IncludePrivateEscalations Whether to include private escalations
 	IncludePrivateEscalations *bool `json:"include_private_escalations,omitempty"`
 
-	// IncludePrivateIncidents Whether to include private incidents
-	IncludePrivateIncidents bool `json:"include_private_incidents"`
+	// IncludePrivateIncidents DEPRECATED: use `private_incident_scope` instead. Mutually exclusive with `private_incident_scope` — sending both returns a validation error.
+	IncludePrivateIncidents *bool `json:"include_private_incidents,omitempty"`
 
 	// Name Name provided by the user when creating the workflow
 	Name string `json:"name"`
@@ -9575,6 +9615,9 @@ type WorkflowsCreateWorkflowPayloadV2 struct {
 
 	// OwningTeamIds IDs of the teams that own this workflow
 	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
+	// PrivateIncidentScope Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none
+	PrivateIncidentScope *WorkflowsCreateWorkflowPayloadV2PrivateIncidentScope `json:"private_incident_scope,omitempty"`
 
 	// RunsOnIncidentModes Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
 	RunsOnIncidentModes []WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes `json:"runs_on_incident_modes"`
@@ -9594,6 +9637,9 @@ type WorkflowsCreateWorkflowPayloadV2 struct {
 	// Trigger Trigger to set on the workflow
 	Trigger string `json:"trigger"`
 }
+
+// WorkflowsCreateWorkflowPayloadV2PrivateIncidentScope Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none
+type WorkflowsCreateWorkflowPayloadV2PrivateIncidentScope string
 
 // WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes defines model for WorkflowsCreateWorkflowPayloadV2.RunsOnIncidentModes.
 type WorkflowsCreateWorkflowPayloadV2RunsOnIncidentModes string
@@ -9642,8 +9688,8 @@ type WorkflowsUpdateWorkflowPayloadV2 struct {
 	// IncludePrivateEscalations Whether to include private escalations
 	IncludePrivateEscalations *bool `json:"include_private_escalations,omitempty"`
 
-	// IncludePrivateIncidents Whether to include private incidents
-	IncludePrivateIncidents bool `json:"include_private_incidents"`
+	// IncludePrivateIncidents DEPRECATED: use `private_incident_scope` instead. Mutually exclusive with `private_incident_scope` — sending both returns a validation error.
+	IncludePrivateIncidents *bool `json:"include_private_incidents,omitempty"`
 
 	// Name Name provided by the user when creating the workflow
 	Name string `json:"name"`
@@ -9653,6 +9699,9 @@ type WorkflowsUpdateWorkflowPayloadV2 struct {
 
 	// OwningTeamIds IDs of the teams that own this workflow
 	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
+	// PrivateIncidentScope Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none
+	PrivateIncidentScope *WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScope `json:"private_incident_scope,omitempty"`
 
 	// RunsOnIncidentModes Which incident modes should this workflow run on? By default, workflows only run on standard incidents, but can also be configured to run on test and retrospective incidents.
 	RunsOnIncidentModes []WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes `json:"runs_on_incident_modes"`
@@ -9672,6 +9721,9 @@ type WorkflowsUpdateWorkflowPayloadV2 struct {
 	// Steps Steps that are executed as part of the workflow
 	Steps []StepConfigPayloadV2 `json:"steps"`
 }
+
+// WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScope Which private incidents this workflow acts on: every private incident (all), those an owning team can see (owning_teams), or none
+type WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScope string
 
 // WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes defines model for WorkflowsUpdateWorkflowPayloadV2.RunsOnIncidentModes.
 type WorkflowsUpdateWorkflowPayloadV2RunsOnIncidentModes string

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -20,9 +21,13 @@ import (
 )
 
 var (
-	_ resource.Resource                = &IncidentWorkflowResource{}
-	_ resource.ResourceWithImportState = &IncidentWorkflowResource{}
+	_ resource.Resource                   = &IncidentWorkflowResource{}
+	_ resource.ResourceWithImportState    = &IncidentWorkflowResource{}
+	_ resource.ResourceWithValidateConfig = &IncidentWorkflowResource{}
 )
+
+// privateIncidentScopes are the valid values for the private_incident_scope attribute.
+var privateIncidentScopes = []string{"all", "owning_teams", "none"}
 
 type IncidentWorkflowResource struct {
 	client           *client.ClientWithResponses
@@ -44,6 +49,7 @@ type IncidentWorkflowResourceModel struct {
 	Expressions               models.IncidentEngineExpressions     `tfsdk:"expressions"`
 	OnceFor                   []types.String                       `tfsdk:"once_for"`
 	IncludePrivateIncidents   types.Bool                           `tfsdk:"include_private_incidents"`
+	PrivateIncidentScope      types.String                         `tfsdk:"private_incident_scope"`
 	IncludePrivateEscalations types.Bool                           `tfsdk:"include_private_escalations"`
 	OwningTeamIDs             types.Set                            `tfsdk:"owning_team_ids"`
 	ContinueOnStepError       types.Bool                           `tfsdk:"continue_on_step_error"`
@@ -128,7 +134,14 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 			},
 			"include_private_incidents": schema.BoolAttribute{
 				MarkdownDescription: apischema.Docstring("WorkflowV2", "include_private_incidents"),
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				DeprecationMessage:  "Use `private_incident_scope` instead. Setting both `include_private_incidents` and `private_incident_scope` is not allowed.",
+			},
+			"private_incident_scope": schema.StringAttribute{
+				MarkdownDescription: EnumValuesDescription("WorkflowV2", "private_incident_scope"),
+				Optional:            true,
+				Computed:            true,
 			},
 			"include_private_escalations": schema.BoolAttribute{
 				MarkdownDescription: apischema.Docstring("WorkflowV2", "include_private_escalations"),
@@ -195,23 +208,34 @@ func (r *IncidentWorkflowResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	payload := client.WorkflowsCreateWorkflowPayloadV2{
-		Trigger:                 data.Trigger.ValueString(),
-		Name:                    data.Name.ValueString(),
-		OnceFor:                 onceFor,
-		ConditionGroups:         data.ConditionGroups.ToPayload(),
-		Steps:                   toPayloadSteps(data.Steps),
-		Expressions:             data.Expressions.ToPayload(),
-		RunsOnIncidents:         client.WorkflowsCreateWorkflowPayloadV2RunsOnIncidents(data.RunsOnIncidents.ValueString()),
-		RunsOnIncidentModes:     runsOnIncidentModes,
-		Folder:                  data.Folder.ValueStringPointer(),
-		Shortform:               data.Shortform.ValueStringPointer(),
-		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
-		OwningTeamIds:           toOwningTeamIDs(data.OwningTeamIDs),
-		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
-		State:                   lo.ToPtr(client.WorkflowsCreateWorkflowPayloadV2State(data.State.ValueString())),
+		Trigger:             data.Trigger.ValueString(),
+		Name:                data.Name.ValueString(),
+		OnceFor:             onceFor,
+		ConditionGroups:     data.ConditionGroups.ToPayload(),
+		Steps:               toPayloadSteps(data.Steps),
+		Expressions:         data.Expressions.ToPayload(),
+		RunsOnIncidents:     client.WorkflowsCreateWorkflowPayloadV2RunsOnIncidents(data.RunsOnIncidents.ValueString()),
+		RunsOnIncidentModes: runsOnIncidentModes,
+		Folder:              data.Folder.ValueStringPointer(),
+		Shortform:           data.Shortform.ValueStringPointer(),
+		OwningTeamIds:       toOwningTeamIDs(data.OwningTeamIDs),
+		ContinueOnStepError: data.ContinueOnStepError.ValueBool(),
+		State:               lo.ToPtr(client.WorkflowsCreateWorkflowPayloadV2State(data.State.ValueString())),
 		Annotations: &map[string]string{
 			"incident.io/terraform/version": r.terraformVersion,
 		},
+	}
+
+	// Read from config, not the plan: scope is Computed, so the plan can carry a
+	// value from state the user never set, which would shadow a bool change.
+	var cfgScope types.String
+	var cfgBool types.Bool
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("private_incident_scope"), &cfgScope)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("include_private_incidents"), &cfgBool)...)
+	if !cfgScope.IsNull() {
+		payload.PrivateIncidentScope = lo.ToPtr(client.WorkflowsCreateWorkflowPayloadV2PrivateIncidentScope(cfgScope.ValueString()))
+	} else if !cfgBool.IsNull() {
+		payload.IncludePrivateIncidents = lo.ToPtr(cfgBool.ValueBool())
 	}
 
 	if !data.IncludePrivateEscalations.IsNull() {
@@ -262,23 +286,34 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	payload := client.WorkflowsV2UpdateWorkflowJSONRequestBody{
-		Name:                    data.Name.ValueString(),
-		ConditionGroups:         data.ConditionGroups.ToPayload(),
-		Steps:                   toPayloadSteps(data.Steps),
-		Expressions:             data.Expressions.ToPayload(),
-		OnceFor:                 onceFor,
-		RunsOnIncidents:         client.WorkflowsUpdateWorkflowPayloadV2RunsOnIncidents(data.RunsOnIncidents.ValueString()),
-		RunsOnIncidentModes:     runsOnIncidentModes,
-		Folder:                  data.Folder.ValueStringPointer(),
-		Shortform:               data.Shortform.ValueStringPointer(),
-		IncludePrivateIncidents: data.IncludePrivateIncidents.ValueBool(),
-		OwningTeamIds:           toOwningTeamIDs(data.OwningTeamIDs),
-		ContinueOnStepError:     data.ContinueOnStepError.ValueBool(),
-		State:                   lo.ToPtr(client.WorkflowsUpdateWorkflowPayloadV2State(data.State.ValueString())),
+		Name:                data.Name.ValueString(),
+		ConditionGroups:     data.ConditionGroups.ToPayload(),
+		Steps:               toPayloadSteps(data.Steps),
+		Expressions:         data.Expressions.ToPayload(),
+		OnceFor:             onceFor,
+		RunsOnIncidents:     client.WorkflowsUpdateWorkflowPayloadV2RunsOnIncidents(data.RunsOnIncidents.ValueString()),
+		RunsOnIncidentModes: runsOnIncidentModes,
+		Folder:              data.Folder.ValueStringPointer(),
+		Shortform:           data.Shortform.ValueStringPointer(),
+		OwningTeamIds:       toOwningTeamIDs(data.OwningTeamIDs),
+		ContinueOnStepError: data.ContinueOnStepError.ValueBool(),
+		State:               lo.ToPtr(client.WorkflowsUpdateWorkflowPayloadV2State(data.State.ValueString())),
 		Annotations: &map[string]string{
 			"incident.io/terraform/version": r.terraformVersion,
 		},
 		SkipStepUpgrades: lo.ToPtr(true),
+	}
+
+	// Read from config, not the plan: scope is Computed, so the plan can carry a
+	// value from state the user never set, which would shadow a bool change.
+	var cfgScope types.String
+	var cfgBool types.Bool
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("private_incident_scope"), &cfgScope)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("include_private_incidents"), &cfgBool)...)
+	if !cfgScope.IsNull() {
+		payload.PrivateIncidentScope = lo.ToPtr(client.WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScope(cfgScope.ValueString()))
+	} else if !cfgBool.IsNull() {
+		payload.IncludePrivateIncidents = lo.ToPtr(cfgBool.ValueBool())
 	}
 
 	if !data.IncludePrivateEscalations.IsNull() {
@@ -379,6 +414,36 @@ func toOwningTeamIDs(set types.Set) *[]string {
 	}
 
 	return &teamIDs
+}
+
+// ValidateConfig rejects setting both include_private_incidents and the
+// private_incident_scope that supersedes it (the API treats them as mutually
+// exclusive), and checks private_incident_scope is a recognised value.
+func (r *IncidentWorkflowResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var includePrivate types.Bool
+	var scope types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("include_private_incidents"), &includePrivate)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("private_incident_scope"), &scope)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scopeSet := !scope.IsNull() && !scope.IsUnknown()
+	boolSet := !includePrivate.IsNull() && !includePrivate.IsUnknown()
+
+	if scopeSet && boolSet {
+		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+			"Cannot set both include_private_incidents and private_incident_scope",
+			"include_private_incidents is deprecated in favour of private_incident_scope; set only one of them.",
+		))
+	}
+
+	if scopeSet && !lo.Contains(privateIncidentScopes, scope.ValueString()) {
+		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+			"Invalid private_incident_scope",
+			fmt.Sprintf("private_incident_scope must be one of %v, got %q.", privateIncidentScopes, scope.ValueString()),
+		))
+	}
 }
 
 func toPayloadSteps(steps []IncidentWorkflowStep) []client.StepConfigPayloadV2 {

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -136,7 +136,7 @@ We'd generally recommend building workflows in our [web dashboard](https://app.i
 				MarkdownDescription: apischema.Docstring("WorkflowV2", "include_private_incidents"),
 				Optional:            true,
 				Computed:            true,
-				DeprecationMessage:  "Use `private_incident_scope` instead. Setting both `include_private_incidents` and `private_incident_scope` is not allowed.",
+				DeprecationMessage:  "Use `private_incident_scope` instead. When both are set they must agree (include_private_incidents is true for the all and owning_teams scopes, false for none).",
 			},
 			"private_incident_scope": schema.StringAttribute{
 				MarkdownDescription: EnumValuesDescription("WorkflowV2", "private_incident_scope"),
@@ -416,9 +416,9 @@ func toOwningTeamIDs(set types.Set) *[]string {
 	return &teamIDs
 }
 
-// ValidateConfig rejects setting both include_private_incidents and the
-// private_incident_scope that supersedes it (the API treats them as mutually
-// exclusive), and checks private_incident_scope is a recognised value.
+// ValidateConfig blocks an unrecognised private_incident_scope, or an include_private_incidents
+// that contradicts it. The bool is true whenever the scope touches private incidents (all or
+// owning_teams), false for none; the API accepts both when they agree, so only disagreement errors.
 func (r *IncidentWorkflowResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var includePrivate types.Bool
 	var scope types.String
@@ -431,18 +431,22 @@ func (r *IncidentWorkflowResource) ValidateConfig(ctx context.Context, req resou
 	scopeSet := !scope.IsNull() && !scope.IsUnknown()
 	boolSet := !includePrivate.IsNull() && !includePrivate.IsUnknown()
 
-	if scopeSet && boolSet {
-		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
-			"Cannot set both include_private_incidents and private_incident_scope",
-			"include_private_incidents is deprecated in favour of private_incident_scope; set only one of them.",
-		))
-	}
-
 	if scopeSet && !lo.Contains(privateIncidentScopes, scope.ValueString()) {
 		resp.Diagnostics.Append(diag.NewErrorDiagnostic(
 			"Invalid private_incident_scope",
 			fmt.Sprintf("private_incident_scope must be one of %v, got %q.", privateIncidentScopes, scope.ValueString()),
 		))
+		return
+	}
+
+	if scopeSet && boolSet {
+		touchesPrivate := scope.ValueString() != "none"
+		if includePrivate.ValueBool() != touchesPrivate {
+			resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+				"include_private_incidents and private_incident_scope disagree",
+				"include_private_incidents is deprecated in favour of private_incident_scope. When both are set they must agree: include_private_incidents is true for the all and owning_teams scopes and false for none. Prefer setting only private_incident_scope.",
+			))
+		}
 	}
 }
 

--- a/internal/provider/incident_workflow_resource.go
+++ b/internal/provider/incident_workflow_resource.go
@@ -226,15 +226,17 @@ func (r *IncidentWorkflowResource) Create(ctx context.Context, req resource.Crea
 		},
 	}
 
-	// Read from config, not the plan: scope is Computed, so the plan can carry a
-	// value from state the user never set, which would shadow a bool change.
+	// Forward whichever privacy fields the user set in config (ValidateConfig
+	// already ensures they agree). Read from config, not the plan: both are
+	// Computed, so the plan can carry a value from state the user never set.
 	var cfgScope types.String
 	var cfgBool types.Bool
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("private_incident_scope"), &cfgScope)...)
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("include_private_incidents"), &cfgBool)...)
 	if !cfgScope.IsNull() {
 		payload.PrivateIncidentScope = lo.ToPtr(client.WorkflowsCreateWorkflowPayloadV2PrivateIncidentScope(cfgScope.ValueString()))
-	} else if !cfgBool.IsNull() {
+	}
+	if !cfgBool.IsNull() {
 		payload.IncludePrivateIncidents = lo.ToPtr(cfgBool.ValueBool())
 	}
 
@@ -304,15 +306,17 @@ func (r *IncidentWorkflowResource) Update(ctx context.Context, req resource.Upda
 		SkipStepUpgrades: lo.ToPtr(true),
 	}
 
-	// Read from config, not the plan: scope is Computed, so the plan can carry a
-	// value from state the user never set, which would shadow a bool change.
+	// Forward whichever privacy fields the user set in config (ValidateConfig
+	// already ensures they agree). Read from config, not the plan: both are
+	// Computed, so the plan can carry a value from state the user never set.
 	var cfgScope types.String
 	var cfgBool types.Bool
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("private_incident_scope"), &cfgScope)...)
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("include_private_incidents"), &cfgBool)...)
 	if !cfgScope.IsNull() {
 		payload.PrivateIncidentScope = lo.ToPtr(client.WorkflowsUpdateWorkflowPayloadV2PrivateIncidentScope(cfgScope.ValueString()))
-	} else if !cfgBool.IsNull() {
+	}
+	if !cfgBool.IsNull() {
 		payload.IncludePrivateIncidents = lo.ToPtr(cfgBool.ValueBool())
 	}
 

--- a/internal/provider/incident_workflow_resource_test.go
+++ b/internal/provider/incident_workflow_resource_test.go
@@ -280,22 +280,34 @@ func TestAccIncidentWorkflowResourcePrivateIncidentScope(t *testing.T) {
 					resource.TestCheckResourceAttr("incident_workflow.example", "private_incident_scope", "none"),
 				),
 			},
+			// Both fields set together is accepted as long as they agree (the round-trip case).
+			{
+				Config: testAccIncidentWorkflowConfigPrivacy(`
+  include_private_incidents = true
+  private_incident_scope    = "all"`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_workflow.example", "private_incident_scope", "all"),
+					resource.TestCheckResourceAttr("incident_workflow.example", "include_private_incidents", "true"),
+				),
+			},
 		},
 	})
 }
 
-// TestAccIncidentWorkflowResourcePrivateScopeConflict checks that setting both the
-// deprecated bool and the scope is rejected at plan time (mirrors the API's 422).
+// TestAccIncidentWorkflowResourcePrivateScopeConflict checks that contradictory bool/scope values
+// are rejected at plan time (mirrors the API's 422); agreeing values are covered by
+// TestAccIncidentWorkflowResourcePrivateIncidentScope.
 func TestAccIncidentWorkflowResourcePrivateScopeConflict(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				// none does not touch private incidents, so the bool must be false to agree.
 				Config: testAccIncidentWorkflowConfigPrivacy(`
-  include_private_incidents = false
+  include_private_incidents = true
   private_incident_scope    = "none"`),
-				ExpectError: regexp.MustCompile("Cannot set both"),
+				ExpectError: regexp.MustCompile("disagree"),
 			},
 		},
 	})

--- a/internal/provider/incident_workflow_resource_test.go
+++ b/internal/provider/incident_workflow_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
 	"text/template"
 
@@ -233,6 +234,73 @@ func TestAccIncidentWorkflowResourceOwningTeamIDs(t *testing.T) {
 	})
 }
 
+// TestAccIncidentWorkflowResourcePrivateIncidentScope checks that private_incident_scope
+// round-trips and that the deprecated include_private_incidents is derived from it on read.
+func TestAccIncidentWorkflowResourcePrivateIncidentScope(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with scope = all; the deprecated bool is derived to true.
+			{
+				Config: testAccIncidentWorkflowConfigPrivacy(`private_incident_scope = "all"`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_workflow.example", "private_incident_scope", "all"),
+					resource.TestCheckResourceAttr("incident_workflow.example", "include_private_incidents", "true"),
+				),
+			},
+			// Import round-trip.
+			{
+				ResourceName:      "incident_workflow.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update to scope = none; derived bool flips to false.
+			{
+				Config: testAccIncidentWorkflowConfigPrivacy(`private_incident_scope = "none"`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_workflow.example", "private_incident_scope", "none"),
+					resource.TestCheckResourceAttr("incident_workflow.example", "include_private_incidents", "false"),
+				),
+			},
+			// Legacy path: setting only the deprecated bool still works and derives the scope.
+			{
+				Config: testAccIncidentWorkflowConfigPrivacy(`include_private_incidents = true`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_workflow.example", "include_private_incidents", "true"),
+					resource.TestCheckResourceAttr("incident_workflow.example", "private_incident_scope", "all"),
+				),
+			},
+			// Flipping only the deprecated bool must reach the API even
+			// though a scope is now carried in state — decisions read config, not plan.
+			{
+				Config: testAccIncidentWorkflowConfigPrivacy(`include_private_incidents = false`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("incident_workflow.example", "include_private_incidents", "false"),
+					resource.TestCheckResourceAttr("incident_workflow.example", "private_incident_scope", "none"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccIncidentWorkflowResourcePrivateScopeConflict checks that setting both the
+// deprecated bool and the scope is rejected at plan time (mirrors the API's 422).
+func TestAccIncidentWorkflowResourcePrivateScopeConflict(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIncidentWorkflowConfigPrivacy(`
+  include_private_incidents = false
+  private_incident_scope    = "none"`),
+				ExpectError: regexp.MustCompile("Cannot set both"),
+			},
+		},
+	})
+}
+
 // testAccIncidentWorkflowResourceConfigOwningTeams renders a workflow owning teamCount
 // self-provisioned Team catalog entries (0 omits owning_team_ids entirely).
 func testAccIncidentWorkflowResourceConfigOwningTeams(teamCount int) string {
@@ -298,4 +366,44 @@ resource "incident_workflow" "example" {
 		TeamIndices:  lo.Range(teamCount),
 		TeamIDs:      teamIDs,
 	})
+}
+
+// testAccIncidentWorkflowConfigPrivacy renders a minimal workflow with the given
+// privacy attribute lines spliced in (e.g. a private_incident_scope assignment).
+func testAccIncidentWorkflowConfigPrivacy(privacy string) string {
+	return testRunTemplate("incident_workflow_privacy", `
+resource "incident_workflow" "example" {
+  name    = "Private scope workflow"
+  trigger = "incident.updated"
+  condition_groups = [
+    {
+      conditions = [
+        {
+          subject        = "incident.status.category"
+          operation      = "one_of"
+          param_bindings = [{ array_value = [{ literal = "open" }] }]
+        }
+      ]
+    }
+  ]
+  steps = [
+    {
+      id   = "01HXVEA7Y0VWQBJB4F2X8WNRW6"
+      name = "incident.create_follow_ups"
+      param_bindings = [
+        { value = { reference = "incident" } },
+        { array_value = [{ literal = "Write postmortem" }] },
+        {}
+      ]
+    }
+  ]
+  expressions            = []
+  once_for               = ["incident"]
+  {{ .Privacy }}
+  continue_on_step_error = false
+  runs_on_incidents      = "newly_created"
+  runs_on_incident_modes = ["standard"]
+  state                  = "draft"
+}
+`, struct{ Privacy string }{Privacy: privacy})
 }

--- a/internal/provider/schema_converters.go
+++ b/internal/provider/schema_converters.go
@@ -50,6 +50,7 @@ func (r *IncidentWorkflowResource) buildModel(ctx context.Context, workflow clie
 		OnceFor:                   buildOnceFor(workflow.OnceFor),
 		RunsOnIncidentModes:       buildRunsOnIncidentModes(workflow.RunsOnIncidentModes),
 		IncludePrivateIncidents:   types.BoolValue(workflow.IncludePrivateIncidents),
+		PrivateIncidentScope:      types.StringValue(string(workflow.PrivateIncidentScope)),
 		IncludePrivateEscalations: types.BoolPointerValue(lo.ToPtr(workflow.IncludePrivateEscalations)),
 		OwningTeamIDs:             buildOwningTeamIDs(workflow.OwningTeamIds),
 		ContinueOnStepError:       types.BoolValue(workflow.ContinueOnStepError),


### PR DESCRIPTION
expose the ternary private_incident_scope (all/owning_teams/none) on the incident_workflow resource, mirroring the public API v2 change, and deprecate the include_private_incidents bool it supersedes.

the API returns both fields (bool is derived from the scope) and accepts both on write as long as they agree. So both attributes are optional+computed (each round-trips whichever the other side fills, avoiding drift on existing workflows), the create/update paths send exactly one (scope wins, else the legacy bool, else neither- in which case the API defaults to none on create and leaves it unchanged on update), and ValidateConfig rejects contradictory values at plan time. Regenerates the client and docs from a spec patched with the new field.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which private incidents workflows can target; incorrect scope or migration from the legacy bool could alter workflow behavior in production.
> 
> **Overview**
> Adds **`private_incident_scope`** (`all`, `owning_teams`, `none`) on `incident_workflow`, aligned with the public API v2 ternary for which private incidents a workflow may run on.
> 
> **`include_private_incidents`** stays supported but is **deprecated** and documented as derived from scope (`true` for `all`/`owning_teams`, `false` for `none`). Both attributes are optional and computed so existing state can round-trip without drift; create/update only send privacy fields the user actually set in config (not computed plan values), and **ValidateConfig** fails the plan when scope and the legacy bool disagree.
> 
> Provider docs schema is regenerated to list the new optional attribute and move the bool under Optional with a deprecation note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f71fad345519667de3e782683059896bebfe34b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->