### PR TITLE
Bump Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/incident-io/terraform-provider-incident
 
-go 1.23.7
+go 1.26.5
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/internal/provider/incident_escalation_path_data_source.go
+++ b/internal/provider/incident_escalation_path_data_source.go
@@ -55,7 +55,7 @@ func (d *IncidentEscalationPathDataSource) getEscalationPathTypeID(ctx context.C
 	d.escalationPathTypeIDOnce.Do(func() {
 		typesResult, err := d.client.CatalogV3ListTypesWithResponse(ctx)
 		if err == nil && typesResult.StatusCode() >= 400 {
-			err = fmt.Errorf(string(typesResult.Body))
+			err = fmt.Errorf("%s", typesResult.Body)
 		}
 		if err != nil {
 			d.escalationPathTypeIDLookupErr = fmt.Errorf("unable to list catalog types, got error: %s", err)
@@ -431,7 +431,7 @@ func (d *IncidentEscalationPathDataSource) Read(ctx context.Context, req datasou
 			PageSize:      1,
 		})
 		if err == nil && entriesResult.StatusCode() >= 400 {
-			err = fmt.Errorf(string(entriesResult.Body))
+			err = fmt.Errorf("%s", entriesResult.Body)
 		}
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list catalog entries, got error: %s", err))

--- a/internal/provider/incident_schedule_data_source.go
+++ b/internal/provider/incident_schedule_data_source.go
@@ -57,7 +57,7 @@ func (d *IncidentScheduleDataSource) getScheduleTypeID(ctx context.Context) (str
 	d.scheduleTypeIDOnce.Do(func() {
 		typesResult, err := d.client.CatalogV3ListTypesWithResponse(ctx)
 		if err == nil && typesResult.StatusCode() >= 400 {
-			err = fmt.Errorf(string(typesResult.Body))
+			err = fmt.Errorf("%s", typesResult.Body)
 		}
 		if err != nil {
 			d.scheduleTypeIDLookupError = fmt.Errorf("unable to list catalog types, got error: %s", err)
@@ -119,7 +119,7 @@ func (d *IncidentScheduleDataSource) Read(ctx context.Context, req datasource.Re
 			PageSize:      1,
 		})
 		if err == nil && entriesResult.StatusCode() >= 400 {
-			err = fmt.Errorf(string(entriesResult.Body))
+			err = fmt.Errorf("%s", entriesResult.Body)
 		}
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list catalog entries, got error: %s", err))


### PR DESCRIPTION
## What

Bumps the `go` directive in `go.mod` from `1.23.7` to `1.26.5`.

Every CI job resolves its toolchain with `go-version-file: 'go.mod'`, so `go.mod` is the single source of truth — no workflow changes needed.

## Why the extra changes

Raising the language version past 1.24 turns on `go vet`'s printf check for **non-constant format strings**. `go test` runs that vet subset, so it breaks the build rather than just warning.

That surfaced four pre-existing calls handing a raw response body to `fmt.Errorf` as the *format* string:

- `internal/provider/incident_escalation_path_data_source.go:58` and `:434`
- `internal/provider/incident_schedule_data_source.go:60` and `:122`

```diff
-err = fmt.Errorf(string(typesResult.Body))
+err = fmt.Errorf("%s", typesResult.Body)
```

Beyond appeasing vet, this is a small genuine fix: an API response body containing a literal `%s` or `%!` would previously have rendered as a mangled error message. (`Body` is `[]byte`, so `%s` handles it directly and the `string()` conversion goes away.)

These four were latent on `master` — invisible at `go 1.23.7`, and they'd have broken the next Go bump for any reason.

## Context

Split out of #411 (the `kin-openapi` 0.132.0 → 0.144.0 dependabot bump), which failed CI for **two** unrelated reasons. This PR fixes the second one only.

The first is a genuine incompatibility and is *not* addressed here: kin-openapi 0.144.0 changed `Discriminator.Mapping` from `map[string]string` to `map[string]MappingRef`, which no longer compiles against the pinned `oapi-codegen v2.4.1` used by `go generate` to build `internal/client`. The latest `oapi-codegen` (v2.8.0) still requires `kin-openapi v0.142.0`, so no released version supports 0.144.0 yet — #411 needs to wait for upstream regardless of this PR.

## Testing

Locally on `go1.26.5`:

- `go build -v .` — passes
- `go vet ./...` — clean (was 4 errors)
- `golangci-lint run` — 0 issues
- `go generate ./...` — succeeds, produces no diff (the `generate` job's check)

Acceptance tests need `INCIDENT_API_KEY`, so they're left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain bump plus narrow error-formatting fixes in data source HTTP error handling; no auth, persistence, or API contract changes.
> 
> **Overview**
> **Raises the module Go version from `1.23.7` to `1.26.5`**, so CI and local builds pick up the newer toolchain via `go-version-file: go.mod`.
> 
> With Go 1.24+, **`go vet` flags non-constant format strings in `fmt.Errorf`**, which breaks `go test` until fixed. Four catalog API error branches in the **escalation path** and **schedule** data sources are updated from `fmt.Errorf(string(body))` to **`fmt.Errorf("%s", body)`**, so vet passes and API error bodies with `%` sequences are not misinterpreted as format directives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c97ca435d74347e6ece835dca36be91d0581e906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->