### PR TITLE
ONC-12990: Add retry_config to escalation path levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Add optional `retry_config` to `incident_escalation_path` levels, allowing you
+  to configure repeated notifications on a single level.
+
 ## v6.0.1
 
 - Warn at plan time when an edit to an `incident_schedule_rotation_beta` lands on a change already scheduled on that rotation: a rollout replaces that change, and an edit without one rewrites it rather than changing who is on call now. Easy to miss after importing a rotation.

--- a/docs/data-sources/escalation_path.md
+++ b/docs/data-sources/escalation_path.md
@@ -448,11 +448,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -545,11 +555,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -613,11 +633,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -787,11 +817,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -884,11 +924,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -952,11 +1002,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -1020,11 +1080,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -1271,11 +1341,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -1368,11 +1448,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -1436,11 +1526,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -1610,11 +1710,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -1707,11 +1817,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -1775,11 +1895,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -1843,11 +1973,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -1911,11 +2051,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -2239,11 +2389,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -2336,11 +2496,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -2404,11 +2574,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -2578,11 +2758,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -2675,11 +2865,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -2743,11 +2943,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -2811,11 +3021,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -3062,11 +3282,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -3159,11 +3389,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -3227,11 +3467,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -3401,11 +3651,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -3498,11 +3758,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -3566,11 +3836,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -3634,11 +3914,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -3702,11 +3992,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -3770,11 +4070,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.else_path.level.round_robin_config`
@@ -4175,11 +4485,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -4272,11 +4592,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -4340,11 +4670,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -4514,11 +4854,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -4611,11 +4961,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -4679,11 +5039,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -4747,11 +5117,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -4998,11 +5378,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -5095,11 +5485,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -5163,11 +5563,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -5337,11 +5747,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -5434,11 +5854,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -5502,11 +5932,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -5570,11 +6010,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -5638,11 +6088,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -5966,11 +6426,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -6063,11 +6533,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -6131,11 +6611,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -6305,11 +6795,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -6402,11 +6902,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -6470,11 +6980,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -6538,11 +7058,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -6789,11 +7319,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.round_robin_config`
@@ -6886,11 +7426,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.round_robin_config`
@@ -6954,11 +7504,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -7128,11 +7688,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.round_robin_config`
@@ -7225,11 +7795,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -7293,11 +7873,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -7361,11 +7951,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -7429,11 +8029,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.if_else.then_path.level.round_robin_config`
@@ -7497,11 +8107,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--if_else--then_path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--if_else--then_path--level--round_robin_config"></a>
 ### Nested Schema for `path.if_else.then_path.level.round_robin_config`
@@ -7565,11 +8185,21 @@ Read-Only:
 Read-Only:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--level--round_robin_config))
 - `targets` (Attributes List) The targets (users or schedules) for this level (see [below for nested schema](#nestedatt--path--level--targets))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
 - `time_to_ack_weekday_interval_config_id` (String) If the time to ack is relative to a time window, this identifies which window it is relative to
+
+<a id="nestedatt--path--level--retry_config"></a>
+### Nested Schema for `path.level.retry_config`
+
+Read-Only:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+
 
 <a id="nestedatt--path--level--round_robin_config"></a>
 ### Nested Schema for `path.level.round_robin_config`

--- a/docs/resources/escalation_path.md
+++ b/docs/resources/escalation_path.md
@@ -602,6 +602,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -620,6 +621,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -717,6 +727,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -735,6 +746,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -800,6 +820,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -818,6 +839,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -998,6 +1028,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -1016,6 +1047,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -1113,6 +1153,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -1131,6 +1172,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -1196,6 +1246,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -1214,6 +1265,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -1279,6 +1339,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -1297,6 +1358,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -1560,6 +1630,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -1578,6 +1649,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -1675,6 +1755,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -1693,6 +1774,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -1758,6 +1848,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -1776,6 +1867,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -1956,6 +2056,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -1974,6 +2075,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -2071,6 +2181,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -2089,6 +2200,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -2154,6 +2274,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -2172,6 +2293,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -2237,6 +2367,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -2255,6 +2386,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -2320,6 +2460,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -2338,6 +2479,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -2684,6 +2834,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -2702,6 +2853,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -2799,6 +2959,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -2817,6 +2978,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -2882,6 +3052,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -2900,6 +3071,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -3080,6 +3260,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -3098,6 +3279,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -3195,6 +3385,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -3213,6 +3404,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -3278,6 +3478,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -3296,6 +3497,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -3361,6 +3571,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -3379,6 +3590,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -3642,6 +3862,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -3660,6 +3881,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -3757,6 +3987,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -3775,6 +4006,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -3840,6 +4080,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -3858,6 +4099,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -4038,6 +4288,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -4056,6 +4307,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -4153,6 +4413,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -4171,6 +4432,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -4236,6 +4506,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -4254,6 +4525,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -4319,6 +4599,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -4337,6 +4618,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -4402,6 +4692,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -4420,6 +4711,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -4485,6 +4785,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -4503,6 +4804,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--then_path--level--round_robin_config"></a>
@@ -4932,6 +5242,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -4950,6 +5261,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -5047,6 +5367,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -5065,6 +5386,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -5130,6 +5460,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -5148,6 +5479,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -5328,6 +5668,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -5346,6 +5687,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -5443,6 +5793,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -5461,6 +5812,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -5526,6 +5886,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -5544,6 +5905,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -5609,6 +5979,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -5627,6 +5998,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -5890,6 +6270,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -5908,6 +6289,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -6005,6 +6395,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -6023,6 +6414,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -6088,6 +6488,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -6106,6 +6507,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -6286,6 +6696,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -6304,6 +6715,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -6401,6 +6821,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -6419,6 +6840,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -6484,6 +6914,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -6502,6 +6933,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -6567,6 +7007,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -6585,6 +7026,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -6650,6 +7100,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -6668,6 +7119,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -7014,6 +7474,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -7032,6 +7493,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -7129,6 +7599,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -7147,6 +7618,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -7212,6 +7692,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -7230,6 +7711,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -7410,6 +7900,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -7428,6 +7919,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -7525,6 +8025,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -7543,6 +8044,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -7608,6 +8118,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -7626,6 +8137,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -7691,6 +8211,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -7709,6 +8230,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -7972,6 +8502,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -7990,6 +8521,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--then_path--level--round_robin_config"></a>
@@ -8087,6 +8627,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -8105,6 +8646,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--if_else--else_path--level--round_robin_config"></a>
@@ -8170,6 +8720,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -8188,6 +8739,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -8368,6 +8928,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -8386,6 +8947,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.then_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--then_path--level--round_robin_config"></a>
@@ -8483,6 +9053,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -8501,6 +9072,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -8566,6 +9146,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -8584,6 +9165,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -8649,6 +9239,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -8667,6 +9258,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -8732,6 +9332,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -8750,6 +9351,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--if_else--else_path--level--round_robin_config"></a>
@@ -8815,6 +9425,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--if_else--else_path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -8833,6 +9444,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--if_else--else_path--level--retry_config"></a>
+### Nested Schema for `path.if_else.else_path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--if_else--else_path--level--round_robin_config"></a>
@@ -8898,6 +9518,7 @@ Required:
 Optional:
 
 - `ack_mode` (String) Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
