### PR TITLE
Make incident_schedule_sync_rule and incident_schedule_sync_target importable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Document import support for `incident_schedule_sync_target` and `incident_schedule_sync_rule`, the last two resources whose registry pages had no import example. Targets import by their ID; rules are nested under a schedule in the API, so they import by `schedule_id:rule_id`.
+- Make importing either resource read it from the API up front, so the imported state is fully populated and an ID that doesn't exist fails with a clear message rather than silently importing an empty resource. An import ID with an empty schedule or rule ID is now rejected too, and an unexpected successful API response without a body returns a diagnostic instead of panicking.
+
 ## v5.45.0
 
 - Add `group_alerts_summary` to the v3 `incident_alert_route` resource, on Slack and MS Teams channel targets under `message_config.destinations`. When enabled, grouped alerts render as a single editable group-summary message per channel instead of one message per alert.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -154,6 +154,22 @@ TF_CLI_CONFIG_FILE=./dev.tfrc terraform plan
 TF_CLI_CONFIG_FILE=./dev.tfrc terraform apply
 ```
 
+## Import support
+
+Every resource supports `terraform import`, and each resource's registry page documents how.
+When you add a resource, implement `resource.ResourceWithImportState` and add an
+`examples/resources/<resource_name>/import.sh` showing the command: `tfplugindocs` renders that
+script into the "Import" section of the resource's page, so without it the resource looks
+un-importable even though the code supports it.
+
+`ImportState` should populate the whole model from the API rather than writing only the ID
+attributes. That keeps imported state identical to what `Read` produces, makes an ID that doesn't
+exist fail with a clear diagnostic instead of importing an empty resource, and avoids the untyped
+collection attributes that break `import {}` blocks with a "Value Conversion Error". For a resource
+nested under a parent (like a sync rule under a schedule), take a composite
+`parent_id:resource_id` import ID, as `incident_catalog_type_attribute` and
+`incident_schedule_sync_rule` do.
+
 ## Schema Attributes - What to use when
 
 ### `Optional`

--- a/docs/resources/schedule_sync_rule.md
+++ b/docs/resources/schedule_sync_rule.md
@@ -68,3 +68,19 @@ Valid values: `all_users`, `on_call`.
 ### Read-Only
 
 - `id` (String) Unique identifier of the sync rule
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+#!/bin/bash
+
+# Import a schedule sync rule using the format schedule_id:rule_id
+# Sync rules belong to a schedule, so both IDs are required: use the
+# ListScheduleSyncRules API endpoint for a schedule to find its rules' IDs
+# Replace the IDs with real IDs from your incident.io organization
+terraform import incident_schedule_sync_rule.example 01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX
+```

