### PR TITLE
Add owning_team_ids to catalog type resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `owning_team_ids` to catalog type resource and data source
+
 ## v5.43.1
 
 - Fix `Value Conversion Error` (`Path: path`) when importing an `incident_catalog_type_attribute` via an `import {}` block. When the API response for the catalog type did not contain the imported attribute, `buildModel` produced an untyped `path` list (`types.List[DynamicPseudoType]`) that the framework rejected while writing state. `buildModel` now always writes a fully-typed `path`, `ImportState` populates the full model (and returns a clear diagnostic if the catalog type or attribute can't be found), and `Read` removes the resource from state if the attribute no longer exists.

--- a/docs/data-sources/catalog_type.md
+++ b/docs/data-sources/catalog_type.md
@@ -48,5 +48,6 @@ resource "incident_catalog_entries" "services" {
 
 - `description` (String) Human readble description of this type
 - `id` (String) ID of this catalog type
+- `owning_team_ids` (Set of String) IDs of the teams that own this catalog type
 - `source_repo_url` (String) The url of the external repository where this type is managed. If set, users will not be able to edit the catalog type (or its entries) via the UI, and will instead be provided a link to this URL.
 - `use_name_as_identifier` (Boolean) If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.

--- a/docs/resources/catalog_type.md
+++ b/docs/resources/catalog_type.md
@@ -57,6 +57,7 @@ resource "incident_catalog_type" "service_tier" {
   EOF
   categories      = ["service"]
   source_repo_url = "https://github.com/mycompany/infrastructure"
+  owning_team_ids = ["01FCNDV6P870EA6S7TK1DSYD5H"]
 }
 ```
 
@@ -72,6 +73,7 @@ resource "incident_catalog_type" "service_tier" {
 ### Optional
 
 - `categories` (List of String) The categories that this type belongs to, to be shown in the web dashboard. Possible values are: `customer`, `issue-tracker`, `product-feature`, `service`, `on-call`, `team`, `user`.
+- `owning_team_ids` (Set of String) IDs of the teams that own this catalog type
 - `type_name` (String) The type name of this catalog type, to be used when defining attributes. This is immutable once a CatalogType has been created. For non-externally sync types, it must follow the pattern Custom["SomeName"]
 - `use_name_as_identifier` (Boolean) If enabled, you can refer to entries of this type by their name, as well as their external ID and any aliases.
 

--- a/examples/resources/incident_catalog_type/resource.tf
+++ b/examples/resources/incident_catalog_type/resource.tf
@@ -7,4 +7,5 @@ resource "incident_catalog_type" "service_tier" {
   EOF
   categories      = ["service"]
   source_repo_url = "https://github.com/mycompany/infrastructure"
+  owning_team_ids = ["01FCNDV6P870EA6S7TK1DSYD5H"]
 }

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -105,7 +105,7 @@
       "APIKeyTeamRoleV1": {
         "example": {
           "description": "can view data, like public incidents and organization settings",
-          "name": "schedules_editor"
+          "name": "catalog_editor"
         },
         "properties": {
           "description": {
@@ -116,6 +116,7 @@
           "name": {
             "description": "API key role name that may be granted for team-scoped access",
             "enum": [
+              "catalog_editor",
               "schedules_editor",
               "schedules_reader",
               "schedule_overrides_editor",
@@ -125,7 +126,7 @@
               "workflows_editor",
               "private_workflows_editor"
             ],
-            "example": "schedules_editor",
+            "example": "catalog_editor",
             "type": "string",
             "x-public-api-version": "v1"
           }
@@ -138,6 +139,7 @@
       },
       "APIKeyV1": {
         "example": {
+          "comments": "Requested in https://example.slack.com/archives/C123/p456",
           "created_at": "2021-08-17T13:28:57.801578Z",
           "creator": {
             "api_key": {
@@ -167,12 +169,19 @@
           "team_roles": [
             {
               "description": "can view data, like public incidents and organization settings",
-              "name": "schedules_editor"
+              "name": "catalog_editor"
             }
           ],
           "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
         },
         "properties": {
+          "comments": {
+            "description": "Freeform notes about this API key",
+            "example": "Requested in https://example.slack.com/archives/C123/p456",
+            "maxLength": 5000,
+            "pattern": "^[^\u0000]*$",
+            "type": "string"
+          },
           "created_at": {
             "description": "When the API key was created",
             "example": "2021-08-17T13:28:57.801578Z",
@@ -227,7 +236,7 @@
             "example": [
               {
                 "description": "can view data, like public incidents and organization settings",
-                "name": "schedules_editor"
+                "name": "catalog_editor"
               }
             ],
             "items": {
@@ -256,6 +265,7 @@
       },
       "APIKeysCreatePayloadV1": {
         "example": {
+          "comments": "Requested in https://example.slack.com/archives/C123/p456",
           "name": "My test API key",
           "role_names": [
             "viewer",
@@ -269,6 +279,13 @@
           ]
         },
         "properties": {
+          "comments": {
+            "description": "Freeform notes about the API key",
+            "example": "Requested in https://example.slack.com/archives/C123/p456",
+            "maxLength": 5000,
+            "pattern": "^[^\u0000]*$",
+            "type": "string"
+          },
           "name": {
             "description": "Human-readable name for the new API key",
             "example": "My test API key",
@@ -337,6 +354,7 @@
             ],
             "items": {
               "enum": [
+                "catalog_editor",
                 "schedules_editor",
                 "schedules_reader",
                 "schedule_overrides_editor",
@@ -346,7 +364,7 @@
                 "workflows_editor",
                 "private_workflows_editor"
               ],
-              "example": "schedules_editor",
+              "example": "catalog_editor",
               "type": "string"
             },
             "type": "array"
@@ -363,6 +381,7 @@
       "APIKeysCreateResultV1": {
         "example": {
           "api_key": {
+            "comments": "Requested in https://example.slack.com/archives/C123/p456",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "creator": {
               "api_key": {
@@ -392,7 +411,7 @@
             "team_roles": [
               {
                 "description": "can view data, like public incidents and organization settings",
-                "name": "schedules_editor"
+                "name": "catalog_editor"
               }
             ],
             "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -419,6 +438,7 @@
         "example": {
           "api_keys": [
             {
+              "comments": "Requested in https://example.slack.com/archives/C123/p456",
               "created_at": "2021-08-17T13:28:57.801578Z",
               "creator": {
                 "api_key": {
@@ -448,7 +468,7 @@
               "team_roles": [
                 {
                   "description": "can view data, like public incidents and organization settings",
-                  "name": "schedules_editor"
+                  "name": "catalog_editor"
                 }
               ],
               "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -463,6 +483,7 @@
           "api_keys": {
             "example": [
               {
+                "comments": "Requested in https://example.slack.com/archives/C123/p456",
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "creator": {
                   "api_key": {
@@ -492,7 +513,7 @@
                 "team_roles": [
                   {
                     "description": "can view data, like public incidents and organization settings",
-                    "name": "schedules_editor"
+                    "name": "catalog_editor"
                   }
                 ],
                 "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -536,6 +557,7 @@
       "APIKeysRotateResultV1": {
         "example": {
           "api_key": {
+            "comments": "Requested in https://example.slack.com/archives/C123/p456",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "creator": {
               "api_key": {
@@ -565,7 +587,7 @@
             "team_roles": [
               {
                 "description": "can view data, like public incidents and organization settings",
-                "name": "schedules_editor"
+                "name": "catalog_editor"
               }
             ],
             "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -591,6 +613,7 @@
       "APIKeysShowResultV1": {
         "example": {
           "api_key": {
+            "comments": "Requested in https://example.slack.com/archives/C123/p456",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "creator": {
               "api_key": {
@@ -620,7 +643,7 @@
             "team_roles": [
               {
                 "description": "can view data, like public incidents and organization settings",
-                "name": "schedules_editor"
+                "name": "catalog_editor"
               }
             ],
             "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -638,6 +661,7 @@
       },
       "APIKeysUpdatePayloadV1": {
         "example": {
+          "comments": "Requested in https://example.slack.com/archives/C123/p456",
           "name": "My test API key",
           "role_names": [
             "viewer",
@@ -651,6 +675,13 @@
           ]
         },
         "properties": {
+          "comments": {
+            "description": "Freeform notes about the API key",
+            "example": "Requested in https://example.slack.com/archives/C123/p456",
+            "maxLength": 5000,
+            "pattern": "^[^\u0000]*$",
+            "type": "string"
+          },
           "name": {
             "description": "Human-readable name for the API key",
             "example": "My test API key",
@@ -719,6 +750,7 @@
             ],
             "items": {
               "enum": [
+                "catalog_editor",
                 "schedules_editor",
                 "schedules_reader",
                 "schedule_overrides_editor",
@@ -728,7 +760,7 @@
                 "workflows_editor",
                 "private_workflows_editor"
               ],
-              "example": "schedules_editor",
+              "example": "catalog_editor",
               "type": "string"
             },
             "type": "array"
@@ -745,6 +777,7 @@
       "APIKeysUpdateResultV1": {
         "example": {
           "api_key": {
+            "comments": "Requested in https://example.slack.com/archives/C123/p456",
             "created_at": "2021-08-17T13:28:57.801578Z",
             "creator": {
               "api_key": {
@@ -774,7 +807,7 @@
             "team_roles": [
               {
                 "description": "can view data, like public incidents and organization settings",
-                "name": "schedules_editor"
+                "name": "catalog_editor"
               }
             ],
             "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -4492,6 +4525,20 @@
                 }
               }
             },
+            "membership_teams": {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
             "name": {
               "autogenerated": false,
               "binding": {
@@ -4821,6 +4868,20 @@
                 }
               }
             },
+            "membership_teams": {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
             "name": {
               "autogenerated": false,
               "binding": {
@@ -4987,6 +5048,20 @@
               }
             }
           },
+          "membership_teams": {
+            "binding": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
           "name": {
             "autogenerated": false,
             "binding": {
@@ -5093,6 +5168,9 @@
           "incident_type": {
             "$ref": "#/components/schemas/AlertRouteTemplateBindingPayloadV2"
           },
+          "membership_teams": {
+            "$ref": "#/components/schemas/AlertRouteTemplateBindingPayloadV2"
+          },
           "name": {
             "$ref": "#/components/schemas/AlertRouteAutoGeneratedTemplateBindingPayloadV2"
           },
@@ -5149,6 +5227,20 @@
             }
           },
           "incident_type": {
+            "binding": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "membership_teams": {
             "binding": {
               "array_value": [
                 {
@@ -5254,6 +5346,9 @@
           "incident_type": {
             "$ref": "#/components/schemas/AlertRouteTemplateBindingPayloadV3"
           },
+          "membership_teams": {
+            "$ref": "#/components/schemas/AlertRouteTemplateBindingPayloadV3"
+          },
           "name": {
             "$ref": "#/components/schemas/AlertRouteAutoGeneratedTemplateBindingPayloadV3"
           },
@@ -5311,6 +5406,22 @@
             }
           },
           "incident_type": {
+            "binding": {
+              "array_value": [
+                {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "label": "Lawrence Jones",
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "membership_teams": {
             "binding": {
               "array_value": [
                 {
@@ -5444,6 +5555,9 @@
           "incident_type": {
             "$ref": "#/components/schemas/AlertRouteTemplateBindingV2"
           },
+          "membership_teams": {
+            "$ref": "#/components/schemas/AlertRouteTemplateBindingV2"
+          },
           "name": {
             "$ref": "#/components/schemas/AlertRouteAutoGeneratedTemplateBindingV2"
           },
@@ -5500,6 +5614,20 @@
             }
           },
           "incident_type": {
+            "binding": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          },
+          "membership_teams": {
             "binding": {
               "array_value": [
                 {
@@ -5603,6 +5731,9 @@
             "$ref": "#/components/schemas/AlertRouteTemplateBindingV3"
           },
           "incident_type": {
+            "$ref": "#/components/schemas/AlertRouteTemplateBindingV3"
+          },
+          "membership_teams": {
             "$ref": "#/components/schemas/AlertRouteTemplateBindingV3"
           },
           "name": {
@@ -6313,6 +6444,22 @@
               }
             },
             "incident_type": {
+              "binding": {
+                "array_value": [
+                  {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "label": "Lawrence Jones",
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "membership_teams": {
               "binding": {
                 "array_value": [
                   {
@@ -7130,6 +7277,20 @@
                 }
               },
               "incident_type": {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "membership_teams": {
                 "binding": {
                   "array_value": [
                     {
@@ -7986,6 +8147,20 @@
                 }
               }
             },
+            "membership_teams": {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
             "name": {
               "autogenerated": false,
               "binding": {
@@ -8682,6 +8857,20 @@
                 }
               },
               "incident_type": {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "membership_teams": {
                 "binding": {
                   "array_value": [
                     {
@@ -9493,6 +9682,22 @@
                   }
                 }
               },
+              "membership_teams": {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
               "name": {
                 "autogenerated": false,
                 "binding": {
@@ -9924,6 +10129,20 @@
                   }
                 },
                 "incident_type": {
+                  "binding": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "membership_teams": {
                   "binding": {
                     "array_value": [
                       {
@@ -10585,6 +10804,22 @@
                   }
                 }
               },
+              "membership_teams": {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
               "name": {
                 "autogenerated": false,
                 "binding": {
@@ -11016,6 +11251,20 @@
                   }
                 },
                 "incident_type": {
+                  "binding": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "membership_teams": {
                   "binding": {
                     "array_value": [
                       {
@@ -11520,6 +11769,20 @@
               }
             },
             "incident_type": {
+              "binding": {
+                "array_value": [
+                  {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                ],
+                "value": {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              }
+            },
+            "membership_teams": {
               "binding": {
                 "array_value": [
                   {
@@ -12237,6 +12500,20 @@
                 }
               },
               "incident_type": {
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
+              "membership_teams": {
                 "binding": {
                   "array_value": [
                     {
@@ -13056,6 +13333,22 @@
                   }
                 }
               },
+              "membership_teams": {
+                "binding": {
+                  "array_value": [
+                    {
+                      "label": "Lawrence Jones",
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "value": {
+                    "label": "Lawrence Jones",
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              },
               "name": {
                 "autogenerated": false,
                 "binding": {
@@ -13487,6 +13780,20 @@
                   }
                 },
                 "incident_type": {
+                  "binding": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "membership_teams": {
                   "binding": {
                     "array_value": [
                       {
@@ -17729,6 +18036,19 @@
         },
         "type": "object"
       },
+      "AuditLogPolicyMetadataV2": {
+        "example": {
+          "run_on_private_incidents": "true"
+        },
+        "properties": {
+          "run_on_private_incidents": {
+            "description": "Whether the policy evaluates private incidents",
+            "example": "true",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "AuditLogPrivateAlertAccessAttemptedMetadataV2": {
         "example": {
           "outcome": "granted"
@@ -17778,6 +18098,46 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "AuditLogPrivateIncidentAccessAttemptedMetadataV2V2": {
+        "example": {
+          "access_type": "N/A",
+          "outcome": "granted",
+          "team_id": "01G0J1EXE7AXZ2C93K61WBPYEH"
+        },
+        "properties": {
+          "access_type": {
+            "description": "How the user was granted access to the private incident, or N/A when access was denied",
+            "enum": [
+              "N/A",
+              "global_access",
+              "direct_membership",
+              "team_membership"
+            ],
+            "example": "N/A",
+            "type": "string"
+          },
+          "outcome": {
+            "description": "Whether or not the user was able to access the private incident",
+            "enum": [
+              "granted",
+              "denied"
+            ],
+            "example": "granted",
+            "type": "string"
+          },
+          "team_id": {
+            "description": "The ID of the team through which access was granted, or N/A when access_type is not team_membership",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "type": "string"
+          }
+        },
+        "required": [
+          "outcome",
+          "access_type",
+          "team_id"
+        ],
         "type": "object"
       },
       "AuditLogPrivateInsightsExportedMetadataV2": {
@@ -17998,6 +18358,7 @@
               "schedule_sync_rule",
               "schedule_sync_target",
               "policy",
+              "policy_report_schedule",
               "post_incident_task",
               "postmortem_template",
               "postmortem_template_section",
@@ -18006,6 +18367,7 @@
               "scim_group",
               "schedule",
               "team_role",
+              "secret",
               "severity",
               "status_page",
               "status_page_sub_page",
@@ -25741,6 +26103,88 @@
         ],
         "type": "object"
       },
+      "AuditLogsPolicyCreatedV2": {
+        "example": {
+          "action": "policy.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "run_on_private_incidents": "true"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Follow-ups must be closed within 3 weeks",
+              "type": "policy"
+            }
+          ],
+          "version": 2
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "policy.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogPolicyMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Follow-ups must be closed within 3 weeks",
+                "type": "policy"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
       "AuditLogsPolicyDeletedV1": {
         "example": {
           "action": "policy.deleted",
@@ -25792,6 +26236,231 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "name": "Follow-ups must be closed within 3 weeks",
                 "type": "policy"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsPolicyReportScheduleCreatedV1": {
+        "example": {
+          "action": "policy_report_schedule.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Weekly overdue follow-ups report",
+              "type": "policy_report_schedule"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "policy_report_schedule.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Weekly overdue follow-ups report",
+                "type": "policy_report_schedule"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsPolicyReportScheduleDeletedV1": {
+        "example": {
+          "action": "policy_report_schedule.deleted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Weekly overdue follow-ups report",
+              "type": "policy_report_schedule"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "policy_report_schedule.deleted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Weekly overdue follow-ups report",
+                "type": "policy_report_schedule"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsPolicyReportScheduleUpdatedV1": {
+        "example": {
+          "action": "policy_report_schedule.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Weekly overdue follow-ups report",
+              "type": "policy_report_schedule"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "policy_report_schedule.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Weekly overdue follow-ups report",
+                "type": "policy_report_schedule"
               }
             ],
             "items": {
@@ -25888,6 +26557,88 @@
           "actor",
           "targets",
           "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsPolicyUpdatedV2": {
+        "example": {
+          "action": "policy.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "run_on_private_incidents": "true"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Follow-ups must be closed within 3 weeks",
+              "type": "policy"
+            }
+          ],
+          "version": 2
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "policy.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogPolicyMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Follow-ups must be closed within 3 weeks",
+                "type": "policy"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
         ],
         "type": "object"
       },
@@ -27247,6 +27998,90 @@
           "version": {
             "description": "Which version the event is",
             "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "AuditLogsPrivateIncidentAccessAttemptedV2": {
+        "example": {
+          "action": "private_incident.access_attempted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "access_type": "N/A",
+            "outcome": "granted",
+            "team_id": "01G0J1EXE7AXZ2C93K61WBPYEH"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "#INC-123 The website is slow",
+              "type": "incident"
+            }
+          ],
+          "version": 2
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "private_incident.access_attempted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogPrivateIncidentAccessAttemptedMetadataV2V2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "#INC-123 The website is slow",
+                "type": "incident"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 2,
             "format": "int64",
             "type": "integer"
           }
@@ -29719,6 +30554,306 @@
           "targets",
           "context",
           "metadata"
+        ],
+        "type": "object"
+      },
+      "AuditLogsSecretCreatedV1": {
+        "example": {
+          "action": "secret.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Datadog webhook signing key",
+              "type": "secret"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "secret.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Datadog webhook signing key",
+                "type": "secret"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsSecretDeletedV1": {
+        "example": {
+          "action": "secret.deleted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Datadog webhook signing key",
+              "type": "secret"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "secret.deleted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Datadog webhook signing key",
+                "type": "secret"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsSecretRotatedV1": {
+        "example": {
+          "action": "secret.rotated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Datadog webhook signing key",
+              "type": "secret"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "secret.rotated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Datadog webhook signing key",
+                "type": "secret"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsSecretUpdatedV1": {
+        "example": {
+          "action": "secret.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Datadog webhook signing key",
+              "type": "secret"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "secret.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Datadog webhook signing key",
+                "type": "secret"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
         ],
         "type": "object"
       },
@@ -32389,6 +33524,9 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "icon": "alert",
           "name": "Kubernetes Cluster",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "ranked": true,
           "source_repo_url": "https://github.com/my-company/incident-io-catalog",
           "type_name": "Custom[\"BackstageGroup\"]",
@@ -32483,6 +33621,17 @@
             "description": "Name is the human readable name of this type",
             "example": "Kubernetes Cluster",
             "type": "string"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this catalog type",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
           },
           "ranked": {
             "description": "If this type should be ranked",
@@ -32590,6 +33739,9 @@
             "is_team_type": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "ranked": true,
             "registry_type": "PagerDutyService",
             "required_integrations": [
@@ -33468,6 +34620,9 @@
             "is_team_type": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "ranked": true,
             "registry_type": "PagerDutyService",
             "required_integrations": [
@@ -33755,6 +34910,9 @@
               "is_team_type": false,
               "last_synced_at": "2021-08-17T13:28:57.801578Z",
               "name": "Kubernetes Cluster",
+              "owning_team_ids": [
+                "01G0J1EXE7AXZ2C93K61WBPYEH"
+              ],
               "ranked": true,
               "registry_type": "PagerDutyService",
               "required_integrations": [
@@ -33807,6 +34965,9 @@
                 "is_team_type": false,
                 "last_synced_at": "2021-08-17T13:28:57.801578Z",
                 "name": "Kubernetes Cluster",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "ranked": true,
                 "registry_type": "PagerDutyService",
                 "required_integrations": [
@@ -34111,6 +35272,9 @@
             "is_team_type": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "ranked": true,
             "registry_type": "PagerDutyService",
             "required_integrations": [
@@ -34234,6 +35398,9 @@
             "is_team_type": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "ranked": true,
             "registry_type": "PagerDutyService",
             "required_integrations": [
@@ -35031,6 +36198,9 @@
           "is_team_type": false,
           "last_synced_at": "2021-08-17T13:28:57.801578Z",
           "name": "Kubernetes Cluster",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "ranked": true,
           "registry_type": "PagerDutyService",
           "required_integrations": [
@@ -35188,6 +36358,17 @@
             "description": "Name is the human readable name of this type",
             "example": "Kubernetes Cluster",
             "type": "string"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this catalog type",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
           },
           "ranked": {
             "description": "If this type should be ranked",
@@ -35590,6 +36771,9 @@
             "is_team_type": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "ranked": true,
             "registry_type": "PagerDutyService",
             "required_integrations": [
@@ -35768,6 +36952,9 @@
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "icon": "alert",
           "name": "Kubernetes Cluster",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
           "ranked": true,
           "source_repo_url": "https://github.com/my-company/incident-io-catalog",
           "use_name_as_identifier": true
@@ -35861,6 +37048,17 @@
             "description": "Name is the human readable name of this type",
             "example": "Kubernetes Cluster",
             "type": "string"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this catalog type",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
           },
           "ranked": {
             "description": "If this type should be ranked",
@@ -35963,6 +37161,9 @@
             "is_team_type": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "ranked": true,
             "registry_type": "PagerDutyService",
             "required_integrations": [
@@ -36188,6 +37389,9 @@
             "is_team_type": false,
             "last_synced_at": "2021-08-17T13:28:57.801578Z",
             "name": "Kubernetes Cluster",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
             "ranked": true,
             "registry_type": "PagerDutyService",
             "required_integrations": [
@@ -46257,6 +47461,7 @@
               "outlook_calendar_event",
               "slack_file",
               "salesforce_case",
+              "arbitrary_url",
               "scrubbed",
               "statuspage_incident"
             ],
@@ -47383,7 +48588,7 @@
             "viewer"
           ],
           "team_roles": [
-            "schedules_editor"
+            "catalog_editor"
           ],
           "teams": [
             {
@@ -47450,11 +48655,12 @@
           "team_roles": {
             "description": "If set, these roles apply to requests that operate on resources owned by any of the teams in the 'teams' array. These are in addition to any 'roles' which are applied on all requests.",
             "example": [
-              "schedules_editor"
+              "catalog_editor"
             ],
             "items": {
               "description": "API key team roles",
               "enum": [
+                "catalog_editor",
                 "schedules_editor",
                 "schedules_reader",
                 "schedule_overrides_editor",
@@ -47464,7 +48670,7 @@
                 "workflows_editor",
                 "private_workflows_editor"
               ],
-              "example": "schedules_editor",
+              "example": "catalog_editor",
               "type": "string",
               "x-public-api-version": "v1"
             },
@@ -47607,8 +48813,10 @@
         "example": {
           "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
           "resource": {
+            "emoji": "rocket",
             "external_id": "123",
             "resource_type": "pager_duty_incident",
+            "title": "Impact tracking spreadsheet",
             "url": "https://github.com/company/repo/pull/123"
           }
         },
@@ -47620,11 +48828,18 @@
           },
           "resource": {
             "example": {
+              "emoji": "rocket",
               "external_id": "123",
               "resource_type": "pager_duty_incident",
+              "title": "Impact tracking spreadsheet",
               "url": "https://github.com/company/repo/pull/123"
             },
             "properties": {
+              "emoji": {
+                "description": "Emoji shortcode representing the link, without surrounding colons. Only supported for the arbitrary_url resource type.",
+                "example": "rocket",
+                "type": "string"
+              },
               "external_id": {
                 "description": "ID of the resource in the external system",
                 "example": "123",
@@ -47647,10 +48862,16 @@
                   "outlook_calendar_event",
                   "slack_file",
                   "salesforce_case",
+                  "arbitrary_url",
                   "scrubbed",
                   "statuspage_incident"
                 ],
                 "example": "pager_duty_incident",
+                "type": "string"
+              },
+              "title": {
+                "description": "Human readable title for the link. Only supported for the arbitrary_url resource type.",
+                "example": "Impact tracking spreadsheet",
                 "type": "string"
               },
               "url": {
@@ -60505,6 +61726,65 @@
         ],
         "type": "object"
       },
+      "StatusPageRetrospectiveIncidentUpdateV2": {
+        "description": "A single update in the reconstructed timeline of a retrospective status page incident.",
+        "example": {
+          "component_statuses": [
+            {
+              "component_id": "01FCNDV6P870EA6S7TK1DSYDG2",
+              "component_status": "operational"
+            }
+          ],
+          "incident_status": "investigating",
+          "message": "We are currently investigating reports of elevated error rates affecting our API.",
+          "published_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "properties": {
+          "component_statuses": {
+            "description": "An array of mappings from component ID to component status at the time this update was published",
+            "example": [
+              {
+                "component_id": "01FCNDV6P870EA6S7TK1DSYDG2",
+                "component_status": "operational"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageIncidentAffectedComponentV2"
+            },
+            "type": "array"
+          },
+          "incident_status": {
+            "description": "Current status for this incident",
+            "enum": [
+              "investigating",
+              "identified",
+              "monitoring",
+              "resolved"
+            ],
+            "example": "investigating",
+            "type": "string",
+            "x-public-api-version": "v2"
+          },
+          "message": {
+            "description": "Markdown update on what's changed about this status page incident",
+            "example": "We are currently investigating reports of elevated error rates affecting our API.",
+            "maxLength": 4096,
+            "type": "string"
+          },
+          "published_at": {
+            "description": "When this update was published. Must be in the past.",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "incident_status",
+          "message",
+          "published_at"
+        ],
+        "type": "object"
+      },
       "StatusPageStructureComponentV2": {
         "example": {
           "component_id": "01FCNDV6P870EA6S7TK1DSYDG1",
@@ -61260,6 +62540,111 @@
         "properties": {
           "status_page_maintenance_update": {
             "$ref": "#/components/schemas/StatusPageMaintenanceUpdateV2"
+          }
+        },
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageRetrospectiveIncidentPayloadV2": {
+        "example": {
+          "idempotency_key": "historical-incident-2021-08-17",
+          "name": "Elevated API latency",
+          "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "updates": [
+            {
+              "component_statuses": [
+                {
+                  "component_id": "01FCNDV6P870EA6S7TK1DSYDG2",
+                  "component_status": "operational"
+                }
+              ],
+              "incident_status": "investigating",
+              "message": "We are currently investigating reports of elevated error rates affecting our API.",
+              "published_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ]
+        },
+        "properties": {
+          "idempotency_key": {
+            "description": "A unique key to de-duplicate requests. If you send a request with an idempotency_key that was already used, the original response will be returned.",
+            "example": "historical-incident-2021-08-17",
+            "type": "string"
+          },
+          "name": {
+            "description": "A title for the incident",
+            "example": "Elevated API latency",
+            "maxLength": 200,
+            "type": "string"
+          },
+          "status_page_id": {
+            "description": "ID of the status page. You can find this by calling the ListStatusPages endpoint.",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "updates": {
+            "description": "The reconstructed timeline of updates for this incident, ordered chronologically (earliest first). The final update must set incident_status to \"resolved\".",
+            "example": [
+              {
+                "component_statuses": [
+                  {
+                    "component_id": "01FCNDV6P870EA6S7TK1DSYDG2",
+                    "component_status": "operational"
+                  }
+                ],
+                "incident_status": "investigating",
+                "message": "We are currently investigating reports of elevated error rates affecting our API.",
+                "published_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StatusPageRetrospectiveIncidentUpdateV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "status_page_id",
+          "name",
+          "idempotency_key",
+          "updates"
+        ],
+        "type": "object"
+      },
+      "StatusPagesCreateStatusPageRetrospectiveIncidentResultV2": {
+        "example": {
+          "status_page_incident": {
+            "component_impacts": [
+              {
+                "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                "component_status": "degraded_performance",
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "start_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "incident_status": "investigating",
+            "name": "Elevated API latency",
+            "published_at": "2021-08-17T13:28:57.801578Z",
+            "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "updates": [
+              {
+                "component_statuses": [
+                  {
+                    "component_id": "01FCNDV6P870EA6S7TK1DSYDG2",
+                    "component_status": "operational"
+                  }
+                ],
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "incident_status": "investigating",
+                "message": "abc123",
+                "published_at": "2021-08-17T13:28:57.801578Z",
+                "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1"
+              }
+            ]
+          }
+        },
+        "properties": {
+          "status_page_incident": {
+            "$ref": "#/components/schemas/StatusPageIncidentV2"
           }
         },
         "type": "object"
@@ -62782,7 +64167,7 @@
               "viewer"
             ],
             "team_roles": [
-              "schedules_editor"
+              "catalog_editor"
             ],
             "teams": [
               {
@@ -68308,6 +69693,7 @@
           }
         },
         "required": [
+          "include_private_incidents",
           "id",
           "name",
           "trigger",
@@ -68316,7 +69702,6 @@
           "expressions",
           "condition_groups",
           "steps",
-          "include_private_incidents",
           "private_incident_scope",
           "include_private_escalations",
           "runs_on_incident_modes",
@@ -68933,6 +70318,7 @@
           }
         },
         "required": [
+          "include_private_incidents",
           "id",
           "name",
           "trigger",
@@ -68941,7 +70327,6 @@
           "expressions",
           "condition_groups",
           "steps",
-          "include_private_incidents",
           "private_incident_scope",
           "include_private_escalations",
           "runs_on_incident_modes",
@@ -71922,6 +73307,7 @@
                 "example": {
                   "api_keys": [
                     {
+                      "comments": "Requested in https://example.slack.com/archives/C123/p456",
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "creator": {
                         "api_key": {
@@ -71951,7 +73337,7 @@
                       "team_roles": [
                         {
                           "description": "can view data, like public incidents and organization settings",
-                          "name": "schedules_editor"
+                          "name": "catalog_editor"
                         }
                       ],
                       "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -71988,6 +73374,7 @@
           "content": {
             "application/json": {
               "example": {
+                "comments": "Requested in https://example.slack.com/archives/C123/p456",
                 "name": "My test API key",
                 "role_names": [
                   "viewer",
@@ -72013,6 +73400,7 @@
               "application/json": {
                 "example": {
                   "api_key": {
+                    "comments": "Requested in https://example.slack.com/archives/C123/p456",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "creator": {
                       "api_key": {
@@ -72042,7 +73430,7 @@
                     "team_roles": [
                       {
                         "description": "can view data, like public incidents and organization settings",
-                        "name": "schedules_editor"
+                        "name": "catalog_editor"
                       }
                     ],
                     "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -72126,6 +73514,7 @@
               "application/json": {
                 "example": {
                   "api_key": {
+                    "comments": "Requested in https://example.slack.com/archives/C123/p456",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "creator": {
                       "api_key": {
@@ -72155,7 +73544,7 @@
                     "team_roles": [
                       {
                         "description": "can view data, like public incidents and organization settings",
-                        "name": "schedules_editor"
+                        "name": "catalog_editor"
                       }
                     ],
                     "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -72201,6 +73590,7 @@
           "content": {
             "application/json": {
               "example": {
+                "comments": "Requested in https://example.slack.com/archives/C123/p456",
                 "name": "My test API key",
                 "role_names": [
                   "viewer",
@@ -72226,6 +73616,7 @@
               "application/json": {
                 "example": {
                   "api_key": {
+                    "comments": "Requested in https://example.slack.com/archives/C123/p456",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "creator": {
                       "api_key": {
@@ -72255,7 +73646,7 @@
                     "team_roles": [
                       {
                         "description": "can view data, like public incidents and organization settings",
-                        "name": "schedules_editor"
+                        "name": "catalog_editor"
                       }
                     ],
                     "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -72318,6 +73709,7 @@
               "application/json": {
                 "example": {
                   "api_key": {
+                    "comments": "Requested in https://example.slack.com/archives/C123/p456",
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "creator": {
                       "api_key": {
@@ -72347,7 +73739,7 @@
                     "team_roles": [
                       {
                         "description": "can view data, like public incidents and organization settings",
-                        "name": "schedules_editor"
+                        "name": "catalog_editor"
                       }
                     ],
                     "token_last_issued_at": "2021-08-17T13:28:57.801578Z"
@@ -72990,7 +74382,7 @@
                       "viewer"
                     ],
                     "team_roles": [
-                      "schedules_editor"
+                      "catalog_editor"
                     ],
                     "teams": [
                       {
@@ -73073,6 +74465,7 @@
                 "outlook_calendar_event",
                 "slack_file",
                 "salesforce_case",
+                "arbitrary_url",
                 "scrubbed",
                 "statuspage_incident"
               ],
@@ -73119,7 +74512,7 @@
         ]
       },
       "post": {
-        "description": "Attaches an external resource to an incident.\n\nYou must provide a resource with resource_type and either external_id or url, but not both.\n\nWhen providing a url, the server will create the attachment from that link for the given resource type if the integration is installed and the link is valid.",
+        "description": "Attaches an external resource to an incident.\n\nYou must provide a resource with resource_type and either external_id or url, but not both.\n\nWhen providing a url, the server will create the attachment from that link for the given resource type if the integration is installed and the link is valid.\n\nTo attach an arbitrary link that isn't backed by an integration, use the arbitrary_url resource type with a url, and optionally a title and emoji.",
         "operationId": "Incident Attachments V1#Create",
         "requestBody": {
           "content": {
@@ -73127,8 +74520,10 @@
               "example": {
                 "incident_id": "01FDAG4SAP5TYPT98WGR2N7W91",
                 "resource": {
+                  "emoji": "rocket",
                   "external_id": "123",
                   "resource_type": "pager_duty_incident",
+                  "title": "Impact tracking spreadsheet",
                   "url": "https://github.com/company/repo/pull/123"
                 }
               },
@@ -77498,6 +78893,20 @@
                       }
                     }
                   },
+                  "membership_teams": {
+                    "binding": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  },
                   "name": {
                     "autogenerated": false,
                     "binding": {
@@ -78000,6 +79409,22 @@
                         }
                       },
                       "incident_type": {
+                        "binding": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
+                      "membership_teams": {
                         "binding": {
                           "array_value": [
                             {
@@ -78610,6 +80035,22 @@
                           }
                         }
                       },
+                      "membership_teams": {
+                        "binding": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
                       "name": {
                         "autogenerated": false,
                         "binding": {
@@ -79093,6 +80534,20 @@
                     }
                   },
                   "incident_type": {
+                    "binding": {
+                      "array_value": [
+                        {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      ],
+                      "value": {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    }
+                  },
+                  "membership_teams": {
                     "binding": {
                       "array_value": [
                         {
@@ -79609,6 +81064,22 @@
                         }
                       },
                       "incident_type": {
+                        "binding": {
+                          "array_value": [
+                            {
+                              "label": "Lawrence Jones",
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "label": "Lawrence Jones",
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
+                      "membership_teams": {
                         "binding": {
                           "array_value": [
                             {
@@ -90981,6 +92452,95 @@
         "x-docs-resource-type": "StatusPageMaintenanceV2"
       }
     },
+    "/v2/status_page_retrospective_incidents": {
+      "post": {
+        "description": "Create a retrospective (historical) status page incident.\n\nUse this to backfill a completed incident with a reconstructed timeline of past updates, for example when migrating from another status page provider. Every update's published_at must be in the past, the updates must be ordered chronologically (earliest first), and the final update must set incident_status to \"resolved\".\n\nRetrospective incidents never notify subscribers.\n\nAs this endpoint is intended for bulk historical backfill, it has a dedicated rate limit of 5 requests per second (with a burst allowance of 300 requests) per API key. If you exceed it you'll receive a 429 response with a Retry-After header; back off and retry to resume your backfill.\n\nThis endpoint requires an API key with the \"Create status page incidents, status page maintenance windows, and publish status page updates\" scope.",
+        "operationId": "Status Pages V2#CreateStatusPageRetrospectiveIncident",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "idempotency_key": "historical-incident-2021-08-17",
+                "name": "Elevated API latency",
+                "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "updates": [
+                  {
+                    "component_statuses": [
+                      {
+                        "component_id": "01FCNDV6P870EA6S7TK1DSYDG2",
+                        "component_status": "operational"
+                      }
+                    ],
+                    "incident_status": "investigating",
+                    "message": "We are currently investigating reports of elevated error rates affecting our API.",
+                    "published_at": "2021-08-17T13:28:57.801578Z"
+                  }
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/StatusPagesCreateStatusPageRetrospectiveIncidentPayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "status_page_incident": {
+                    "component_impacts": [
+                      {
+                        "component_id": "01GW7P4ES31Q6V1ZQH321T0GJN",
+                        "component_status": "degraded_performance",
+                        "end_at": "2021-08-17T13:28:57.801578Z",
+                        "start_at": "2021-08-17T13:28:57.801578Z"
+                      }
+                    ],
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "incident_status": "investigating",
+                    "name": "Elevated API latency",
+                    "published_at": "2021-08-17T13:28:57.801578Z",
+                    "status_page_id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "updates": [
+                      {
+                        "component_statuses": [
+                          {
+                            "component_id": "01FCNDV6P870EA6S7TK1DSYDG2",
+                            "component_status": "operational"
+                          }
+                        ],
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "incident_status": "investigating",
+                        "message": "abc123",
+                        "published_at": "2021-08-17T13:28:57.801578Z",
+                        "status_page_incident_id": "01FCNDV6P870EA6S7TK1DSYDG1"
+                      }
+                    ]
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/StatusPagesCreateStatusPageRetrospectiveIncidentResultV2"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "CreateStatusPageRetrospectiveIncident Status Pages V2",
+        "tags": [
+          "Status Pages V2"
+        ],
+        "x-display-name": "Create retrospective",
+        "x-docs-display-name": "Create retrospective",
+        "x-docs-group-name": "Status Page Incidents V2",
+        "x-docs-resource-type": "StatusPageIncidentV2",
+        "x-rbac-scopes": [
+          "status_pages.publish_updates"
+        ]
+      }
+    },
     "/v2/status_page_structures/{status_page_id}": {
       "get": {
         "description": "Show the structure of a status page.\n\nThis endpoint requires a valid API key but no specific scopes. Returns the components and component groups configured on a status page. Use this to find component IDs when specifying affected components for incidents or maintenance windows.",
@@ -93613,6 +95173,20 @@
                         }
                       }
                     },
+                    "membership_teams": {
+                      "binding": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    },
                     "name": {
                       "autogenerated": false,
                       "binding": {
@@ -94076,6 +95650,20 @@
                           }
                         },
                         "incident_type": {
+                          "binding": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
+                        "membership_teams": {
                           "binding": {
                             "array_value": [
                               {
@@ -94638,6 +96226,20 @@
                             }
                           }
                         },
+                        "membership_teams": {
+                          "binding": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
                         "name": {
                           "autogenerated": false,
                           "binding": {
@@ -95105,6 +96707,20 @@
                       }
                     },
                     "incident_type": {
+                      "binding": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    },
+                    "membership_teams": {
                       "binding": {
                         "array_value": [
                           {
@@ -95595,6 +97211,20 @@
                             }
                           }
                         },
+                        "membership_teams": {
+                          "binding": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        },
                         "name": {
                           "autogenerated": false,
                           "binding": {
@@ -95885,6 +97515,9 @@
                     "is_team_type": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "ranked": true,
                     "registry_type": "PagerDutyService",
                     "required_integrations": [
@@ -96224,6 +97857,9 @@
                     "is_team_type": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "ranked": true,
                     "registry_type": "PagerDutyService",
                     "required_integrations": [
@@ -96375,6 +98011,9 @@
                     "is_team_type": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "ranked": true,
                     "registry_type": "PagerDutyService",
                     "required_integrations": [
@@ -96492,6 +98131,9 @@
                       "is_team_type": false,
                       "last_synced_at": "2021-08-17T13:28:57.801578Z",
                       "name": "Kubernetes Cluster",
+                      "owning_team_ids": [
+                        "01G0J1EXE7AXZ2C93K61WBPYEH"
+                      ],
                       "ranked": true,
                       "registry_type": "PagerDutyService",
                       "required_integrations": [
@@ -96559,6 +98201,9 @@
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
                 "icon": "alert",
                 "name": "Kubernetes Cluster",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "ranked": true,
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                 "type_name": "Custom[\"BackstageGroup\"]",
@@ -96594,6 +98239,9 @@
                     "is_team_type": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "ranked": true,
                     "registry_type": "PagerDutyService",
                     "required_integrations": [
@@ -96718,6 +98366,9 @@
                     "is_team_type": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "ranked": true,
                     "registry_type": "PagerDutyService",
                     "required_integrations": [
@@ -96798,6 +98449,9 @@
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
                 "icon": "alert",
                 "name": "Kubernetes Cluster",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
                 "ranked": true,
                 "source_repo_url": "https://github.com/my-company/incident-io-catalog",
                 "use_name_as_identifier": true
@@ -96832,6 +98486,9 @@
                     "is_team_type": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "ranked": true,
                     "registry_type": "PagerDutyService",
                     "required_integrations": [
@@ -96951,6 +98608,9 @@
                     "is_team_type": false,
                     "last_synced_at": "2021-08-17T13:28:57.801578Z",
                     "name": "Kubernetes Cluster",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
                     "ranked": true,
                     "registry_type": "PagerDutyService",
                     "required_integrations": [
@@ -102010,6 +103670,55 @@
         ]
       }
     },
+    "/x-audit-logs/policy.created.2": {
+      "get": {
+        "description": "This entry is created whenever a policy is created",
+        "operationId": "PolicyCreatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "policy.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "run_on_private_incidents": "true"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Follow-ups must be closed within 3 weeks",
+                      "type": "policy"
+                    }
+                  ],
+                  "version": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsPolicyCreatedV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
     "/x-audit-logs/policy.deleted.1": {
       "get": {
         "description": "This entry is created whenever a policy is deleted",
@@ -102091,6 +103800,193 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsPolicyUpdatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/policy.updated.2": {
+      "get": {
+        "description": "This entry is created whenever a policy is updated",
+        "operationId": "PolicyUpdatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "policy.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "run_on_private_incidents": "true"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Follow-ups must be closed within 3 weeks",
+                      "type": "policy"
+                    }
+                  ],
+                  "version": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsPolicyUpdatedV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/policy_report_schedule.created.1": {
+      "get": {
+        "description": "This entry is created whenever a policy report schedule is created",
+        "operationId": "PolicyReportScheduleCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "policy_report_schedule.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Weekly overdue follow-ups report",
+                      "type": "policy_report_schedule"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsPolicyReportScheduleCreatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/policy_report_schedule.deleted.1": {
+      "get": {
+        "description": "This entry is created whenever a policy report schedule is deleted",
+        "operationId": "PolicyReportScheduleDeletedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "policy_report_schedule.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Weekly overdue follow-ups report",
+                      "type": "policy_report_schedule"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsPolicyReportScheduleDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/policy_report_schedule.updated.1": {
+      "get": {
+        "description": "This entry is created whenever a policy report schedule is updated",
+        "operationId": "PolicyReportScheduleUpdatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "policy_report_schedule.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Weekly overdue follow-ups report",
+                      "type": "policy_report_schedule"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsPolicyReportScheduleUpdatedV1"
                 }
               }
             },
@@ -102928,6 +104824,57 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsPrivateIncidentAccessAttemptedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/private_incident.access_attempted.2": {
+      "get": {
+        "description": "This entry is created whenever someone attempts to access a private incident.",
+        "operationId": "PrivateIncidentAccessAttemptedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "private_incident.access_attempted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "access_type": "N/A",
+                    "outcome": "granted",
+                    "team_id": "01G0J1EXE7AXZ2C93K61WBPYEH"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "#INC-123 The website is slow",
+                      "type": "incident"
+                    }
+                  ],
+                  "version": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsPrivateIncidentAccessAttemptedV2"
                 }
               }
             },
@@ -104428,6 +106375,190 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsScimGroupSeatMappingsUpdatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/secret.created.1": {
+      "get": {
+        "description": "This entry is created whenever a secret is created",
+        "operationId": "SecretCreatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "secret.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Datadog webhook signing key",
+                      "type": "secret"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsSecretCreatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/secret.deleted.1": {
+      "get": {
+        "description": "This entry is created whenever a secret is deleted",
+        "operationId": "SecretDeletedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "secret.deleted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Datadog webhook signing key",
+                      "type": "secret"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsSecretDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/secret.rotated.1": {
+      "get": {
+        "description": "This entry is created whenever a secret's value is rotated",
+        "operationId": "SecretRotatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "secret.rotated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Datadog webhook signing key",
+                      "type": "secret"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsSecretRotatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/secret.updated.1": {
+      "get": {
+        "description": "This entry is created whenever a secret's metadata is updated",
+        "operationId": "SecretUpdatedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "secret.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Datadog webhook signing key",
+                      "type": "secret"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsSecretUpdatedV1"
                 }
               }
             },

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -54,6 +54,7 @@ const (
 // Defines values for APIKeyTeamRoleV1Name.
 const (
 	APIKeyTeamRoleV1NameApiKeysManage           APIKeyTeamRoleV1Name = "api_keys_manage"
+	APIKeyTeamRoleV1NameCatalogEditor           APIKeyTeamRoleV1Name = "catalog_editor"
 	APIKeyTeamRoleV1NameEscalationCreator       APIKeyTeamRoleV1Name = "escalation_creator"
 	APIKeyTeamRoleV1NameOnCallEditor            APIKeyTeamRoleV1Name = "on_call_editor"
 	APIKeyTeamRoleV1NamePrivateWorkflowsEditor  APIKeyTeamRoleV1Name = "private_workflows_editor"
@@ -99,6 +100,7 @@ const (
 // Defines values for APIKeysCreatePayloadV1TeamRoleNames.
 const (
 	APIKeysCreatePayloadV1TeamRoleNamesApiKeysManage           APIKeysCreatePayloadV1TeamRoleNames = "api_keys_manage"
+	APIKeysCreatePayloadV1TeamRoleNamesCatalogEditor           APIKeysCreatePayloadV1TeamRoleNames = "catalog_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesEscalationCreator       APIKeysCreatePayloadV1TeamRoleNames = "escalation_creator"
 	APIKeysCreatePayloadV1TeamRoleNamesOnCallEditor            APIKeysCreatePayloadV1TeamRoleNames = "on_call_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesPrivateWorkflowsEditor  APIKeysCreatePayloadV1TeamRoleNames = "private_workflows_editor"
@@ -144,6 +146,7 @@ const (
 // Defines values for APIKeysUpdatePayloadV1TeamRoleNames.
 const (
 	APIKeysUpdatePayloadV1TeamRoleNamesApiKeysManage           APIKeysUpdatePayloadV1TeamRoleNames = "api_keys_manage"
+	APIKeysUpdatePayloadV1TeamRoleNamesCatalogEditor           APIKeysUpdatePayloadV1TeamRoleNames = "catalog_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesEscalationCreator       APIKeysUpdatePayloadV1TeamRoleNames = "escalation_creator"
 	APIKeysUpdatePayloadV1TeamRoleNamesOnCallEditor            APIKeysUpdatePayloadV1TeamRoleNames = "on_call_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesPrivateWorkflowsEditor  APIKeysUpdatePayloadV1TeamRoleNames = "private_workflows_editor"
@@ -1095,6 +1098,7 @@ const (
 
 // Defines values for ExternalResourceV1ResourceType.
 const (
+	ExternalResourceV1ResourceTypeArbitraryUrl                ExternalResourceV1ResourceType = "arbitrary_url"
 	ExternalResourceV1ResourceTypeAtlassianStatuspageIncident ExternalResourceV1ResourceType = "atlassian_statuspage_incident"
 	ExternalResourceV1ResourceTypeDatadogMonitorAlert         ExternalResourceV1ResourceType = "datadog_monitor_alert"
 	ExternalResourceV1ResourceTypeGithubPullRequest           ExternalResourceV1ResourceType = "github_pull_request"
@@ -1185,6 +1189,7 @@ const (
 // Defines values for IdentityV1TeamRoles.
 const (
 	IdentityV1TeamRolesApiKeysManage           IdentityV1TeamRoles = "api_keys_manage"
+	IdentityV1TeamRolesCatalogEditor           IdentityV1TeamRoles = "catalog_editor"
 	IdentityV1TeamRolesEscalationCreator       IdentityV1TeamRoles = "escalation_creator"
 	IdentityV1TeamRolesOnCallEditor            IdentityV1TeamRoles = "on_call_editor"
 	IdentityV1TeamRolesPrivateWorkflowsEditor  IdentityV1TeamRoles = "private_workflows_editor"
@@ -1196,6 +1201,7 @@ const (
 
 // Defines values for IncidentAttachmentsCreatePayloadV1ResourceResourceType.
 const (
+	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeArbitraryUrl                IncidentAttachmentsCreatePayloadV1ResourceResourceType = "arbitrary_url"
 	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeAtlassianStatuspageIncident IncidentAttachmentsCreatePayloadV1ResourceResourceType = "atlassian_statuspage_incident"
 	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeDatadogMonitorAlert         IncidentAttachmentsCreatePayloadV1ResourceResourceType = "datadog_monitor_alert"
 	IncidentAttachmentsCreatePayloadV1ResourceResourceTypeGithubPullRequest           IncidentAttachmentsCreatePayloadV1ResourceResourceType = "github_pull_request"
@@ -1624,6 +1630,14 @@ const (
 	StatusPageMaintenanceV2MaintenanceStatusMaintenanceScheduled  StatusPageMaintenanceV2MaintenanceStatus = "maintenance_scheduled"
 )
 
+// Defines values for StatusPageRetrospectiveIncidentUpdateV2IncidentStatus.
+const (
+	StatusPageRetrospectiveIncidentUpdateV2IncidentStatusIdentified    StatusPageRetrospectiveIncidentUpdateV2IncidentStatus = "identified"
+	StatusPageRetrospectiveIncidentUpdateV2IncidentStatusInvestigating StatusPageRetrospectiveIncidentUpdateV2IncidentStatus = "investigating"
+	StatusPageRetrospectiveIncidentUpdateV2IncidentStatusMonitoring    StatusPageRetrospectiveIncidentUpdateV2IncidentStatus = "monitoring"
+	StatusPageRetrospectiveIncidentUpdateV2IncidentStatusResolved      StatusPageRetrospectiveIncidentUpdateV2IncidentStatus = "resolved"
+)
+
 // Defines values for StatusPagesCreateStatusPageIncidentPayloadV2IncidentStatus.
 const (
 	StatusPagesCreateStatusPageIncidentPayloadV2IncidentStatusIdentified    StatusPagesCreateStatusPageIncidentPayloadV2IncidentStatus = "identified"
@@ -1634,10 +1648,10 @@ const (
 
 // Defines values for StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatus.
 const (
-	StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatusIdentified    StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatus = "identified"
-	StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatusInvestigating StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatus = "investigating"
-	StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatusMonitoring    StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatus = "monitoring"
-	StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatusResolved      StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatus = "resolved"
+	Identified    StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatus = "identified"
+	Investigating StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatus = "investigating"
+	Monitoring    StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatus = "monitoring"
+	Resolved      StatusPagesCreateStatusPageIncidentUpdatePayloadV2IncidentStatus = "resolved"
 )
 
 // Defines values for StatusPagesCreateStatusPageMaintenancePayloadV2MaintenanceStatus.
@@ -1843,6 +1857,7 @@ const (
 
 // Defines values for IncidentAttachmentsV1ListParamsResourceType.
 const (
+	ArbitraryUrl                IncidentAttachmentsV1ListParamsResourceType = "arbitrary_url"
 	AtlassianStatuspageIncident IncidentAttachmentsV1ListParamsResourceType = "atlassian_statuspage_incident"
 	DatadogMonitorAlert         IncidentAttachmentsV1ListParamsResourceType = "datadog_monitor_alert"
 	GithubPullRequest           IncidentAttachmentsV1ListParamsResourceType = "github_pull_request"
@@ -1948,6 +1963,9 @@ type APIKeyTeamRoleV1Name string
 
 // APIKeyV1 defines model for APIKeyV1.
 type APIKeyV1 struct {
+	// Comments Freeform notes about this API key
+	Comments *string `json:"comments,omitempty"`
+
 	// CreatedAt When the API key was created
 	CreatedAt time.Time `json:"created_at"`
 	Creator   ActorV1   `json:"creator"`
@@ -1976,6 +1994,9 @@ type APIKeyV1 struct {
 
 // APIKeysCreatePayloadV1 defines model for APIKeysCreatePayloadV1.
 type APIKeysCreatePayloadV1 struct {
+	// Comments Freeform notes about the API key
+	Comments *string `json:"comments,omitempty"`
+
 	// Name Human-readable name for the new API key
 	Name string `json:"name"`
 
@@ -2030,6 +2051,9 @@ type APIKeysShowResultV1 struct {
 
 // APIKeysUpdatePayloadV1 defines model for APIKeysUpdatePayloadV1.
 type APIKeysUpdatePayloadV1 struct {
+	// Comments Freeform notes about the API key
+	Comments *string `json:"comments,omitempty"`
+
 	// Name Human-readable name for the API key
 	Name string `json:"name"`
 
@@ -2764,51 +2788,55 @@ type AlertRouteIncidentConfigV3 struct {
 // AlertRouteIncidentTemplatePayloadV2 defines model for AlertRouteIncidentTemplatePayloadV2.
 type AlertRouteIncidentTemplatePayloadV2 struct {
 	// CustomFields Custom fields configuration
-	CustomFields  *[]AlertRouteCustomFieldBindingPayloadV2         `json:"custom_fields,omitempty"`
-	IncidentMode  *AlertRouteTemplateBindingPayloadV2              `json:"incident_mode,omitempty"`
-	IncidentType  *AlertRouteTemplateBindingPayloadV2              `json:"incident_type,omitempty"`
-	Name          AlertRouteAutoGeneratedTemplateBindingPayloadV2  `json:"name"`
-	Severity      *AlertRouteSeverityBindingPayloadV2              `json:"severity,omitempty"`
-	StartInTriage *AlertRouteTemplateBindingPayloadV2              `json:"start_in_triage,omitempty"`
-	Summary       *AlertRouteAutoGeneratedTemplateBindingPayloadV2 `json:"summary,omitempty"`
-	Workspace     *AlertRouteTemplateBindingPayloadV2              `json:"workspace,omitempty"`
+	CustomFields    *[]AlertRouteCustomFieldBindingPayloadV2         `json:"custom_fields,omitempty"`
+	IncidentMode    *AlertRouteTemplateBindingPayloadV2              `json:"incident_mode,omitempty"`
+	IncidentType    *AlertRouteTemplateBindingPayloadV2              `json:"incident_type,omitempty"`
+	MembershipTeams *AlertRouteTemplateBindingPayloadV2              `json:"membership_teams,omitempty"`
+	Name            AlertRouteAutoGeneratedTemplateBindingPayloadV2  `json:"name"`
+	Severity        *AlertRouteSeverityBindingPayloadV2              `json:"severity,omitempty"`
+	StartInTriage   *AlertRouteTemplateBindingPayloadV2              `json:"start_in_triage,omitempty"`
+	Summary         *AlertRouteAutoGeneratedTemplateBindingPayloadV2 `json:"summary,omitempty"`
+	Workspace       *AlertRouteTemplateBindingPayloadV2              `json:"workspace,omitempty"`
 }
 
 // AlertRouteIncidentTemplatePayloadV3 defines model for AlertRouteIncidentTemplatePayloadV3.
 type AlertRouteIncidentTemplatePayloadV3 struct {
 	// CustomFields Custom fields configuration
-	CustomFields  *[]AlertRouteCustomFieldBindingPayloadV3         `json:"custom_fields,omitempty"`
-	IncidentMode  *AlertRouteTemplateBindingPayloadV3              `json:"incident_mode,omitempty"`
-	IncidentType  *AlertRouteTemplateBindingPayloadV3              `json:"incident_type,omitempty"`
-	Name          AlertRouteAutoGeneratedTemplateBindingPayloadV3  `json:"name"`
-	Severity      *AlertRouteSeverityBindingPayloadV3              `json:"severity,omitempty"`
-	StartInTriage *AlertRouteTemplateBindingPayloadV3              `json:"start_in_triage,omitempty"`
-	Summary       *AlertRouteAutoGeneratedTemplateBindingPayloadV3 `json:"summary,omitempty"`
+	CustomFields    *[]AlertRouteCustomFieldBindingPayloadV3         `json:"custom_fields,omitempty"`
+	IncidentMode    *AlertRouteTemplateBindingPayloadV3              `json:"incident_mode,omitempty"`
+	IncidentType    *AlertRouteTemplateBindingPayloadV3              `json:"incident_type,omitempty"`
+	MembershipTeams *AlertRouteTemplateBindingPayloadV3              `json:"membership_teams,omitempty"`
+	Name            AlertRouteAutoGeneratedTemplateBindingPayloadV3  `json:"name"`
+	Severity        *AlertRouteSeverityBindingPayloadV3              `json:"severity,omitempty"`
+	StartInTriage   *AlertRouteTemplateBindingPayloadV3              `json:"start_in_triage,omitempty"`
+	Summary         *AlertRouteAutoGeneratedTemplateBindingPayloadV3 `json:"summary,omitempty"`
 }
 
 // AlertRouteIncidentTemplateV2 defines model for AlertRouteIncidentTemplateV2.
 type AlertRouteIncidentTemplateV2 struct {
 	// CustomFields Custom fields configuration
-	CustomFields  *[]AlertRouteCustomFieldBindingV2         `json:"custom_fields,omitempty"`
-	IncidentMode  *AlertRouteTemplateBindingV2              `json:"incident_mode,omitempty"`
-	IncidentType  *AlertRouteTemplateBindingV2              `json:"incident_type,omitempty"`
-	Name          AlertRouteAutoGeneratedTemplateBindingV2  `json:"name"`
-	Severity      *AlertRouteSeverityBindingV2              `json:"severity,omitempty"`
-	StartInTriage *AlertRouteTemplateBindingV2              `json:"start_in_triage,omitempty"`
-	Summary       *AlertRouteAutoGeneratedTemplateBindingV2 `json:"summary,omitempty"`
-	Workspace     *AlertRouteTemplateBindingV2              `json:"workspace,omitempty"`
+	CustomFields    *[]AlertRouteCustomFieldBindingV2         `json:"custom_fields,omitempty"`
+	IncidentMode    *AlertRouteTemplateBindingV2              `json:"incident_mode,omitempty"`
+	IncidentType    *AlertRouteTemplateBindingV2              `json:"incident_type,omitempty"`
+	MembershipTeams *AlertRouteTemplateBindingV2              `json:"membership_teams,omitempty"`
+	Name            AlertRouteAutoGeneratedTemplateBindingV2  `json:"name"`
+	Severity        *AlertRouteSeverityBindingV2              `json:"severity,omitempty"`
+	StartInTriage   *AlertRouteTemplateBindingV2              `json:"start_in_triage,omitempty"`
+	Summary         *AlertRouteAutoGeneratedTemplateBindingV2 `json:"summary,omitempty"`
+	Workspace       *AlertRouteTemplateBindingV2              `json:"workspace,omitempty"`
 }
 
 // AlertRouteIncidentTemplateV3 defines model for AlertRouteIncidentTemplateV3.
 type AlertRouteIncidentTemplateV3 struct {
 	// CustomFields Custom fields configuration
-	CustomFields  *[]AlertRouteCustomFieldBindingV3         `json:"custom_fields,omitempty"`
-	IncidentMode  *AlertRouteTemplateBindingV3              `json:"incident_mode,omitempty"`
-	IncidentType  *AlertRouteTemplateBindingV3              `json:"incident_type,omitempty"`
-	Name          AlertRouteAutoGeneratedTemplateBindingV3  `json:"name"`
-	Severity      *AlertRouteSeverityBindingV3              `json:"severity,omitempty"`
-	StartInTriage *AlertRouteTemplateBindingV3              `json:"start_in_triage,omitempty"`
-	Summary       *AlertRouteAutoGeneratedTemplateBindingV3 `json:"summary,omitempty"`
+	CustomFields    *[]AlertRouteCustomFieldBindingV3         `json:"custom_fields,omitempty"`
+	IncidentMode    *AlertRouteTemplateBindingV3              `json:"incident_mode,omitempty"`
+	IncidentType    *AlertRouteTemplateBindingV3              `json:"incident_type,omitempty"`
+	MembershipTeams *AlertRouteTemplateBindingV3              `json:"membership_teams,omitempty"`
+	Name            AlertRouteAutoGeneratedTemplateBindingV3  `json:"name"`
+	Severity        *AlertRouteSeverityBindingV3              `json:"severity,omitempty"`
+	StartInTriage   *AlertRouteTemplateBindingV3              `json:"start_in_triage,omitempty"`
+	Summary         *AlertRouteAutoGeneratedTemplateBindingV3 `json:"summary,omitempty"`
 }
 
 // AlertRouteSeverityBindingPayloadV2 defines model for AlertRouteSeverityBindingPayloadV2.
@@ -3657,6 +3685,9 @@ type CatalogCreateTypePayloadV3 struct {
 	// Name Name is the human readable name of this type
 	Name string `json:"name"`
 
+	// OwningTeamIds IDs of the teams that own this catalog type
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
 	// Ranked If this type should be ranked
 	Ranked *bool `json:"ranked,omitempty"`
 
@@ -4217,6 +4248,9 @@ type CatalogTypeV3 struct {
 	// Name Name is the human readable name of this type
 	Name string `json:"name"`
 
+	// OwningTeamIds IDs of the teams that own this catalog type
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
 	// Ranked If this type should be ranked
 	Ranked bool `json:"ranked"`
 
@@ -4356,6 +4390,9 @@ type CatalogUpdateTypePayloadV3 struct {
 
 	// Name Name is the human readable name of this type
 	Name string `json:"name"`
+
+	// OwningTeamIds IDs of the teams that own this catalog type
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
 
 	// Ranked If this type should be ranked
 	Ranked *bool `json:"ranked,omitempty"`
@@ -6276,11 +6313,17 @@ type IncidentAttachmentsCreatePayloadV1 struct {
 	// IncidentId ID of the incident to add an attachment to
 	IncidentId string `json:"incident_id"`
 	Resource   struct {
+		// Emoji Emoji shortcode representing the link, without surrounding colons. Only supported for the arbitrary_url resource type.
+		Emoji *string `json:"emoji,omitempty"`
+
 		// ExternalId ID of the resource in the external system
 		ExternalId *string `json:"external_id,omitempty"`
 
 		// ResourceType E.g. PagerDuty: the external system that holds the resource
 		ResourceType IncidentAttachmentsCreatePayloadV1ResourceResourceType `json:"resource_type"`
+
+		// Title Human readable title for the link. Only supported for the arbitrary_url resource type.
+		Title *string `json:"title,omitempty"`
 
 		// Url URL of the external resource to attach for the given resource type.
 		Url *string `json:"url,omitempty"`
@@ -8912,6 +8955,24 @@ type StatusPageMaintenanceV2 struct {
 // StatusPageMaintenanceV2MaintenanceStatus Current status for this maintenance window
 type StatusPageMaintenanceV2MaintenanceStatus string
 
+// StatusPageRetrospectiveIncidentUpdateV2 A single update in the reconstructed timeline of a retrospective status page incident.
+type StatusPageRetrospectiveIncidentUpdateV2 struct {
+	// ComponentStatuses An array of mappings from component ID to component status at the time this update was published
+	ComponentStatuses *[]StatusPageIncidentAffectedComponentV2 `json:"component_statuses,omitempty"`
+
+	// IncidentStatus Current status for this incident
+	IncidentStatus StatusPageRetrospectiveIncidentUpdateV2IncidentStatus `json:"incident_status"`
+
+	// Message Markdown update on what's changed about this status page incident
+	Message string `json:"message"`
+
+	// PublishedAt When this update was published. Must be in the past.
+	PublishedAt time.Time `json:"published_at"`
+}
+
+// StatusPageRetrospectiveIncidentUpdateV2IncidentStatus Current status for this incident
+type StatusPageRetrospectiveIncidentUpdateV2IncidentStatus string
+
 // StatusPageStructureComponentV2 defines model for StatusPageStructureComponentV2.
 type StatusPageStructureComponentV2 struct {
 	// ComponentId The ID of the affected component. This may be found by calling the ShowStatusPageStructure endpoint.
@@ -9099,6 +9160,26 @@ type StatusPagesCreateStatusPageMaintenanceUpdatePayloadV2MaintenanceStatus stri
 // StatusPagesCreateStatusPageMaintenanceUpdateResultV2 defines model for StatusPagesCreateStatusPageMaintenanceUpdateResultV2.
 type StatusPagesCreateStatusPageMaintenanceUpdateResultV2 struct {
 	StatusPageMaintenanceUpdate *StatusPageMaintenanceUpdateV2 `json:"status_page_maintenance_update,omitempty"`
+}
+
+// StatusPagesCreateStatusPageRetrospectiveIncidentPayloadV2 defines model for StatusPagesCreateStatusPageRetrospectiveIncidentPayloadV2.
+type StatusPagesCreateStatusPageRetrospectiveIncidentPayloadV2 struct {
+	// IdempotencyKey A unique key to de-duplicate requests. If you send a request with an idempotency_key that was already used, the original response will be returned.
+	IdempotencyKey string `json:"idempotency_key"`
+
+	// Name A title for the incident
+	Name string `json:"name"`
+
+	// StatusPageId ID of the status page. You can find this by calling the ListStatusPages endpoint.
+	StatusPageId string `json:"status_page_id"`
+
+	// Updates The reconstructed timeline of updates for this incident, ordered chronologically (earliest first). The final update must set incident_status to "resolved".
+	Updates []StatusPageRetrospectiveIncidentUpdateV2 `json:"updates"`
+}
+
+// StatusPagesCreateStatusPageRetrospectiveIncidentResultV2 defines model for StatusPagesCreateStatusPageRetrospectiveIncidentResultV2.
+type StatusPagesCreateStatusPageRetrospectiveIncidentResultV2 struct {
+	StatusPageIncident *StatusPageIncidentV2 `json:"status_page_incident,omitempty"`
 }
 
 // StatusPagesListResponseIncidentsResultV1 defines model for StatusPagesListResponseIncidentsResultV1.
@@ -10629,6 +10710,9 @@ type StatusPagesV2CreateStatusPageMaintenanceUpdateJSONRequestBody = StatusPages
 // StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody defines body for StatusPagesV2CreateStatusPageMaintenance for application/json ContentType.
 type StatusPagesV2CreateStatusPageMaintenanceJSONRequestBody = StatusPagesCreateStatusPageMaintenancePayloadV2
 
+// StatusPagesV2CreateStatusPageRetrospectiveIncidentJSONRequestBody defines body for StatusPagesV2CreateStatusPageRetrospectiveIncident for application/json ContentType.
+type StatusPagesV2CreateStatusPageRetrospectiveIncidentJSONRequestBody = StatusPagesCreateStatusPageRetrospectiveIncidentPayloadV2
+
 // TelemetryV2UpdateDataSourceJSONRequestBody defines body for TelemetryV2UpdateDataSource for application/json ContentType.
 type TelemetryV2UpdateDataSourceJSONRequestBody = TelemetryUpdateDataSourcePayloadV2
 
@@ -11400,6 +11484,11 @@ type ClientInterface interface {
 
 	// StatusPagesV2ShowStatusPageMaintenance request
 	StatusPagesV2ShowStatusPageMaintenance(ctx context.Context, statusPageMaintenanceId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StatusPagesV2CreateStatusPageRetrospectiveIncidentWithBody request with any body
+	StatusPagesV2CreateStatusPageRetrospectiveIncidentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	StatusPagesV2CreateStatusPageRetrospectiveIncident(ctx context.Context, body StatusPagesV2CreateStatusPageRetrospectiveIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// StatusPagesV2ShowStatusPageStructure request
 	StatusPagesV2ShowStatusPageStructure(ctx context.Context, statusPageId string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -14449,6 +14538,30 @@ func (c *Client) StatusPagesV2CreateStatusPageMaintenance(ctx context.Context, b
 
 func (c *Client) StatusPagesV2ShowStatusPageMaintenance(ctx context.Context, statusPageMaintenanceId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewStatusPagesV2ShowStatusPageMaintenanceRequest(c.Server, statusPageMaintenanceId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageRetrospectiveIncidentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageRetrospectiveIncidentRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StatusPagesV2CreateStatusPageRetrospectiveIncident(ctx context.Context, body StatusPagesV2CreateStatusPageRetrospectiveIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStatusPagesV2CreateStatusPageRetrospectiveIncidentRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -23347,6 +23460,46 @@ func NewStatusPagesV2ShowStatusPageMaintenanceRequest(server string, statusPageM
 	return req, nil
 }
 
+// NewStatusPagesV2CreateStatusPageRetrospectiveIncidentRequest calls the generic StatusPagesV2CreateStatusPageRetrospectiveIncident builder with application/json body
+func NewStatusPagesV2CreateStatusPageRetrospectiveIncidentRequest(server string, body StatusPagesV2CreateStatusPageRetrospectiveIncidentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewStatusPagesV2CreateStatusPageRetrospectiveIncidentRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewStatusPagesV2CreateStatusPageRetrospectiveIncidentRequestWithBody generates requests for StatusPagesV2CreateStatusPageRetrospectiveIncident with any type of body
+func NewStatusPagesV2CreateStatusPageRetrospectiveIncidentRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/status_page_retrospective_incidents")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewStatusPagesV2ShowStatusPageStructureRequest generates requests for StatusPagesV2ShowStatusPageStructure
 func NewStatusPagesV2ShowStatusPageStructureRequest(server string, statusPageId string) (*http.Request, error) {
 	var err error
@@ -25604,6 +25757,11 @@ type ClientWithResponsesInterface interface {
 
 	// StatusPagesV2ShowStatusPageMaintenanceWithResponse request
 	StatusPagesV2ShowStatusPageMaintenanceWithResponse(ctx context.Context, statusPageMaintenanceId string, reqEditors ...RequestEditorFn) (*StatusPagesV2ShowStatusPageMaintenanceResponse, error)
+
+	// StatusPagesV2CreateStatusPageRetrospectiveIncidentWithBodyWithResponse request with any body
+	StatusPagesV2CreateStatusPageRetrospectiveIncidentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse, error)
+
+	StatusPagesV2CreateStatusPageRetrospectiveIncidentWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageRetrospectiveIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse, error)
 
 	// StatusPagesV2ShowStatusPageStructureWithResponse request
 	StatusPagesV2ShowStatusPageStructureWithResponse(ctx context.Context, statusPageId string, reqEditors ...RequestEditorFn) (*StatusPagesV2ShowStatusPageStructureResponse, error)
@@ -29557,6 +29715,28 @@ func (r StatusPagesV2ShowStatusPageMaintenanceResponse) StatusCode() int {
 	return 0
 }
 
+type StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *StatusPagesCreateStatusPageRetrospectiveIncidentResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type StatusPagesV2ShowStatusPageStructureResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -32446,6 +32626,23 @@ func (c *ClientWithResponses) StatusPagesV2ShowStatusPageMaintenanceWithResponse
 		return nil, err
 	}
 	return ParseStatusPagesV2ShowStatusPageMaintenanceResponse(rsp)
+}
+
+// StatusPagesV2CreateStatusPageRetrospectiveIncidentWithBodyWithResponse request with arbitrary body returning *StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageRetrospectiveIncidentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageRetrospectiveIncidentWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageRetrospectiveIncidentResponse(rsp)
+}
+
+func (c *ClientWithResponses) StatusPagesV2CreateStatusPageRetrospectiveIncidentWithResponse(ctx context.Context, body StatusPagesV2CreateStatusPageRetrospectiveIncidentJSONRequestBody, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse, error) {
+	rsp, err := c.StatusPagesV2CreateStatusPageRetrospectiveIncident(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStatusPagesV2CreateStatusPageRetrospectiveIncidentResponse(rsp)
 }
 
 // StatusPagesV2ShowStatusPageStructureWithResponse request returning *StatusPagesV2ShowStatusPageStructureResponse
@@ -37123,6 +37320,32 @@ func ParseStatusPagesV2ShowStatusPageMaintenanceResponse(rsp *http.Response) (*S
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStatusPagesV2CreateStatusPageRetrospectiveIncidentResponse parses an HTTP response from a StatusPagesV2CreateStatusPageRetrospectiveIncidentWithResponse call
+func ParseStatusPagesV2CreateStatusPageRetrospectiveIncidentResponse(rsp *http.Response) (*StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StatusPagesV2CreateStatusPageRetrospectiveIncidentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest StatusPagesCreateStatusPageRetrospectiveIncidentResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
 
 	}
 

--- a/internal/provider/incident_catalog_type_data_source.go
+++ b/internal/provider/incident_catalog_type_data_source.go
@@ -61,6 +61,11 @@ func (i *IncidentCatalogTypeDataSource) Schema(ctx context.Context, req datasour
 				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "use_name_as_identifier"),
 				Computed:            true,
 			},
+			"owning_team_ids": schema.SetAttribute{
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "owning_team_ids"),
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
 		},
 	}
 }
@@ -127,7 +132,10 @@ func (i *IncidentCatalogTypeDataSource) Read(ctx context.Context, req datasource
 		return
 	}
 
-	modelResp := new(IncidentCatalogTypeResource).buildModel(*catalogType)
+	emptyPlan := &IncidentCatalogTypeResourceModel{
+		OwningTeamIDs: types.SetNull(types.StringType),
+	}
+	modelResp := new(IncidentCatalogTypeResource).buildModel(*catalogType, emptyPlan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &modelResp)...)
 }

--- a/internal/provider/incident_catalog_type_data_source.go
+++ b/internal/provider/incident_catalog_type_data_source.go
@@ -132,10 +132,10 @@ func (i *IncidentCatalogTypeDataSource) Read(ctx context.Context, req datasource
 		return
 	}
 
-	emptyPlan := &IncidentCatalogTypeResourceModel{
-		OwningTeamIDs: types.SetNull(types.StringType),
-	}
-	modelResp := new(IncidentCatalogTypeResource).buildModel(*catalogType, emptyPlan)
+	modelResp := new(IncidentCatalogTypeResource).buildModel(*catalogType, nil)
+	// A data source is read-only and recomputed on every read, so there's no
+	// perpetual-diff concern: always surface the owning teams the API returns.
+	modelResp.OwningTeamIDs = owningTeamIDsToSet(catalogType.OwningTeamIds)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &modelResp)...)
 }

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -306,15 +306,28 @@ func (r *IncidentCatalogTypeResource) buildModel(catalogType client.CatalogTypeV
 	}
 	model.Categories = types.ListValueMust(types.StringType, categories)
 
-	if catalogType.OwningTeamIds != nil && prior != nil && !prior.OwningTeamIDs.IsUnknown() && !prior.OwningTeamIDs.IsNull() {
-		elements := make([]attr.Value, len(*catalogType.OwningTeamIds))
-		for i, id := range *catalogType.OwningTeamIds {
-			elements[i] = types.StringValue(id)
-		}
-		model.OwningTeamIDs = types.SetValueMust(types.StringType, elements)
+	// The API always returns owning_team_ids, but a practitioner who never sets the
+	// attribute should keep it null rather than picking up a perpetual diff. Only
+	// reflect owners back into state when the prior config actually managed them.
+	if prior != nil && !prior.OwningTeamIDs.IsUnknown() && !prior.OwningTeamIDs.IsNull() {
+		model.OwningTeamIDs = owningTeamIDsToSet(catalogType.OwningTeamIds)
 	} else {
 		model.OwningTeamIDs = types.SetNull(types.StringType)
 	}
 
 	return model
+}
+
+// owningTeamIDsToSet converts the API's owning team IDs into a set, treating a nil
+// slice as a null set.
+func owningTeamIDsToSet(ids *[]string) types.Set {
+	if ids == nil {
+		return types.SetNull(types.StringType)
+	}
+	elements := make([]attr.Value, len(*ids))
+	for i, id := range *ids {
+		elements[i] = types.StringValue(id)
+	}
+
+	return types.SetValueMust(types.StringType, elements)
 }

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -39,6 +39,7 @@ type IncidentCatalogTypeResourceModel struct {
 	SourceRepoURL       types.String `tfsdk:"source_repo_url"`
 	Categories          types.List   `tfsdk:"categories"`
 	UseNameAsIdentifier types.Bool   `tfsdk:"use_name_as_identifier"`
+	OwningTeamIDs       types.Set    `tfsdk:"owning_team_ids"`
 }
 
 func NewIncidentCatalogTypeResource() resource.Resource {
@@ -105,6 +106,11 @@ func (r *IncidentCatalogTypeResource) Schema(ctx context.Context, req resource.S
 				Optional:            true,
 				Computed:            true,
 			},
+			"owning_team_ids": schema.SetAttribute{
+				MarkdownDescription: apischema.Docstring("CatalogTypeV3", "owning_team_ids"),
+				Optional:            true,
+				ElementType:         types.StringType,
+			},
 		},
 	}
 }
@@ -165,6 +171,15 @@ func (r *IncidentCatalogTypeResource) Create(ctx context.Context, req resource.C
 	}
 	requestBody.Categories = lo.ToPtr(categories)
 
+	if !data.OwningTeamIDs.IsUnknown() && !data.OwningTeamIDs.IsNull() {
+		ids := []string{}
+		resp.Diagnostics.Append(data.OwningTeamIDs.ElementsAs(ctx, &ids, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		requestBody.OwningTeamIds = &ids
+	}
+
 	result, err := r.client.CatalogV3CreateTypeWithResponse(ctx, requestBody)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create catalog type, got error: %s", err))
@@ -172,7 +187,7 @@ func (r *IncidentCatalogTypeResource) Create(ctx context.Context, req resource.C
 	}
 
 	tflog.Trace(ctx, fmt.Sprintf("created a catalog type resource with id=%s", result.JSON201.CatalogType.Id))
-	data = r.buildModel(result.JSON201.CatalogType)
+	data = r.buildModel(result.JSON201.CatalogType, data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -196,7 +211,7 @@ func (r *IncidentCatalogTypeResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	data = r.buildModel(result.JSON200.CatalogType)
+	data = r.buildModel(result.JSON200.CatalogType, data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -236,13 +251,22 @@ func (r *IncidentCatalogTypeResource) Update(ctx context.Context, req resource.U
 	}
 	requestBody.Categories = lo.ToPtr(categories)
 
+	if !data.OwningTeamIDs.IsUnknown() && !data.OwningTeamIDs.IsNull() {
+		ids := []string{}
+		resp.Diagnostics.Append(data.OwningTeamIDs.ElementsAs(ctx, &ids, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		requestBody.OwningTeamIds = &ids
+	}
+
 	result, err := r.client.CatalogV3UpdateTypeWithResponse(ctx, data.ID.ValueString(), requestBody)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update catalog type, got error: %s", err))
 		return
 	}
 
-	data = r.buildModel(result.JSON200.CatalogType)
+	data = r.buildModel(result.JSON200.CatalogType, data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -264,7 +288,7 @@ func (r *IncidentCatalogTypeResource) ImportState(ctx context.Context, req resou
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func (r *IncidentCatalogTypeResource) buildModel(catalogType client.CatalogTypeV3) *IncidentCatalogTypeResourceModel {
+func (r *IncidentCatalogTypeResource) buildModel(catalogType client.CatalogTypeV3, prior *IncidentCatalogTypeResourceModel) *IncidentCatalogTypeResourceModel {
 	model := &IncidentCatalogTypeResourceModel{
 		ID:                  types.StringValue(catalogType.Id),
 		Name:                types.StringValue(catalogType.Name),
@@ -281,6 +305,16 @@ func (r *IncidentCatalogTypeResource) buildModel(catalogType client.CatalogTypeV
 		categories = append(categories, types.StringValue(string(category)))
 	}
 	model.Categories = types.ListValueMust(types.StringType, categories)
+
+	if catalogType.OwningTeamIds != nil && prior != nil && !prior.OwningTeamIDs.IsUnknown() && !prior.OwningTeamIDs.IsNull() {
+		elements := make([]attr.Value, len(*catalogType.OwningTeamIds))
+		for i, id := range *catalogType.OwningTeamIds {
+			elements[i] = types.StringValue(id)
+		}
+		model.OwningTeamIDs = types.SetValueMust(types.StringType, elements)
+	} else {
+		model.OwningTeamIDs = types.SetNull(types.StringType)
+	}
 
 	return model
 }

--- a/internal/provider/incident_catalog_type_resource.go
+++ b/internal/provider/incident_catalog_type_resource.go
@@ -318,14 +318,14 @@ func (r *IncidentCatalogTypeResource) buildModel(catalogType client.CatalogTypeV
 	return model
 }
 
-// owningTeamIDsToSet converts the API's owning team IDs into a set, treating a nil
-// slice as a null set.
+// owningTeamIDsToSet converts the API's owning team IDs into a set. A nil slice
+// becomes an empty set (not null): the API omits the field when there are no owners,
+// so a practitioner who configured an empty set must read it back as empty to avoid an
+// inconsistent-result error.
 func owningTeamIDsToSet(ids *[]string) types.Set {
-	if ids == nil {
-		return types.SetNull(types.StringType)
-	}
-	elements := make([]attr.Value, len(*ids))
-	for i, id := range *ids {
+	slice := lo.FromPtr(ids)
+	elements := make([]attr.Value, len(slice))
+	for i, id := range slice {
 		elements[i] = types.StringValue(id)
 	}
 

--- a/internal/provider/incident_catalog_type_resource_test.go
+++ b/internal/provider/incident_catalog_type_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -124,6 +125,48 @@ func TestAccIncidentCatalogTypeResource(t *testing.T) {
 	})
 }
 
+// TestAccIncidentCatalogTypeResourceOwningTeams exercises the owning_team_ids
+// attribute. It's gated on a real team catalog-entry ID being supplied via
+// TF_ACC_OWNING_TEAM_ID, so CI without one skips. The create-without-owners drift
+// case is already covered by the ImportStateVerify steps in the tests above.
+func TestAccIncidentCatalogTypeResourceOwningTeams(t *testing.T) {
+	teamID := os.Getenv("TF_ACC_OWNING_TEAM_ID")
+	if teamID == "" {
+		t.Skip("TF_ACC_OWNING_TEAM_ID is not set: skipping owning_team_ids test")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with a single owning team
+			{
+				Config: testAccIncidentCatalogTypeResourceConfigWithOwningTeams([]string{teamID}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_catalog_type.example", "owning_team_ids.#", "1"),
+					resource.TestCheckResourceAttr(
+						"incident_catalog_type.example", "owning_team_ids.0", teamID),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "incident_catalog_type.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update to manage ownership as exactly empty
+			{
+				Config: testAccIncidentCatalogTypeResourceConfigWithOwningTeams([]string{}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_catalog_type.example", "owning_team_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func generateTypeName() string {
 	// The test run ID is a uuid, which won't be accepted. Strip it down to
 	// something allowed
@@ -154,6 +197,36 @@ resource "incident_catalog_type" "example" {
   source_repo_url = "https://github.com/incident-io/terraform-demo"
 }
 `))
