### PR TITLE
Mark secret_token on incident_alert_source as sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+#### Breaking changes
+
+- **`secret_token` on `incident_alert_source` is now marked sensitive**, so it is redacted in plan and apply output instead of being printed in full. That token authenticates anyone sending events to the source, and printing it meant it landed in the logs of any CI runner applying the change. The value is unchanged and is still stored in plain text in state, as all Terraform values are.
+- This is breaking for configurations that pass the token somewhere Terraform does not accept a sensitive value, most commonly an `output` block without `sensitive = true`. Wrap the reference in `nonsensitive()` to keep the old behaviour:
+
+  ```terraform
+  output "secret_token" {
+    value = nonsensitive(incident_alert_source.example.secret_token)
+  }
+  ```
+
+  The equivalent attribute on the `incident_alert_sources` data source has been sensitive since it was added in v5.9.0; this brings the resource in line with it.
+
 ## v6.0.1
 
 - Warn at plan time when an edit to an `incident_schedule_rotation_beta` lands on a change already scheduled on that rotation: a rollout replaces that change, and an edit without one rewrites it rather than changing who is on call now. Easy to miss after importing a rotation.

--- a/docs/data-sources/alert_sources.md
+++ b/docs/data-sources/alert_sources.md
@@ -51,6 +51,8 @@ output "webhook_alert_sources_count" {
 
 output "webhook_alert_source_details" {
   description = "Details of webhook alert sources"
+  # secret_token is a sensitive value, so any output including it must say so.
+  sensitive = true
   value = [for source in data.incident_alert_sources.webhooks_only.alert_sources : {
     id           = source.id
     name         = source.name

--- a/docs/resources/alert_source.md
+++ b/docs/resources/alert_source.md
@@ -151,7 +151,7 @@ resource "aws_sns_topic_subscription" "incidentio_alert_source" {
 
 - `alert_events_url` (String) URL that can be used to send alert events to this source. This is only set for sources that accept webhook/HTTP events; email sources use the email_address field, and integration-based sources (like Jira) receive events through their native integrations.
 - `id` (String) The ID of this alert source
-- `secret_token` (String) Secret token used to authenticate this source, if applicable. If applicable, this is the token that must be included in either the query string or the 'Authorization' header when sending events to this alert source.
+- `secret_token` (String, Sensitive) Secret token used to authenticate this source, if applicable. If applicable, this is the token that must be included in either the query string or the 'Authorization' header when sending events to this alert source.
 
 <a id="nestedatt--template"></a>
 ### Nested Schema for `template`

--- a/examples/data-sources/incident_alert_sources/data-source.tf
+++ b/examples/data-sources/incident_alert_sources/data-source.tf
@@ -33,6 +33,8 @@ output "webhook_alert_sources_count" {
 
 output "webhook_alert_source_details" {
   description = "Details of webhook alert sources"
+  # secret_token is a sensitive value, so any output including it must say so.
+  sensitive = true
   value = [for source in data.incident_alert_sources.webhooks_only.alert_sources : {
     id           = source.id
     name         = source.name

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -281,12 +281,17 @@ func (r *IncidentAlertSourceResource) Schema(ctx context.Context, req resource.S
 			},
 			"secret_token": schema.StringAttribute{
 				Computed: true,
-				// We do *not* mark this as sensitive, since it is no more sensitive
-				// than other values in the Terraform state.
+				// This token authenticates anyone sending events to the alert source, so
+				// it is more sensitive than the rest of the resource and should not be
+				// printed in plan output, which often ends up in CI logs.
 				//
-				// If we marked this as sensitive, it would not appear in CLI output,
-				// which makes setting up new alert sources more difficult than
-				// necessary.
+				// It is still stored in plain text in state, as all Terraform values are.
+				// To read it during setup, wrap it in nonsensitive():
+				//
+				//   output "secret_token" {
+				//     value = nonsensitive(incident_alert_source.example.secret_token)
+				//   }
+				Sensitive:           true,
 				MarkdownDescription: apischema.Docstring("AlertSourceV2", "secret_token"),
 				PlanModifiers: []planmodifier.String{
 					// This does not change after creation


### PR DESCRIPTION
Fixes #219.

`secret_token` on `incident_alert_source` carried a comment arguing it was no more sensitive than anything else in Terraform state, and that hiding it made setting up a new alert source harder than it needed to be.

That reasoning was reversed in #219: the token authenticates anyone sending events to the alert source, so unlike a name it carries security and billing implications, and printing it in plan output means it lands in the logs of any CI runner applying the change (the reporter hit this with Atlantis). We agreed on the issue to make the change, and marked the attribute sensitive on the `incident_alert_sources` data source ahead of it in #222 specifically to soften the break — but the resource itself was never updated, so the two have disagreed since v5.9.0.

## Changes

- `Sensitive: true` on `secret_token` in the alert source resource schema, replacing the outdated comment with one explaining the current reasoning and pointing at `nonsensitive()`.
- Fix the `incident_alert_sources` data source example, which passes `secret_token` into an `output` block. Since that attribute became sensitive in v5.9.0 the example as written fails with `Output refers to sensitive values`, so it now sets `sensitive = true`.
- Regenerated docs and a CHANGELOG entry under a **Breaking changes** heading.

## Breaking change

The value itself is unchanged, and it is still stored in plain text in state as all Terraform values are — the only difference is that it is redacted in plan and apply output. That breaks configurations passing the token somewhere Terraform does not accept a sensitive value, most commonly an `output` without `sensitive = true`. The escape hatch, which also covers the setup ergonomics the original comment was worried about:

```terraform
output "secret_token" {
  value = nonsensitive(incident_alert_source.example.secret_token)
}
```

Worth deciding whether this rides in the next minor with the breaking-change note, or waits for v7.

## Testing

`go build ./...`, `go vet` and `gofmt` are clean, and the non-provider packages pass. I could not run `internal/provider` or `go generate ./...` in my sandbox — both need the Terraform CLI, and downloading it is blocked by the network policy (`checkpoint-api.hashicorp.com` returns 403). The doc changes are therefore hand-applied rather than generated: `docs/resources/alert_source.md` gets the `(String, Sensitive)` marker matching the data source's existing line, and the embedded example was verified byte-identical to the `.tf` file, which I checked is `terraform fmt`-clean via `hclwrite.Format`. Worth confirming the `generate` job comes back green rather than taking my word for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E66Y6JayjjTjuWQoiSh7Fp)_