### PR TITLE
changelog for v5.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v5.43.0
+
+- Add `private_incident_scope` to workflow resource (`all` / `owning_teams` / `none`), deprecating `include_private_incidents`. The two may be set together as long as they agree (`include_private_incidents` is `true` for the `all` and `owning_teams` scopes, `false` for `none`)
+
 ## v5.42.0
 
 - Add `owning_team_ids` to workflow resource


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changelog-only change with no runtime or schema impact from this PR.
> 
> **Overview**
> Adds a **v5.43.0** section to `CHANGELOG.md` documenting the workflow resource change: new `private_incident_scope` (`all` / `owning_teams` / `none`) replaces the deprecated `include_private_incidents` boolean, with both allowed together only when their semantics match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa10143cdaa4aa11778d2d2dbbda921d0dcb6233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->