### PR TITLE
Changelog for v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v6.1.0
+
 - Add optional `retry_config` to `incident_escalation_path` levels, allowing you
   to configure repeated notifications on a single level.
 


### PR DESCRIPTION
Cuts `v6.1.0` by moving the single `## Unreleased` entry under a versioned heading, so the published changelog attributes the change to the version users will actually resolve. Without this the entry would ship under "Unreleased" on the registry page, which reads as unshipped work.

Minor rather than patch: `retry_config` is a new optional block on `incident_escalation_path` levels. It adds configurable surface, but nothing existing changes shape, so no configuration needs updating. Before it landed the provider ignored the field entirely, which silently stripped per-level retries on the read, modify, write cycle for anyone who had set them in the dashboard.

`CHANGELOG.md` is in the Tests workflow's `paths-ignore`, so CI is skipped here. The Tests run on the `retry_config` merge commit (`baf636a`) was green across all three acceptance-test legs, against the live API.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>