### PR TITLE
Changelog for v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 ## Unreleased
 
+## v6.0.0
+
 #### Breaking changes
 
 - **Terraform 1.14 is now the minimum supported version.** HashiCorp only patch the latest two Terraform minors, and until now this provider's acceptance tests ran solely against Terraform 1.2, which has been end-of-life since 2022. We now test against the Terraform versions still receiving patches, and no longer test anything older. Nothing enforces this at install time — the provider still advertises protocol 6, so it may keep working on older CLIs — but we won't be fixing issues that only reproduce below 1.14. Pin to v5.x if you need to stay on an older Terraform.
 
 #### Other changes
 
-- Add `incident_schedule_beta` and `incident_schedule_rotation_beta` resources, along with matching data sources, for the v3 schedules API. A schedule and its rotations are now separate resources, so adding or editing one rotation no longer means rewriting the whole schedule, and each rotation can be managed on its own. `incident_schedule_beta` covers the schedule itself — name, timezone, owning teams and public holidays — and starts with no rotations, so nobody is on call until one is added. `incident_schedule_rotation_beta` covers the people in a rotation, how often they hand over, how many are on call at once, and optional working hours.
-- These resources are beta. They are named `_beta` because their schemas may change in ways that aren't backwards compatible while we settle the design, and they're versioned separately from the rest of the provider for that reason. The existing `incident_schedule` resource and data source are unchanged, continue to use the v2 API, and are not deprecated.
+- Add beta support for the v3 schedules API, as `incident_schedule_beta` and `incident_schedule_rotation_beta` resources with matching data sources. A schedule and its rotations are separate resources, so a rotation can be managed on its own. Note that a new `incident_schedule_beta` has no rotations, so nobody is on call until one is added.
+- These resources are beta: their schemas may change in ways that aren't backwards compatible while we settle the design, which is why they're named `_beta` and versioned separately from the rest of the provider. The existing `incident_schedule` resource and data source are unchanged, continue to use the v2 API, and are not deprecated.
 - The provider is now tested directly against OpenTofu on every change, rather than relying on Terraform compatibility to cover it.
+- Keep `Computed` attributes nested inside collections planning as unknown rather than null when a new element is added, which the update to `terraform-plugin-framework` 1.19.0 would otherwise have changed. Without this, adding an entry to an existing `incident_catalog_entries`, a node to an `incident_escalation_path`, or a template to an `incident_alert_source` could fail the apply with `Provider produced inconsistent result after apply`.
 
 ## v5.46.1
 


### PR DESCRIPTION
Cuts `v6.0.0` by moving everything under `## Unreleased` into a versioned heading. Major bump, since Terraform 1.14 becomes the minimum supported version.

## Also in here

- **The beta schedules entries are trimmed** to the shape of the change, the beta caveat, and the fact that a new schedule has no rotations so nobody is on call until one is added. The per-attribute tour of each resource is on the registry pages.
- **Adds an entry for the plan-modifier change** that came in with the framework bump. It reads as internal, but it's what stops adding an entry to an existing `incident_catalog_entries` (or a node to an escalation path, or a template to an alert source) failing the apply with `Provider produced inconsistent result after apply`.

The goreleaser v2 upgrade and the `lo` bump are left out, as neither changes anything for someone installing `v6.0.0`.

## Tests

`CHANGELOG.md` is in `paths-ignore`, so the Tests workflow is skipped. No required status checks on master, so that doesn't block the merge.

## After merging

Per RELEASE.md:

```
git checkout master && git pull
git tag v6.0.0
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CHANGELOG edit with no runtime or provider behavior changes in this diff.
> 
> **Overview**
> **Cuts `v6.0.0`** by moving prior **Unreleased** notes into a versioned section and leaving **Unreleased** empty for the next cycle.
> 
> The **v6.0.0** notes document the **major** bump: **Terraform 1.14** as the stated minimum supported version (with guidance to stay on **v5.x** for older CLIs). **Other changes** are tightened for release: beta **v3 schedules** (`incident_schedule_beta` / `incident_schedule_rotation_beta` and data sources), direct **OpenTofu** testing, and a new bullet explaining **plan modifiers** that keep nested **Computed** collection fields **unknown** (not **null**) when elements are added—avoiding **Provider produced inconsistent result after apply** on resources like **`incident_catalog_entries`**, **`incident_escalation_path`**, and **`incident_alert_source`** after the **terraform-plugin-framework** 1.19.0 bump.
> 
> Beta schedules copy is **shortened** (less per-attribute detail; registry docs carry the rest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645b592080caf4ac92c466337f56330dcd79e145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->