### PR TITLE
Fix alert route grace_period_seconds inconsistent result after apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix `Provider produced inconsistent result after apply` on `incident_alert_route` when `escalation_config.when_alert_joins_group.mode` is `on_priority_increase` (or any mode other than `on_each_new_alert`) and `grace_period_seconds` is not set. The API echoes back a zero `grace_period_seconds` for these modes, but the field is only configurable with `on_each_new_alert` (it is rejected by validation and never sent otherwise), so the plan holds null. The provider now only reads `grace_period_seconds` into state when the mode is `on_each_new_alert`, matching how it is validated and sent.
+
 ## v5.44.1
 
 - Fix `Provider produced inconsistent result after apply` on `incident_alert_route` when `escalation_config.escalation_targets` sets an escalation path. For escalation-path targets the API echoes the same binding back in `users` for legacy compatibility; the provider surfaced that duplicate, leaving the read-back set element (`users` non-null) unable to correlate with the planned element (`users = null`). The provider now keeps only `escalation_paths` for escalation-path targets.

--- a/internal/provider/models/alert_route_v3_model.go
+++ b/internal/provider/models/alert_route_v3_model.go
@@ -48,8 +48,15 @@ func whenAlertJoinsGroupFromAPI(in *client.AlertRouteWhenAlertJoinsGroupV3) type
 		return types.ObjectNull(WhenAlertJoinsGroupAttrTypes())
 	}
 
+	// The grace period only applies when re-escalating on each new alert. For
+	// other modes the API still returns a (zero) value, but it isn't a
+	// configurable field there: ValidateConfig rejects it and whenAlertJoinsGroupToPayload
+	// never sends it, so the config/plan always holds null. Mirror that here and
+	// leave it null unless the mode is on_each_new_alert, otherwise a server-sent
+	// 0 would clash with the null plan and produce a "Provider produced
+	// inconsistent result after apply" error.
 	gracePeriodSeconds := types.Int64Null()
-	if in.GracePeriodSeconds != nil {
+	if in.Mode == client.AlertRouteWhenAlertJoinsGroupV3ModeOnEachNewAlert && in.GracePeriodSeconds != nil {
 		gracePeriodSeconds = types.Int64Value(int64(*in.GracePeriodSeconds))
 	}
 

--- a/internal/provider/models/alert_route_v3_model_test.go
+++ b/internal/provider/models/alert_route_v3_model_test.go
@@ -407,3 +407,68 @@ func TestAlertRouteV3CustomFieldsNullVsEmpty(t *testing.T) {
 		t.Errorf("custom_fields: expected length 0, got %d", len(gotEmpty.IncidentConfig.Template.CustomFields))
 	}
 }
+
+// TestWhenAlertJoinsGroupFromAPIGracePeriodByMode covers the mapping of
+// grace_period_seconds out of the API. The grace period is only a real,
+// configurable field when mode is on_each_new_alert. For on_priority_increase
+// the API still echoes back a (zero) grace_period_seconds, but the config/plan
+// always holds null there (ValidateConfig rejects setting it). If we copied the
+// server's 0 into state, apply would fail with "Provider produced inconsistent
+// result after apply: was null, but now cty.NumberIntVal(0)".
+func TestWhenAlertJoinsGroupFromAPIGracePeriodByMode(t *testing.T) {
+	tests := []struct {
+		name           string
+		mode           client.AlertRouteWhenAlertJoinsGroupV3Mode
+		apiGrace       *int32
+		wantGraceNull  bool
+		wantGraceValue int64
+	}{
+		{
+			name:           "on_each_new_alert carries the grace period",
+			mode:           client.AlertRouteWhenAlertJoinsGroupV3ModeOnEachNewAlert,
+			apiGrace:       lo.ToPtr(int32(60)),
+			wantGraceNull:  false,
+			wantGraceValue: 60,
+		},
+		{
+			name:          "on_priority_increase ignores a server-sent zero",
+			mode:          client.AlertRouteWhenAlertJoinsGroupV3ModeOnPriorityIncrease,
+			apiGrace:      lo.ToPtr(int32(0)),
+			wantGraceNull: true,
+		},
+		{
+			name:          "on_priority_increase with nil grace stays null",
+			mode:          client.AlertRouteWhenAlertJoinsGroupV3ModeOnPriorityIncrease,
+			apiGrace:      nil,
+			wantGraceNull: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := whenAlertJoinsGroupFromAPI(&client.AlertRouteWhenAlertJoinsGroupV3{
+				Mode:               tc.mode,
+				GracePeriodSeconds: tc.apiGrace,
+			})
+
+			var m AlertRouteWhenAlertJoinsGroupModel
+			obj.As(context.Background(), &m, basetypes.ObjectAsOptions{})
+
+			if got := m.Mode.ValueString(); got != string(tc.mode) {
+				t.Errorf("mode: got %q, want %q", got, tc.mode)
+			}
+			if tc.wantGraceNull {
+				if !m.GracePeriodSeconds.IsNull() {
+					t.Errorf("grace_period_seconds: expected null, got %d", m.GracePeriodSeconds.ValueInt64())
+				}
+				return
+			}
+			if m.GracePeriodSeconds.IsNull() {
+				t.Fatal("grace_period_seconds: expected a value, got null")
+			}
+			if got := m.GracePeriodSeconds.ValueInt64(); got != tc.wantGraceValue {
+				t.Errorf("grace_period_seconds: got %d, want %d", got, tc.wantGraceValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes a `Provider produced inconsistent result after apply` error on `incident_alert_route` (reported by a customer on v5.44.1):

```
.escalation_config.when_alert_joins_group.grace_period_seconds: was null, but now cty.NumberIntVal(0).
```

## Why

Setting:

```hcl
escalation_config = {
  when_alert_joins_group = {
    mode = "on_priority_increase"
  }
}
```

triggers the error. `grace_period_seconds` is only a configurable field when `mode = on_each_new_alert`:

- `ValidateConfig` rejects `grace_period_seconds` for any other mode (so the user can't set it — setting `0` also fails validation), and
- `whenAlertJoinsGroupToPayload` only sends it for `on_each_new_alert`.

So for `on_priority_increase` the plan always holds `null`. But the API echoes back a zero `grace_period_seconds` regardless of mode, and `whenAlertJoinsGroupFromAPI` copied that `0` straight into state — null in plan, `0` in state → inconsistent result.

## Fix

`whenAlertJoinsGroupFromAPI` now only reads `grace_period_seconds` into state when `mode == on_each_new_alert`, mirroring the existing `toPayload` and `ValidateConfig` behaviour. This makes the read path self-consistent with how the field is validated and written.

Added a table-driven unit test (`TestWhenAlertJoinsGroupFromAPIGracePeriodByMode`) covering both modes, including a server-sent zero for `on_priority_increase`.