### PR TITLE
Don't break applies when a scheduled user is deactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Stop `terraform apply` breaking when a user referenced by `email` or `slack_user_id` in the `incident_user` data source has been deactivated (e.g. offboarded). These lookups now include inactive users, so an already-scheduled user still resolves instead of failing the apply. The data source also exposes a computed `is_active` attribute and emits a plan-time warning (rather than an error) when it resolves an inactive user, nudging authors to move on-call responsibilities to an active user.
 - Document import support for `incident_schedule_sync_target` and `incident_schedule_sync_rule`, the last two resources whose registry pages had no import example. Targets import by their ID; rules are nested under a schedule in the API, so they import by `schedule_id:rule_id`.
 - Make importing either resource read it from the API up front, so the imported state is fully populated and an ID that doesn't exist fails with a clear message rather than silently importing an empty resource. An import ID with an empty schedule or rule ID is now rejected too, and an unexpected successful API response without a body returns a diagnostic instead of panicking.
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -26,4 +26,5 @@ Users all have a single base role, and can be assigned multiple custom roles. Th
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `is_active` (Boolean) Whether the user is active. False if the user has been deactivated (e.g. offboarded) or is not yet active.
 - `name` (String)

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -60508,6 +60508,67 @@
         ],
         "type": "object"
       },
