### PR TITLE
Add group_alerts_summary to the v3 alert route resource

### DIFF
--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -1515,6 +1515,10 @@ Required:
 - `binding` (Attributes) (see [below for nested schema](#nestedatt--message_config--destinations--ms_teams_targets--binding))
 - `channel_visibility` (String) The visibility of the channel
 
+Optional:
+
+- `group_alerts_summary` (Boolean) Whether grouped alerts should render as a single group-summary message per channel
+
 <a id="nestedatt--message_config--destinations--ms_teams_targets--binding"></a>
 ### Nested Schema for `message_config.destinations.ms_teams_targets.binding`
 
@@ -1550,6 +1554,10 @@ Required:
 
 - `binding` (Attributes) (see [below for nested schema](#nestedatt--message_config--destinations--slack_targets--binding))
 - `channel_visibility` (String) The visibility of the channel
+
+Optional:
+
+- `group_alerts_summary` (Boolean) Whether grouped alerts should render as a single group-summary message per channel
 
 <a id="nestedatt--message_config--destinations--slack_targets--binding"></a>
 ### Nested Schema for `message_config.destinations.slack_targets.binding`

--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -111,6 +111,10 @@ resource "incident_alert_route" "service_alerts" {
             ]
           }
           channel_visibility = "public"
+
+          // When grouping is enabled, collapse grouped alerts into a single
+          // group-summary message per channel instead of one message per alert.
+          group_alerts_summary = true
         }
       }
     ]

--- a/examples/resources/incident_alert_route/resource.tf
+++ b/examples/resources/incident_alert_route/resource.tf
@@ -90,6 +90,10 @@ resource "incident_alert_route" "service_alerts" {
             ]
           }
           channel_visibility = "public"
+
+          // When grouping is enabled, collapse grouped alerts into a single
+          // group-summary message per channel instead of one message per alert.
+          group_alerts_summary = true
         }
       }
     ]

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -89,7 +89,9 @@
               "notification_methods_unredacted_viewer",
               "incident_workload_viewer",
               "incident_workload_private_viewer",
-              "act_on_behalf_of_users"
+              "act_on_behalf_of_users",
+              "secrets_manage",
+              "secrets_use"
             ],
             "example": "viewer",
             "type": "string",
@@ -124,7 +126,9 @@
               "escalation_creator",
               "api_keys_manage",
               "workflows_editor",
-              "private_workflows_editor"
+              "private_workflows_editor",
+              "secrets_manage",
+              "secrets_use"
             ],
             "example": "catalog_editor",
             "type": "string",
@@ -329,7 +333,9 @@
                 "notification_methods_unredacted_viewer",
                 "incident_workload_viewer",
                 "incident_workload_private_viewer",
-                "act_on_behalf_of_users"
+                "act_on_behalf_of_users",
+                "secrets_manage",
+                "secrets_use"
               ],
               "example": "viewer",
               "type": "string"
@@ -362,7 +368,9 @@
                 "escalation_creator",
                 "api_keys_manage",
                 "workflows_editor",
-                "private_workflows_editor"
+                "private_workflows_editor",
+                "secrets_manage",
+                "secrets_use"
               ],
               "example": "catalog_editor",
               "type": "string"
@@ -725,7 +733,9 @@
                 "notification_methods_unredacted_viewer",
                 "incident_workload_viewer",
                 "incident_workload_private_viewer",
-                "act_on_behalf_of_users"
+                "act_on_behalf_of_users",
+                "secrets_manage",
+                "secrets_use"
               ],
               "example": "viewer",
               "type": "string"
@@ -758,7 +768,9 @@
                 "escalation_creator",
                 "api_keys_manage",
                 "workflows_editor",
-                "private_workflows_editor"
+                "private_workflows_editor",
+                "secrets_manage",
+                "secrets_use"
               ],
               "example": "catalog_editor",
               "type": "string"
@@ -2037,7 +2049,8 @@
                     "reference": "incident.severity"
                   }
                 },
-                "channel_visibility": "public"
+                "channel_visibility": "public",
+                "group_alerts_summary": false
               },
               "slack_targets": {
                 "binding": {
@@ -2052,7 +2065,8 @@
                     "reference": "incident.severity"
                   }
                 },
-                "channel_visibility": "public"
+                "channel_visibility": "public",
+                "group_alerts_summary": false
               }
             }
           ],
@@ -2111,7 +2125,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "public"
+                  "channel_visibility": "public",
+                  "group_alerts_summary": false
                 },
                 "slack_targets": {
                   "binding": {
@@ -2126,7 +2141,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "public"
+                  "channel_visibility": "public",
+                  "group_alerts_summary": false
                 }
               }
             ],
@@ -2191,7 +2207,8 @@
                     "reference": "incident.severity"
                   }
                 },
-                "channel_visibility": "abc123"
+                "channel_visibility": "abc123",
+                "group_alerts_summary": false
               },
               "slack_targets": {
                 "binding": {
@@ -2206,7 +2223,8 @@
                     "reference": "incident.severity"
                   }
                 },
-                "channel_visibility": "abc123"
+                "channel_visibility": "abc123",
+                "group_alerts_summary": false
               }
             }
           ],
@@ -2271,7 +2289,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "abc123"
+                  "channel_visibility": "abc123",
+                  "group_alerts_summary": false
                 },
                 "slack_targets": {
                   "binding": {
@@ -2286,7 +2305,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "abc123"
+                  "channel_visibility": "abc123",
+                  "group_alerts_summary": false
                 }
               }
             ],
@@ -2343,7 +2363,8 @@
                 "reference": "incident.severity"
               }
             },
-            "channel_visibility": "public"
+            "channel_visibility": "public",
+            "group_alerts_summary": false
           },
           "slack_targets": {
             "binding": {
@@ -2358,7 +2379,8 @@
                 "reference": "incident.severity"
               }
             },
-            "channel_visibility": "public"
+            "channel_visibility": "public",
+            "group_alerts_summary": false
           }
         },
         "properties": {
@@ -2450,7 +2472,8 @@
                 "reference": "incident.severity"
               }
             },
-            "channel_visibility": "abc123"
+            "channel_visibility": "abc123",
+            "group_alerts_summary": false
           },
           "slack_targets": {
             "binding": {
@@ -2465,7 +2488,8 @@
                 "reference": "incident.severity"
               }
             },
-            "channel_visibility": "abc123"
+            "channel_visibility": "abc123",
+            "group_alerts_summary": false
           }
         },
         "properties": {
@@ -3568,7 +3592,8 @@
               "reference": "incident.severity"
             }
           },
-          "channel_visibility": "public"
+          "channel_visibility": "public",
+          "group_alerts_summary": false
         },
         "properties": {
           "binding": {
@@ -3585,6 +3610,11 @@
             ],
             "example": "public",
             "type": "string"
+          },
+          "group_alerts_summary": {
+            "description": "Whether grouped alerts should render as a single group-summary message per channel",
+            "example": false,
+            "type": "boolean"
           }
         },
         "required": [
@@ -3641,7 +3671,8 @@
               "reference": "incident.severity"
             }
           },
-          "channel_visibility": "abc123"
+          "channel_visibility": "abc123",
+          "group_alerts_summary": false
         },
         "properties": {
           "binding": {
@@ -3651,6 +3682,11 @@
             "description": "The visibility of the channel",
             "example": "abc123",
             "type": "string"
+          },
+          "group_alerts_summary": {
+            "description": "Whether grouped alerts should render as a single group-summary message per channel",
+            "example": false,
+            "type": "boolean"
           }
         },
         "required": [
@@ -7412,7 +7448,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "abc123"
+                  "channel_visibility": "abc123",
+                  "group_alerts_summary": false
                 },
                 "slack_targets": {
                   "binding": {
@@ -7427,7 +7464,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "abc123"
+                  "channel_visibility": "abc123",
+                  "group_alerts_summary": false
                 }
               }
             ],
@@ -8986,7 +9024,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "public"
+                  "channel_visibility": "public",
+                  "group_alerts_summary": false
                 },
                 "slack_targets": {
                   "binding": {
@@ -9001,7 +9040,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "public"
+                  "channel_visibility": "public",
+                  "group_alerts_summary": false
                 }
               }
             ],
@@ -10264,7 +10304,8 @@
                         "reference": "incident.severity"
                       }
                     },
-                    "channel_visibility": "abc123"
+                    "channel_visibility": "abc123",
+                    "group_alerts_summary": false
                   },
                   "slack_targets": {
                     "binding": {
@@ -10279,7 +10320,8 @@
                         "reference": "incident.severity"
                       }
                     },
-                    "channel_visibility": "abc123"
+                    "channel_visibility": "abc123",
+                    "group_alerts_summary": false
                   }
                 }
               ],
@@ -11386,7 +11428,8 @@
                         "reference": "incident.severity"
                       }
                     },
-                    "channel_visibility": "abc123"
+                    "channel_visibility": "abc123",
+                    "group_alerts_summary": false
                   },
                   "slack_targets": {
                     "binding": {
@@ -11401,7 +11444,8 @@
                         "reference": "incident.severity"
                       }
                     },
-                    "channel_visibility": "abc123"
+                    "channel_visibility": "abc123",
+                    "group_alerts_summary": false
                   }
                 }
               ],
@@ -12629,7 +12673,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "public"
+                  "channel_visibility": "public",
+                  "group_alerts_summary": false
                 },
                 "slack_targets": {
                   "binding": {
@@ -12644,7 +12689,8 @@
                       "reference": "incident.severity"
                     }
                   },
-                  "channel_visibility": "public"
+                  "channel_visibility": "public",
+                  "group_alerts_summary": false
                 }
               }
             ],
@@ -13915,7 +13961,8 @@
                         "reference": "incident.severity"
                       }
                     },
-                    "channel_visibility": "abc123"
+                    "channel_visibility": "abc123",
+                    "group_alerts_summary": false
                   },
                   "slack_targets": {
                     "binding": {
@@ -13930,7 +13977,8 @@
                         "reference": "incident.severity"
                       }
                     },
-                    "channel_visibility": "abc123"
+                    "channel_visibility": "abc123",
+                    "group_alerts_summary": false
                   }
                 }
               ],
@@ -14556,6 +14604,7 @@
               "coralogix",
               "cronitor",
               "crowdstrike_falcon",
+              "dash0",
               "datadog",
               "dynatrace",
               "elasticsearch",
@@ -14590,6 +14639,7 @@
               "sumo_logic",
               "uptime",
               "vercel",
+              "wiz",
               "zendesk"
             ],
             "example": "alertmanager",
@@ -14852,6 +14902,7 @@
               "coralogix",
               "cronitor",
               "crowdstrike_falcon",
+              "dash0",
               "datadog",
               "dynatrace",
               "elasticsearch",
@@ -14886,6 +14937,7 @@
               "sumo_logic",
               "uptime",
               "vercel",
+              "wiz",
               "zendesk"
             ],
             "example": "alertmanager",
@@ -17775,6 +17827,43 @@
         ],
         "type": "object"
       },
