### PR TITLE
Changelog for v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.0.1
+
 - Warn at plan time when an edit to an `incident_schedule_rotation_beta` lands on a change already scheduled on that rotation: a rollout replaces that change, and an edit without one rewrites it rather than changing who is on call now. Easy to miss after importing a rotation.
 - Document `import` blocks on every resource's registry page, above the existing `terraform import` command. Config-driven import can be reviewed and applied like any other change, rather than needing a command run by hand.
 


### PR DESCRIPTION
Cuts `v6.0.1` by moving both `## Unreleased` entries under a versioned heading. Patch bump: neither change adds or alters any resource, attribute or behaviour you configure. One is a new plan-time warning, the other is documentation.

## Tests

`CHANGELOG.md` is in `paths-ignore`, so the Tests workflow is skipped. No required status checks on master, so that doesn't block the merge.

## After merging

Per RELEASE.md:

```
git checkout master && git pull
git tag v6.0.1
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `CHANGELOG.md` is modified; no runtime or provider code changes.
> 
> **Overview**
> **Cuts the v6.0.1 release in `CHANGELOG.md`** by adding a `## v6.0.1` section and moving the two items that were under `## Unreleased` into it, leaving `## Unreleased` empty for the next cycle.
> 
> The listed changes are documentation-only for this file: they describe provider behaviour already shipped (plan-time warning on `incident_schedule_rotation_beta` edits that collide with scheduled changes, and registry docs for `import` blocks)—this PR does not implement those features.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee71c3af85b449e7ce081dd3b52d8f7768ad8bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->