+- `retry_config` (Attributes) (see [below for nested schema](#nestedatt--path--level--retry_config))
 - `round_robin_config` (Attributes) (see [below for nested schema](#nestedatt--path--level--round_robin_config))
 - `time_to_ack_interval_condition` (String) If the time to ack is relative to a time window, this defines whether we move when the window is active or inactive
 - `time_to_ack_seconds` (Number) How long should we wait for this level to acknowledge before proceeding to the next node in the path?
@@ -8916,6 +9537,15 @@ Optional:
 
 - `schedule_mode` (String) Only set for schedule targets, this specifies which users to fetch from the schedule. Use currently_on_call to notify whoever is on call right now across the schedule, all_users to notify every user attached to the schedule, or all_users_for_rota / currently_on_call_for_rota / next_on_call_for_rota to scope to a specific rota (in which case selected_rota_id is required). next_on_call notifies whoever is next on call across the schedule.
 - `selected_rota_id` (String) For schedule targets, identifies which rota on the schedule the schedule_mode applies to. Required when schedule_mode is all_users_for_rota, currently_on_call_for_rota, or next_on_call_for_rota; must be omitted for other schedule_mode values.
+
+
+<a id="nestedatt--path--level--retry_config"></a>
+### Nested Schema for `path.level.retry_config`
+
+Required:
+
+- `attempts` (Number) The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+- `interval_seconds` (Number) How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
 
 
 <a id="nestedatt--path--level--round_robin_config"></a>

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -41816,6 +41816,9 @@
             "example": "all",
             "type": "string"
           },
+          "retry_config": {
+            "$ref": "#/components/schemas/EscalationPathRetryConfigV2"
+          },
           "round_robin_config": {
             "$ref": "#/components/schemas/EscalationPathRoundRobinConfigV2"
           },
@@ -42207,6 +42210,31 @@
         "required": [
           "repeat_after_seconds",
           "delay_repeat_on_activity"
+        ],
+        "type": "object"
+      },
+      "EscalationPathRetryConfigV2": {
+        "example": {
+          "attempts": 3,
+          "interval_seconds": 300
+        },
+        "properties": {
+          "attempts": {
+            "description": "The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.",
+            "example": 3,
+            "format": "int64",
+            "type": "integer"
+          },
+          "interval_seconds": {
+            "description": "How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).",
+            "example": 300,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "attempts",
+          "interval_seconds"
         ],
         "type": "object"
       },

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -11361,6 +11361,9 @@ type EscalationPathNodeLevelV2 struct {
 	// Example: all
 	AckMode *EscalationPathNodeLevelV2AckMode `json:"ack_mode,omitempty"`
 
+	// RetryConfig Example: {"attempts":3,"interval_seconds":300}
+	RetryConfig *EscalationPathRetryConfigV2 `json:"retry_config,omitempty"`
+
 	// RoundRobinConfig Example: {"enabled":false,"rotate_after_seconds":120}
 	RoundRobinConfig *EscalationPathRoundRobinConfigV2 `json:"round_robin_config,omitempty"`
 
@@ -11541,6 +11544,19 @@ type EscalationPathRepeatConfigV2 struct {
 	//
 	// Example: 1800
 	RepeatAfterSeconds int32 `json:"repeat_after_seconds"`
+}
+
+// EscalationPathRetryConfigV2 Example: {"attempts":3,"interval_seconds":300}
+type EscalationPathRetryConfigV2 struct {
+	// Attempts The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.
+	//
+	// Example: 3
+	Attempts int64 `json:"attempts"`
+
+	// IntervalSeconds How long we wait between attempts at this level, in seconds. Must be a whole number of minutes (divisible by 60).
+	//
+	// Example: 300
+	IntervalSeconds int64 `json:"interval_seconds"`
 }
 
 // EscalationPathRoundRobinConfigV2 Example: {"enabled":false,"rotate_after_seconds":120}

--- a/internal/provider/incident_escalation_path_data_source.go
+++ b/internal/provider/incident_escalation_path_data_source.go
@@ -219,6 +219,19 @@ func (d *IncidentEscalationPathDataSource) getPathSchema(depth int) schema.Neste
 							},
 						},
 					},
+					"retry_config": schema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"attempts": schema.Int64Attribute{
+								Computed:            true,
+								MarkdownDescription: apischema.Docstring("EscalationPathRetryConfigV2", "attempts"),
+							},
+							"interval_seconds": schema.Int64Attribute{
+								Computed:            true,
+								MarkdownDescription: apischema.Docstring("EscalationPathRetryConfigV2", "interval_seconds"),
+							},
+						},
+					},
 					"time_to_ack_seconds": schema.Int64Attribute{
 						Computed:            true,
 						MarkdownDescription: apischema.Docstring("EscalationPathNodeLevelV2", "time_to_ack_seconds"),

--- a/internal/provider/incident_escalation_path_resource.go
+++ b/internal/provider/incident_escalation_path_resource.go
@@ -65,6 +65,7 @@ type IncidentEscalationPathNodeIfElse struct {
 type IncidentEscalationPathNodeLevel struct {
 	Targets                          types.List                          `tfsdk:"targets"`
 	RoundRobinConfig                 *IncidentEscalationRoundRobinConfig `tfsdk:"round_robin_config"`
+	RetryConfig                      *IncidentEscalationRetryConfig      `tfsdk:"retry_config"`
 	TimeToAckIntervalCondition       types.String                        `tfsdk:"time_to_ack_interval_condition"`
 	TimeToAckSeconds                 types.Int64                         `tfsdk:"time_to_ack_seconds"`
 	TimeToAckWeekdayIntervalConfigID types.String                        `tfsdk:"time_to_ack_weekday_interval_config_id"`
@@ -93,6 +94,11 @@ type IncidentEscalationPathNodeRepeat struct {
 type IncidentEscalationRoundRobinConfig struct {
 	Enabled            types.Bool  `tfsdk:"enabled"`
 	RotateAfterSeconds types.Int64 `tfsdk:"rotate_after_seconds"`
+}
+
+type IncidentEscalationRetryConfig struct {
+	Attempts        types.Int64 `tfsdk:"attempts"`
+	IntervalSeconds types.Int64 `tfsdk:"interval_seconds"`
 }
 
 type IncidentEscalationPathTarget struct {
@@ -138,6 +144,10 @@ func nodeAttrTypes(depth int) map[string]attr.Type {
 			"round_robin_config": types.ObjectType{AttrTypes: map[string]attr.Type{
 				"enabled":              types.BoolType,
 				"rotate_after_seconds": types.Int64Type,
+			}},
+			"retry_config": types.ObjectType{AttrTypes: map[string]attr.Type{
+				"attempts":         types.Int64Type,
+				"interval_seconds": types.Int64Type,
 			}},
 			"time_to_ack_seconds":                    types.Int64Type,
 			"time_to_ack_interval_condition":         types.StringType,
@@ -311,6 +321,19 @@ func (r *IncidentEscalationPathResource) getPathSchema(depth int) schema.NestedA
 							"rotate_after_seconds": schema.Int64Attribute{
 								MarkdownDescription: apischema.Docstring("EscalationPathRoundRobinConfigV2", "rotate_after_seconds"),
 								Optional:            true,
+							},
+						},
+					},
+					"retry_config": schema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]schema.Attribute{
+							"attempts": schema.Int64Attribute{
+								MarkdownDescription: apischema.Docstring("EscalationPathRetryConfigV2", "attempts"),
+								Required:            true,
+							},
+							"interval_seconds": schema.Int64Attribute{
+								MarkdownDescription: apischema.Docstring("EscalationPathRetryConfigV2", "interval_seconds"),
+								Required:            true,
 							},
 						},
 					},
@@ -949,6 +972,12 @@ func (r *IncidentEscalationPathResource) toPathModel(ctx context.Context, nodes 
 					RotateAfterSeconds: rotateAfterSeconds,
 				}
 			}
+			if value := node.Level.RetryConfig; value != nil {
+				elem.Level.RetryConfig = &IncidentEscalationRetryConfig{
+					Attempts:        types.Int64Value(value.Attempts),
+					IntervalSeconds: types.Int64Value(value.IntervalSeconds),
+				}
+			}
 			if value := node.Level.TimeToAckSeconds; value != nil {
 				elem.Level.TimeToAckSeconds = types.Int64Value(*value)
 			}
@@ -1112,6 +1141,13 @@ func (r *IncidentEscalationPathResource) toPathPayload(ctx context.Context, path
 				elem.Level.RoundRobinConfig = &client.EscalationPathRoundRobinConfigV2{
 					Enabled:            node.Level.RoundRobinConfig.Enabled.ValueBool(),
 					RotateAfterSeconds: node.Level.RoundRobinConfig.RotateAfterSeconds.ValueInt64Pointer(),
+				}
+			}
+
+			if node.Level.RetryConfig != nil {
+				elem.Level.RetryConfig = &client.EscalationPathRetryConfigV2{
+					Attempts:        node.Level.RetryConfig.Attempts.ValueInt64(),
+					IntervalSeconds: node.Level.RetryConfig.IntervalSeconds.ValueInt64(),
 				}
 			}
 

--- a/internal/provider/incident_escalation_path_resource_test.go
+++ b/internal/provider/incident_escalation_path_resource_test.go
@@ -572,6 +572,95 @@ resource "incident_escalation_path" "rota_modes" {
 `, teamTypeName(), name, name, StableSuffix("tf-acceptance-test-rota-modes"))
 }
 
+func TestAccIncidentEscalationPathRetryConfig(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and read a level that pages more than once via retry_config.
+			{
+				Config: testAccIncidentEscalationPathResourceConfigWithRetryConfig(
+					StableSuffix("EP retry-config"),
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.retries", "path.0.level.retry_config.attempts", "3"),
+					resource.TestCheckResourceAttr(
+						"incident_escalation_path.retries", "path.0.level.retry_config.interval_seconds", "60"),
+				),
+			},
+			{
+				ResourceName:      "incident_escalation_path.retries",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccIncidentEscalationPathResourceConfigWithRetryConfig(name string) string {
+	return fmt.Sprintf(`
+data "incident_catalog_type" "team" {
+  name = %[1]q
+}
+
+resource "incident_catalog_entry" "terraform_retries" {
+  catalog_type_id    = data.incident_catalog_type.team.id
+  external_id        = %[4]q
+  name               = %[4]q
+  attribute_values   = []
+  managed_attributes = []
+}
+
+resource "incident_schedule" "retries" {
+  name     = %[2]q
+  timezone = "Europe/London"
+  rotations = [{
+    id   = "primary"
+    name = "Primary"
+    versions = [{
+      handover_start_at = "2024-05-01T12:00:00Z"
+      users             = []
+      layers = [{
+        id   = "primary"
+        name = "Primary"
+      }]
+      handovers = [{
+        interval_type = "daily"
+        interval      = 1
+      }]
+    }]
+  }]
+  team_ids = [incident_catalog_entry.terraform_retries.id]
+}
+
+resource "incident_escalation_path" "retries" {
+  name = %[3]q
+
+  path = [
+    {
+      type = "level"
+      level = {
+        targets = [{
+          type    = "schedule"
+          id      = incident_schedule.retries.id
+          urgency = "high"
+        }]
+        time_to_ack_seconds = 300
+
+        retry_config = {
+          attempts         = 3
+          interval_seconds = 60
+        }
+      }
+    }
+  ]
+
+  team_ids = [incident_catalog_entry.terraform_retries.id]
+}
+`, teamTypeName(), name, name, StableSuffix("tf-acceptance-test-retries"))
+}
+
 func TestAccIncidentEscalationPathSelectedRotaIDValidation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/incident_escalation_path_roundtrip_test.go
+++ b/internal/provider/incident_escalation_path_roundtrip_test.go
@@ -147,3 +147,72 @@ func TestEscalationPathRoundTrip(t *testing.T) {
 		t.Fatalf("expected nested then-path level target to round-trip")
 	}
 }
+
+// TestEscalationPathRetryConfigRoundTrip proves a level's retry_config survives
+// the API -> model -> payload conversion. Without carrying the field in both
+// directions, a read/modify/write (as Terraform does on every apply) silently
+// dropped the retry configuration.
+func TestEscalationPathRetryConfigRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	r := &IncidentEscalationPathResource{}
+
+	ep := client.EscalationPathV2{
+		Id:   "ep-1",
+		Name: "Retry path",
+		Path: []client.EscalationPathNodeV2{
+			{
+				Id:   "node-1",
+				Type: client.EscalationPathNodeV2TypeLevel,
+				Level: &client.EscalationPathNodeLevelV2{
+					Targets: []client.EscalationPathTargetV2{
+						{
+							Id:      "schedule-1",
+							Type:    client.EscalationPathTargetV2TypeSchedule,
+							Urgency: client.EscalationPathTargetV2UrgencyHigh,
+						},
+					},
+					TimeToAckSeconds: lo.ToPtr(int64(300)),
+					RetryConfig: &client.EscalationPathRetryConfigV2{
+						Attempts:        3,
+						IntervalSeconds: 60,
+					},
+				},
+			},
+		},
+	}
+
+	var diags diag.Diagnostics
+	model := r.buildModel(ctx, ep, &diags)
+	if diags.HasError() {
+		t.Fatalf("buildModel produced errors: %#v", diags)
+	}
+
+	nodes := decodeNodes(ctx, model.Path, &diags)
+	if diags.HasError() {
+		t.Fatalf("decodeNodes produced errors: %#v", diags)
+	}
+	if len(nodes) != 1 || nodes[0].Level == nil {
+		t.Fatalf("expected a single level node in the model")
+	}
+	if rc := nodes[0].Level.RetryConfig; rc == nil {
+		t.Fatalf("expected retry_config to survive into the model")
+	} else if rc.Attempts.ValueInt64() != 3 || rc.IntervalSeconds.ValueInt64() != 60 {
+		t.Fatalf("unexpected retry_config in model: %+v", rc)
+	}
+
+	var payloadDiags diag.Diagnostics
+	payload := r.toPathPayload(ctx, model.Path, &payloadDiags)
+	if payloadDiags.HasError() {
+		t.Fatalf("toPathPayload produced errors: %#v", payloadDiags)
+	}
+	if len(payload) != 1 || payload[0].Level == nil {
+		t.Fatalf("expected a single level node in the payload")
+	}
+	rc := payload[0].Level.RetryConfig
+	if rc == nil {
+		t.Fatalf("expected retry_config to survive into the payload")
+	}
+	if rc.Attempts != 3 || rc.IntervalSeconds != 60 {
+		t.Fatalf("unexpected retry_config in payload: %+v", rc)
+	}
+}


### PR DESCRIPTION
Expose the per level retry configuration that already exists in the dashboard on incident_escalation_path levels, as an optional retry_config block with attempts and interval_seconds. The provider previously ignored the field, so a terraform apply against a path that used retries silently removed them on the read, modify, write cycle.

The embedded OpenAPI schema gains the EscalationPathRetryConfigV2 type and the retry_config property on the level, the client is regenerated, and the field is wired through the resource schema, the data source, and the model conversions in both directions. This depends on the public API change in core being deployed first.