+      "AuditLogAnnouncementRuleMetadataV2": {
+        "example": {
+          "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+          "after_private_incident_scope": "owning_teams",
+          "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1",
+          "before_private_incident_scope": "none"
+        },
+        "properties": {
+          "after_owning_team_ids": {
+            "description": "Catalog entry IDs of the owning teams after the change, comma separated",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+            "type": "string"
+          },
+          "after_private_incident_scope": {
+            "description": "Which private incidents the rule acts on after the change (all, owning_teams, none)",
+            "example": "owning_teams",
+            "type": "string"
+          },
+          "before_owning_team_ids": {
+            "description": "Catalog entry IDs of the owning teams before the change, comma separated",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1",
+            "type": "string"
+          },
+          "before_private_incident_scope": {
+            "description": "Which private incidents the rule acted on before the change (all, owning_teams, none; empty on create)",
+            "example": "none",
+            "type": "string"
+          }
+        },
+        "required": [
+          "before_owning_team_ids",
+          "after_owning_team_ids",
+          "before_private_incident_scope",
+          "after_private_incident_scope"
+        ],
+        "type": "object"
+      },
       "AuditLogCatalogAttributeUpdatedMetadataV2": {
         "example": {
           "after_values": [
@@ -20515,6 +20604,91 @@
         ],
         "type": "object"
       },
+      "AuditLogsAnnouncementRuleCreatedV2": {
+        "example": {
+          "action": "announcement_rule.created",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+            "after_private_incident_scope": "owning_teams",
+            "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1",
+            "before_private_incident_scope": "none"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "#engineering",
+              "type": "announcement_rule"
+            }
+          ],
+          "version": 2
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "announcement_rule.created",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogAnnouncementRuleMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "#engineering",
+                "type": "announcement_rule"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
       "AuditLogsAnnouncementRuleDeletedV1": {
         "example": {
           "action": "announcement_rule.deleted",
@@ -20662,6 +20836,91 @@
           "actor",
           "targets",
           "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsAnnouncementRuleUpdatedV2": {
+        "example": {
+          "action": "announcement_rule.updated",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+            "after_private_incident_scope": "owning_teams",
+            "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1",
+            "before_private_incident_scope": "none"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "#engineering",
+              "type": "announcement_rule"
+            }
+          ],
+          "version": 2
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "announcement_rule.updated",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogAnnouncementRuleMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "#engineering",
+                "type": "announcement_rule"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
         ],
         "type": "object"
       },
@@ -30683,6 +30942,176 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
                 "name": "Datadog webhook signing key",
                 "type": "secret"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsSecretReferenceAddedV1": {
+        "example": {
+          "action": "secret.reference_added",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Datadog webhook signing key",
+              "type": "secret"
+            },
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Nudge to write a postmortem",
+              "type": "workflow"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "secret.reference_added",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Datadog webhook signing key",
+                "type": "secret"
+              },
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Nudge to write a postmortem",
+                "type": "workflow"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsSecretReferenceRemovedV1": {
+        "example": {
+          "action": "secret.reference_removed",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Datadog webhook signing key",
+              "type": "secret"
+            },
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Nudge to write a postmortem",
+              "type": "workflow"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "secret.reference_removed",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Datadog webhook signing key",
+                "type": "secret"
+              },
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Nudge to write a postmortem",
+                "type": "workflow"
               }
             ],
             "items": {
@@ -48644,7 +49073,9 @@
                 "notification_methods_unredacted_viewer",
                 "incident_workload_viewer",
                 "incident_workload_private_viewer",
-                "act_on_behalf_of_users"
+                "act_on_behalf_of_users",
+                "secrets_manage",
+                "secrets_use"
               ],
               "example": "viewer",
               "type": "string",
@@ -48668,7 +49099,9 @@
                 "escalation_creator",
                 "api_keys_manage",
                 "workflows_editor",
-                "private_workflows_editor"
+                "private_workflows_editor",
+                "secrets_manage",
+                "secrets_use"
               ],
               "example": "catalog_editor",
               "type": "string",
@@ -59376,6 +59809,7 @@
               }
             }
           ],
+          "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
           "team_ids": [
             "01JPQA75EPNEES4479P16P4XAB"
           ],
@@ -59463,6 +59897,11 @@
             },
             "type": "array"
           },
+          "permalink": {
+            "description": "A permanent link to this schedule in the incident.io dashboard",
+            "example": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
+            "type": "string"
+          },
           "team_ids": {
             "description": "IDs of teams that own this schedule",
             "example": [
@@ -59490,6 +59929,7 @@
           "name",
           "timezone",
           "team_ids",
+          "permalink",
           "created_at",
           "updated_at",
           "annotations"
@@ -59748,6 +60188,7 @@
                 }
               }
             ],
+            "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
             "team_ids": [
               "01JPQA75EPNEES4479P16P4XAB"
             ],
@@ -59988,6 +60429,7 @@
                   }
                 }
               ],
+              "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
               "team_ids": [
                 "01JPQA75EPNEES4479P16P4XAB"
               ],
@@ -60095,6 +60537,7 @@
                     }
                   }
                 ],
+                "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
                 "team_ids": [
                   "01JPQA75EPNEES4479P16P4XAB"
                 ],
@@ -60580,6 +61023,7 @@
                 }
               }
             ],
+            "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
             "team_ids": [
               "01JPQA75EPNEES4479P16P4XAB"
             ],
@@ -60840,6 +61284,7 @@
                 }
               }
             ],
+            "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
             "team_ids": [
               "01JPQA75EPNEES4479P16P4XAB"
             ],
@@ -60927,6 +61372,444 @@
         },
         "required": [
           "schedule_sync_rule"
+        ],
+        "type": "object"
+      },
+      "SecretV2": {
+        "description": "A secret is a named credential that workflows can reference, for example\nan auth token for an outgoing webhook.\n\nIts value can be set and rotated but never read back: the API stores it\nencrypted and only ever returns masked metadata (the last four characters of\nthe current value). Update the value with the rotate action, which appends a\nnew version and retires the previous one.",
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "description": "Auth token for the PagerDuty outgoing webhook",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "last_four_chars": "c123",
+          "name": "PagerDuty webhook token",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
+          "updated_at": "2021-08-17T13:28:57.801578Z",
+          "version": 3
+        },
+        "properties": {
+          "created_at": {
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "description": {
+            "description": "Optional description of what this secret is for",
+            "example": "Auth token for the PagerDuty outgoing webhook",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this secret",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "last_four_chars": {
+            "description": "The last four characters of the current value, for masked display. Absent when the value is four characters or shorter.",
+            "example": "c123",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human-readable name, unique within the organisation amongst unarchived secrets",
+            "example": "PagerDuty webhook token",
+            "type": "string"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this secret. Empty means the secret is owned by the whole organisation.",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "updated_at": {
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "version": {
+            "description": "The current version number, incremented on each rotation",
+            "example": 3,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "version",
+          "owning_team_ids",
+          "created_at",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "SecretVersionV2": {
+        "description": "A single version of a secret's value. Only metadata is exposed; the value itself is never returned.",
+        "example": {
+          "created_at": "2021-08-17T13:28:57.801578Z",
+          "created_by": {
+            "alert": {
+              "id": "01GW2G3V0S59R238FAHPDS1R66",
+              "title": "*errors.withMessage: PG::Error failed to connect"
+            },
+            "api_key": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My test API key"
+            },
+            "user": {
+              "email": "lisa@incident.io",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Lisa Karlin Curtis",
+              "role": "owner",
+              "slack_user_id": "U02AYNF2XJM"
+            },
+            "workflow": {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "My little workflow"
+            }
+          },
+          "last_four_chars": "c123",
+          "version": 3
+        },
+        "properties": {
+          "created_at": {
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/ActorV2"
+          },
+          "last_four_chars": {
+            "description": "The last four characters of this version's value, for masked display. Absent when the value was four characters or shorter.",
+            "example": "c123",
+            "type": "string"
+          },
+          "version": {
+            "description": "The version number, incremented on each rotation",
+            "example": 3,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "version",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "SecretsCreatePayloadV2": {
+        "example": {
+          "description": "Auth token for the PagerDuty outgoing webhook",
+          "name": "PagerDuty webhook token",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
+          "value": "sk_live_abc123"
+        },
+        "properties": {
+          "description": {
+            "description": "Optional description of what this secret is for",
+            "example": "Auth token for the PagerDuty outgoing webhook",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human-readable name, unique within the organisation amongst unarchived secrets",
+            "example": "PagerDuty webhook token",
+            "type": "string"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this secret. When empty or omitted, the secret is owned by the whole organisation.",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "value": {
+            "description": "The secret's plaintext value. It's stored encrypted and never returned by the API.",
+            "example": "sk_live_abc123",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ],
+        "type": "object"
+      },
+      "SecretsCreateResultV2": {
+        "example": {
+          "secret": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Auth token for the PagerDuty outgoing webhook",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "last_four_chars": "c123",
+            "name": "PagerDuty webhook token",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "version": 3
+          }
+        },
+        "properties": {
+          "secret": {
+            "$ref": "#/components/schemas/SecretV2"
+          }
+        },
+        "required": [
+          "secret"
+        ],
+        "type": "object"
+      },
+      "SecretsListResultV2": {
+        "example": {
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          },
+          "secrets": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "description": "Auth token for the PagerDuty outgoing webhook",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "last_four_chars": "c123",
+              "name": "PagerDuty webhook token",
+              "owning_team_ids": [
+                "01G0J1EXE7AXZ2C93K61WBPYEH"
+              ],
+              "updated_at": "2021-08-17T13:28:57.801578Z",
+              "version": 3
+            }
+          ]
+        },
+        "properties": {
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          },
+          "secrets": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "description": "Auth token for the PagerDuty outgoing webhook",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "last_four_chars": "c123",
+                "name": "PagerDuty webhook token",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
+                "updated_at": "2021-08-17T13:28:57.801578Z",
+                "version": 3
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SecretV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "secrets"
+        ],
+        "type": "object"
+      },
+      "SecretsRotatePayloadV2": {
+        "example": {
+          "value": "sk_live_def456"
+        },
+        "properties": {
+          "value": {
+            "description": "The secret's new plaintext value. It's stored encrypted and never returned by the API.",
+            "example": "sk_live_def456",
+            "type": "string"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "SecretsRotateResultV2": {
+        "example": {
+          "secret": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Auth token for the PagerDuty outgoing webhook",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "last_four_chars": "c123",
+            "name": "PagerDuty webhook token",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "version": 3
+          }
+        },
+        "properties": {
+          "secret": {
+            "$ref": "#/components/schemas/SecretV2"
+          }
+        },
+        "required": [
+          "secret"
+        ],
+        "type": "object"
+      },
+      "SecretsShowResultV2": {
+        "example": {
+          "secret": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Auth token for the PagerDuty outgoing webhook",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "last_four_chars": "c123",
+            "name": "PagerDuty webhook token",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "version": 3
+          },
+          "versions": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "created_by": {
+                "alert": {
+                  "id": "01GW2G3V0S59R238FAHPDS1R66",
+                  "title": "*errors.withMessage: PG::Error failed to connect"
+                },
+                "api_key": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My test API key"
+                },
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "owner",
+                  "slack_user_id": "U02AYNF2XJM"
+                },
+                "workflow": {
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "My little workflow"
+                }
+              },
+              "last_four_chars": "c123",
+              "version": 3
+            }
+          ]
+        },
+        "properties": {
+          "secret": {
+            "$ref": "#/components/schemas/SecretV2"
+          },
+          "versions": {
+            "description": "The secret's versions, newest first",
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "created_by": {
+                  "alert": {
+                    "id": "01GW2G3V0S59R238FAHPDS1R66",
+                    "title": "*errors.withMessage: PG::Error failed to connect"
+                  },
+                  "api_key": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My test API key"
+                  },
+                  "user": {
+                    "email": "lisa@incident.io",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "Lisa Karlin Curtis",
+                    "role": "owner",
+                    "slack_user_id": "U02AYNF2XJM"
+                  },
+                  "workflow": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "name": "My little workflow"
+                  }
+                },
+                "last_four_chars": "c123",
+                "version": 3
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SecretVersionV2"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "secret",
+          "versions"
+        ],
+        "type": "object"
+      },
+      "SecretsUpdatePayloadV2": {
+        "example": {
+          "description": "Auth token for the PagerDuty outgoing webhook",
+          "name": "PagerDuty webhook token",
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ]
+        },
+        "properties": {
+          "description": {
+            "description": "Optional description of what this secret is for",
+            "example": "Auth token for the PagerDuty outgoing webhook",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human-readable name, unique within the organisation amongst unarchived secrets",
+            "example": "PagerDuty webhook token",
+            "type": "string"
+          },
+          "owning_team_ids": {
+            "description": "IDs of the teams that own this secret. When omitted, the existing owning teams are left unchanged.",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SecretsUpdateResultV2": {
+        "example": {
+          "secret": {
+            "created_at": "2021-08-17T13:28:57.801578Z",
+            "description": "Auth token for the PagerDuty outgoing webhook",
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "last_four_chars": "c123",
+            "name": "PagerDuty webhook token",
+            "owning_team_ids": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "updated_at": "2021-08-17T13:28:57.801578Z",
+            "version": 3
+          }
+        },
+        "properties": {
+          "secret": {
+            "$ref": "#/components/schemas/SecretV2"
+          }
+        },
+        "required": [
+          "secret"
         ],
         "type": "object"
       },
@@ -78415,6 +79298,16 @@
               "example": "some-random-string",
               "type": "string"
             }