--- a/docs/resources/schedule_sync_target.md
+++ b/docs/resources/schedule_sync_target.md
@@ -60,3 +60,22 @@ Required:
 Optional:
 
 - `slack_team_id` (String) Slack workspace ID where the user group should be created. Required for Enterprise Grid organizations with multiple workspaces.
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+#!/bin/bash
+
+# Import a schedule sync target using its ID
+# Replace the ID with a real ID from your incident.io organization
+#
+# The Slack user group of an imported target already exists, so the imported
+# configuration should point at it with slack_user_group_id (the group's Slack
+# ID, which is in state after the import). new_slack_user_group asks us to
+# create a group, so leaving it set plans a replacement of the target
+terraform import incident_schedule_sync_target.example 01ABC123DEF456GHI789JKL
+```

--- a/examples/resources/incident_schedule_sync_rule/import.sh
+++ b/examples/resources/incident_schedule_sync_rule/import.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Import a schedule sync rule using the format schedule_id:rule_id
+# Sync rules belong to a schedule, so both IDs are required: use the
+# ListScheduleSyncRules API endpoint for a schedule to find its rules' IDs
+# Replace the IDs with real IDs from your incident.io organization
+terraform import incident_schedule_sync_rule.example 01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX

--- a/examples/resources/incident_schedule_sync_target/import.sh
+++ b/examples/resources/incident_schedule_sync_target/import.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Import a schedule sync target using its ID
+# Replace the ID with a real ID from your incident.io organization
+#
+# The Slack user group of an imported target already exists, so the imported
+# configuration should point at it with slack_user_group_id (the group's Slack
+# ID, which is in state after the import). new_slack_user_group asks us to
+# create a group, so leaving it set plans a replacement of the target
+terraform import incident_schedule_sync_target.example 01ABC123DEF456GHI789JKL

--- a/internal/provider/incident_schedule_sync_rule_import_test.go
+++ b/internal/provider/incident_schedule_sync_rule_import_test.go
@@ -1,0 +1,69 @@
+package provider
+
+import "testing"
+
+// TestParseScheduleSyncRuleImportID covers the composite import ID a sync rule
+// is identified by: both the schedule and the rule ID are required, since rules
+// are nested under a schedule in the API.
+func TestParseScheduleSyncRuleImportID(t *testing.T) {
+	cases := []struct {
+		name           string
+		importID       string
+		wantScheduleID string
+		wantRuleID     string
+		wantOK         bool
+	}{
+		{
+			name:           "schedule and rule ID",
+			importID:       "01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX",
+			wantScheduleID: "01ABC123DEF456GHI789JKL",
+			wantRuleID:     "01MNO456PQR789STU012VWX",
+			wantOK:         true,
+		},
+		{
+			name:           "surrounding whitespace",
+			importID:       " 01ABC123DEF456GHI789JKL : 01MNO456PQR789STU012VWX ",
+			wantScheduleID: "01ABC123DEF456GHI789JKL",
+			wantRuleID:     "01MNO456PQR789STU012VWX",
+			wantOK:         true,
+		},
+		{
+			name:     "rule ID only",
+			importID: "01MNO456PQR789STU012VWX",
+		},
+		{
+			name:     "missing schedule ID",
+			importID: ":01MNO456PQR789STU012VWX",
+		},
+		{
+			name:     "missing rule ID",
+			importID: "01ABC123DEF456GHI789JKL:",
+		},
+		{
+			name:     "too many parts",
+			importID: "01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX:extra",
+		},
+		{
+			name:     "empty",
+			importID: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheduleID, ruleID, ok := parseScheduleSyncRuleImportID(tc.importID)
+			if ok != tc.wantOK {
+				t.Fatalf("parseScheduleSyncRuleImportID(%q) ok = %v, want %v", tc.importID, ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if scheduleID != tc.wantScheduleID {
+				t.Errorf("schedule ID = %q, want %q", scheduleID, tc.wantScheduleID)
+			}
+			if ruleID != tc.wantRuleID {
+				t.Errorf("rule ID = %q, want %q", ruleID, tc.wantRuleID)
+			}
+		})
+	}
+}

--- a/internal/provider/incident_schedule_sync_rule_resource.go
+++ b/internal/provider/incident_schedule_sync_rule_resource.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -145,6 +144,14 @@ func (r *IncidentScheduleSyncRuleResource) Read(ctx context.Context, req resourc
 		return
 	}
 
+	if result.JSON200 == nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to read schedule sync rule: unexpected response from API (status %s)", result.Status()),
+		)
+		return
+	}
+
 	data = models.ScheduleSyncRuleResourceModel{}.FromAPI(result.JSON200.ScheduleSyncRule)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -187,24 +194,61 @@ func (r *IncidentScheduleSyncRuleResource) Delete(ctx context.Context, req resou
 	}
 }
 
+// parseScheduleSyncRuleImportID splits the composite import ID a sync rule is
+// identified by. Rules are nested under a schedule in the API, so both IDs are
+// needed to look one up.
+func parseScheduleSyncRuleImportID(importID string) (scheduleID string, ruleID string, ok bool) {
+	idParts := strings.Split(strings.TrimSpace(importID), ":")
+	if len(idParts) == 2 {
+		scheduleID, ruleID = strings.TrimSpace(idParts[0]), strings.TrimSpace(idParts[1])
+	}
+
+	return scheduleID, ruleID, scheduleID != "" && ruleID != ""
+}
+
 func (r *IncidentScheduleSyncRuleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Import ID format: schedule_id:rule_id
-	idParts := strings.Split(req.ID, ":")
-	if len(idParts) != 2 {
+	scheduleID, ruleID, ok := parseScheduleSyncRuleImportID(req.ID)
+	if !ok {
 		resp.Diagnostics.AddError(
 			"Invalid Import ID",
-			"The import ID must be in the format: schedule_id:rule_id",
+			fmt.Sprintf("The import ID must be in the format: schedule_id:rule_id (got %q)", req.ID),
 		)
 		return
 	}
 
-	scheduleID := idParts[0]
-	ruleID := idParts[1]
-
 	tflog.Info(ctx, fmt.Sprintf("Importing schedule sync rule with schedule_id=%s and rule_id=%s", scheduleID, ruleID))
 
-	claimResource(ctx, r.client, ruleID, &resp.Diagnostics, client.ScheduleSyncRule, r.terraformVersion)
+	// Populate the full model rather than just the IDs, so the imported state
+	// matches what Read would produce and a missing rule fails with a clear
+	// message instead of an empty import.
+	result, err := r.client.SchedulesV2ShowScheduleSyncRuleWithResponse(ctx, scheduleID, ruleID)
+	if err != nil {
+		httpErr := client.HTTPError{}
+		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+			resp.Diagnostics.AddError(
+				"Schedule Sync Rule Not Found",
+				fmt.Sprintf("No sync rule with ID %q exists on schedule %q. Import IDs must be in the format schedule_id:rule_id.", ruleID, scheduleID),
+			)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read schedule sync rule, got error: %s", err))
+		return
+	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), ruleID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("schedule_id"), scheduleID)...)
+	if result.JSON200 == nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to read schedule sync rule: unexpected response from API (status %s)", result.Status()),
+		)
+		return
+	}
+
+	claimResource(ctx, r.client, ruleID, &resp.Diagnostics, client.ScheduleSyncRule, r.terraformVersion)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data := models.ScheduleSyncRuleResourceModel{}.FromAPI(result.JSON200.ScheduleSyncRule)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/incident_schedule_sync_rule_resource_test.go
+++ b/internal/provider/incident_schedule_sync_rule_resource_test.go
@@ -72,6 +72,12 @@ func TestAccIncidentScheduleSyncRuleResource_InvalidImportID(t *testing.T) {
 				ImportStateId: "invalid-id-without-colon",
 				ExpectError:   regexp.MustCompile(`The import ID must be in the format: schedule_id:rule_id`),
 			},
+			{
+				ResourceName:  "incident_schedule_sync_rule.test",
+				ImportState:   true,
+				ImportStateId: ":01ABC123DEF456GHI789JKL",
+				ExpectError:   regexp.MustCompile(`The import ID must be in the format: schedule_id:rule_id`),
+			},
 		},
 	})
 }

--- a/internal/provider/incident_schedule_sync_target_resource.go
+++ b/internal/provider/incident_schedule_sync_target_resource.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -203,6 +203,14 @@ func (r *IncidentScheduleSyncTargetResource) Read(ctx context.Context, req resou
 		return
 	}
 
+	if result.JSON200 == nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to read schedule sync target: unexpected response from API (status %s)", result.Status()),
+		)
+		return
+	}
+
 	// Preserve new_slack_user_group from state since it's not returned by API
 	newSlackUserGroup := data.NewSlackUserGroup
 
@@ -254,6 +262,51 @@ func (r *IncidentScheduleSyncTargetResource) Delete(ctx context.Context, req res
 }
 
 func (r *IncidentScheduleSyncTargetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	claimResource(ctx, r.client, req.ID, &resp.Diagnostics, client.ScheduleSyncTarget, r.terraformVersion)
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	targetID := strings.TrimSpace(req.ID)
+	if targetID == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			"The import ID must be the ID of the sync target to import.",
+		)
+		return
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("Importing schedule sync target with id=%s", targetID))
+
+	// Populate the full model rather than just the ID, so the imported state
+	// matches what Read would produce and a missing target fails with a clear
+	// message instead of an empty import.
+	result, err := r.client.ScheduleSyncTargetsV2ShowWithResponse(ctx, targetID)
+	if err != nil {
+		httpErr := client.HTTPError{}
+		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+			resp.Diagnostics.AddError(
+				"Schedule Sync Target Not Found",
+				fmt.Sprintf("No sync target exists with ID %q.", targetID),
+			)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read schedule sync target, got error: %s", err))
+		return
+	}
+
+	if result.JSON200 == nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to read schedule sync target: unexpected response from API (status %s)", result.Status()),
+		)
+		return
+	}
+
+	claimResource(ctx, r.client, targetID, &resp.Diagnostics, client.ScheduleSyncTarget, r.terraformVersion)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// new_slack_user_group describes how to create a Slack user group, so it is
+	// never part of an imported target: the group already exists, and the
+	// imported configuration should reference it with slack_user_group_id.
+	data := models.ScheduleSyncTargetResourceModel{}.FromAPI(result.JSON200.ScheduleSyncTarget)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`incident_schedule_sync_rule` and `incident_schedule_sync_target` were the only two resources whose registry pages carried no Import section, so they read as un-importable even though both implement `ResourceWithImportState`. The gap was `examples/resources/<name>/import.sh`: `tfplugindocs` renders that script into the resource page's "Import" section, and without it the section is omitted entirely.

This adds the two missing examples, regenerates the docs, and hardens both `ImportState` implementations so the documented behaviour actually holds. All 18 resource pages now document import.

## Changes

**Import examples and docs** — `import.sh` for both resources, plus the regenerated `docs/resources/schedule_sync_{rule,target}.md`. Targets import by their ID; rules are nested under a schedule in the API, so they import by `schedule_id:rule_id` (the same shape as `incident_catalog_type_attribute`). The target example calls out that an imported target should reference its existing Slack user group with `slack_user_group_id`, because `new_slack_user_group` asks us to *create* a group and leaving it set plans a replacement of the target.

**Full state on import** — both resources previously wrote only their ID attributes and left the rest to the follow-up `Read`. That meant an ID that didn't exist was claimed as a Terraform-managed resource and imported as an empty object before failing later, and the state written during import didn't match what `Read` produces (the class of mismatch behind the `import {}` "Value Conversion Error" fixed for `incident_catalog_type_attribute` in v5.43.1). Both now fetch the resource first, claim it only once it is confirmed to exist, and set the whole model, with a clear diagnostic naming the missing target/rule.

**Import ID validation** — a sync rule import ID with an empty schedule or rule ID (`:rule_id`, `schedule_id:`) is now rejected with the format hint instead of being treated as valid, and the error quotes the ID received. The parsing is extracted into `parseScheduleSyncRuleImportID` with unit test coverage.

**Nil response bodies** — `Read` and `ImportState` on both resources returned a nil-pointer dereference if the API returned an unexpected 2xx without a JSON body; they now return a diagnostic with the status, matching the `incident_escalation_path` fix in v5.41.1.

**DEVELOPING.md** — a short "Import support" section recording that every resource needs an `import.sh` and that `ImportState` should populate the whole model, so this doesn't regress with the next resource.

## Testing

Acceptance tests for these resources need Slack `usergroups:write` and are gated behind `TF_ACC_SLACK_USER_GROUPS`, so they don't run in CI. To verify end to end I ran the built provider (via `dev_overrides`) against a local stub of the three endpoints involved (`ScheduleSyncTargetsV2Show`, `SchedulesV2ShowScheduleSyncRule`, `ManagedResourcesV2CreateManagedResource`):

- `terraform import` of both resources succeeds and writes complete state (`add_bot_to_group`, `slack_user_group_id`, `slack_team_id` for the target; `schedule_id`, `schedule_sync_target_id`, `sync_type`, `rotation_id` for the rule), and the subsequent `terraform plan` reports **No changes**.
- The same via `import {}` blocks plans **2 to import, 0 to add, 0 to change, 0 to destroy** — no drift, no conversion errors.
- Error paths: a non-existent target ID gives `Schedule Sync Target Not Found`; `no-colon` and `:rule_id` give `The import ID must be in the format: schedule_id:rule_id (got …)`; a well-formed ID for a rule that doesn't exist gives `Schedule Sync Rule Not Found`.
- Confirmed the documented `new_slack_user_group` caveat: keeping it in the configuration after import plans a destroy-and-create, which Terraform surfaces itself with "Warning: this will destroy the imported resource".

Also: `go build ./...`, `go generate ./...` (idempotent — only the two doc pages change), unit tests, and `golangci-lint run` (0 issues).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e73a31d-8eec-489a-9f59-0871324c0ce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e73a31d-8eec-489a-9f59-0871324c0ce6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