+      "SchedulesListOverridesResultV2": {
+        "example": {
+          "overrides": [
+            {
+              "created_at": "2021-08-17T13:28:57.801578Z",
+              "end_at": "2021-08-17T13:28:57.801578Z",
+              "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "layer_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "schedule_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "start_at": "2021-08-17T13:28:57.801578Z",
+              "updated_at": "2021-08-17T13:28:57.801578Z",
+              "user": {
+                "email": "lisa@incident.io",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "name": "Lisa Karlin Curtis",
+                "role": "owner",
+                "slack_user_id": "U02AYNF2XJM"
+              }
+            }
+          ],
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          }
+        },
+        "properties": {
+          "overrides": {
+            "example": [
+              {
+                "created_at": "2021-08-17T13:28:57.801578Z",
+                "end_at": "2021-08-17T13:28:57.801578Z",
+                "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "layer_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "schedule_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "start_at": "2021-08-17T13:28:57.801578Z",
+                "updated_at": "2021-08-17T13:28:57.801578Z",
+                "user": {
+                  "email": "lisa@incident.io",
+                  "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                  "name": "Lisa Karlin Curtis",
+                  "role": "owner",
+                  "slack_user_id": "U02AYNF2XJM"
+                }
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ScheduleOverrideV2"
+            },
+            "type": "array"
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          }
+        },
+        "required": [
+          "overrides"
+        ],
+        "type": "object"
+      },
       "SchedulesListResultV2": {
         "example": {
           "pagination_meta": {
@@ -64894,6 +64955,7 @@
           ],
           "email": "lisa@incident.io",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "is_active": true,
           "name": "Lisa Karlin Curtis",
           "role": "owner",
           "seats": {
@@ -64930,6 +64992,11 @@
             "example": "01FCNDV6P870EA6S7TK1DSYDG0",
             "type": "string"
           },
+          "is_active": {
+            "description": "Whether the user is active. False if the user has been deactivated (e.g. offboarded) or is not yet active.",
+            "example": true,
+            "type": "boolean"
+          },
           "name": {
             "description": "Name of the user",
             "example": "Lisa Karlin Curtis",
@@ -64960,6 +65027,7 @@
           "base_role",
           "custom_roles",
           "seats",
+          "is_active",
           "role",
           "id",
           "name"
@@ -65088,6 +65156,7 @@
               ],
               "email": "lisa@incident.io",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "is_active": true,
               "name": "Lisa Karlin Curtis",
               "role": "owner",
               "seats": {
@@ -65121,6 +65190,7 @@
                 ],
                 "email": "lisa@incident.io",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "is_active": true,
                 "name": "Lisa Karlin Curtis",
                 "role": "owner",
                 "seats": {
@@ -65180,6 +65250,7 @@
             ],
             "email": "lisa@incident.io",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "is_active": true,
             "name": "Lisa Karlin Curtis",
             "role": "owner",
             "seats": {
@@ -90634,6 +90705,130 @@
       }
     },
     "/v2/schedule_overrides": {
+      "get": {
+        "description": "List the overrides on a schedule.\n\nOverrides are one-off changes layered on top of the rotations, such as someone\ncovering a colleague's shift. This returns the overrides themselves: to see the\neffective schedule with overrides already merged in, use the schedule entries\nendpoint instead.\n\nOverrides belong to a specific layer of a specific rotation, so you can narrow the\nresults with `rotation_id` and `layer_id`.\n\nArchived overrides are not returned.",
+        "operationId": "Schedules V2#ListOverrides",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "description": "The ID of the schedule to get overrides for.",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "query",
+            "name": "schedule_id",
+            "required": true,
+            "schema": {
+              "description": "The ID of the schedule to get overrides for.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "If set, only return overrides on this rotation.",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "query",
+            "name": "rotation_id",
+            "schema": {
+              "description": "If set, only return overrides on this rotation.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "If set, only return overrides on this layer.",
+            "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+            "in": "query",
+            "name": "layer_id",
+            "schema": {
+              "description": "If set, only return overrides on this layer.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "Integer number of records to return",
+            "example": 25,
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 25,
+              "description": "Integer number of records to return",
+              "example": 25,
+              "format": "int64",
+              "maximum": 250,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "An override's ID. This endpoint will return a list of overrides after this ID in relation to the API response order.",
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": "01FDAG4SAP5TYPT98WGR2N7W91"
+              }
+            },
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "description": "An override's ID. This endpoint will return a list of overrides after this ID in relation to the API response order.",
+              "example": "01FDAG4SAP5TYPT98WGR2N7W91",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "overrides": [
+                    {
+                      "created_at": "2021-08-17T13:28:57.801578Z",
+                      "end_at": "2021-08-17T13:28:57.801578Z",
+                      "id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "layer_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "rotation_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "schedule_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "start_at": "2021-08-17T13:28:57.801578Z",
+                      "updated_at": "2021-08-17T13:28:57.801578Z",
+                      "user": {
+                        "email": "lisa@incident.io",
+                        "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                        "name": "Lisa Karlin Curtis",
+                        "role": "owner",
+                        "slack_user_id": "U02AYNF2XJM"
+                      }
+                    }
+                  ],
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SchedulesListOverridesResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "ListOverrides Schedules V2",
+        "tags": [
+          "Schedules V2"
+        ],
+        "x-display-name": "List",
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Schedule Overrides V2",
+        "x-docs-resource-type": "ScheduleOverrideV2",
+        "x-rbac-scopes": [
+          "schedules.view"
+        ]
+      },
       "post": {
         "description": "Create a new schedule override.",
         "operationId": "Schedules V2#CreateOverride",
@@ -94296,6 +94491,18 @@
           },
           {
             "allowEmptyValue": true,
+            "description": "Include deactivated or not-yet-active users (defaults to false). Useful for resolving users who have since been offboarded.",
+            "example": true,
+            "in": "query",
+            "name": "include_inactive",
+            "schema": {
+              "description": "Include deactivated or not-yet-active users (defaults to false). Useful for resolving users who have since been offboarded.",
+              "example": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "allowEmptyValue": true,
             "description": "Integer number of records to return",
             "example": 25,
             "in": "query",
@@ -94349,6 +94556,7 @@
                       ],
                       "email": "lisa@incident.io",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "is_active": true,
                       "name": "Lisa Karlin Curtis",
                       "role": "owner",
                       "seats": {
@@ -94419,6 +94627,7 @@
                     ],
                     "email": "lisa@incident.io",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "is_active": true,
                     "name": "Lisa Karlin Curtis",
                     "role": "owner",
                     "seats": {

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -8622,6 +8622,12 @@ type SchedulesCreateScheduleSyncRuleResultV2 struct {
 	ScheduleSyncRule ScheduleSyncRuleV2 `json:"schedule_sync_rule"`
 }
 
+// SchedulesListOverridesResultV2 defines model for SchedulesListOverridesResultV2.
+type SchedulesListOverridesResultV2 struct {
+	Overrides      []ScheduleOverrideV2    `json:"overrides"`
+	PaginationMeta *PaginationMetaResultV2 `json:"pagination_meta,omitempty"`
+}
+
 // SchedulesListResultV2 defines model for SchedulesListResultV2.
 type SchedulesListResultV2 struct {
 	PaginationMeta *PaginationMetaResultWithTotalV2 `json:"pagination_meta,omitempty"`
@@ -9647,6 +9653,9 @@ type UserWithRolesV2 struct {
 	// Id Unique identifier of the user
 	Id string `json:"id"`
 
+	// IsActive Whether the user is active. False if the user has been deactivated (e.g. offboarded) or is not yet active.
+	IsActive bool `json:"is_active"`
+
 	// Name Name of the user
 	Name string `json:"name"`
 
@@ -10515,6 +10524,24 @@ type SchedulesV2ListScheduleEntriesParams struct {
 	EntryWindowEnd *time.Time `form:"entry_window_end,omitempty" json:"entry_window_end,omitempty"`
 }
 
+// SchedulesV2ListOverridesParams defines parameters for SchedulesV2ListOverrides.
+type SchedulesV2ListOverridesParams struct {
+	// ScheduleId The ID of the schedule to get overrides for.
+	ScheduleId string `form:"schedule_id" json:"schedule_id"`
+
+	// RotationId If set, only return overrides on this rotation.
+	RotationId *string `form:"rotation_id,omitempty" json:"rotation_id,omitempty"`
+
+	// LayerId If set, only return overrides on this layer.
+	LayerId *string `form:"layer_id,omitempty" json:"layer_id,omitempty"`
+
+	// PageSize Integer number of records to return
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// After An override's ID. This endpoint will return a list of overrides after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
+}
+
 // ScheduleSyncTargetsV2ListParams defines parameters for ScheduleSyncTargetsV2List.
 type ScheduleSyncTargetsV2ListParams struct {
 	// PageSize Integer number of records to return
@@ -10624,6 +10651,9 @@ type UsersV2ListParams struct {
 
 	// SlackUserId Filter by Slack user ID
 	SlackUserId *string `form:"slack_user_id,omitempty" json:"slack_user_id,omitempty"`
+
+	// IncludeInactive Include deactivated or not-yet-active users (defaults to false). Useful for resolving users who have since been offboarded.
+	IncludeInactive *bool `form:"include_inactive,omitempty" json:"include_inactive,omitempty"`
 
 	// PageSize Integer number of records to return
 	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
@@ -11551,6 +11581,9 @@ type ClientInterface interface {
 
 	// SchedulesV2ListScheduleEntries request
 	SchedulesV2ListScheduleEntries(ctx context.Context, params *SchedulesV2ListScheduleEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SchedulesV2ListOverrides request
+	SchedulesV2ListOverrides(ctx context.Context, params *SchedulesV2ListOverridesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SchedulesV2CreateOverrideWithBody request with any body
 	SchedulesV2CreateOverrideWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -14219,6 +14252,18 @@ func (c *Client) ManagedResourcesV2CreateManagedResource(ctx context.Context, bo
 
 func (c *Client) SchedulesV2ListScheduleEntries(ctx context.Context, params *SchedulesV2ListScheduleEntriesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSchedulesV2ListScheduleEntriesRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SchedulesV2ListOverrides(ctx context.Context, params *SchedulesV2ListOverridesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSchedulesV2ListOverridesRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -22259,6 +22304,115 @@ func NewSchedulesV2ListScheduleEntriesRequest(server string, params *SchedulesV2
 	return req, nil
 }
 
+// NewSchedulesV2ListOverridesRequest generates requests for SchedulesV2ListOverrides
+func NewSchedulesV2ListOverridesRequest(server string, params *SchedulesV2ListOverridesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/schedule_overrides")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "schedule_id", runtime.ParamLocationQuery, params.ScheduleId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if params.RotationId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "rotation_id", runtime.ParamLocationQuery, *params.RotationId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.LayerId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "layer_id", runtime.ParamLocationQuery, *params.LayerId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PageSize != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page_size", runtime.ParamLocationQuery, *params.PageSize); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.After != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "after", runtime.ParamLocationQuery, *params.After); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewSchedulesV2CreateOverrideRequest calls the generic SchedulesV2CreateOverride builder with application/json body
 func NewSchedulesV2CreateOverrideRequest(server string, body SchedulesV2CreateOverrideJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -24316,6 +24470,22 @@ func NewUsersV2ListRequest(server string, params *UsersV2ListParams) (*http.Requ
 
 		}
 
+		if params.IncludeInactive != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_inactive", runtime.ParamLocationQuery, *params.IncludeInactive); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.PageSize != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page_size", runtime.ParamLocationQuery, *params.PageSize); err != nil {
@@ -26255,6 +26425,9 @@ type ClientWithResponsesInterface interface {
 
 	// SchedulesV2ListScheduleEntriesWithResponse request
 	SchedulesV2ListScheduleEntriesWithResponse(ctx context.Context, params *SchedulesV2ListScheduleEntriesParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListScheduleEntriesResponse, error)
+
+	// SchedulesV2ListOverridesWithResponse request
+	SchedulesV2ListOverridesWithResponse(ctx context.Context, params *SchedulesV2ListOverridesParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListOverridesResponse, error)
 
 	// SchedulesV2CreateOverrideWithBodyWithResponse request with any body
 	SchedulesV2CreateOverrideWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SchedulesV2CreateOverrideResponse, error)
@@ -29699,6 +29872,28 @@ func (r SchedulesV2ListScheduleEntriesResponse) StatusCode() int {
 	return 0
 }
 
+type SchedulesV2ListOverridesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SchedulesListOverridesResultV2
+}
+
+// Status returns HTTPResponse.Status
+func (r SchedulesV2ListOverridesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SchedulesV2ListOverridesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type SchedulesV2CreateOverrideResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -33015,6 +33210,15 @@ func (c *ClientWithResponses) SchedulesV2ListScheduleEntriesWithResponse(ctx con
 		return nil, err
 	}
 	return ParseSchedulesV2ListScheduleEntriesResponse(rsp)
+}
+
+// SchedulesV2ListOverridesWithResponse request returning *SchedulesV2ListOverridesResponse
+func (c *ClientWithResponses) SchedulesV2ListOverridesWithResponse(ctx context.Context, params *SchedulesV2ListOverridesParams, reqEditors ...RequestEditorFn) (*SchedulesV2ListOverridesResponse, error) {
+	rsp, err := c.SchedulesV2ListOverrides(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSchedulesV2ListOverridesResponse(rsp)
 }
 
 // SchedulesV2CreateOverrideWithBodyWithResponse request with arbitrary body returning *SchedulesV2CreateOverrideResponse
@@ -37425,6 +37629,32 @@ func ParseSchedulesV2ListScheduleEntriesResponse(rsp *http.Response) (*Schedules
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest SchedulesListScheduleEntriesResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSchedulesV2ListOverridesResponse parses an HTTP response from a SchedulesV2ListOverridesWithResponse call
+func ParseSchedulesV2ListOverridesResponse(rsp *http.Response) (*SchedulesV2ListOverridesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SchedulesV2ListOverridesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SchedulesListOverridesResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/incident_user_data_source.go
+++ b/internal/provider/incident_user_data_source.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/samber/lo"
+
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
@@ -29,6 +32,7 @@ type IncidentUserDataSourceModel struct {
 	ID          types.String `tfsdk:"id" json:"id"`
 	Name        types.String `tfsdk:"name" json:"name"`
 	SlackUserID types.String `tfsdk:"slack_user_id" json:"slack_user_id"`
+	IsActive    types.Bool   `tfsdk:"is_active" json:"is_active"`
 }
 
 type IncidentUserRequest struct {
@@ -73,8 +77,11 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 		}
 		user = &result.JSON200.User
 	} else if !data.Email.IsNull() {
+		// Include inactive users so a scheduled user who has since been
+		// deactivated (offboarded) still resolves — otherwise the apply breaks.
 		result, err := i.client.UsersV2ListWithResponse(ctx, &client.UsersV2ListParams{
-			Email: data.Email.ValueStringPointer(),
+			Email:           data.Email.ValueStringPointer(),
+			IncludeInactive: lo.ToPtr(true),
 		})
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
@@ -90,7 +97,8 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 		user = &result.JSON200.Users[0]
 	} else if !data.SlackUserID.IsNull() {
 		result, err := i.client.UsersV2ListWithResponse(ctx, &client.UsersV2ListParams{
-			SlackUserId: data.SlackUserID.ValueStringPointer(),
+			SlackUserId:     data.SlackUserID.ValueStringPointer(),
+			IncludeInactive: lo.ToPtr(true),
 		})
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
@@ -109,6 +117,33 @@ func (i *IncidentUserDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
+	// Warn (but don't fail) when a config references an inactive user. We still
+	// resolve them so an apply doesn't break the moment someone is offboarded,
+	// but nudge authors to move on-call responsibilities to an active user. An
+	// inactive user is either deactivated (the common case, offboarding) or not
+	// yet active — the public API only exposes is_active, so the message covers
+	// both rather than asserting deactivation.
+	if !user.IsActive {
+		lookup := path.Root("email")
+		switch {
+		case !data.ID.IsNull():
+			lookup = path.Root("id")
+		case !data.SlackUserID.IsNull():
+			lookup = path.Root("slack_user_id")
+		}
+		resp.Diagnostics.AddAttributeWarning(
+			lookup,
+			"User is not active",
+			fmt.Sprintf(
+				"User %q (%s) is not active — they've either been deactivated "+
+					"(e.g. offboarded) or are not yet active. Referencing inactive users "+
+					"(e.g. in schedules or escalation paths) is discouraged — move these "+
+					"responsibilities to an active user.",
+				user.Name, user.Id,
+			),
+		)
+	}
+
 	modelResp := i.buildModel(*user)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &modelResp)...)
 }
@@ -119,6 +154,7 @@ func (i *IncidentUserDataSource) buildModel(userType client.UserWithRolesV2) *In
 		ID:          types.StringValue(userType.Id),
 		Name:        types.StringValue(userType.Name),
 		SlackUserID: types.StringPointerValue(userType.SlackUserId),
+		IsActive:    types.BoolValue(userType.IsActive),
 	}
 
 	return model
@@ -139,6 +175,10 @@ func (i *IncidentUserDataSource) Schema(ctx context.Context, req datasource.Sche
 			},
 			"slack_user_id": schema.StringAttribute{
 				Optional: true,
+			},
+			"is_active": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Whether the user is active. False if the user has been deactivated (e.g. offboarded) or is not yet active.",
 			},
 		},
 	}


### PR DESCRIPTION
Mirrors [incident-io/core#67418](https://github.com/incident-io/core/pull/67418) into the published provider (the same data-source change, now that the API has shipped).

## Problem

A deactivated (offboarded) user currently breaks `terraform apply`. The `incident_user` data source resolves `email` / `slack_user_id` lookups through the users **List**, which filters to active users only. So the moment a scheduled user is offboarded, that lookup returns not-found and the whole apply fails — even though lookup by `id` still works. Customers who reference users by email/Slack ID (the natural, readable way) are the ones who get burned.

## What this does

`incident_user` data source:
- **Resolves inactive users** — sets `include_inactive=true` on the email and `slack_user_id` lookups, so an already-scheduled user who's since been offboarded still resolves rather than failing the apply.
- **Exposes a computed `is_active` attribute** so config authors can see and branch on it.
- **Emits a plan-time warning** (warn, don't block) when it resolves an inactive user, nudging authors to move on-call responsibilities to an active user.

## Codegen

- Synced the public API schema (`internal/apischema/public-schema-v3-including-secret-endpoints.json`) and regenerated the client (`go generate ./internal/client`) — this adds the `include_inactive` List param and the `is_active` field on `UserWithRolesV2`.
- Regenerated docs via tfplugindocs (`is_active` now listed on the user data source page).

## Testing

- `go build ./...` and `go vet ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow data-source read-path change with backward-compatible behavior (more users resolve successfully); main caveat is configs may now plan with warnings for inactive references instead of failing.
> 
> **Overview**
> **`incident_user` email and `slack_user_id` lookups no longer fail after someone is offboarded.** Those list calls now pass `include_inactive=true`, so Terraform can still resolve users referenced in schedules and similar config instead of erroring on apply.
> 
> The data source adds a computed **`is_active`** attribute and surfaces a **plan-time warning** (not an error) when the resolved user is inactive, pointing authors toward moving on-call ownership to an active user. Lookup by `id` is unchanged aside from populating `is_active` and the same warning when applicable.
> 
> Provider docs and the changelog are updated; the public API schema and generated HTTP client are synced to pick up `include_inactive` on user list and `is_active` on user objects (plus unrelated schema additions such as schedule override listing in the client).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb3c2f3370f06b8ab61cc1daed413c1e1845ad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->