+          },
+          {
+            "description": "Query parameters",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "style": "deepObject"
           }
         ],
         "requestBody": {
@@ -90099,6 +90992,7 @@
                           }
                         }
                       ],
+                      "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
                       "team_ids": [
                         "01JPQA75EPNEES4479P16P4XAB"
                       ],
@@ -90298,6 +91192,7 @@
                         }
                       }
                     ],
+                    "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
                     "team_ids": [
                       "01JPQA75EPNEES4479P16P4XAB"
                     ],
@@ -90474,6 +91369,7 @@
                         }
                       }
                     ],
+                    "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
                     "team_ids": [
                       "01JPQA75EPNEES4479P16P4XAB"
                     ],
@@ -90686,6 +91582,7 @@
                         }
                       }
                     ],
+                    "permalink": "https://app.incident.io/acme/on-call/schedules/01G0J1EXE7AXZ2C93K61WBPYEH",
                     "team_ids": [
                       "01JPQA75EPNEES4479P16P4XAB"
                     ],
@@ -91589,6 +92486,424 @@
         "x-docs-resource-type": "ScheduleSyncRuleV2",
         "x-rbac-scopes": [
           "schedule_sync_rules.update"
+        ]
+      }
+    },
+    "/v2/secrets": {
+      "get": {
+        "description": "List all secrets for this organisation. Returns metadata only, never values.",
+        "operationId": "Secrets V2#List",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "description": "Integer number of records to return",
+            "example": 25,
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 25,
+              "description": "Integer number of records to return",
+              "example": 25,
+              "format": "int64",
+              "maximum": 250,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "A secret's ID. This endpoint will return a list of secrets after this ID in relation to the API response order.",
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            },
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "description": "A secret's ID. This endpoint will return a list of secrets after this ID in relation to the API response order.",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "Filter to secrets owned by any of these teams",
+            "example": [
+              "abc123"
+            ],
+            "in": "query",
+            "name": "team_ids",
+            "schema": {
+              "description": "Filter to secrets owned by any of these teams",
+              "example": [
+                "abc123"
+              ],
+              "items": {
+                "example": "abc123",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  },
+                  "secrets": [
+                    {
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "description": "Auth token for the PagerDuty outgoing webhook",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "last_four_chars": "c123",
+                      "name": "PagerDuty webhook token",
+                      "owning_team_ids": [
+                        "01G0J1EXE7AXZ2C93K61WBPYEH"
+                      ],
+                      "updated_at": "2021-08-17T13:28:57.801578Z",
+                      "version": 3
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SecretsListResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "List Secrets V2",
+        "tags": [
+          "Secrets V2"
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Secrets V2",
+        "x-docs-resource-type": "SecretV2",
+        "x-rbac-scopes": [
+          "secrets.view_metadata"
+        ]
+      },
+      "post": {
+        "description": "Create a new secret with its initial value.",
+        "operationId": "Secrets V2#Create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "description": "Auth token for the PagerDuty outgoing webhook",
+                "name": "PagerDuty webhook token",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
+                "value": "sk_live_abc123"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SecretsCreatePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "secret": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Auth token for the PagerDuty outgoing webhook",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "last_four_chars": "c123",
+                    "name": "PagerDuty webhook token",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "version": 3
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SecretsCreateResultV2"
+                }
+              }
+            },
+            "description": "Created response."
+          }
+        },
+        "summary": "Create Secrets V2",
+        "tags": [
+          "Secrets V2"
+        ],
+        "x-docs-display-name": "Create",
+        "x-docs-group-name": "Secrets V2",
+        "x-docs-resource-type": "SecretV2",
+        "x-rbac-scopes": [
+          "secrets.create"
+        ]
+      }
+    },
+    "/v2/secrets/{id}": {
+      "delete": {
+        "description": "Delete a secret, permanently removing its value. Fails if the secret is still referenced by a workflow.",
+        "operationId": "Secrets V2#Destroy",
+        "parameters": [
+          {
+            "description": "The secret's ID",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The secret's ID",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        },
+        "summary": "Destroy Secrets V2",
+        "tags": [
+          "Secrets V2"
+        ],
+        "x-docs-display-name": "Delete",
+        "x-docs-group-name": "Secrets V2",
+        "x-docs-resource-type": "SecretV2",
+        "x-rbac-scopes": [
+          "secrets.delete"
+        ]
+      },
+      "get": {
+        "description": "Show a single secret's metadata, including its version history. Never returns values.",
+        "operationId": "Secrets V2#Show",
+        "parameters": [
+          {
+            "description": "The secret's ID",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The secret's ID",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "secret": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Auth token for the PagerDuty outgoing webhook",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "last_four_chars": "c123",
+                    "name": "PagerDuty webhook token",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "version": 3
+                  },
+                  "versions": [
+                    {
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "created_by": {
+                        "alert": {
+                          "id": "01GW2G3V0S59R238FAHPDS1R66",
+                          "title": "*errors.withMessage: PG::Error failed to connect"
+                        },
+                        "api_key": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My test API key"
+                        },
+                        "user": {
+                          "email": "lisa@incident.io",
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "Lisa Karlin Curtis",
+                          "role": "owner",
+                          "slack_user_id": "U02AYNF2XJM"
+                        },
+                        "workflow": {
+                          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                          "name": "My little workflow"
+                        }
+                      },
+                      "last_four_chars": "c123",
+                      "version": 3
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SecretsShowResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "Show Secrets V2",
+        "tags": [
+          "Secrets V2"
+        ],
+        "x-docs-display-name": "Show",
+        "x-docs-group-name": "Secrets V2",
+        "x-docs-resource-type": "SecretV2",
+        "x-rbac-scopes": [
+          "secrets.view_metadata"
+        ]
+      },
+      "put": {
+        "description": "Update a secret's metadata. Does not change the value: use the rotate action for that.",
+        "operationId": "Secrets V2#Update",
+        "parameters": [
+          {
+            "description": "The secret's ID",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The secret's ID",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "description": "Auth token for the PagerDuty outgoing webhook",
+                "name": "PagerDuty webhook token",
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SecretsUpdatePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "secret": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Auth token for the PagerDuty outgoing webhook",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "last_four_chars": "c123",
+                    "name": "PagerDuty webhook token",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "version": 3
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SecretsUpdateResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "Update Secrets V2",
+        "tags": [
+          "Secrets V2"
+        ],
+        "x-docs-display-name": "Update",
+        "x-docs-group-name": "Secrets V2",
+        "x-docs-resource-type": "SecretV2",
+        "x-rbac-scopes": [
+          "secrets.update"
+        ]
+      }
+    },
+    "/v2/secrets/{id}/actions/rotate": {
+      "post": {
+        "description": "Rotate a secret's value, replacing the current value with a new one. The previous value is retired and can no longer be read.",
+        "operationId": "Secrets V2#Rotate",
+        "parameters": [
+          {
+            "description": "The secret's ID",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "The secret's ID",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "value": "sk_live_def456"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/SecretsRotatePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "secret": {
+                    "created_at": "2021-08-17T13:28:57.801578Z",
+                    "description": "Auth token for the PagerDuty outgoing webhook",
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "last_four_chars": "c123",
+                    "name": "PagerDuty webhook token",
+                    "owning_team_ids": [
+                      "01G0J1EXE7AXZ2C93K61WBPYEH"
+                    ],
+                    "updated_at": "2021-08-17T13:28:57.801578Z",
+                    "version": 3
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SecretsRotateResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "Rotate Secrets V2",
+        "tags": [
+          "Secrets V2"
+        ],
+        "x-docs-display-name": "Rotate",
+        "x-docs-group-name": "Secrets V2",
+        "x-docs-resource-type": "SecretV2",
+        "x-rbac-scopes": [
+          "secrets.update"
         ]
       }
     },
@@ -95289,7 +96604,8 @@
                             "reference": "incident.severity"
                           }
                         },
-                        "channel_visibility": "public"
+                        "channel_visibility": "public",
+                        "group_alerts_summary": false
                       },
                       "slack_targets": {
                         "binding": {
@@ -95304,7 +96620,8 @@
                             "reference": "incident.severity"
                           }
                         },
-                        "channel_visibility": "public"
+                        "channel_visibility": "public",
+                        "group_alerts_summary": false
                       }
                     }
                   ],
@@ -95785,7 +97102,8 @@
                                 "reference": "incident.severity"
                               }
                             },
-                            "channel_visibility": "abc123"
+                            "channel_visibility": "abc123",
+                            "group_alerts_summary": false
                           },
                           "slack_targets": {
                             "binding": {
@@ -95800,7 +97118,8 @@
                                 "reference": "incident.severity"
                               }
                             },
-                            "channel_visibility": "abc123"
+                            "channel_visibility": "abc123",
+                            "group_alerts_summary": false
                           }
                         }
                       ],
@@ -96348,7 +97667,8 @@
                                 "reference": "incident.severity"
                               }
                             },
-                            "channel_visibility": "abc123"
+                            "channel_visibility": "abc123",
+                            "group_alerts_summary": false
                           },
                           "slack_targets": {
                             "binding": {
@@ -96363,7 +97683,8 @@
                                 "reference": "incident.severity"
                               }
                             },
-                            "channel_visibility": "abc123"
+                            "channel_visibility": "abc123",
+                            "group_alerts_summary": false
                           }
                         }
                       ],
@@ -96836,7 +98157,8 @@
                             "reference": "incident.severity"
                           }
                         },
-                        "channel_visibility": "public"
+                        "channel_visibility": "public",
+                        "group_alerts_summary": false
                       },
                       "slack_targets": {
                         "binding": {
@@ -96851,7 +98173,8 @@
                             "reference": "incident.severity"
                           }
                         },
-                        "channel_visibility": "public"
+                        "channel_visibility": "public",
+                        "group_alerts_summary": false
                       }
                     }
                   ],
@@ -97333,7 +98656,8 @@
                                 "reference": "incident.severity"
                               }
                             },
