### PR TITLE
Changelog for v5.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
-- Add optional `permanent_member_user_ids` to `incident_schedule_sync_rule`, naming users who stay in the synced Slack user group regardless of who is on call. Omit the attribute to leave existing members unchanged on update; set it to `[]` to clear them. Requires the public API support from [incident-io/core#67760](https://github.com/incident-io/core/pull/67760).
+## v5.46.0
+
+- Add optional `permanent_member_user_ids` to `incident_schedule_sync_rule`, naming users who stay in the synced Slack user group regardless of who is on call. Omit the attribute to leave existing members unchanged on update; set it to `[]` to clear them.
 - Stop `terraform apply` breaking when a user referenced by `email` or `slack_user_id` in the `incident_user` data source has been deactivated (e.g. offboarded). These lookups now include inactive users, so an already-scheduled user still resolves instead of failing the apply. The data source also exposes a computed `is_active` attribute and emits a plan-time warning (rather than an error) when it resolves an inactive user, nudging authors to move on-call responsibilities to an active user.
 - Document import support for `incident_schedule_sync_target` and `incident_schedule_sync_rule`, the last two resources whose registry pages had no import example. Targets import by their ID; rules are nested under a schedule in the API, so they import by `schedule_id:rule_id`.
 - Make importing either resource read it from the API up front, so the imported state is fully populated and an ID that doesn't exist fails with a clear message rather than silently importing an empty resource. An import ID with an empty schedule or rule ID is now rejected too, and an unexpected successful API response without a body returns a diagnostic instead of panicking.


### PR DESCRIPTION
Cuts `v5.46.0` by moving everything under `## Unreleased` into a versioned heading. Minor bump, since the release adds new attributes (`permanent_member_user_ids`, `is_active`) rather than only fixing bugs.

Also drops the `incident-io/core#67760` link from the `permanent_member_user_ids` entry — it points at a private repo, so it's a dead end for anyone reading the changelog on the Terraform registry, and the API support it referred to is already live.

Once this merges, tag the merge commit on `master` to trigger the release workflow:

```sh
git tag -s v5.46.0 -m v5.46.0
git push origin v5.46.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only release housekeeping with no runtime or Terraform behavior changes.
> 
> **Overview**
> **Release notes:** Promotes the former `## Unreleased` entries into **`## v5.46.0`**, leaving **`## Unreleased`** empty for the next cycle.
> 
> For the `permanent_member_user_ids` bullet, removes the link to private repo **incident-io/core#67760** so registry readers aren’t pointed at an inaccessible reference; the feature description is unchanged.
> 
> No provider code or schema changes in this PR—only **CHANGELOG.md**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d38d873ea901eacbcade4666944f71728868d40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->