### PR TITLE
Upgrade goreleaser to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           args: release --clean
-          version: "~> v1"
+          version: "~> v2"
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
@@ -33,7 +34,7 @@ builds:
         goarch: arm
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-  - format: zip
+  - formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   extra_files:


### PR DESCRIPTION
Supersedes #247.

## What

- `goreleaser-action` v4.2.0 → v6.4.0, and goreleaser itself `~> v1` → `~> v2`
- `.goreleaser.yml`: add the now-mandatory `version: 2`, and migrate `archives.format: zip` → `archives.formats: [zip]`

## Why

goreleaser v1 is end of life. It's also the direct cause of the v5.46.1 release failure: v1's hardcoded list of valid build targets still contains `windows/arm`, so it kept trying to build a port that Go 1.25 removed. v2's list has no such entry.

Dependabot opened #247 for the action bump a year ago, but it only touched the workflow. Merging it as-is would have swapped the "unsupported GOOS/GOARCH pair" failure for a config failure, because v2 rejects the current config:

```
• only version: 2 configuration files are supported, yours is version: 0
• DEPRECATED: archives.format should not be used anymore
⨯ check failed
```

Neither problem shows up in PR CI, since the release workflow only runs on `v*` tag pushes — the first test would be the next release. Hence the local verification below.

## Verification

`goreleaser check` passes clean, no deprecation warnings:

```
• checking                                  path=.goreleaser.yml
• 1 configuration file(s) validated
```

A full `release --snapshot --clean --skip=sign,publish` also succeeds, producing **13 archives** — the same set as the real v5.46.1 release, with no `windows_arm`. `SHA256SUMS` still includes the `manifest.json` extra file, and archive contents match the v1-built release exactly:

```
# v2 snapshot                          # released v5.46.1 (v1-built)
CHANGELOG.md                           CHANGELOG.md
LICENSE                                LICENSE
README.md                              README.md
terraform-provider-incident_v5.46.1…   terraform-provider-incident_v5.46.1
```

## Note

The `windows/arm` `ignore` entry added in #434 is now redundant, since v2 filters the pair out itself. It's kept as documentation of why the pair is excluded — happy to drop it if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only run on version tag pushes but directly control signed release artifacts and publishing; misconfiguration would surface at the next release, not in normal PR CI.
> 
> **Overview**
> Upgrades the **tag-triggered release pipeline** from GoReleaser v1 to v2 so releases stay supported and avoid building removed targets like `windows/arm` under Go 1.25.
> 
> In `.github/workflows/release.yml`, `goreleaser-action` moves to **v6.4.0** and the pinned GoReleaser CLI becomes **`~> v2`**. In `.goreleaser.yml`, the config declares **`version: 2`** and archives use **`formats: [zip]`** instead of the deprecated `format: zip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff53e0e028bd77c3de837e95fb857b43688be7a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->