-                            "channel_visibility": "abc123"
+                            "channel_visibility": "abc123",
+                            "group_alerts_summary": false
                           },
                           "slack_targets": {
                             "binding": {
@@ -97348,7 +98672,8 @@
                                 "reference": "incident.severity"
                               }
                             },
-                            "channel_visibility": "abc123"
+                            "channel_visibility": "abc123",
+                            "group_alerts_summary": false
                           }
                         }
                       ],
@@ -98968,6 +100293,10 @@
       "name": "Schedules V2"
     },
     {
+      "description": "Manage secrets: named credentials that workflows can reference. A secret's value can be set and rotated but is never returned by the API.",
+      "name": "Secrets V2"
+    },
+    {
       "description": "Manage incident severities.\n\nEach incident has a severity, picked from one of the severities configured in your\norganisations settings.\n\nSeverities help categorise incidents, and communicate urgency/impact. You can use\nseverities when filtering incidents in the dashboard, and in workflows and announcement\nrules.\n",
       "name": "Severities V1"
     },
@@ -100075,6 +101404,58 @@
         ]
       }
     },
+    "/x-audit-logs/announcement_rule.created.2": {
+      "get": {
+        "description": "This entry is created whenever a announcement rule is created",
+        "operationId": "AnnouncementRuleCreatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "announcement_rule.created",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+                    "after_private_incident_scope": "owning_teams",
+                    "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1",
+                    "before_private_incident_scope": "none"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "#engineering",
+                      "type": "announcement_rule"
+                    }
+                  ],
+                  "version": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAnnouncementRuleCreatedV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
     "/x-audit-logs/announcement_rule.deleted.1": {
       "get": {
         "description": "This entry is created whenever a announcement rule is deleted",
@@ -100156,6 +101537,58 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsAnnouncementRuleUpdatedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/announcement_rule.updated.2": {
+      "get": {
+        "description": "This entry is created whenever a announcement rule is updated",
+        "operationId": "AnnouncementRuleUpdatedV2",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "announcement_rule.updated",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "after_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG2",
+                    "after_private_incident_scope": "owning_teams",
+                    "before_owning_team_ids": "01FCNDV6P870EA6S7TK1DSYDG0,01FCNDV6P870EA6S7TK1DSYDG1",
+                    "before_private_incident_scope": "none"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "#engineering",
+                      "type": "announcement_rule"
+                    }
+                  ],
+                  "version": 2
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsAnnouncementRuleUpdatedV2"
                 }
               }
             },
@@ -106467,6 +107900,108 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsSecretDeletedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/secret.reference_added.1": {
+      "get": {
+        "description": "This entry is created whenever a secret is referenced by a workflow for the first time",
+        "operationId": "SecretReferenceAddedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "secret.reference_added",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Datadog webhook signing key",
+                      "type": "secret"
+                    },
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Nudge to write a postmortem",
+                      "type": "workflow"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsSecretReferenceAddedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/secret.reference_removed.1": {
+      "get": {
+        "description": "This entry is created whenever a secret stops being referenced by a workflow",
+        "operationId": "SecretReferenceRemovedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "secret.reference_removed",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Datadog webhook signing key",
+                      "type": "secret"
+                    },
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Nudge to write a postmortem",
+                      "type": "workflow"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsSecretReferenceRemovedV1"
                 }
               }
             },

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -18479,6 +18479,22 @@
         ],
         "type": "object"
       },