+
+var catalogTypeWithOwningTeamsTemplate = template.Must(template.New("incident_catalog_type_with_owning_teams").Funcs(sprig.TxtFuncMap()).Parse(`
+resource "incident_catalog_type" "example" {
+  name        = {{ quote .Name }}
+  description = {{ quote .Description }}
+
+  source_repo_url = "https://github.com/incident-io/terraform-demo"
+
+  owning_team_ids = [{{ range $i, $id := .OwningTeamIDs }}{{ if $i }}, {{ end }}{{ quote $id }}{{ end }}]
+}
+`))
+
+func testAccIncidentCatalogTypeResourceConfigWithOwningTeams(owningTeamIDs []string) string {
+	model := struct {
+		Name          string
+		Description   string
+		OwningTeamIDs []string
+	}{
+		Name:          StableSuffix("Service"),
+		Description:   "Catalog Type Acceptance tests",
+		OwningTeamIDs: owningTeamIDs,
+	}
+
+	var buf bytes.Buffer
+	if err := catalogTypeWithOwningTeamsTemplate.Execute(&buf, model); err != nil {
+		panic(err)
+	}
+
+	return buf.String()
+}
 
 func catalogTypeDefault() client.CatalogTypeV2 {
 	return client.CatalogTypeV2{


### PR DESCRIPTION
The `incident_catalog_type` resource and data source did not expose `owning_team_ids`, so catalog type ownership could not be managed through Terraform.

This re-vendors the public v3 spec (which now carries the field) and regenerates the client, then adds `owning_team_ids` to both. On the resource it is optional with no default, so the field is only sent when configured and owners are only reflected back into state when the practitioner actually manages them, mirroring `team_ids` on `incident_schedule` to avoid a perpetual diff for types that never set it. An empty set is read back as empty rather than null so `owning_team_ids = []` round-trips cleanly, and the data source always surfaces the owners the API returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)