### PR TITLE
Bump GitHub Actions: checkout v7, setup-go v7, import-gpg v7, setup-terraform v4.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,16 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # v5.3.0
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-go@v6.2.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@v7.0.0
         with:
           go-version-file: 'go.mod'
       - run: go mod download
@@ -43,12 +43,12 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-go@v6.2.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@v7.0.0
         with:
           go-version-file: 'go.mod'
       # Required to `terraform fmt` the generated files
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
       - run: go generate ./...
@@ -79,11 +79,11 @@ jobs:
         terraform:
           - '1.2.*'
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-go@v6.2.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@v7.0.0
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false


### PR DESCRIPTION
> **Stacked on #417** (which is itself stacked on #416). Base is `deps-crypto-net-circl`, so the diff here shows only the workflow changes. Nothing in this PR touches `go.mod`, so it's independent in content — happy to retarget it straight at `master` if you'd rather merge it first.

Groups four dependabot PRs. All four edit the same two workflow files, so merged separately each one conflicts with the last:

| PR | Action | From | To |
|---|---|---|---|
| #396 | `actions/checkout` | 5.0.0 | 7.0.0 |
| #397 | `actions/setup-go` | 6.2.0 | 7.0.0 |
| #395 | `crazy-max/ghaction-import-gpg` | 5.3.0 | 7.0.0 |
| #394 | `hashicorp/setup-terraform` | 4.0.0 | 4.0.1 |

I verified every SHA pin against the GitHub API rather than trusting the diff — each one resolves to the tag its trailing comment claims:

```
OK  actions/checkout               v7.0.0 -> 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
OK  actions/setup-go              v7.0.0 -> b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
OK  crazy-max/ghaction-import-gpg v7.0.0 -> 2dc316deee8e90f13e1a351ab510b4d5bc0c82cd
OK  hashicorp/setup-terraform     v4.0.1 -> dfe3c3f87815947d99a8997f908cb6525fc44e9e
```

## What's excluded, and why

**#247 (goreleaser-action 4.2.0 → 6.4.0) is deliberately left out.** It isn't just a pin bump — it also changes `version: "~> v1"` to `"~> v2"`. Our `.goreleaser.yml` is a v1-style config with no `version:` key, which goreleaser v2 rejects outright, so merging #247 as-is would break releases. It needs a config migration and deserves its own PR.

## Coverage caveat

The `test.yml` changes are exercised by this PR's own CI run — checkout v7, setup-go v7 and setup-terraform v4.0.1 all run here.

The `release.yml` changes are **not**. That workflow only triggers on `v*` tag pushes, so the `setup-go` SHA bump and the `ghaction-import-gpg` v5→v7 bump in it are unverified until the next release. `ghaction-import-gpg` crossing two majors is the one I'd keep an eye on, since a failure there means an unsigned or failed release rather than a red check.

## Not changed

`test.yml` refers to `setup-go` by bare tag while `release.yml` pins by SHA. Dependabot maintains both forms and normalising them isn't this PR's job, so I left the inconsistency alone.

Once merged, #396, #397, #395 and #394 can all be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin bumps with no runtime or provider code changes; the main residual risk is the unverified release workflow path until the next tagged release, especially the two-major `ghaction-import-gpg` upgrade.
> 
> **Overview**
> Bumps pinned GitHub Actions versions in **`release.yml`** and **`test.yml`** so four Dependabot updates can land in one change without merge conflicts.
> 
> In **`test.yml`**, `actions/checkout` moves to **v7.0.0**, `actions/setup-go` to **v7.0.0**, and `hashicorp/setup-terraform` to **v4.0.1** across the build, generate, and acceptance-test jobs. In **`release.yml`**, checkout and setup-go get the same major bumps (with SHA pins), and **`crazy-max/ghaction-import-gpg`** jumps **v5.3.0 → v7.0.0**. **`goreleaser/goreleaser-action`** is unchanged (a separate v2 migration was intentionally excluded).
> 
> The test workflow changes are exercised by normal PR CI; release-only steps (GPG import and pinned setup-go there) only run on **`v*`** tag pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4221dc19d260bce7d24ea6ab87b5749429f2cd2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->