### PR TITLE
Bump kin-openapi to 0.144.0 and fix maintenance window test panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
-	github.com/getkin/kin-openapi v0.142.0
+	github.com/getkin/kin-openapi v0.144.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/terraform-plugin-docs v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUork
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/getkin/kin-openapi v0.142.0 h1:izj0vBdFprMhitfzaX8sTqztsEQyvwhssBoB6n8NO7w=
-github.com/getkin/kin-openapi v0.142.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
+github.com/getkin/kin-openapi v0.144.0 h1:hIRcTH+KjLfkLpYU6bSSfdFpi0fZi1fp+hSPi4aQu9Y=
+github.com/getkin/kin-openapi v0.144.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=

--- a/internal/provider/incident_maintenance_window_resource_test.go
+++ b/internal/provider/incident_maintenance_window_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/incident-io/terraform-provider-incident/internal/client"
 )
 
-func testAccMaintenanceWindowLeadUserID() string {
+func testAccMaintenanceWindowLeadUserID(t *testing.T) string {
 	if id := os.Getenv("TF_ACC_LEAD_USER_ID"); id != "" {
 		return id
 	}
@@ -28,22 +28,26 @@ func testAccMaintenanceWindowLeadUserID() string {
 
 	c, err := client.New(context.Background(), apiKey, endpoint, "test")
 	if err != nil {
-		panic("error creating client to fetch lead user ID: " + err.Error())
+		t.Fatalf("error creating client to fetch lead user ID: %s", err)
 	}
 
 	result, err := c.UsersV2ListWithResponse(context.Background(), &client.UsersV2ListParams{})
 	if err != nil {
-		panic("error listing users: " + err.Error())
+		t.Fatalf("error listing users: %s", err)
 	}
 	if result.JSON200 == nil || len(result.JSON200.Users) == 0 {
-		panic("no users found in test workspace")
+		t.Fatal("no users found in test workspace")
 	}
 
 	return result.JSON200.Users[0].Id
 }
 
 func TestAccIncidentMaintenanceWindowResource(t *testing.T) {
-	model := maintenanceWindowDefault()
+	// Skip before building the model, which needs a live API call to look up a
+	// lead user ID.
+	testAccPreCheck(t)
+
+	model := maintenanceWindowDefault(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -108,7 +112,11 @@ func TestAccIncidentMaintenanceWindowResource(t *testing.T) {
 }
 
 func TestAccIncidentMaintenanceWindowResourceWithOptionalFields(t *testing.T) {
-	model := maintenanceWindowDefault()
+	// Skip before building the model, which needs a live API call to look up a
+	// lead user ID.
+	testAccPreCheck(t)
+
+	model := maintenanceWindowDefault(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -260,7 +268,7 @@ resource "incident_maintenance_window" "example" {
 }
 `))
 
-func maintenanceWindowDefault() maintenanceWindowModel {
+func maintenanceWindowDefault(t *testing.T) maintenanceWindowModel {
 	// Use dates in the future to avoid issues with validation
 	startAt := time.Now().Add(24 * time.Hour).Truncate(time.Second).UTC().Format(time.RFC3339)
 	endAt := time.Now().Add(28 * time.Hour).Truncate(time.Second).UTC().Format(time.RFC3339)
@@ -269,7 +277,7 @@ func maintenanceWindowDefault() maintenanceWindowModel {
 		Name:          "Test Maintenance Window",
 		StartAt:       startAt,
 		EndAt:         endAt,
-		LeadUserID:    testAccMaintenanceWindowLeadUserID(),
+		LeadUserID:    testAccMaintenanceWindowLeadUserID(t),
 		ShowInSidebar: true,
 	}
 }


### PR DESCRIPTION
Supersedes #411, which cannot go green.

## kin-openapi 0.144.0

Same `go.mod` / `go.sum` change as the Dependabot PR — `github.com/getkin/kin-openapi` 0.142.0 → 0.144.0.

## Why #411 failed

`TestAccIncidentMaintenanceWindowResource` (and its `WithOptionalFields` sibling) built their model *before* calling `resource.Test`:

```go
model := maintenanceWindowDefault()   // chains into a live GET /v2/users
resource.Test(t, resource.TestCase{
    PreCheck: func() { testAccPreCheck(t) },   // too late to prevent it
```

`maintenanceWindowDefault` calls `testAccMaintenanceWindowLeadUserID`, which hits the API to find a lead user ID and **panics** on failure. The `PreCheck` skip runs inside `resource.Test`, so it never gets the chance to fire.

Dependabot PRs run under Dependabot's secret scope (`Secret source: Dependabot` in the logs), so `secrets.INCIDENT_API_KEY` is empty. The call 401s and panics, which kills the whole `internal/provider` test binary:

```
--- FAIL: TestAccIncidentMaintenanceWindowResource (0.26s)
panic: error listing users: Get "https://api.incident.io/v2/users": status 401:
      "code": "missing_authorization_material"
FAIL	github.com/incident-io/terraform-provider-incident/internal/provider	7.071s
make: *** [Makefile:10: testacc] Error 1
```

Every other acceptance test skipped cleanly with `No INCIDENT_API_KEY environment variable set` — only this one brought the package down. Introduced in 3417a5c (~4 months ago); master is green because pushes to master *do* get the secret. This affects **every** Dependabot PR and every fork PR, not just this bump.

## The fix

- Call `testAccPreCheck(t)` at the top of both tests, so they skip before any API call — matching every other acceptance test in the package.
- Replace the `panic`s in `testAccMaintenanceWindowLeadUserID` with `t.Fatalf`, so a transient API error fails that one test instead of the entire package.

## Testing

Reproduced the CI condition locally (no API key, `TF_ACC=1`):

```
=== RUN   TestAccIncidentMaintenanceWindowResource
    provider_test.go:27: No INCIDENT_API_KEY environment variable set, skipping
--- SKIP: TestAccIncidentMaintenanceWindowResource (0.00s)
=== RUN   TestAccIncidentMaintenanceWindowResourceWithOptionalFields
    provider_test.go:27: No INCIDENT_API_KEY environment variable set, skipping
--- SKIP: TestAccIncidentMaintenanceWindowResourceWithOptionalFields (0.00s)
=== RUN   TestAccIncidentMaintenanceWindowResourceInvalidTimestamp
    provider_test.go:27: No INCIDENT_API_KEY environment variable set, skipping
--- SKIP: TestAccIncidentMaintenanceWindowResourceInvalidTimestamp (0.00s)
PASS
```

Skips cleanly instead of panicking. Note I verified the maintenance-window tests specifically, not the full package run — and the *positive* path (tests actually running with a valid key) is exercised by CI on this PR, which does have the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency patch bump plus test-only ordering and error handling; no provider runtime behavior changes.
> 
> **Overview**
> Bumps **`github.com/getkin/kin-openapi`** from **0.142.0** to **0.144.0** in `go.mod` / `go.sum`.
> 
> Fixes maintenance window acceptance tests that could **panic the whole `internal/provider` package** when `INCIDENT_API_KEY` is missing (e.g. Dependabot or fork CI). **`TestAccIncidentMaintenanceWindowResource`** and **`WithOptionalFields`** now call **`testAccPreCheck(t)`** before **`maintenanceWindowDefault(t)`**, so they skip like other acc tests instead of hitting **`GET /v2/users`** during model setup. **`testAccMaintenanceWindowLeadUserID`** and **`maintenanceWindowDefault`** take **`*testing.T`** and use **`t.Fatalf` / `t.Fatal`** instead of **`panic`** on client or API errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1054d7ec47079698ea135d3a83ca7c459fee3fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->