+      "AuditLogTelemetryDataSourceWriteAccessMetadataV2": {
+        "example": {
+          "tools": "create_issue:chat=execute, delete_issue:chat=execute"
+        },
+        "properties": {
+          "tools": {
+            "description": "The tools whose permission changed, comma separated",
+            "example": "create_issue:chat=execute, delete_issue:chat=execute",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tools"
+        ],
+        "type": "object"
+      },
       "AuditLogUserLoggedInMetadataV2": {
         "example": {
           "login_method": "slack_oidc"
@@ -32633,6 +32649,170 @@
           "actor",
           "targets",
           "context"
+        ],
+        "type": "object"
+      },
+      "AuditLogsTelemetryDataSourceWriteAccessGrantedV1": {
+        "example": {
+          "action": "telemetry_data_source.write_access_granted",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "tools": "create_issue:chat=execute, delete_issue:chat=execute"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Grafana Cloud",
+              "type": "telemetry_data_source"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "telemetry_data_source.write_access_granted",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogTelemetryDataSourceWriteAccessMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Grafana Cloud",
+                "type": "telemetry_data_source"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "AuditLogsTelemetryDataSourceWriteAccessRevokedV1": {
+        "example": {
+          "action": "telemetry_data_source.write_access_revoked",
+          "actor": {
+            "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "metadata": {
+              "user_base_role_slug": "admin",
+              "user_custom_role_slugs": "engineering,security"
+            },
+            "name": "John Doe",
+            "type": "user"
+          },
+          "context": {
+            "location": "1.2.3.4",
+            "user_agent": "Chrome/91.0.4472.114"
+          },
+          "metadata": {
+            "tools": "create_issue:chat=execute, delete_issue:chat=execute"
+          },
+          "occurred_at": "2021-08-17T13:28:57.801578Z",
+          "targets": [
+            {
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "name": "Grafana Cloud",
+              "type": "telemetry_data_source"
+            }
+          ],
+          "version": 1
+        },
+        "properties": {
+          "action": {
+            "description": "The type of log entry that this is",
+            "example": "telemetry_data_source.write_access_revoked",
+            "type": "string"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/AuditLogActorV2"
+          },
+          "context": {
+            "$ref": "#/components/schemas/AuditLogEntryContextV2"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AuditLogTelemetryDataSourceWriteAccessMetadataV2"
+          },
+          "occurred_at": {
+            "description": "When the entry occurred",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "targets": {
+            "description": "The custom field that was created",
+            "example": [
+              {
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Grafana Cloud",
+                "type": "telemetry_data_source"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AuditLogTargetV2"
+            },
+            "type": "array"
+          },
+          "version": {
+            "description": "Which version the event is",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "action",
+          "occurred_at",
+          "version",
+          "actor",
+          "targets",
+          "context",
+          "metadata"
         ],
         "type": "object"
       },
@@ -108922,6 +109102,104 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/AuditLogsTelemetryDataSourceUninstalledV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/telemetry_data_source.write_access_granted.1": {
+      "get": {
+        "description": "This entry is created whenever tools on a connector are allowed to change the connected system",
+        "operationId": "TelemetryDataSourceWriteAccessGrantedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "telemetry_data_source.write_access_granted",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "tools": "create_issue:chat=execute, delete_issue:chat=execute"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Grafana Cloud",
+                      "type": "telemetry_data_source"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTelemetryDataSourceWriteAccessGrantedV1"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "tags": [
+          "Audit logs"
+        ]
+      }
+    },
+    "/x-audit-logs/telemetry_data_source.write_access_revoked.1": {
+      "get": {
+        "description": "This entry is created whenever tools on a connector lose permission to change the connected system",
+        "operationId": "TelemetryDataSourceWriteAccessRevokedV1",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "action": "telemetry_data_source.write_access_revoked",
+                  "actor": {
+                    "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "metadata": {
+                      "user_base_role_slug": "admin",
+                      "user_custom_role_slugs": "engineering,security"
+                    },
+                    "name": "John Doe",
+                    "type": "user"
+                  },
+                  "context": {
+                    "location": "1.2.3.4",
+                    "user_agent": "Chrome/91.0.4472.114"
+                  },
+                  "metadata": {
+                    "tools": "create_issue:chat=execute, delete_issue:chat=execute"
+                  },
+                  "occurred_at": "2021-08-17T13:28:57.801578Z",
+                  "targets": [
+                    {
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "name": "Grafana Cloud",
+                      "type": "telemetry_data_source"
+                    }
+                  ],
+                  "version": 1
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsTelemetryDataSourceWriteAccessRevokedV1"
                 }
               }
             },

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -44,6 +44,8 @@ const (
 	APIKeyRoleV1NameScheduleOverridesEditor             APIKeyRoleV1Name = "schedule_overrides_editor"
 	APIKeyRoleV1NameSchedulesEditor                     APIKeyRoleV1Name = "schedules_editor"
 	APIKeyRoleV1NameSchedulesReader                     APIKeyRoleV1Name = "schedules_reader"
+	APIKeyRoleV1NameSecretsManage                       APIKeyRoleV1Name = "secrets_manage"
+	APIKeyRoleV1NameSecretsUse                          APIKeyRoleV1Name = "secrets_use"
 	APIKeyRoleV1NameSecuritySettingsEditor              APIKeyRoleV1Name = "security_settings_editor"
 	APIKeyRoleV1NameStatusPagePublisher                 APIKeyRoleV1Name = "status_page_publisher"
 	APIKeyRoleV1NameTeamMembershipsManage               APIKeyRoleV1Name = "team_memberships_manage"
@@ -61,6 +63,8 @@ const (
 	APIKeyTeamRoleV1NameScheduleOverridesEditor APIKeyTeamRoleV1Name = "schedule_overrides_editor"
 	APIKeyTeamRoleV1NameSchedulesEditor         APIKeyTeamRoleV1Name = "schedules_editor"
 	APIKeyTeamRoleV1NameSchedulesReader         APIKeyTeamRoleV1Name = "schedules_reader"
+	APIKeyTeamRoleV1NameSecretsManage           APIKeyTeamRoleV1Name = "secrets_manage"
+	APIKeyTeamRoleV1NameSecretsUse              APIKeyTeamRoleV1Name = "secrets_use"
 	APIKeyTeamRoleV1NameWorkflowsEditor         APIKeyTeamRoleV1Name = "workflows_editor"
 )
 
@@ -90,6 +94,8 @@ const (
 	APIKeysCreatePayloadV1RoleNamesScheduleOverridesEditor             APIKeysCreatePayloadV1RoleNames = "schedule_overrides_editor"
 	APIKeysCreatePayloadV1RoleNamesSchedulesEditor                     APIKeysCreatePayloadV1RoleNames = "schedules_editor"
 	APIKeysCreatePayloadV1RoleNamesSchedulesReader                     APIKeysCreatePayloadV1RoleNames = "schedules_reader"
+	APIKeysCreatePayloadV1RoleNamesSecretsManage                       APIKeysCreatePayloadV1RoleNames = "secrets_manage"
+	APIKeysCreatePayloadV1RoleNamesSecretsUse                          APIKeysCreatePayloadV1RoleNames = "secrets_use"
 	APIKeysCreatePayloadV1RoleNamesSecuritySettingsEditor              APIKeysCreatePayloadV1RoleNames = "security_settings_editor"
 	APIKeysCreatePayloadV1RoleNamesStatusPagePublisher                 APIKeysCreatePayloadV1RoleNames = "status_page_publisher"
 	APIKeysCreatePayloadV1RoleNamesTeamMembershipsManage               APIKeysCreatePayloadV1RoleNames = "team_memberships_manage"
@@ -107,6 +113,8 @@ const (
 	APIKeysCreatePayloadV1TeamRoleNamesScheduleOverridesEditor APIKeysCreatePayloadV1TeamRoleNames = "schedule_overrides_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesSchedulesEditor         APIKeysCreatePayloadV1TeamRoleNames = "schedules_editor"
 	APIKeysCreatePayloadV1TeamRoleNamesSchedulesReader         APIKeysCreatePayloadV1TeamRoleNames = "schedules_reader"
+	APIKeysCreatePayloadV1TeamRoleNamesSecretsManage           APIKeysCreatePayloadV1TeamRoleNames = "secrets_manage"
+	APIKeysCreatePayloadV1TeamRoleNamesSecretsUse              APIKeysCreatePayloadV1TeamRoleNames = "secrets_use"
 	APIKeysCreatePayloadV1TeamRoleNamesWorkflowsEditor         APIKeysCreatePayloadV1TeamRoleNames = "workflows_editor"
 )
 
@@ -136,6 +144,8 @@ const (
 	APIKeysUpdatePayloadV1RoleNamesScheduleOverridesEditor             APIKeysUpdatePayloadV1RoleNames = "schedule_overrides_editor"
 	APIKeysUpdatePayloadV1RoleNamesSchedulesEditor                     APIKeysUpdatePayloadV1RoleNames = "schedules_editor"
 	APIKeysUpdatePayloadV1RoleNamesSchedulesReader                     APIKeysUpdatePayloadV1RoleNames = "schedules_reader"
+	APIKeysUpdatePayloadV1RoleNamesSecretsManage                       APIKeysUpdatePayloadV1RoleNames = "secrets_manage"
+	APIKeysUpdatePayloadV1RoleNamesSecretsUse                          APIKeysUpdatePayloadV1RoleNames = "secrets_use"
 	APIKeysUpdatePayloadV1RoleNamesSecuritySettingsEditor              APIKeysUpdatePayloadV1RoleNames = "security_settings_editor"
 	APIKeysUpdatePayloadV1RoleNamesStatusPagePublisher                 APIKeysUpdatePayloadV1RoleNames = "status_page_publisher"
 	APIKeysUpdatePayloadV1RoleNamesTeamMembershipsManage               APIKeysUpdatePayloadV1RoleNames = "team_memberships_manage"
@@ -153,6 +163,8 @@ const (
 	APIKeysUpdatePayloadV1TeamRoleNamesScheduleOverridesEditor APIKeysUpdatePayloadV1TeamRoleNames = "schedule_overrides_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesSchedulesEditor         APIKeysUpdatePayloadV1TeamRoleNames = "schedules_editor"
 	APIKeysUpdatePayloadV1TeamRoleNamesSchedulesReader         APIKeysUpdatePayloadV1TeamRoleNames = "schedules_reader"
+	APIKeysUpdatePayloadV1TeamRoleNamesSecretsManage           APIKeysUpdatePayloadV1TeamRoleNames = "secrets_manage"
+	APIKeysUpdatePayloadV1TeamRoleNamesSecretsUse              APIKeysUpdatePayloadV1TeamRoleNames = "secrets_use"
 	APIKeysUpdatePayloadV1TeamRoleNamesWorkflowsEditor         APIKeysUpdatePayloadV1TeamRoleNames = "workflows_editor"
 )
 
@@ -293,6 +305,7 @@ const (
 	AlertSourceV2SourceTypeCoralogix         AlertSourceV2SourceType = "coralogix"
 	AlertSourceV2SourceTypeCronitor          AlertSourceV2SourceType = "cronitor"
 	AlertSourceV2SourceTypeCrowdstrikeFalcon AlertSourceV2SourceType = "crowdstrike_falcon"
+	AlertSourceV2SourceTypeDash0             AlertSourceV2SourceType = "dash0"
 	AlertSourceV2SourceTypeDatadog           AlertSourceV2SourceType = "datadog"
 	AlertSourceV2SourceTypeDynatrace         AlertSourceV2SourceType = "dynatrace"
 	AlertSourceV2SourceTypeElasticsearch     AlertSourceV2SourceType = "elasticsearch"
@@ -327,6 +340,7 @@ const (
 	AlertSourceV2SourceTypeSumoLogic         AlertSourceV2SourceType = "sumo_logic"
 	AlertSourceV2SourceTypeUptime            AlertSourceV2SourceType = "uptime"
 	AlertSourceV2SourceTypeVercel            AlertSourceV2SourceType = "vercel"
+	AlertSourceV2SourceTypeWiz               AlertSourceV2SourceType = "wiz"
 	AlertSourceV2SourceTypeZendesk           AlertSourceV2SourceType = "zendesk"
 )
 
@@ -344,6 +358,7 @@ const (
 	AlertSourcesCreatePayloadV2SourceTypeCoralogix         AlertSourcesCreatePayloadV2SourceType = "coralogix"
 	AlertSourcesCreatePayloadV2SourceTypeCronitor          AlertSourcesCreatePayloadV2SourceType = "cronitor"
 	AlertSourcesCreatePayloadV2SourceTypeCrowdstrikeFalcon AlertSourcesCreatePayloadV2SourceType = "crowdstrike_falcon"
+	AlertSourcesCreatePayloadV2SourceTypeDash0             AlertSourcesCreatePayloadV2SourceType = "dash0"
 	AlertSourcesCreatePayloadV2SourceTypeDatadog           AlertSourcesCreatePayloadV2SourceType = "datadog"
 	AlertSourcesCreatePayloadV2SourceTypeDynatrace         AlertSourcesCreatePayloadV2SourceType = "dynatrace"
 	AlertSourcesCreatePayloadV2SourceTypeElasticsearch     AlertSourcesCreatePayloadV2SourceType = "elasticsearch"
@@ -378,6 +393,7 @@ const (
 	AlertSourcesCreatePayloadV2SourceTypeSumoLogic         AlertSourcesCreatePayloadV2SourceType = "sumo_logic"
 	AlertSourcesCreatePayloadV2SourceTypeUptime            AlertSourcesCreatePayloadV2SourceType = "uptime"
 	AlertSourcesCreatePayloadV2SourceTypeVercel            AlertSourcesCreatePayloadV2SourceType = "vercel"
+	AlertSourcesCreatePayloadV2SourceTypeWiz               AlertSourcesCreatePayloadV2SourceType = "wiz"
 	AlertSourcesCreatePayloadV2SourceTypeZendesk           AlertSourcesCreatePayloadV2SourceType = "zendesk"
 )
 
@@ -1179,6 +1195,8 @@ const (
 	IdentityV1RolesScheduleOverridesEditor             IdentityV1Roles = "schedule_overrides_editor"
 	IdentityV1RolesSchedulesEditor                     IdentityV1Roles = "schedules_editor"
 	IdentityV1RolesSchedulesReader                     IdentityV1Roles = "schedules_reader"
+	IdentityV1RolesSecretsManage                       IdentityV1Roles = "secrets_manage"
+	IdentityV1RolesSecretsUse                          IdentityV1Roles = "secrets_use"
 	IdentityV1RolesSecuritySettingsEditor              IdentityV1Roles = "security_settings_editor"
 	IdentityV1RolesStatusPagePublisher                 IdentityV1Roles = "status_page_publisher"
 	IdentityV1RolesTeamMembershipsManage               IdentityV1Roles = "team_memberships_manage"
@@ -1196,6 +1214,8 @@ const (
 	IdentityV1TeamRolesScheduleOverridesEditor IdentityV1TeamRoles = "schedule_overrides_editor"
 	IdentityV1TeamRolesSchedulesEditor         IdentityV1TeamRoles = "schedules_editor"
 	IdentityV1TeamRolesSchedulesReader         IdentityV1TeamRoles = "schedules_reader"
+	IdentityV1TeamRolesSecretsManage           IdentityV1TeamRoles = "secrets_manage"
+	IdentityV1TeamRolesSecretsUse              IdentityV1TeamRoles = "secrets_use"
 	IdentityV1TeamRolesWorkflowsEditor         IdentityV1TeamRoles = "workflows_editor"
 )
 
@@ -2572,6 +2592,9 @@ type AlertRouteChannelTargetPayloadV3 struct {
 
 	// ChannelVisibility The visibility of the channel
 	ChannelVisibility AlertRouteChannelTargetPayloadV3ChannelVisibility `json:"channel_visibility"`
+
+	// GroupAlertsSummary Whether grouped alerts should render as a single group-summary message per channel
+	GroupAlertsSummary *bool `json:"group_alerts_summary,omitempty"`
 }
 
 // AlertRouteChannelTargetPayloadV3ChannelVisibility The visibility of the channel
@@ -2591,6 +2614,9 @@ type AlertRouteChannelTargetV3 struct {
 
 	// ChannelVisibility The visibility of the channel
 	ChannelVisibility string `json:"channel_visibility"`
+
+	// GroupAlertsSummary Whether grouped alerts should render as a single group-summary message per channel
+	GroupAlertsSummary *bool `json:"group_alerts_summary,omitempty"`
 }
 
 // AlertRouteCustomFieldBindingPayloadV2 defines model for AlertRouteCustomFieldBindingPayloadV2.
@@ -8523,6 +8549,9 @@ type ScheduleV2 struct {
 	// NextShifts The shifts after the next changeover. Note that on the list schedules endpoint, this will always be empty if the page size requested is greater than 25.
 	NextShifts *[]ScheduleEntryV2 `json:"next_shifts,omitempty"`
 
+	// Permalink A permanent link to this schedule in the incident.io dashboard
+	Permalink string `json:"permalink"`
+
 	// TeamIds IDs of teams that own this schedule
 	TeamIds []string `json:"team_ids"`
 
@@ -8702,6 +8731,138 @@ type SchedulesUpdateScheduleSyncRuleResultV2 struct {
 	// single rotation. As the schedule's shifts change hands, we keep the target's
 	// Slack user group membership in step with the rule.
 	ScheduleSyncRule ScheduleSyncRuleV2 `json:"schedule_sync_rule"`
+}
+
+// SecretV2 A secret is a named credential that workflows can reference, for example
+// an auth token for an outgoing webhook.
+//
+// Its value can be set and rotated but never read back: the API stores it
+// encrypted and only ever returns masked metadata (the last four characters of
+// the current value). Update the value with the rotate action, which appends a
+// new version and retires the previous one.
+type SecretV2 struct {
+	CreatedAt time.Time `json:"created_at"`
+
+	// Description Optional description of what this secret is for
+	Description *string `json:"description,omitempty"`
+
+	// Id Unique identifier for this secret
+	Id string `json:"id"`
+
+	// LastFourChars The last four characters of the current value, for masked display. Absent when the value is four characters or shorter.
+	LastFourChars *string `json:"last_four_chars,omitempty"`
+
+	// Name Human-readable name, unique within the organisation amongst unarchived secrets
+	Name string `json:"name"`
+
+	// OwningTeamIds IDs of the teams that own this secret. Empty means the secret is owned by the whole organisation.
+	OwningTeamIds []string  `json:"owning_team_ids"`
+	UpdatedAt     time.Time `json:"updated_at"`
+
+	// Version The current version number, incremented on each rotation
+	Version int64 `json:"version"`
+}
+
+// SecretVersionV2 A single version of a secret's value. Only metadata is exposed; the value itself is never returned.
+type SecretVersionV2 struct {
+	CreatedAt time.Time `json:"created_at"`
+	CreatedBy *ActorV2  `json:"created_by,omitempty"`
+
+	// LastFourChars The last four characters of this version's value, for masked display. Absent when the value was four characters or shorter.
+	LastFourChars *string `json:"last_four_chars,omitempty"`
+
+	// Version The version number, incremented on each rotation
+	Version int64 `json:"version"`
+}
+
+// SecretsCreatePayloadV2 defines model for SecretsCreatePayloadV2.
+type SecretsCreatePayloadV2 struct {
+	// Description Optional description of what this secret is for
+	Description *string `json:"description,omitempty"`
+
+	// Name Human-readable name, unique within the organisation amongst unarchived secrets
+	Name string `json:"name"`
+
+	// OwningTeamIds IDs of the teams that own this secret. When empty or omitted, the secret is owned by the whole organisation.
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
+	// Value The secret's plaintext value. It's stored encrypted and never returned by the API.
+	Value string `json:"value"`
+}
+
+// SecretsCreateResultV2 defines model for SecretsCreateResultV2.
+type SecretsCreateResultV2 struct {
+	// Secret A secret is a named credential that workflows can reference, for example
+	// an auth token for an outgoing webhook.
+	//
+	// Its value can be set and rotated but never read back: the API stores it
+	// encrypted and only ever returns masked metadata (the last four characters of
+	// the current value). Update the value with the rotate action, which appends a
+	// new version and retires the previous one.
+	Secret SecretV2 `json:"secret"`
+}
+
+// SecretsListResultV2 defines model for SecretsListResultV2.
+type SecretsListResultV2 struct {
+	PaginationMeta *PaginationMetaResultV2 `json:"pagination_meta,omitempty"`
+	Secrets        []SecretV2              `json:"secrets"`
+}
+
+// SecretsRotatePayloadV2 defines model for SecretsRotatePayloadV2.
+type SecretsRotatePayloadV2 struct {
+	// Value The secret's new plaintext value. It's stored encrypted and never returned by the API.
+	Value string `json:"value"`
+}
+
+// SecretsRotateResultV2 defines model for SecretsRotateResultV2.
+type SecretsRotateResultV2 struct {
+	// Secret A secret is a named credential that workflows can reference, for example
+	// an auth token for an outgoing webhook.
+	//
+	// Its value can be set and rotated but never read back: the API stores it
+	// encrypted and only ever returns masked metadata (the last four characters of
+	// the current value). Update the value with the rotate action, which appends a
+	// new version and retires the previous one.
+	Secret SecretV2 `json:"secret"`
+}
+
+// SecretsShowResultV2 defines model for SecretsShowResultV2.
+type SecretsShowResultV2 struct {
+	// Secret A secret is a named credential that workflows can reference, for example
+	// an auth token for an outgoing webhook.
+	//
+	// Its value can be set and rotated but never read back: the API stores it
+	// encrypted and only ever returns masked metadata (the last four characters of
+	// the current value). Update the value with the rotate action, which appends a
+	// new version and retires the previous one.
+	Secret SecretV2 `json:"secret"`
+
+	// Versions The secret's versions, newest first
+	Versions []SecretVersionV2 `json:"versions"`
+}
+
+// SecretsUpdatePayloadV2 defines model for SecretsUpdatePayloadV2.
+type SecretsUpdatePayloadV2 struct {
+	// Description Optional description of what this secret is for
+	Description *string `json:"description,omitempty"`
+
+	// Name Human-readable name, unique within the organisation amongst unarchived secrets
+	Name string `json:"name"`
+
+	// OwningTeamIds IDs of the teams that own this secret. When omitted, the existing owning teams are left unchanged.
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+}
+
+// SecretsUpdateResultV2 defines model for SecretsUpdateResultV2.
+type SecretsUpdateResultV2 struct {
+	// Secret A secret is a named credential that workflows can reference, for example
+	// an auth token for an outgoing webhook.
+	//
+	// Its value can be set and rotated but never read back: the API stores it
+	// encrypted and only ever returns masked metadata (the last four characters of
+	// the current value). Update the value with the rotate action, which appends a
+	// new version and retires the previous one.
+	Secret SecretV2 `json:"secret"`
 }
 
 // SeveritiesCreatePayloadV1 defines model for SeveritiesCreatePayloadV1.
@@ -10107,6 +10268,9 @@ type AlertEventsV2CreateHTTPParams struct {
 	// Token Token used to authenticate the request, generated when configuring the alert source. Will be consumed via a URL query string parameter
 	Token *string `form:"token,omitempty" json:"token,omitempty"`
 
+	// Query Query parameters
+	Query *map[string]interface{} `json:"query,omitempty"`
+
 	// Authorization Whatever is provided in the Authorization header. We support either Basic or Bearer authorization with the secret provided on the alert source.
 	Authorization *string `json:"authorization,omitempty"`
 }
@@ -10376,6 +10540,18 @@ type SchedulesV2ListScheduleSyncRulesParams struct {
 
 	// After A sync rule's ID. This endpoint will return a list of sync rules after this ID in relation to the API response order.
 	After *string `form:"after,omitempty" json:"after,omitempty"`
+}
+
+// SecretsV2ListParams defines parameters for SecretsV2List.
+type SecretsV2ListParams struct {
+	// PageSize Integer number of records to return
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// After A secret's ID. This endpoint will return a list of secrets after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
+
+	// TeamIds Filter to secrets owned by any of these teams
+	TeamIds *[]string `form:"team_ids,omitempty" json:"team_ids,omitempty"`
 }
 
 // StatusPagesV2ListStatusPageIncidentsParams defines parameters for StatusPagesV2ListStatusPageIncidents.
@@ -10694,6 +10870,15 @@ type SchedulesV2CreateScheduleSyncRuleJSONRequestBody = SchedulesCreateScheduleS
 
 // SchedulesV2UpdateScheduleSyncRuleJSONRequestBody defines body for SchedulesV2UpdateScheduleSyncRule for application/json ContentType.
 type SchedulesV2UpdateScheduleSyncRuleJSONRequestBody = SchedulesUpdateScheduleSyncRulePayloadV2
+
+// SecretsV2CreateJSONRequestBody defines body for SecretsV2Create for application/json ContentType.
+type SecretsV2CreateJSONRequestBody = SecretsCreatePayloadV2
+
+// SecretsV2UpdateJSONRequestBody defines body for SecretsV2Update for application/json ContentType.
+type SecretsV2UpdateJSONRequestBody = SecretsUpdatePayloadV2
+
+// SecretsV2RotateJSONRequestBody defines body for SecretsV2Rotate for application/json ContentType.
+type SecretsV2RotateJSONRequestBody = SecretsRotatePayloadV2
 
 // StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody defines body for StatusPagesV2CreateStatusPageIncidentUpdate for application/json ContentType.
 type StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody = StatusPagesCreateStatusPageIncidentUpdatePayloadV2
@@ -11447,6 +11632,30 @@ type ClientInterface interface {
 	SchedulesV2UpdateScheduleSyncRuleWithBody(ctx context.Context, scheduleId string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SchedulesV2UpdateScheduleSyncRule(ctx context.Context, scheduleId string, id string, body SchedulesV2UpdateScheduleSyncRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SecretsV2List request
+	SecretsV2List(ctx context.Context, params *SecretsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SecretsV2CreateWithBody request with any body
+	SecretsV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SecretsV2Create(ctx context.Context, body SecretsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SecretsV2Destroy request
+	SecretsV2Destroy(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SecretsV2Show request
+	SecretsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SecretsV2UpdateWithBody request with any body
+	SecretsV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SecretsV2Update(ctx context.Context, id string, body SecretsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SecretsV2RotateWithBody request with any body
+	SecretsV2RotateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SecretsV2Rotate(ctx context.Context, id string, body SecretsV2RotateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// StatusPagesV2CreateStatusPageIncidentUpdateWithBody request with any body
 	StatusPagesV2CreateStatusPageIncidentUpdateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -14370,6 +14579,114 @@ func (c *Client) SchedulesV2UpdateScheduleSyncRuleWithBody(ctx context.Context, 
 
 func (c *Client) SchedulesV2UpdateScheduleSyncRule(ctx context.Context, scheduleId string, id string, body SchedulesV2UpdateScheduleSyncRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSchedulesV2UpdateScheduleSyncRuleRequest(c.Server, scheduleId, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SecretsV2List(ctx context.Context, params *SecretsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSecretsV2ListRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SecretsV2CreateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSecretsV2CreateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SecretsV2Create(ctx context.Context, body SecretsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSecretsV2CreateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SecretsV2Destroy(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSecretsV2DestroyRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SecretsV2Show(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSecretsV2ShowRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SecretsV2UpdateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSecretsV2UpdateRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SecretsV2Update(ctx context.Context, id string, body SecretsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSecretsV2UpdateRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SecretsV2RotateWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSecretsV2RotateRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SecretsV2Rotate(ctx context.Context, id string, body SecretsV2RotateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSecretsV2RotateRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -18460,6 +18777,22 @@ func NewAlertEventsV2CreateHTTPRequestWithBody(server string, alertSourceConfigI
 		if params.Token != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "token", runtime.ParamLocationQuery, *params.Token); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Query != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("deepObject", true, "query", runtime.ParamLocationQuery, *params.Query); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -22871,6 +23204,289 @@ func NewSchedulesV2UpdateScheduleSyncRuleRequestWithBody(server string, schedule
 	return req, nil
 }
 
+// NewSecretsV2ListRequest generates requests for SecretsV2List
+func NewSecretsV2ListRequest(server string, params *SecretsV2ListParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/secrets")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.PageSize != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page_size", runtime.ParamLocationQuery, *params.PageSize); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.After != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.TeamIds != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "team_ids", runtime.ParamLocationQuery, *params.TeamIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSecretsV2CreateRequest calls the generic SecretsV2Create builder with application/json body
+func NewSecretsV2CreateRequest(server string, body SecretsV2CreateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSecretsV2CreateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewSecretsV2CreateRequestWithBody generates requests for SecretsV2Create with any type of body
+func NewSecretsV2CreateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/secrets")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewSecretsV2DestroyRequest generates requests for SecretsV2Destroy
+func NewSecretsV2DestroyRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/secrets/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSecretsV2ShowRequest generates requests for SecretsV2Show
+func NewSecretsV2ShowRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/secrets/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSecretsV2UpdateRequest calls the generic SecretsV2Update builder with application/json body
+func NewSecretsV2UpdateRequest(server string, id string, body SecretsV2UpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSecretsV2UpdateRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewSecretsV2UpdateRequestWithBody generates requests for SecretsV2Update with any type of body
+func NewSecretsV2UpdateRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/secrets/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewSecretsV2RotateRequest calls the generic SecretsV2Rotate builder with application/json body
+func NewSecretsV2RotateRequest(server string, id string, body SecretsV2RotateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSecretsV2RotateRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewSecretsV2RotateRequestWithBody generates requests for SecretsV2Rotate with any type of body
+func NewSecretsV2RotateRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/secrets/%s/actions/rotate", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewStatusPagesV2CreateStatusPageIncidentUpdateRequest calls the generic StatusPagesV2CreateStatusPageIncidentUpdate builder with application/json body
 func NewStatusPagesV2CreateStatusPageIncidentUpdateRequest(server string, body StatusPagesV2CreateStatusPageIncidentUpdateJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -25720,6 +26336,30 @@ type ClientWithResponsesInterface interface {
 	SchedulesV2UpdateScheduleSyncRuleWithBodyWithResponse(ctx context.Context, scheduleId string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateScheduleSyncRuleResponse, error)
 
 	SchedulesV2UpdateScheduleSyncRuleWithResponse(ctx context.Context, scheduleId string, id string, body SchedulesV2UpdateScheduleSyncRuleJSONRequestBody, reqEditors ...RequestEditorFn) (*SchedulesV2UpdateScheduleSyncRuleResponse, error)
+
+	// SecretsV2ListWithResponse request
+	SecretsV2ListWithResponse(ctx context.Context, params *SecretsV2ListParams, reqEditors ...RequestEditorFn) (*SecretsV2ListResponse, error)
+
+	// SecretsV2CreateWithBodyWithResponse request with any body
+	SecretsV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SecretsV2CreateResponse, error)
+
+	SecretsV2CreateWithResponse(ctx context.Context, body SecretsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*SecretsV2CreateResponse, error)
+
+	// SecretsV2DestroyWithResponse request
+	SecretsV2DestroyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SecretsV2DestroyResponse, error)
+
+	// SecretsV2ShowWithResponse request
+	SecretsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SecretsV2ShowResponse, error)
+
+	// SecretsV2UpdateWithBodyWithResponse request with any body
+	SecretsV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SecretsV2UpdateResponse, error)
+
+	SecretsV2UpdateWithResponse(ctx context.Context, id string, body SecretsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*SecretsV2UpdateResponse, error)
+
+	// SecretsV2RotateWithBodyWithResponse request with any body
+	SecretsV2RotateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SecretsV2RotateResponse, error)
+
+	SecretsV2RotateWithResponse(ctx context.Context, id string, body SecretsV2RotateJSONRequestBody, reqEditors ...RequestEditorFn) (*SecretsV2RotateResponse, error)
 
 	// StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse request with any body
 	StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*StatusPagesV2CreateStatusPageIncidentUpdateResponse, error)
@@ -29517,6 +30157,137 @@ func (r SchedulesV2UpdateScheduleSyncRuleResponse) StatusCode() int {
 	return 0
 }
 
+type SecretsV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SecretsListResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r SecretsV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SecretsV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SecretsV2CreateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *SecretsCreateResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r SecretsV2CreateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SecretsV2CreateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SecretsV2DestroyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r SecretsV2DestroyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SecretsV2DestroyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SecretsV2ShowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SecretsShowResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r SecretsV2ShowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SecretsV2ShowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SecretsV2UpdateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SecretsUpdateResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r SecretsV2UpdateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SecretsV2UpdateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SecretsV2RotateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SecretsRotateResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r SecretsV2RotateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SecretsV2RotateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type StatusPagesV2CreateStatusPageIncidentUpdateResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -32505,6 +33276,84 @@ func (c *ClientWithResponses) SchedulesV2UpdateScheduleSyncRuleWithResponse(ctx 
 		return nil, err
 	}
 	return ParseSchedulesV2UpdateScheduleSyncRuleResponse(rsp)
+}
+
+// SecretsV2ListWithResponse request returning *SecretsV2ListResponse
+func (c *ClientWithResponses) SecretsV2ListWithResponse(ctx context.Context, params *SecretsV2ListParams, reqEditors ...RequestEditorFn) (*SecretsV2ListResponse, error) {
+	rsp, err := c.SecretsV2List(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSecretsV2ListResponse(rsp)
+}
+
+// SecretsV2CreateWithBodyWithResponse request with arbitrary body returning *SecretsV2CreateResponse
+func (c *ClientWithResponses) SecretsV2CreateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SecretsV2CreateResponse, error) {
+	rsp, err := c.SecretsV2CreateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSecretsV2CreateResponse(rsp)
+}
+
+func (c *ClientWithResponses) SecretsV2CreateWithResponse(ctx context.Context, body SecretsV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*SecretsV2CreateResponse, error) {
+	rsp, err := c.SecretsV2Create(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSecretsV2CreateResponse(rsp)
+}
+
+// SecretsV2DestroyWithResponse request returning *SecretsV2DestroyResponse
+func (c *ClientWithResponses) SecretsV2DestroyWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SecretsV2DestroyResponse, error) {
+	rsp, err := c.SecretsV2Destroy(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSecretsV2DestroyResponse(rsp)
+}
+
+// SecretsV2ShowWithResponse request returning *SecretsV2ShowResponse
+func (c *ClientWithResponses) SecretsV2ShowWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*SecretsV2ShowResponse, error) {
+	rsp, err := c.SecretsV2Show(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSecretsV2ShowResponse(rsp)
+}
+
+// SecretsV2UpdateWithBodyWithResponse request with arbitrary body returning *SecretsV2UpdateResponse
+func (c *ClientWithResponses) SecretsV2UpdateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SecretsV2UpdateResponse, error) {
+	rsp, err := c.SecretsV2UpdateWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSecretsV2UpdateResponse(rsp)
+}
+
+func (c *ClientWithResponses) SecretsV2UpdateWithResponse(ctx context.Context, id string, body SecretsV2UpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*SecretsV2UpdateResponse, error) {
+	rsp, err := c.SecretsV2Update(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSecretsV2UpdateResponse(rsp)
+}
+
+// SecretsV2RotateWithBodyWithResponse request with arbitrary body returning *SecretsV2RotateResponse
+func (c *ClientWithResponses) SecretsV2RotateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SecretsV2RotateResponse, error) {
+	rsp, err := c.SecretsV2RotateWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSecretsV2RotateResponse(rsp)
+}
+
+func (c *ClientWithResponses) SecretsV2RotateWithResponse(ctx context.Context, id string, body SecretsV2RotateJSONRequestBody, reqEditors ...RequestEditorFn) (*SecretsV2RotateResponse, error) {
+	rsp, err := c.SecretsV2Rotate(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSecretsV2RotateResponse(rsp)
 }
 
 // StatusPagesV2CreateStatusPageIncidentUpdateWithBodyWithResponse request with arbitrary body returning *StatusPagesV2CreateStatusPageIncidentUpdateResponse
@@ -37082,6 +37931,152 @@ func ParseSchedulesV2UpdateScheduleSyncRuleResponse(rsp *http.Response) (*Schedu
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest SchedulesUpdateScheduleSyncRuleResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSecretsV2ListResponse parses an HTTP response from a SecretsV2ListWithResponse call
+func ParseSecretsV2ListResponse(rsp *http.Response) (*SecretsV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SecretsV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SecretsListResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSecretsV2CreateResponse parses an HTTP response from a SecretsV2CreateWithResponse call
+func ParseSecretsV2CreateResponse(rsp *http.Response) (*SecretsV2CreateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SecretsV2CreateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest SecretsCreateResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSecretsV2DestroyResponse parses an HTTP response from a SecretsV2DestroyWithResponse call
+func ParseSecretsV2DestroyResponse(rsp *http.Response) (*SecretsV2DestroyResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SecretsV2DestroyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseSecretsV2ShowResponse parses an HTTP response from a SecretsV2ShowWithResponse call
+func ParseSecretsV2ShowResponse(rsp *http.Response) (*SecretsV2ShowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SecretsV2ShowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SecretsShowResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSecretsV2UpdateResponse parses an HTTP response from a SecretsV2UpdateWithResponse call
+func ParseSecretsV2UpdateResponse(rsp *http.Response) (*SecretsV2UpdateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SecretsV2UpdateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SecretsUpdateResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSecretsV2RotateResponse parses an HTTP response from a SecretsV2RotateWithResponse call
+func ParseSecretsV2RotateResponse(rsp *http.Response) (*SecretsV2RotateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SecretsV2RotateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SecretsRotateResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -256,6 +257,7 @@ func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.Sc
 										"group_alerts_summary": schema.BoolAttribute{
 											Optional:            true,
 											Computed:            true,
+											Default:             booldefault.StaticBool(false),
 											MarkdownDescription: apischema.Docstring("AlertRouteChannelTargetV3", "group_alerts_summary"),
 											PlanModifiers: []planmodifier.Bool{
 												boolplanmodifier.UseStateForUnknown(),
@@ -279,6 +281,7 @@ func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.Sc
 										"group_alerts_summary": schema.BoolAttribute{
 											Optional:            true,
 											Computed:            true,
+											Default:             booldefault.StaticBool(false),
 											MarkdownDescription: apischema.Docstring("AlertRouteChannelTargetV3", "group_alerts_summary"),
 											PlanModifiers: []planmodifier.Bool{
 												boolplanmodifier.UseStateForUnknown(),

--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -252,6 +253,12 @@ func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.Sc
 											Required:            true,
 											MarkdownDescription: apischema.Docstring("AlertRouteChannelTargetV3", "channel_visibility"),
 										},
+										"group_alerts_summary": schema.BoolAttribute{
+											Optional:            true,
+											Computed:            true,
+											Default:             booldefault.StaticBool(false),
+											MarkdownDescription: apischema.Docstring("AlertRouteChannelTargetV3", "group_alerts_summary"),
+										},
 									},
 								},
 								"slack_targets": schema.SingleNestedAttribute{
@@ -266,6 +273,12 @@ func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.Sc
 										"channel_visibility": schema.StringAttribute{
 											Required:            true,
 											MarkdownDescription: apischema.Docstring("AlertRouteChannelTargetV3", "channel_visibility"),
+										},
+										"group_alerts_summary": schema.BoolAttribute{
+											Optional:            true,
+											Computed:            true,
+											Default:             booldefault.StaticBool(false),
+											MarkdownDescription: apischema.Docstring("AlertRouteChannelTargetV3", "group_alerts_summary"),
 										},
 									},
 								},

--- a/internal/provider/incident_alert_route_resource.go
+++ b/internal/provider/incident_alert_route_resource.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -256,8 +256,10 @@ func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.Sc
 										"group_alerts_summary": schema.BoolAttribute{
 											Optional:            true,
 											Computed:            true,
-											Default:             booldefault.StaticBool(false),
 											MarkdownDescription: apischema.Docstring("AlertRouteChannelTargetV3", "group_alerts_summary"),
+											PlanModifiers: []planmodifier.Bool{
+												boolplanmodifier.UseStateForUnknown(),
+											},
 										},
 									},
 								},
@@ -277,8 +279,10 @@ func (r *IncidentAlertRouteResource) Schema(ctx context.Context, req resource.Sc
 										"group_alerts_summary": schema.BoolAttribute{
 											Optional:            true,
 											Computed:            true,
-											Default:             booldefault.StaticBool(false),
 											MarkdownDescription: apischema.Docstring("AlertRouteChannelTargetV3", "group_alerts_summary"),
+											PlanModifiers: []planmodifier.Bool{
+												boolplanmodifier.UseStateForUnknown(),
+											},
 										},
 									},
 								},

--- a/internal/provider/incident_alert_route_v3_resource_test.go
+++ b/internal/provider/incident_alert_route_v3_resource_test.go
@@ -116,7 +116,6 @@ func TestAccIncidentAlertRouteV3ResourceComprehensive(t *testing.T) {
 					// Message config (destinations).
 					resource.TestCheckResourceAttr("incident_alert_route.comprehensive", "message_config.destinations.#", "1"),
 					resource.TestCheckResourceAttr("incident_alert_route.comprehensive", "message_config.destinations.0.slack_targets.channel_visibility", "public"),
-					resource.TestCheckResourceAttr("incident_alert_route.comprehensive", "message_config.destinations.0.slack_targets.group_alerts_summary", "false"),
 
 					// Escalation config with when_alert_joins_group.
 					resource.TestCheckResourceAttr("incident_alert_route.comprehensive", "escalation_config.when_alert_joins_group.mode", "on_each_new_alert"),
@@ -404,8 +403,7 @@ resource "incident_alert_route" "comprehensive" {
       {
         condition_groups = []
         slack_targets = {
-          channel_visibility   = "public"
-          group_alerts_summary = false
+          channel_visibility = "public"
           binding = {
             value = {
               literal = %[2]q

--- a/internal/provider/incident_alert_route_v3_resource_test.go
+++ b/internal/provider/incident_alert_route_v3_resource_test.go
@@ -116,6 +116,7 @@ func TestAccIncidentAlertRouteV3ResourceComprehensive(t *testing.T) {
 					// Message config (destinations).
 					resource.TestCheckResourceAttr("incident_alert_route.comprehensive", "message_config.destinations.#", "1"),
 					resource.TestCheckResourceAttr("incident_alert_route.comprehensive", "message_config.destinations.0.slack_targets.channel_visibility", "public"),
+					resource.TestCheckResourceAttr("incident_alert_route.comprehensive", "message_config.destinations.0.slack_targets.group_alerts_summary", "false"),
 
 					// Escalation config with when_alert_joins_group.
 					resource.TestCheckResourceAttr("incident_alert_route.comprehensive", "escalation_config.when_alert_joins_group.mode", "on_each_new_alert"),
@@ -403,7 +404,8 @@ resource "incident_alert_route" "comprehensive" {
       {
         condition_groups = []
         slack_targets = {
-          channel_visibility = "public"
+          channel_visibility   = "public"
+          group_alerts_summary = false
           binding = {
             value = {
               literal = %[2]q

--- a/internal/provider/models/alert_route_v3_model.go
+++ b/internal/provider/models/alert_route_v3_model.go
@@ -101,11 +101,27 @@ type AlertRouteV3GroupingSettingsModel struct {
 }
 
 type AlertRouteV3MessageConfigModel struct {
-	Destinations []AlertRouteChannelConfigModel `tfsdk:"destinations"`
+	Destinations []AlertRouteV3ChannelConfigModel `tfsdk:"destinations"`
 	// Template is the v3 message template. Note the v3 API renamed this field
 	// from message_template to template (the v2 top-level message_template is a
 	// separate, deprecated attribute).
 	Template *IncidentEngineParamBinding `tfsdk:"template"`
+}
+
+// AlertRouteV3ChannelConfigModel mirrors the v2 AlertRouteChannelConfigModel but
+// uses the v3 channel target, which carries the v3-only group_alerts_summary
+// field. Kept separate from the v2 struct so neither is forced to match two
+// different schema shapes.
+type AlertRouteV3ChannelConfigModel struct {
+	ConditionGroups IncidentEngineConditionGroups   `tfsdk:"condition_groups"`
+	MsTeamsTargets  *AlertRouteV3ChannelTargetModel `tfsdk:"ms_teams_targets"`
+	SlackTargets    *AlertRouteV3ChannelTargetModel `tfsdk:"slack_targets"`
+}
+
+type AlertRouteV3ChannelTargetModel struct {
+	Binding            *IncidentEngineParamBinding `tfsdk:"binding"`
+	ChannelVisibility  types.String                `tfsdk:"channel_visibility"`
+	GroupAlertsSummary types.Bool                  `tfsdk:"group_alerts_summary"`
 }
 
 // AlertRouteV3IncidentTemplateModel mirrors the v2 incident template but drops
@@ -295,23 +311,25 @@ func (AlertRouteResourceModel) FromAPIV3WithPlan(apiModel client.AlertRouteV3, p
 	// doesn't produce drift (reconciled against the plan below).
 	result.MessageConfig = &AlertRouteV3MessageConfigModel{}
 	for _, destination := range apiModel.MessageConfig.Destinations {
-		model := AlertRouteChannelConfigModel{
+		model := AlertRouteV3ChannelConfigModel{
 			ConditionGroups: conditionGroupsFromV3(destination.ConditionGroups),
 		}
 
 		if destination.SlackTargets != nil {
 			binding := paramBindingFromV3(destination.SlackTargets.Binding)
-			model.SlackTargets = &AlertRouteChannelTargetModel{
-				ChannelVisibility: types.StringValue(destination.SlackTargets.ChannelVisibility),
-				Binding:           &binding,
+			model.SlackTargets = &AlertRouteV3ChannelTargetModel{
+				ChannelVisibility:  types.StringValue(destination.SlackTargets.ChannelVisibility),
+				Binding:            &binding,
+				GroupAlertsSummary: types.BoolPointerValue(destination.SlackTargets.GroupAlertsSummary),
 			}
 		}
 
 		if destination.MsTeamsTargets != nil {
 			binding := paramBindingFromV3(destination.MsTeamsTargets.Binding)
-			model.MsTeamsTargets = &AlertRouteChannelTargetModel{
-				ChannelVisibility: types.StringValue(destination.MsTeamsTargets.ChannelVisibility),
-				Binding:           &binding,
+			model.MsTeamsTargets = &AlertRouteV3ChannelTargetModel{
+				ChannelVisibility:  types.StringValue(destination.MsTeamsTargets.ChannelVisibility),
+				Binding:            &binding,
+				GroupAlertsSummary: types.BoolPointerValue(destination.MsTeamsTargets.GroupAlertsSummary),
 			}
 		}
 
@@ -331,7 +349,7 @@ func (AlertRouteResourceModel) FromAPIV3WithPlan(apiModel client.AlertRouteV3, p
 	// otherwise leave it nil so an omitted optional stays null.
 	if len(result.MessageConfig.Destinations) == 0 &&
 		plan != nil && plan.MessageConfig != nil && plan.MessageConfig.Destinations != nil {
-		result.MessageConfig.Destinations = []AlertRouteChannelConfigModel{}
+		result.MessageConfig.Destinations = []AlertRouteV3ChannelConfigModel{}
 	}
 
 	// Incident config. auto_decline_enabled and condition_groups are optional in
@@ -596,15 +614,17 @@ func (m AlertRouteResourceModel) ToCreatePayloadV3() client.AlertRoutesCreatePay
 
 			if destination.SlackTargets != nil && destination.SlackTargets.Binding != nil {
 				payloadDestination.SlackTargets = &client.AlertRouteChannelTargetPayloadV3{
-					ChannelVisibility: client.AlertRouteChannelTargetPayloadV3ChannelVisibility(destination.SlackTargets.ChannelVisibility.ValueString()),
-					Binding:           paramBindingToV3Payload(*destination.SlackTargets.Binding),
+					ChannelVisibility:  client.AlertRouteChannelTargetPayloadV3ChannelVisibility(destination.SlackTargets.ChannelVisibility.ValueString()),
+					Binding:            paramBindingToV3Payload(*destination.SlackTargets.Binding),
+					GroupAlertsSummary: destination.SlackTargets.GroupAlertsSummary.ValueBoolPointer(),
 				}
 			}
 
 			if destination.MsTeamsTargets != nil && destination.MsTeamsTargets.Binding != nil {
 				payloadDestination.MsTeamsTargets = &client.AlertRouteChannelTargetPayloadV3{
-					ChannelVisibility: client.AlertRouteChannelTargetPayloadV3ChannelVisibility(destination.MsTeamsTargets.ChannelVisibility.ValueString()),
-					Binding:           paramBindingToV3Payload(*destination.MsTeamsTargets.Binding),
+					ChannelVisibility:  client.AlertRouteChannelTargetPayloadV3ChannelVisibility(destination.MsTeamsTargets.ChannelVisibility.ValueString()),
+					Binding:            paramBindingToV3Payload(*destination.MsTeamsTargets.Binding),
+					GroupAlertsSummary: destination.MsTeamsTargets.GroupAlertsSummary.ValueBoolPointer(),
 				}
 			}
 

--- a/internal/provider/models/alert_route_v3_model_test.go
+++ b/internal/provider/models/alert_route_v3_model_test.go
@@ -52,7 +52,8 @@ func TestAlertRouteV3RoundTrip(t *testing.T) {
 				{
 					ConditionGroups: []client.ConditionGroupV3{},
 					SlackTargets: &client.AlertRouteChannelTargetV3{
-						ChannelVisibility: "public",
+						ChannelVisibility:  "public",
+						GroupAlertsSummary: lo.ToPtr(true),
 						Binding: client.EngineParamBindingV3{
 							Value: &client.EngineParamBindingValueV3{Literal: lo.ToPtr("C123")},
 						},
@@ -134,6 +135,9 @@ func TestAlertRouteV3RoundTrip(t *testing.T) {
 	if model.MessageConfig.Destinations[0].SlackTargets == nil {
 		t.Fatal("slack_targets is nil")
 	}
+	if !model.MessageConfig.Destinations[0].SlackTargets.GroupAlertsSummary.ValueBool() {
+		t.Error("slack_targets.group_alerts_summary should be true")
+	}
 
 	// Escalation config.
 	if !model.EscalationConfig.AutoCancelEscalations.ValueBool() {
@@ -176,6 +180,9 @@ func TestAlertRouteV3RoundTrip(t *testing.T) {
 	slack := payload.MessageConfig.Destinations[0].SlackTargets
 	if slack == nil || slack.Binding.Value == nil || lo.FromPtr(slack.Binding.Value.Literal) != "C123" {
 		t.Errorf("payload slack binding literal mismatch: %+v", slack)
+	}
+	if !lo.FromPtr(slack.GroupAlertsSummary) {
+		t.Errorf("payload slack group_alerts_summary should be true: %+v", slack)
 	}
 	if !payload.EscalationConfig.AutoCancelEscalations {
 		t.Error("payload auto_cancel_escalations should be true")
@@ -225,7 +232,7 @@ func TestAlertRouteV3MessageConfigDestinationsNullVsEmpty(t *testing.T) {
 	// Plan with an explicit, non-nil empty destinations slice.
 	planEmpty := &AlertRouteResourceModel{
 		MessageConfig: &AlertRouteV3MessageConfigModel{
-			Destinations: []AlertRouteChannelConfigModel{},
+			Destinations: []AlertRouteV3ChannelConfigModel{},
 		},
 	}
 


### PR DESCRIPTION
## What

Exposes the per-destination **`group_alerts_summary`** toggle on the v3 `incident_alert_route` resource (Slack and MS Teams channel targets under `message_config.destinations`). Mirrors the field added to the v3 alert routes API in core.

## Design

- **v3-specific model structs** (`AlertRouteV3ChannelConfigModel` / `AlertRouteV3ChannelTargetModel`) instead of extending the struct shared with v2. Both v2 `channel_config` and v3 `message_config` map to the shared target struct, and the API only supports this field on v3 — adding it to the shared struct would break the v2 round-trip ("inconsistent result after apply").
- **`Optional + Computed + Default(false)`** (matching the `booldefault.StaticBool(false)` precedent in the alert_source resource), so an omitted value doesn't drift against the concrete `false` the API always returns.
- **Schema is a fresh snapshot from core** (the documented `cp … && go generate` workflow), which also brings the provider's committed schema up to date with current core master.

## Changes

Hand-written: schema attribute + `booldefault` import, v3 model structs + both conversion directions, unit test, acceptance test, docs, example.
Regenerated: `internal/apischema/…json` (snapshot) and `internal/client/client.gen.go` (`GroupAlertsSummary *bool`, additive).

## Testing

- `go build` / `go vet` / `gofmt` clean
- Model unit tests pass — the round-trip test asserts `group_alerts_summary` survives API → model → payload with `true`
- Acceptance test config uses `group_alerts_summary = false` deliberately (see below)

## ⚠️ Dependencies / sequencing

- **Depends on the core PR** (incident-io/core#66972). The schema snapshot was taken from that unmerged core branch, so **this should merge after core lands**, else the next snapshot from core master would drop the field.
- CI runs `make testacc` against a live API. The acceptance test asserts `group_alerts_summary = **false**` on purpose: `true` is only accepted once the core change is **deployed** to the CI org **and** `FeatureAlertGroupPulseMessages` is enabled there. The `true` round-trip is covered by the unit test instead, so CI isn't blocked on a live deploy + flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)