### PR TITLE
Document import blocks on every resource page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Warn at plan time when an edit to an `incident_schedule_rotation_beta` lands on a change already scheduled on that rotation: a rollout replaces that change, and an edit without one rewrites it rather than changing who is on call now. Easy to miss after importing a rotation.
+- Document `import` blocks on every resource's registry page, above the existing `terraform import` command. Config-driven import can be reviewed and applied like any other change, rather than needing a command run by hand.
 
 ## v6.0.0
 

--- a/docs/resources/alert_attribute.md
+++ b/docs/resources/alert_attribute.md
@@ -56,6 +56,17 @@ resource "incident_alert_attribute" "severity" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import an alert attribute using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_alert_attribute.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/alert_route.md
+++ b/docs/resources/alert_route.md
@@ -1649,6 +1649,22 @@ Optional:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import an alert route using its ID. Replace the ID with a real ID from your
+# incident.io organization.
+#
+# The provider automatically detects which configuration format to import:
+# alert routes where the current format is available import using it
+# (grouping_config), and routes where it isn't available yet import using the
+# deprecated format.
+import {
+  to = incident_alert_route.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -543,6 +543,17 @@ Optional:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import an alert source using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_alert_source.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/catalog_entries.md
+++ b/docs/resources/catalog_entries.md
@@ -263,6 +263,17 @@ Optional:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import catalog entries using the catalog_type_id
+# Replace the ID with a real catalog type ID from your incident.io organization
+import {
+  to = incident_catalog_entries.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/catalog_entry.md
+++ b/docs/resources/catalog_entry.md
@@ -136,6 +136,17 @@ Optional:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a catalog entry using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_catalog_entry.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/catalog_type.md
+++ b/docs/resources/catalog_type.md
@@ -85,6 +85,17 @@ resource "incident_catalog_type" "service_tier" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a catalog type using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_catalog_type.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/catalog_type_attribute.md
+++ b/docs/resources/catalog_type_attribute.md
@@ -125,6 +125,17 @@ NOTE: When enabled, you should use the `managed_attributes` argument on either `
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a catalog type attribute using the format catalog_type_id:attribute_id
+# Replace the IDs with real IDs from your incident.io organization
+import {
+  to = incident_catalog_type_attribute.example
+  id = "01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/custom_field.md
+++ b/docs/resources/custom_field.md
@@ -76,6 +76,17 @@ When this filtering field is set on an incident, the options for this custom fie
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a custom field using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_custom_field.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/custom_field_option.md
+++ b/docs/resources/custom_field_option.md
@@ -62,6 +62,17 @@ resource "incident_custom_field_option" "teams" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a custom field option using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_custom_field_option.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -9002,6 +9002,17 @@ Required:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import an escalation path using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_escalation_path.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/incident_role.md
+++ b/docs/resources/incident_role.md
@@ -50,6 +50,17 @@ resource "incident_incident_role" "comms" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import an incident role using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_incident_role.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -200,6 +200,17 @@ Optional:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a maintenance window using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_maintenance_window.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -201,6 +201,17 @@ Required:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a schedule using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_schedule.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/schedule_beta.md
+++ b/docs/resources/schedule_beta.md
@@ -155,6 +155,17 @@ Required:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a schedule using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_schedule_beta.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/schedule_rotation_beta.md
+++ b/docs/resources/schedule_rotation_beta.md
@@ -208,6 +208,18 @@ Required:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a rotation using its schedule's ID and its own ID, separated by a colon.
+# A rotation is only addressable through the schedule that holds it.
+# Replace both IDs with real ones from your incident.io organization.
+import {
+  to = incident_schedule_rotation_beta.example
+  id = "01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/schedule_sync_rule.md
+++ b/docs/resources/schedule_sync_rule.md
@@ -89,6 +89,19 @@ Omitting the attribute leaves existing permanent members unchanged on update. Se
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a schedule sync rule using the format schedule_id:rule_id
+# Sync rules belong to a schedule, so both IDs are required: use the
+# ListScheduleSyncRules API endpoint for a schedule to find its rules' IDs
+# Replace the IDs with real IDs from your incident.io organization
+import {
+  to = incident_schedule_sync_rule.example
+  id = "01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/schedule_sync_target.md
+++ b/docs/resources/schedule_sync_target.md
@@ -65,6 +65,22 @@ Optional:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a schedule sync target using its ID
+# Replace the ID with a real ID from your incident.io organization
+#
+# The Slack user group of an imported target already exists, so the imported
+# configuration should point at it with slack_user_group_id (the group's Slack
+# ID, which is in state after the import). new_slack_user_group asks us to
+# create a group, so leaving it set plans a replacement of the target
+import {
+  to = incident_schedule_sync_target.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/severity.md
+++ b/docs/resources/severity.md
@@ -52,6 +52,17 @@ resource "incident_severity" "trivial" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a severity using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_severity.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/status.md
+++ b/docs/resources/status.md
@@ -50,6 +50,17 @@ resource "incident_status" "clean_up" {
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a status using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_status.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -447,6 +447,17 @@ Required:
 
 Import is supported using the following syntax:
 
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
+
+```terraform
+# Import a workflow using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_workflow.example
+  id = "01ABC123DEF456GHI789JKL"
+}
+```
+
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell

--- a/examples/resources/incident_alert_attribute/import-by-string-id.tf
+++ b/examples/resources/incident_alert_attribute/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import an alert attribute using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_alert_attribute.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_alert_route/import-by-string-id.tf
+++ b/examples/resources/incident_alert_route/import-by-string-id.tf
@@ -1,0 +1,11 @@
+# Import an alert route using its ID. Replace the ID with a real ID from your
+# incident.io organization.
+#
+# The provider automatically detects which configuration format to import:
+# alert routes where the current format is available import using it
+# (grouping_config), and routes where it isn't available yet import using the
+# deprecated format.
+import {
+  to = incident_alert_route.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_alert_source/import-by-string-id.tf
+++ b/examples/resources/incident_alert_source/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import an alert source using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_alert_source.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_catalog_entries/import-by-string-id.tf
+++ b/examples/resources/incident_catalog_entries/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import catalog entries using the catalog_type_id
+# Replace the ID with a real catalog type ID from your incident.io organization
+import {
+  to = incident_catalog_entries.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_catalog_entry/import-by-string-id.tf
+++ b/examples/resources/incident_catalog_entry/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a catalog entry using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_catalog_entry.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_catalog_type/import-by-string-id.tf
+++ b/examples/resources/incident_catalog_type/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a catalog type using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_catalog_type.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_catalog_type_attribute/import-by-string-id.tf
+++ b/examples/resources/incident_catalog_type_attribute/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a catalog type attribute using the format catalog_type_id:attribute_id
+# Replace the IDs with real IDs from your incident.io organization
+import {
+  to = incident_catalog_type_attribute.example
+  id = "01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX"
+}

--- a/examples/resources/incident_custom_field/import-by-string-id.tf
+++ b/examples/resources/incident_custom_field/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a custom field using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_custom_field.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_custom_field_option/import-by-string-id.tf
+++ b/examples/resources/incident_custom_field_option/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a custom field option using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_custom_field_option.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_escalation_path/import-by-string-id.tf
+++ b/examples/resources/incident_escalation_path/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import an escalation path using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_escalation_path.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_incident_role/import-by-string-id.tf
+++ b/examples/resources/incident_incident_role/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import an incident role using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_incident_role.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_maintenance_window/import-by-string-id.tf
+++ b/examples/resources/incident_maintenance_window/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a maintenance window using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_maintenance_window.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_schedule/import-by-string-id.tf
+++ b/examples/resources/incident_schedule/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a schedule using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_schedule.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_schedule_beta/import-by-string-id.tf
+++ b/examples/resources/incident_schedule_beta/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a schedule using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_schedule_beta.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_schedule_rotation_beta/import-by-string-id.tf
+++ b/examples/resources/incident_schedule_rotation_beta/import-by-string-id.tf
@@ -1,0 +1,7 @@
+# Import a rotation using its schedule's ID and its own ID, separated by a colon.
+# A rotation is only addressable through the schedule that holds it.
+# Replace both IDs with real ones from your incident.io organization.
+import {
+  to = incident_schedule_rotation_beta.example
+  id = "01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX"
+}

--- a/examples/resources/incident_schedule_sync_rule/import-by-string-id.tf
+++ b/examples/resources/incident_schedule_sync_rule/import-by-string-id.tf
@@ -1,0 +1,8 @@
+# Import a schedule sync rule using the format schedule_id:rule_id
+# Sync rules belong to a schedule, so both IDs are required: use the
+# ListScheduleSyncRules API endpoint for a schedule to find its rules' IDs
+# Replace the IDs with real IDs from your incident.io organization
+import {
+  to = incident_schedule_sync_rule.example
+  id = "01ABC123DEF456GHI789JKL:01MNO456PQR789STU012VWX"
+}

--- a/examples/resources/incident_schedule_sync_target/import-by-string-id.tf
+++ b/examples/resources/incident_schedule_sync_target/import-by-string-id.tf
@@ -1,0 +1,11 @@
+# Import a schedule sync target using its ID
+# Replace the ID with a real ID from your incident.io organization
+#
+# The Slack user group of an imported target already exists, so the imported
+# configuration should point at it with slack_user_group_id (the group's Slack
+# ID, which is in state after the import). new_slack_user_group asks us to
+# create a group, so leaving it set plans a replacement of the target
+import {
+  to = incident_schedule_sync_target.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_severity/import-by-string-id.tf
+++ b/examples/resources/incident_severity/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a severity using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_severity.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_status/import-by-string-id.tf
+++ b/examples/resources/incident_status/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a status using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_status.example
+  id = "01ABC123DEF456GHI789JKL"
+}

--- a/examples/resources/incident_workflow/import-by-string-id.tf
+++ b/examples/resources/incident_workflow/import-by-string-id.tf
@@ -1,0 +1,6 @@
+# Import a workflow using its ID
+# Replace the ID with a real ID from your incident.io organization
+import {
+  to = incident_workflow.example
+  id = "01ABC123DEF456GHI789JKL"
+}


### PR DESCRIPTION
Every resource shipped an `import.sh` example and nothing else, so the registry only ever showed the `terraform import` command. Adding `import-by-string-id.tf` alongside it makes tfplugindocs render the `import` block first, with the command as the alternative.

Each block is derived from the sibling `import.sh`, so both sections explain the ID format the same way and each example still stands on its own.

## Testing

`go generate ./...` regenerates all 20 pages with no other diff, `terraform fmt -recursive -check ./examples/` is clean, and build, tests and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example files only; no provider runtime or import behavior changes.
> 
> **Overview**
> Adds **`import-by-string-id.tf`** examples for **20 importable resources** so `tfplugindocs` can render Terraform **1.5+ `import` blocks** on each resource’s registry **Import** section, **above** the existing `terraform import` shell examples.
> 
> Generated resource docs and **CHANGELOG** are updated to describe config-driven import (reviewable in plan/apply) while keeping the same import ID formats and comments as the sibling `import.sh` examples—including composite IDs where needed (e.g. `catalog_type_id:attribute_id`, `schedule_id:rule_id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2422b9f4d29a75240367430a66a22175c8cd739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->