### PR TITLE
Changelog for v5.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
+## v5.46.1
+
 - Fix `Provider produced inconsistent result after apply` on `incident_workflow` when a workflow step gains new parameters, which failed the apply with `.steps[0].param_bindings: new element N has appeared`. Step `param_bindings` are positional, so when a step grows the API pads the bindings out to the new parameter count and creating a workflow returned more bindings than were configured. The provider now drops those trailing empty bindings. Bindings that carry data are kept, so a genuine change made outside Terraform still shows up as a diff.
+- Return a diagnostic instead of panicking when the incident.io API client cannot be created, for example when `INCIDENT_ENDPOINT` is set to an invalid URL. Previously this crashed the provider with a raw Go stack trace; it now reports `Unable to Create incident.io API Client` with the underlying error, like every other failure in the provider.
 
 ## v5.46.0
 


### PR DESCRIPTION
Cuts `v5.46.1` by moving everything under `## Unreleased` into a versioned heading, leaving `## Unreleased` empty for the next cycle.

**Patch bump**, not a minor: everything since `v5.46.0` either fixes a bug or is dependency/CI housekeeping. Nothing adds an attribute or resource, which matches how `v5.44.1`, `v5.44.2`, `v5.43.1` and `v5.41.1` were cut.

Also adds an entry for #331, which merged after `v5.46.0` without one. It swapped a panic in provider `Configure` for a diagnostic — user-facing, so it belongs in the release notes.

Everything else in the 17 commits since `v5.46.0` is dependency bumps, Go/Actions version bumps, and a docs improvement (#312), none of which this changelog tracks.

Once this merges, tag the merge commit on `master` to trigger the release workflow:

```sh
git tag -s v5.46.1 -m v5.46.1
git push origin v5.46.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no runtime or schema changes in this diff.
> 
> **Overview**
> Cuts **v5.46.1** in `CHANGELOG.md` by adding a `## v5.46.1` section and leaving `## Unreleased` empty for the next cycle.
> 
> The new section documents two patch fixes shipped since **v5.46.0**: resolving inconsistent apply results on `incident_workflow` when steps gain padded empty `param_bindings`, and returning a Terraform diagnostic instead of panicking when the incident.io API client cannot be created (e.g. invalid `INCIDENT_ENDPOINT`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af85b1624121cb4d36e30cf5c6c40cd25b332244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->