### PR TITLE
Fix goreleaser build by ignoring windows/arm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,9 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      # The windows/arm (32-bit) port was removed in Go 1.25.
+      - goos: windows
+        goarch: arm
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
   - format: zip


### PR DESCRIPTION
## What

Adds `windows/arm` to the goreleaser build matrix `ignore` list.

## Why

The v5.46.1 release failed with:

```
⨯ release failed after 5m38s  error=failed to build for windows_arm_6: exit status 2: go: unsupported GOOS/GOARCH pair windows/arm
```

Go 1.25 removed the `windows/arm` (32-bit ARM on Windows) port, and this repo is on Go 1.26.5. goreleaser builds the full `goos` × `goarch` cross product, so `windows/arm` was still being attempted.

Adding it to `ignore` subtracts that one pair from the matrix. `windows/arm64` is unaffected — only the 32-bit port was removed — and `linux/arm` / `freebsd/arm` keep building, which is why this is scoped to the pair rather than dropping `arm` from `goarch` wholesale.

No release artifacts were published for v5.46.1 (the build failed before the publish stage), so that tag has been deleted and will be re-cut on top of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-configuration only; no runtime or application code changes.
> 
> **Overview**
> **Fixes failed releases** on Go 1.26 by excluding the `windows/arm` (32-bit Windows ARM) target from the GoReleaser build matrix.
> 
> Go 1.25 dropped that `GOOS`/`GOARCH` pair, so the full `goos` × `goarch` matrix was still trying to build `windows_arm_6` and failing with `unsupported GOOS/GOARCH pair windows/arm`. The change adds that pair to `ignore` with a short comment; **`windows/arm64` and other `arm` builds (e.g. Linux) are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531703b4b8c646e0b957dd89ba66c7a50d324404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->