### PR TITLE
Test acceptance tests against Terraform 1.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,9 +75,9 @@ jobs:
       # Running in parallel will cause each test to collide on resource names.
       max-parallel: 1
       matrix:
-        # We only want to support 1.2.* for now.
         terraform:
           - '1.2.*'
+          - '1.15.*'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@v7.0.0


### PR DESCRIPTION
## What's changed

Adds `1.15.*` to the acceptance test matrix alongside `1.2.*`, so we catch breakage on current Terraform as well as the oldest version we support.

```yaml
      matrix:
        terraform:
          - '1.2.*'
          - '1.15.*'
```

## On concurrency

The acceptance tests share a single incident.io account, so two of these jobs running at once collide on resource names. That's already covered on master, and adding a matrix entry doesn't weaken it:

- `max-parallel: 1` serialises the matrix **within** a run — `1.2.*` finishes completely before `1.15.*` starts.
- The job-level `acceptance-tests` concurrency group with `cancel-in-progress: false` queues **across** runs.

So no extra locking was needed. Worth noting `timeout-minutes: 15` applies per matrix job rather than to the pair, so doubling the matrix doesn't squeeze the time budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow matrix change only; no provider runtime or security logic is modified.
> 
> **Overview**
> **Acceptance tests** now run against **Terraform `1.15.*`** in addition to **`1.2.*`**, so CI covers both the minimum supported CLI and a current release.
> 
> The workflow matrix gains the extra version; **`max-parallel: 1`** and the **`acceptance-tests`** concurrency group are unchanged, so matrix jobs still run one at a time and avoid shared-account name collisions. The comment that limited testing to 1.2.x was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c34931344677dc00c23ee85030e358d35402b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->