### PR TITLE
Validate alert source templates at plan time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Check an `incident_alert_source`'s template at plan time. A reference that doesn't resolve, or a merge strategy the attribute doesn't support, now fails the plan. Previously it failed part way through an apply, after other resources had been created. Templates whose values aren't known until apply are left alone, and when the check can't run the plan warns rather than failing.
+
 ## v6.1.1
 
 - Fix `incident_alert_route` wrongly requiring deprecated v2 attributes

--- a/internal/apischema/public-schema-v3-including-secret-endpoints.json
+++ b/internal/apischema/public-schema-v3-including-secret-endpoints.json
@@ -92,7 +92,8 @@
               "incident_workload_private_viewer",
               "act_on_behalf_of_users",
               "secrets_manage",
-              "secrets_use"
+              "secrets_use",
+              "call_transcripts_viewer"
             ],
             "example": "viewer",
             "type": "string",
@@ -337,7 +338,8 @@
                 "incident_workload_private_viewer",
                 "act_on_behalf_of_users",
                 "secrets_manage",
-                "secrets_use"
+                "secrets_use",
+                "call_transcripts_viewer"
               ],
               "example": "viewer",
               "type": "string"
@@ -738,7 +740,8 @@
                 "incident_workload_private_viewer",
                 "act_on_behalf_of_users",
                 "secrets_manage",
-                "secrets_use"
+                "secrets_use",
+                "call_transcripts_viewer"
               ],
               "example": "viewer",
               "type": "string"
@@ -16352,6 +16355,249 @@
         },
         "required": [
           "alert_source"
+        ],
+        "type": "object"
+      },
+      "AlertSourcesValidatePayloadV2": {
+        "example": {
+          "owning_team_ids": [
+            "01G0J1EXE7AXZ2C93K61WBPYEH"
+          ],
+          "source_type": "alertmanager",
+          "template": {
+            "attributes": [
+              {
+                "alert_attribute_id": "abc123",
+                "binding": {
+                  "array_value": [
+                    {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  ],
+                  "merge_strategy": "first_wins",
+                  "value": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  }
+                }
+              }
+            ],
+            "description": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            },
+            "expressions": [
+              {
+                "else_branch": {
+                  "result": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                },
+                "label": "Team Slack channel",
+                "operations": [
+                  {
+                    "branches": {
+                      "branches": [
+                        {
+                          "condition_groups": [
+                            {
+                              "conditions": [
+                                {
+                                  "operation": "one_of",
+                                  "param_bindings": [
+                                    {
+                                      "array_value": [
+                                        {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      ],
+                                      "value": {
+                                        "literal": "SEV123",
+                                        "reference": "incident.severity"
+                                      }
+                                    }
+                                  ],
+                                  "subject": "incident.severity"
+                                }
+                              ]
+                            }
+                          ],
+                          "result": {
+                            "array_value": [
+                              {
+                                "literal": "SEV123",
+                                "reference": "incident.severity"
+                              }
+                            ],
+                            "value": {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          }
+                        }
+                      ],
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "cast": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      }
+                    },
+                    "concatenate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "filter": {
+                      "condition_groups": [
+                        {
+                          "conditions": [
+                            {
+                              "operation": "one_of",
+                              "param_bindings": [
+                                {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              ],
+                              "subject": "incident.severity"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "navigate": {
+                      "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                    },
+                    "operation_type": "navigate",
+                    "parse": {
+                      "returns": {
+                        "array": true,
+                        "type": "IncidentStatus"
+                      },
+                      "source": "metadata.annotations[\"github.com/repo\"]"
+                    }
+                  }
+                ],
+                "reference": "abc123",
+                "root_reference": "incident.status"
+              }
+            ],
+            "is_private": false,
+            "title": {
+              "literal": "SEV123",
+              "reference": "incident.severity"
+            },
+            "visible_to_teams": {
+              "array_value": [
+                {
+                  "literal": "SEV123",
+                  "reference": "incident.severity"
+                }
+              ],
+              "value": {
+                "literal": "SEV123",
+                "reference": "incident.severity"
+              }
+            }
+          }
+        },
+        "properties": {
+          "owning_team_ids": {
+            "description": "IDs of teams that own this alert source",
+            "example": [
+              "01G0J1EXE7AXZ2C93K61WBPYEH"
+            ],
+            "items": {
+              "example": "abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "source_type": {
+            "description": "Type of alert source",
+            "enum": [
+              "alertmanager",
+              "app_optics",
+              "azure_monitor",
+              "big_panda",
+              "bugsnag",
+              "checkly",
+              "chronosphere",
+              "cloudwatch",
+              "cloudflare",
+              "coralogix",
+              "cronitor",
+              "crowdstrike_falcon",
+              "dash0",
+              "datadog",
+              "dynatrace",
+              "elasticsearch",
+              "email",
+              "expel",
+              "github_issue",
+              "google_cloud",
+              "grafana",
+              "heartbeat",
+              "http",
+              "http_custom",
+              "honeycomb",
+              "incoming_calls",
+              "jira",
+              "jsm",
+              "monte_carlo",
+              "nagios",
+              "new_relic",
+              "opsgenie",
+              "prtg",
+              "pager_duty",
+              "panther",
+              "pingdom",
+              "runscope",
+              "sns",
+              "sentry",
+              "sentry_metric",
+              "service_now",
+              "splunk",
+              "status_cake",
+              "status_page_views",
+              "sumo_logic",
+              "uptime",
+              "vercel",
+              "wiz",
+              "zendesk"
+            ],
+            "example": "alertmanager",
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/AlertTemplatePayloadV2"
+          }
+        },
+        "required": [
+          "source_type",
+          "template"
         ],
         "type": "object"
       },
@@ -33586,6 +33832,175 @@
         ],
         "type": "object"
       },
+      "CallSessionV2": {
+        "description": "A call session is a single occurrence of a call that Scribe attended,\nfor example one Zoom or Google Meet meeting. Several call sessions can exist for\nthe same context: one for each time a call was started.\n\nUse the Call Transcript Entries endpoint to page through what Scribe transcribed\nduring a session.",
+        "example": {
+          "ended_at": "2021-08-17T14:28:57.801578Z",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "incident_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+          "started_at": "2021-08-17T13:28:57.801578Z"
+        },
+        "properties": {
+          "ended_at": {
+            "description": "When the call session ended. Absent while the call is still in progress.",
+            "example": "2021-08-17T14:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this call session",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "incident_id": {
+            "description": "The incident this call session belongs to",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "type": "string"
+          },
+          "started_at": {
+            "description": "When the call session started",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "incident_id",
+          "started_at"
+        ],
+        "type": "object"
+      },
+      "CallSessionsListResultV2": {
+        "example": {
+          "call_sessions": [
+            {
+              "ended_at": "2021-08-17T14:28:57.801578Z",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "incident_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "started_at": "2021-08-17T13:28:57.801578Z"
+            }
+          ],
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          }
+        },
+        "properties": {
+          "call_sessions": {
+            "example": [
+              {
+                "ended_at": "2021-08-17T14:28:57.801578Z",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "incident_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                "started_at": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CallSessionV2"
+            },
+            "type": "array"
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          }
+        },
+        "required": [
+          "call_sessions"
+        ],
+        "type": "object"
+      },
+      "CallTranscriptEntriesListResultV2": {
+        "example": {
+          "call_transcript_entries": [
+            {
+              "content": "I think we should roll back the deploy.",
+              "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "medium": "spoken",
+              "participant_name": "Alice Smith",
+              "timestamp": "2021-08-17T13:28:57.801578Z"
+            }
+          ],
+          "pagination_meta": {
+            "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "page_size": 25
+          }
+        },
+        "properties": {
+          "call_transcript_entries": {
+            "example": [
+              {
+                "content": "I think we should roll back the deploy.",
+                "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                "medium": "spoken",
+                "participant_name": "Alice Smith",
+                "timestamp": "2021-08-17T13:28:57.801578Z"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CallTranscriptEntryV2"
+            },
+            "type": "array"
+          },
+          "pagination_meta": {
+            "$ref": "#/components/schemas/PaginationMetaResultV2"
+          }
+        },
+        "required": [
+          "call_transcript_entries"
+        ],
+        "type": "object"
+      },
+      "CallTranscriptEntryV2": {
+        "description": "A single entry of a Scribe call transcript: one contiguous run of\nspeech, or one in-call chat message, from one participant.",
+        "example": {
+          "content": "I think we should roll back the deploy.",
+          "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+          "medium": "spoken",
+          "participant_name": "Alice Smith",
+          "timestamp": "2021-08-17T13:28:57.801578Z"
+        },
+        "properties": {
+          "content": {
+            "description": "What was said",
+            "example": "I think we should roll back the deploy.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this transcript entry",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "type": "string"
+          },
+          "medium": {
+            "description": "Whether this entry was spoken aloud or sent as an in-call chat message",
+            "enum": [
+              "spoken",
+              "call_chat"
+            ],
+            "example": "spoken",
+            "type": "string"
+          },
+          "participant_name": {
+            "description": "Name of the participant who spoke or sent the message, as reported by the call provider",
+            "example": "Alice Smith",
+            "type": "string"
+          },
+          "timestamp": {
+            "description": "When the participant started speaking",
+            "example": "2021-08-17T13:28:57.801578Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "participant_name",
+          "timestamp",
+          "content",
+          "medium"
+        ],
+        "type": "object"
+      },
       "CatalogBulkUpdateEntriesPayloadV3": {
         "example": {
           "catalog_type_id": "01GW2G3V0S59R238FAHPDS1R66",
@@ -34344,6 +34759,7 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
+            "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
             "estimated_count": 7,
             "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -35225,6 +35641,7 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
+            "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
             "estimated_count": 7,
             "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -35328,7 +35745,7 @@
               "category": "custom",
               "description": "Boolean true or false value",
               "label": "GitHub Repository",
-              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+              "type": "Custom[\"Team\"]",
               "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
             }
           ]
@@ -35340,7 +35757,7 @@
                 "category": "custom",
                 "description": "Boolean true or false value",
                 "label": "GitHub Repository",
-                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+                "type": "Custom[\"Team\"]",
                 "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
               }
             ],
@@ -35361,8 +35778,9 @@
             {
               "category": "custom",
               "description": "Boolean true or false value",
+              "engine_resource_type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
               "label": "GitHub Repository",
-              "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+              "type": "Custom[\"Team\"]",
               "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
             }
           ]
@@ -35373,8 +35791,9 @@
               {
                 "category": "custom",
                 "description": "Boolean true or false value",
+                "engine_resource_type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
                 "label": "GitHub Repository",
-                "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+                "type": "Custom[\"Team\"]",
                 "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
               }
             ],
@@ -35515,6 +35934,7 @@
               "created_at": "2021-08-17T13:28:57.801578Z",
               "description": "Represents Kubernetes clusters that we run inside of GKE.",
               "dynamic_resource_parameter": "abc123",
+              "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
               "estimated_count": 7,
               "icon": "alert",
               "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -35570,6 +35990,7 @@
                 "created_at": "2021-08-17T13:28:57.801578Z",
                 "description": "Represents Kubernetes clusters that we run inside of GKE.",
                 "dynamic_resource_parameter": "abc123",
+                "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
                 "estimated_count": 7,
                 "icon": "alert",
                 "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -35626,7 +36047,7 @@
           "category": "custom",
           "description": "Boolean true or false value",
           "label": "GitHub Repository",
-          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+          "type": "Custom[\"Team\"]",
           "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
         },
         "properties": {
@@ -35651,8 +36072,8 @@
             "type": "string"
           },
           "type": {
-            "description": "Catalog type name for this resource",
-            "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+            "description": "Catalog type name for this resource, as used when setting the type of a catalog type attribute",
+            "example": "Custom[\"Team\"]",
             "type": "string"
           },
           "value_docstring": {
@@ -35674,8 +36095,9 @@
         "example": {
           "category": "custom",
           "description": "Boolean true or false value",
+          "engine_resource_type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
           "label": "GitHub Repository",
-          "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+          "type": "Custom[\"Team\"]",
           "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
         },
         "properties": {
@@ -35694,14 +36116,19 @@
             "example": "Boolean true or false value",
             "type": "string"
           },
+          "engine_resource_type": {
+            "description": "The way this resource type is referenced in the engine, as used when setting the type of an alert attribute",
+            "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+            "type": "string"
+          },
           "label": {
             "description": "Label for this catalog resource type",
             "example": "GitHub Repository",
             "type": "string"
           },
           "type": {
-            "description": "Catalog type name for this resource",
-            "example": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+            "description": "Catalog type name for this resource, as used when setting the type of a catalog type attribute",
+            "example": "Custom[\"Team\"]",
             "type": "string"
           },
           "value_docstring": {
@@ -35712,6 +36139,7 @@
         },
         "required": [
           "type",
+          "engine_resource_type",
           "label",
           "description",
           "value_docstring",
@@ -35877,6 +36305,7 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
+            "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
             "estimated_count": 7,
             "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -36003,6 +36432,7 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
+            "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
             "estimated_count": 7,
             "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -36803,6 +37233,7 @@
           "created_at": "2021-08-17T13:28:57.801578Z",
           "description": "Represents Kubernetes clusters that we run inside of GKE.",
           "dynamic_resource_parameter": "abc123",
+          "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
           "estimated_count": 7,
           "icon": "alert",
           "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -36903,6 +37334,11 @@
           "dynamic_resource_parameter": {
             "description": "If this is a dynamic catalog type, this will be the unique parameter for identitfying this resource externally.",
             "example": "abc123",
+            "type": "string"
+          },
+          "engine_resource_type": {
+            "description": "The way this resource type is referenced in the engine, as used when setting the type of an alert attribute",
+            "example": "CatalogEntry[\"PagerDutyService\"]",
             "type": "string"
           },
           "estimated_count": {
@@ -37033,6 +37469,7 @@
           "name",
           "description",
           "type_name",
+          "engine_resource_type",
           "ranked",
           "schema",
           "icon",
@@ -37376,6 +37813,7 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
+            "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
             "estimated_count": 7,
             "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -37766,6 +38204,7 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
+            "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
             "estimated_count": 7,
             "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -37994,6 +38433,7 @@
             "created_at": "2021-08-17T13:28:57.801578Z",
             "description": "Represents Kubernetes clusters that we run inside of GKE.",
             "dynamic_resource_parameter": "abc123",
+            "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
             "estimated_count": 7,
             "icon": "alert",
             "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -41045,6 +41485,10 @@
               },
               "level": {
                 "ack_mode": "all",
+                "retry_config": {
+                  "attempts": 3,
+                  "interval_seconds": 300
+                },
                 "round_robin_config": {
                   "enabled": false,
                   "rotate_after_seconds": 120
@@ -41121,6 +41565,10 @@
               },
               "level": {
                 "ack_mode": "all",
+                "retry_config": {
+                  "attempts": 3,
+                  "interval_seconds": 300
+                },
                 "round_robin_config": {
                   "enabled": false,
                   "rotate_after_seconds": 120
@@ -41228,6 +41676,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -41311,6 +41763,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -41437,6 +41893,10 @@
               },
               "level": {
                 "ack_mode": "all",
+                "retry_config": {
+                  "attempts": 3,
+                  "interval_seconds": 300
+                },
                 "round_robin_config": {
                   "enabled": false,
                   "rotate_after_seconds": 120
@@ -41521,6 +41981,10 @@
               },
               "level": {
                 "ack_mode": "all",
+                "retry_config": {
+                  "attempts": 3,
+                  "interval_seconds": 300
+                },
                 "round_robin_config": {
                   "enabled": false,
                   "rotate_after_seconds": 120
@@ -41644,6 +42108,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -41735,6 +42203,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -41789,6 +42261,10 @@
       "EscalationPathNodeLevelV2": {
         "example": {
           "ack_mode": "all",
+          "retry_config": {
+            "attempts": 3,
+            "interval_seconds": 300
+          },
           "round_robin_config": {
             "enabled": false,
             "rotate_after_seconds": 120
@@ -41960,6 +42436,10 @@
           },
           "level": {
             "ack_mode": "all",
+            "retry_config": {
+              "attempts": 3,
+              "interval_seconds": 300
+            },
             "round_robin_config": {
               "enabled": false,
               "rotate_after_seconds": 120
@@ -42108,6 +42588,10 @@
           },
           "level": {
             "ack_mode": "all",
+            "retry_config": {
+              "attempts": 3,
+              "interval_seconds": 300
+            },
             "round_robin_config": {
               "enabled": false,
               "rotate_after_seconds": 120
@@ -42223,6 +42707,8 @@
             "description": "The total number of times we page this level, counting the initial page. For example, 3 means three notifications in total. Must be between 2 and 10.",
             "example": 3,
             "format": "int64",
+            "maximum": 10,
+            "minimum": 2,
             "type": "integer"
           },
           "interval_seconds": {
@@ -42382,6 +42868,10 @@
               },
               "level": {
                 "ack_mode": "all",
+                "retry_config": {
+                  "attempts": 3,
+                  "interval_seconds": 300
+                },
                 "round_robin_config": {
                   "enabled": false,
                   "rotate_after_seconds": 120
@@ -42517,6 +43007,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -43071,6 +43565,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -43183,6 +43681,10 @@
               },
               "level": {
                 "ack_mode": "all",
+                "retry_config": {
+                  "attempts": 3,
+                  "interval_seconds": 300
+                },
                 "round_robin_config": {
                   "enabled": false,
                   "rotate_after_seconds": 120
@@ -43289,6 +43791,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -43434,6 +43940,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -43807,6 +44317,10 @@
                   },
                   "level": {
                     "ack_mode": "all",
+                    "retry_config": {
+                      "attempts": 3,
+                      "interval_seconds": 300
+                    },
                     "round_robin_config": {
                       "enabled": false,
                       "rotate_after_seconds": 120
@@ -43934,6 +44448,10 @@
                     },
                     "level": {
                       "ack_mode": "all",
+                      "retry_config": {
+                        "attempts": 3,
+                        "interval_seconds": 300
+                      },
                       "round_robin_config": {
                         "enabled": false,
                         "rotate_after_seconds": 120
@@ -44260,6 +44778,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -44466,6 +44988,10 @@
               },
               "level": {
                 "ack_mode": "all",
+                "retry_config": {
+                  "attempts": 3,
+                  "interval_seconds": 300
+                },
                 "round_robin_config": {
                   "enabled": false,
                   "rotate_after_seconds": 120
@@ -44572,6 +45098,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -44717,6 +45247,10 @@
                 },
                 "level": {
                   "ack_mode": "all",
+                  "retry_config": {
+                    "attempts": 3,
+                    "interval_seconds": 300
+                  },
                   "round_robin_config": {
                     "enabled": false,
                     "rotate_after_seconds": 120
@@ -49287,7 +49821,8 @@
                 "incident_workload_private_viewer",
                 "act_on_behalf_of_users",
                 "secrets_manage",
-                "secrets_use"
+                "secrets_use",
+                "call_transcripts_viewer"
               ],
               "example": "viewer",
               "type": "string",
@@ -49629,21 +50164,34 @@
             "id": "01FCNDV6P870EA6S7TK1DSYD5H",
             "name": "Lasted"
           },
+          "status": "success",
           "value_seconds": 10800
         },
         "properties": {
           "duration_metric": {
             "$ref": "#/components/schemas/IncidentDurationMetricV2"
           },
+          "status": {
+            "description": "Whether value_seconds matches this incident's current timestamps ('success'), or why it doesn't",
+            "enum": [
+              "success",
+              "timestamps_missing",
+              "calculating",
+              "invalid_timestamps"
+            ],
+            "example": "success",
+            "type": "string"
+          },
           "value_seconds": {
-            "description": "The calculated durations for this metric",
+            "description": "The duration we last calculated for this metric, omitted if we've never calculated one. If status isn't 'success', this incident's timestamps have changed since and no longer match this value",
             "example": 10800,
             "format": "int64",
             "type": "integer"
           }
         },
         "required": [
-          "duration_metric"
+          "duration_metric",
+          "status"
         ],
         "type": "object"
       },
@@ -52427,6 +52975,7 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                 "name": "Lasted"
               },
+              "status": "success",
               "value_seconds": 10800
             }
           ],
@@ -52587,6 +53136,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -52856,6 +53406,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -53526,6 +54077,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -53759,6 +54311,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -54258,6 +54811,7 @@
                     "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                     "name": "Lasted"
                   },
+                  "status": "success",
                   "value_seconds": 10800
                 }
               ],
@@ -54428,6 +54982,7 @@
                       "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                       "name": "Lasted"
                     },
+                    "status": "success",
                     "value_seconds": 10800
                   }
                 ],
@@ -54737,6 +55292,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -59988,7 +60544,8 @@
             "description": "Which schedule members sync to the user group",
             "enum": [
               "on_call",
-              "all_users"
+              "all_users",
+              "next_on_call"
             ],
             "example": "on_call",
             "type": "string"
@@ -60001,7 +60558,7 @@
         "type": "object"
       },
       "ScheduleSyncRuleV2": {
-        "description": "A sync rule links a schedule to a sync target, telling us which of the\nschedule's members should flow into the target's Slack user group.\n\nsync_type decides who is synced: on_call syncs only the people currently on\ncall, while all_users syncs everyone on the schedule. By default every\nrotation on the schedule is included; set rotation_id to scope the rule to a\nsingle rotation. As the schedule's shifts change hands, we keep the target's\nSlack user group membership in step with the rule.\n\npermanent_member_user_ids names users who stay in the group whichever way the\nshifts fall, on top of whoever sync_type selects.",
+        "description": "A sync rule links a schedule to a sync target, telling us which of the\nschedule's members should flow into the target's Slack user group.\n\nsync_type decides who is synced: on_call syncs only the people currently on\ncall, next_on_call syncs the people on the next upcoming shift, and all_users\nsyncs everyone on the schedule. By default every rotation on the schedule is\nincluded; set rotation_id to scope the rule to a single rotation. As the\nschedule's shifts change hands, we keep the target's Slack user group\nmembership in step with the rule.\n\npermanent_member_user_ids names users who stay in the group whichever way the\nshifts fall, on top of whoever sync_type selects.",
         "example": {
           "created_at": "2021-08-17T13:28:57.801578Z",
           "id": "01JXYZ000000000000000000CD",
@@ -60075,7 +60632,8 @@
             "description": "Which schedule members sync to the user group",
             "enum": [
               "on_call",
-              "all_users"
+              "all_users",
+              "next_on_call"
             ],
             "example": "on_call",
             "type": "string"
@@ -63067,7 +63625,8 @@
             "description": "Which schedule members sync to the user group",
             "enum": [
               "on_call",
-              "all_users"
+              "all_users",
+              "next_on_call"
             ],
             "example": "on_call",
             "type": "string"
@@ -67391,6 +67950,7 @@
                 "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                 "name": "Lasted"
               },
+              "status": "success",
               "value_seconds": 10800
             }
           ],
@@ -67555,6 +68115,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -68389,6 +68950,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -68554,6 +69116,7 @@
                     "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                     "name": "Lasted"
                   },
+                  "status": "success",
                   "value_seconds": 10800
                 }
               ],
@@ -68734,6 +69297,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -71042,6 +71606,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -71262,6 +71827,7 @@
                     "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                     "name": "Lasted"
                   },
+                  "status": "success",
                   "value_seconds": 10800
                 }
               ],
@@ -71497,6 +72063,7 @@
                   "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                   "name": "Lasted"
                 },
+                "status": "success",
                 "value_seconds": 10800
               }
             ],
@@ -85476,6 +86043,201 @@
         ]
       }
     },
+    "/v2/alert_sources/actions/validate": {
+      "post": {
+        "description": "Check whether an alert source template is valid, without creating or updating anything.\n\nThis validates the template in the same way a create or update would: expressions are\ncompiled and checked against your alert schema and catalog, and merge strategies are checked\nagainst the attributes they bind to. Values that are only known once an alert source exists\nare not validated.",
+        "operationId": "Alert Sources V2#Validate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "owning_team_ids": [
+                  "01G0J1EXE7AXZ2C93K61WBPYEH"
+                ],
+                "source_type": "alertmanager",
+                "template": {
+                  "attributes": [
+                    {
+                      "alert_attribute_id": "abc123",
+                      "binding": {
+                        "array_value": [
+                          {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        ],
+                        "merge_strategy": "first_wins",
+                        "value": {
+                          "literal": "SEV123",
+                          "reference": "incident.severity"
+                        }
+                      }
+                    }
+                  ],
+                  "description": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  },
+                  "expressions": [
+                    {
+                      "else_branch": {
+                        "result": {
+                          "array_value": [
+                            {
+                              "literal": "SEV123",
+                              "reference": "incident.severity"
+                            }
+                          ],
+                          "value": {
+                            "literal": "SEV123",
+                            "reference": "incident.severity"
+                          }
+                        }
+                      },
+                      "label": "Team Slack channel",
+                      "operations": [
+                        {
+                          "branches": {
+                            "branches": [
+                              {
+                                "condition_groups": [
+                                  {
+                                    "conditions": [
+                                      {
+                                        "operation": "one_of",
+                                        "param_bindings": [
+                                          {
+                                            "array_value": [
+                                              {
+                                                "literal": "SEV123",
+                                                "reference": "incident.severity"
+                                              }
+                                            ],
+                                            "value": {
+                                              "literal": "SEV123",
+                                              "reference": "incident.severity"
+                                            }
+                                          }
+                                        ],
+                                        "subject": "incident.severity"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "result": {
+                                  "array_value": [
+                                    {
+                                      "literal": "SEV123",
+                                      "reference": "incident.severity"
+                                    }
+                                  ],
+                                  "value": {
+                                    "literal": "SEV123",
+                                    "reference": "incident.severity"
+                                  }
+                                }
+                              }
+                            ],
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          },
+                          "cast": {
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            }
+                          },
+                          "concatenate": {
+                            "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                          },
+                          "filter": {
+                            "condition_groups": [
+                              {
+                                "conditions": [
+                                  {
+                                    "operation": "one_of",
+                                    "param_bindings": [
+                                      {
+                                        "array_value": [
+                                          {
+                                            "literal": "SEV123",
+                                            "reference": "incident.severity"
+                                          }
+                                        ],
+                                        "value": {
+                                          "literal": "SEV123",
+                                          "reference": "incident.severity"
+                                        }
+                                      }
+                                    ],
+                                    "subject": "incident.severity"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "navigate": {
+                            "reference": "catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"
+                          },
+                          "operation_type": "navigate",
+                          "parse": {
+                            "returns": {
+                              "array": true,
+                              "type": "IncidentStatus"
+                            },
+                            "source": "metadata.annotations[\"github.com/repo\"]"
+                          }
+                        }
+                      ],
+                      "reference": "abc123",
+                      "root_reference": "incident.status"
+                    }
+                  ],
+                  "is_private": false,
+                  "title": {
+                    "literal": "SEV123",
+                    "reference": "incident.severity"
+                  },
+                  "visible_to_teams": {
+                    "array_value": [
+                      {
+                        "literal": "SEV123",
+                        "reference": "incident.severity"
+                      }
+                    ],
+                    "value": {
+                      "literal": "SEV123",
+                      "reference": "incident.severity"
+                    }
+                  }
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/AlertSourcesValidatePayloadV2"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content response."
+          }
+        },
+        "summary": "Validate Alert Sources V2",
+        "tags": [
+          "Alert Sources V2"
+        ],
+        "x-docs-display-name": "Validate",
+        "x-docs-group-name": "Alert Sources V2",
+        "x-docs-resource-type": "AlertSourceV2",
+        "x-rbac-scopes": [
+          "alert_sources.view"
+        ]
+      }
+    },
     "/v2/alert_sources/{id}": {
       "delete": {
         "description": "Delete an existing alert source in your account.",
@@ -86781,6 +87543,187 @@
         ]
       }
     },
+    "/v2/call_sessions": {
+      "get": {
+        "description": "List Scribe call sessions, newest first, filtered by incident.",
+        "operationId": "Call Sessions V2#List",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "description": "Integer number of records to return",
+            "example": 25,
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 25,
+              "description": "Integer number of records to return",
+              "example": 25,
+              "format": "int64",
+              "maximum": 250,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "A call session's ID. This endpoint will return a list of call sessions after this ID in relation to the API response order.",
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            },
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "description": "A call session's ID. This endpoint will return a list of call sessions after this ID in relation to the API response order.",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "Incident whose call sessions you want to list",
+            "example": "01G0J1EXE7AXZ2C93K61WBPYEH",
+            "in": "query",
+            "name": "incident_id",
+            "required": true,
+            "schema": {
+              "description": "Incident whose call sessions you want to list",
+              "example": "01G0J1EXE7AXZ2C93K61WBPYEH",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "call_sessions": [
+                    {
+                      "ended_at": "2021-08-17T14:28:57.801578Z",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "incident_id": "01G0J1EXE7AXZ2C93K61WBPYEH",
+                      "started_at": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ],
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CallSessionsListResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "List Call Sessions V2",
+        "tags": [
+          "Call Sessions V2"
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Call Sessions V2",
+        "x-docs-resource-type": "CallSessionV2",
+        "x-rbac-scopes": [
+          "call_transcripts.view"
+        ]
+      }
+    },
+    "/v2/call_transcript_entries": {
+      "get": {
+        "description": "List transcript entries for a call session, oldest first.\n\nReturns an empty list if your organisation has disabled viewing transcripts.",
+        "operationId": "Call Transcript Entries V2#List",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "description": "Integer number of records to return",
+            "example": 25,
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 25,
+              "description": "Integer number of records to return",
+              "example": 25,
+              "format": "int64",
+              "maximum": 250,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "A transcript entry's ID. This endpoint will return a list of entries after this ID in relation to the API response order.",
+            "examples": {
+              "default": {
+                "summary": "default",
+                "value": "01FCNDV6P870EA6S7TK1DSYDG0"
+              }
+            },
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "description": "A transcript entry's ID. This endpoint will return a list of entries after this ID in relation to the API response order.",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          },
+          {
+            "allowEmptyValue": true,
+            "description": "Call session whose transcript entries you want to list",
+            "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+            "in": "query",
+            "name": "call_session_id",
+            "required": true,
+            "schema": {
+              "description": "Call session whose transcript entries you want to list",
+              "example": "01FCNDV6P870EA6S7TK1DSYDG0",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "call_transcript_entries": [
+                    {
+                      "content": "I think we should roll back the deploy.",
+                      "id": "01FCNDV6P870EA6S7TK1DSYDG0",
+                      "medium": "spoken",
+                      "participant_name": "Alice Smith",
+                      "timestamp": "2021-08-17T13:28:57.801578Z"
+                    }
+                  ],
+                  "pagination_meta": {
+                    "after": "01FCNDV6P870EA6S7TK1DSYDG0",
+                    "page_size": 25
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/CallTranscriptEntriesListResultV2"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "List Call Transcript Entries V2",
+        "tags": [
+          "Call Transcript Entries V2"
+        ],
+        "x-docs-display-name": "List",
+        "x-docs-group-name": "Call Transcript Entries V2",
+        "x-docs-resource-type": "CallTranscriptEntryV2",
+        "x-rbac-scopes": [
+          "call_transcripts.view"
+        ]
+      }
+    },
     "/v2/catalog_entries": {
       "get": {
         "deprecated": true,
@@ -87447,7 +88390,7 @@
                       "category": "custom",
                       "description": "Boolean true or false value",
                       "label": "GitHub Repository",
-                      "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+                      "type": "Custom[\"Team\"]",
                       "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
                     }
                   ]
@@ -88429,6 +89372,10 @@
                           },
                           "level": {
                             "ack_mode": "all",
+                            "retry_config": {
+                              "attempts": 3,
+                              "interval_seconds": 300
+                            },
                             "round_robin_config": {
                               "enabled": false,
                               "rotate_after_seconds": 120
@@ -88561,6 +89508,10 @@
                     },
                     "level": {
                       "ack_mode": "all",
+                      "retry_config": {
+                        "attempts": 3,
+                        "interval_seconds": 300
+                      },
                       "round_robin_config": {
                         "enabled": false,
                         "rotate_after_seconds": 120
@@ -88691,6 +89642,10 @@
                         },
                         "level": {
                           "ack_mode": "all",
+                          "retry_config": {
+                            "attempts": 3,
+                            "interval_seconds": 300
+                          },
                           "round_robin_config": {
                             "enabled": false,
                             "rotate_after_seconds": 120
@@ -88984,6 +89939,10 @@
                         },
                         "level": {
                           "ack_mode": "all",
+                          "retry_config": {
+                            "attempts": 3,
+                            "interval_seconds": 300
+                          },
                           "round_robin_config": {
                             "enabled": false,
                             "rotate_after_seconds": 120
@@ -89180,6 +90139,10 @@
                         },
                         "level": {
                           "ack_mode": "all",
+                          "retry_config": {
+                            "attempts": 3,
+                            "interval_seconds": 300
+                          },
                           "round_robin_config": {
                             "enabled": false,
                             "rotate_after_seconds": 120
@@ -89321,6 +90284,10 @@
                     },
                     "level": {
                       "ack_mode": "all",
+                      "retry_config": {
+                        "attempts": 3,
+                        "interval_seconds": 300
+                      },
                       "round_robin_config": {
                         "enabled": false,
                         "rotate_after_seconds": 120
@@ -89451,6 +90418,10 @@
                         },
                         "level": {
                           "ack_mode": "all",
+                          "retry_config": {
+                            "attempts": 3,
+                            "interval_seconds": 300
+                          },
                           "round_robin_config": {
                             "enabled": false,
                             "rotate_after_seconds": 120
@@ -91580,7 +92551,7 @@
     },
     "/v2/incidents": {
       "get": {
-        "description": "List all incidents for an organisation.\n\nThis endpoint supports a number of filters, which can help find incidents matching certain\ncriteria.\n\nFilters are provided as query parameters, but due to the dynamic nature of what you can\nquery by (different accounts have different custom fields, statuses, etc) they are more\ncomplex than most.\n\nThe maximum page size that can be requested is 250.\n\nTo help, here are some exemplar curl requests with a human description of what they search\nfor.\n\nNote that:\n- Filters may be combined using the filter_mode parameter: 'all' (default) requires all filters\nto match (AND logic), while 'any' requires at least one filter to match (OR logic).\n- IDs are normally in UUID format, but have been replaced with shorter strings to improve\nreadability.\n- All query parameters must be URI encoded.\n\n### By status\n\nWith status of id=ABC, find all incidents that are set to that status:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[one_of]=ABC'\n\nOr all incidents that are not set to status with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[not_in]=ABC'\n\n### By created_at or updated_at\n\nFind all incidents that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and\n\"date_range\" (between two dates). The following example finds all incidents created before\nor on 2021-01-02T00:00:00Z:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[lte]=2021-01-02'\n\nTo find incidents created within a specific date range, use the date_range option with\ntilde-separated dates:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[date_range]=2024-12-02~2024-12-08'\n\n### By status category\n\nFind all incidents that are in a status category. Possible values are \"triage\",\n\"declined\", \"merged\", \"canceled\", \"live\", \"learning\" and \"closed\":\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[one_of]=live'\n\nOr all incidents that are not in a status category:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[not_in]=live'\n\n\n### By severity\n\nWith severity of id=ABC, find all incidents that are set to that severity:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[one_of]=ABC'\n\nOr all incidents where severity rank is greater-than-or-equal-to the rank of severity\nid=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[gte]=ABC'\n\nOr all incidents where severity rank is less-than-or-equal-to the rank of severity id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[lte]=ABC'\n\n### By incident type\n\nWith incident type of id=ABC, find all incidents that are of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[one_of]=ABC'\n\nOr all incidents not of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[not_in]=ABC'\n\n### By incident mode\n\nBy default, we return standard and retrospective incidents. This means that test and\ntutorial incidents are filtered out. To override this behaviour, you can use the\nmode filter to specify which modes you want to get.\n\nTo find incidents of all modes:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=standard\u0026mode[one_of]=retrospective\u0026mode[one_of]=test\u0026mode[one_of]=tutorial'\n\nTo find just test incidents:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=test'\n\n\n### By incident role\n\nRoles and custom fields have another nested layer in the query parameter, to account for\noperations against any of the roles or custom fields created in the account.\n\nWith incident role id=ABC, find all incidents where that role is unset:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_set]=true'\n\nOr where the role has been set:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_set]=false'\n\n### By option custom fields\n\nWith an option custom field id=ABC, all incidents that have field ABC set to the custom\nfield option of id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][one_of]=XYZ'\n\nOr all incidents that do not have custom field id=ABC set to option id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][not_in]=XYZ'\n\n### Sorting\n\nBy default, results are ordered by their creation date. You can use the sort_by parameter\nto reverse this order:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'sort_by=created_at_oldest_first'\n",
+        "description": "List all incidents for an organisation.\n\nThis endpoint supports a number of filters, which can help find incidents matching certain\ncriteria.\n\nFilters are provided as query parameters, but due to the dynamic nature of what you can\nquery by (different accounts have different custom fields, statuses, etc) they are more\ncomplex than most.\n\nThe maximum page size that can be requested is 250.\n\nTo help, here are some exemplar curl requests with a human description of what they search\nfor.\n\nNote that:\n- Filters may be combined using the filter_mode parameter: 'all' (default) requires all filters\nto match (AND logic), while 'any' requires at least one filter to match (OR logic).\n- IDs are normally in UUID format, but have been replaced with shorter strings to improve\nreadability.\n- All query parameters must be URI encoded.\n\n### By status\n\nWith status of id=ABC, find all incidents that are set to that status:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[one_of]=ABC'\n\nOr all incidents that are not set to status with id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status[not_in]=ABC'\n\n### By created_at or updated_at\n\nFind all incidents that follow specified date parameters for created_at and updated_at fields.\nPossible values are \"gte\" (greater than or equal to), \"lte\" (less than or equal to), and\n\"date_range\" (between two dates). The following example finds all incidents created before\nor on 2021-01-02T00:00:00Z:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[lte]=2021-01-02'\n\nTo find incidents created within a specific date range, use the date_range option with\ntilde-separated dates:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'created_at[date_range]=2024-12-02~2024-12-08'\n\n### By status category\n\nFind all incidents that are in a status category. Some categories use a different\nname in the API than the one shown in the dashboard — most notably \"live\" (shown as\n\"Active\") and \"learning\" (shown as \"Post-incident\"). The full mapping is:\n\n| API value  | Shown in app as |\n| ---------- | --------------- |\n| triage     | Triage          |\n| live       | Active          |\n| learning   | Post-incident   |\n| paused     | Paused          |\n| closed     | Closed          |\n| declined   | Declined        |\n| canceled   | Canceled        |\n| merged     | Merged          |\n\nFor example, to find all incidents the dashboard shows as \"Active\", filter on the\n\"live\" category:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[one_of]=live'\n\nOr all incidents that are not in a status category:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'status_category[not_in]=live'\n\n\n### By severity\n\nWith severity of id=ABC, find all incidents that are set to that severity:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[one_of]=ABC'\n\nOr all incidents where severity rank is greater-than-or-equal-to the rank of severity\nid=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[gte]=ABC'\n\nOr all incidents where severity rank is less-than-or-equal-to the rank of severity id=ABC:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'severity[lte]=ABC'\n\n### By incident type\n\nWith incident type of id=ABC, find all incidents that are of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[one_of]=ABC'\n\nOr all incidents not of that type:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_type[not_in]=ABC'\n\n### By incident mode\n\nBy default, we return standard and retrospective incidents. This means that test and\ntutorial incidents are filtered out. To override this behaviour, you can use the\nmode filter to specify which modes you want to get.\n\nTo find incidents of all modes:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=standard\u0026mode[one_of]=retrospective\u0026mode[one_of]=test\u0026mode[one_of]=tutorial'\n\nTo find just test incidents:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'mode[one_of]=test'\n\n\n### By incident role\n\nRoles and custom fields have another nested layer in the query parameter, to account for\noperations against any of the roles or custom fields created in the account.\n\nWith incident role id=ABC, find all incidents where that role is unset:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_set]=true'\n\nOr where the role has been set:\n\n\t\tcurl --get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'incident_role[ABC][is_set]=false'\n\n### By option custom fields\n\nWith an option custom field id=ABC, all incidents that have field ABC set to the custom\nfield option of id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][one_of]=XYZ'\n\nOr all incidents that do not have custom field id=ABC set to option id=XYZ:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'custom_field[ABC][not_in]=XYZ'\n\n### Sorting\n\nBy default, results are ordered by their creation date. You can use the sort_by parameter\nto reverse this order:\n\n\t\tcurl \\\n\t\t\t--get 'https://api.incident.io/v2/incidents' \\\n\t\t\t--data 'sort_by=created_at_oldest_first'\n",
         "operationId": "Incidents V2#List",
         "parameters": [
           {
@@ -92023,6 +92994,7 @@
                             "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                             "name": "Lasted"
                           },
+                          "status": "success",
                           "value_seconds": 10800
                         }
                       ],
@@ -92276,6 +93248,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                           "name": "Lasted"
                         },
+                        "status": "success",
                         "value_seconds": 10800
                       }
                     ],
@@ -92480,6 +93453,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                           "name": "Lasted"
                         },
+                        "status": "success",
                         "value_seconds": 10800
                       }
                     ],
@@ -92737,6 +93711,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                           "name": "Lasted"
                         },
+                        "status": "success",
                         "value_seconds": 10800
                       }
                     ],
@@ -102067,6 +103042,7 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
+                    "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
                     "estimated_count": 7,
                     "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -102409,6 +103385,7 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
+                    "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
                     "estimated_count": 7,
                     "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -102563,6 +103540,7 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
+                    "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
                     "estimated_count": 7,
                     "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -102636,8 +103614,9 @@
                     {
                       "category": "custom",
                       "description": "Boolean true or false value",
+                      "engine_resource_type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
                       "label": "GitHub Repository",
-                      "type": "CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]",
+                      "type": "Custom[\"Team\"]",
                       "value_docstring": "Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"
                     }
                   ]
@@ -102683,6 +103662,7 @@
                       "created_at": "2021-08-17T13:28:57.801578Z",
                       "description": "Represents Kubernetes clusters that we run inside of GKE.",
                       "dynamic_resource_parameter": "abc123",
+                      "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
                       "estimated_count": 7,
                       "icon": "alert",
                       "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -102791,6 +103771,7 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
+                    "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
                     "estimated_count": 7,
                     "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -102918,6 +103899,7 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
+                    "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
                     "estimated_count": 7,
                     "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -103038,6 +104020,7 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
+                    "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
                     "estimated_count": 7,
                     "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -103160,6 +104143,7 @@
                     "created_at": "2021-08-17T13:28:57.801578Z",
                     "description": "Represents Kubernetes clusters that we run inside of GKE.",
                     "dynamic_resource_parameter": "abc123",
+                    "engine_resource_type": "CatalogEntry[\"PagerDutyService\"]",
                     "estimated_count": 7,
                     "icon": "alert",
                     "id": "01FCNDV6P870EA6S7TK1DSYDG0",
@@ -104416,6 +105400,14 @@
     {
       "description": "Read your alerts in incident.io.\n\nAlerts are events ingested from third parties by alert sources. They can trigger incidents and escalations, as configured in alert routes.\nTo view your alerts, you can list all alerts, or show a single alert. \nIf you'd like to view only alerts that are currently firing, you can filter by status. \nTo view the alert that was created for an event in your external system, filter by deduplication key. \n\nIf you'd like to view alerts connected to a particular incident, you can list incident alerts. You can filter by incident_id to find all alerts attached to a particular incident, or by alert_id to find the incident that a particular alert triggered.  \n",
       "name": "Alerts V2"
+    },
+    {
+      "description": "List Scribe call sessions.\n\nCall sessions are the individual meetings Scribe attended: several can accumulate\nover time. Use this endpoint together with Call Transcript Entries to export what\nScribe transcribed during each session.",
+      "name": "Call Sessions V2"
+    },
+    {
+      "description": "List the transcript entries Scribe captured during a call session.\n\nEntries are returned oldest first, ordered by when each participant started\nspeaking. To export a full transcript, page through with 'page_size' and 'after'\nuntil the response no longer includes a 'pagination_meta.after' value.",
+      "name": "Call Transcript Entries V2"
     },
     {
       "description": "Manage and browse catalog resources.\n\nThese endpoints have been deprecated in favour of CatalogV3. The only breaking change is\nthat the 'manual' attribute mode is now split into 'api' and 'dashboard'. We also removed\nthe usage of some types that were deprecated in the V2 API. \n\nUse the incident.io catalog to track services, teams, product features and anything\nelse that helps build a map of your organisation. These different categories of thing\nbecome catalog types, and each instance (like a particular service or team) is a\ncatalog entry.\n\nEach type is made up of a series of attributes, and each attribute has a type. Types\ncan even have attributes that refer to other catalog types.\n\nWe automatically create catalog types when you connect an integration, such as GitHub\nrepositories or PagerDuty services and teams. You can use this API to create custom\ntypes, that are specifically tailored to your organisation.\n\nExamples might be a 'Service' type with an 'Alert channel' which you can point at a\nSlack channel, or 'Team' which specifies its 'Manager' and 'Technical Lead' as Slack\nusers. You can then use these types to create powerful new workflows.\n\nConsider using our official [catalog importer](https://github.com/incident-io/catalog-importer).\nIt can be used to sync catalog data from sources like local files or GitHub and push\nthem into the incident.io catalog without having to directly interact with our public API.\n",
@@ -114961,6 +115953,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                           "name": "Lasted"
                         },
+                        "status": "success",
                         "value_seconds": 10800
                       }
                     ],
@@ -115150,6 +116143,7 @@
                             "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                             "name": "Lasted"
                           },
+                          "status": "success",
                           "value_seconds": 10800
                         }
                       ],
@@ -115354,6 +116348,7 @@
                           "id": "01FCNDV6P870EA6S7TK1DSYD5H",
                           "name": "Lasted"
                         },
+                        "status": "success",
                         "value_seconds": 10800
                       }
                     ],

--- a/internal/client/client.gen.go
+++ b/internal/client/client.gen.go
@@ -22,6 +22,7 @@ import (
 const (
 	APIKeyRoleV1NameActOnBehalfOfUsers                  APIKeyRoleV1Name = "act_on_behalf_of_users"
 	APIKeyRoleV1NameApiKeysManage                       APIKeyRoleV1Name = "api_keys_manage"
+	APIKeyRoleV1NameCallTranscriptsViewer               APIKeyRoleV1Name = "call_transcripts_viewer"
 	APIKeyRoleV1NameCatalogEditor                       APIKeyRoleV1Name = "catalog_editor"
 	APIKeyRoleV1NameCatalogViewer                       APIKeyRoleV1Name = "catalog_viewer"
 	APIKeyRoleV1NameEscalationCreator                   APIKeyRoleV1Name = "escalation_creator"
@@ -60,6 +61,8 @@ func (e APIKeyRoleV1Name) Valid() bool {
 	case APIKeyRoleV1NameActOnBehalfOfUsers:
 		return true
 	case APIKeyRoleV1NameApiKeysManage:
+		return true
+	case APIKeyRoleV1NameCallTranscriptsViewer:
 		return true
 	case APIKeyRoleV1NameCatalogEditor:
 		return true
@@ -175,6 +178,7 @@ func (e APIKeyTeamRoleV1Name) Valid() bool {
 const (
 	APIKeysCreatePayloadV1RoleNamesActOnBehalfOfUsers                  APIKeysCreatePayloadV1RoleNames = "act_on_behalf_of_users"
 	APIKeysCreatePayloadV1RoleNamesApiKeysManage                       APIKeysCreatePayloadV1RoleNames = "api_keys_manage"
+	APIKeysCreatePayloadV1RoleNamesCallTranscriptsViewer               APIKeysCreatePayloadV1RoleNames = "call_transcripts_viewer"
 	APIKeysCreatePayloadV1RoleNamesCatalogEditor                       APIKeysCreatePayloadV1RoleNames = "catalog_editor"
 	APIKeysCreatePayloadV1RoleNamesCatalogViewer                       APIKeysCreatePayloadV1RoleNames = "catalog_viewer"
 	APIKeysCreatePayloadV1RoleNamesEscalationCreator                   APIKeysCreatePayloadV1RoleNames = "escalation_creator"
@@ -213,6 +217,8 @@ func (e APIKeysCreatePayloadV1RoleNames) Valid() bool {
 	case APIKeysCreatePayloadV1RoleNamesActOnBehalfOfUsers:
 		return true
 	case APIKeysCreatePayloadV1RoleNamesApiKeysManage:
+		return true
+	case APIKeysCreatePayloadV1RoleNamesCallTranscriptsViewer:
 		return true
 	case APIKeysCreatePayloadV1RoleNamesCatalogEditor:
 		return true
@@ -328,6 +334,7 @@ func (e APIKeysCreatePayloadV1TeamRoleNames) Valid() bool {
 const (
 	APIKeysUpdatePayloadV1RoleNamesActOnBehalfOfUsers                  APIKeysUpdatePayloadV1RoleNames = "act_on_behalf_of_users"
 	APIKeysUpdatePayloadV1RoleNamesApiKeysManage                       APIKeysUpdatePayloadV1RoleNames = "api_keys_manage"
+	APIKeysUpdatePayloadV1RoleNamesCallTranscriptsViewer               APIKeysUpdatePayloadV1RoleNames = "call_transcripts_viewer"
 	APIKeysUpdatePayloadV1RoleNamesCatalogEditor                       APIKeysUpdatePayloadV1RoleNames = "catalog_editor"
 	APIKeysUpdatePayloadV1RoleNamesCatalogViewer                       APIKeysUpdatePayloadV1RoleNames = "catalog_viewer"
 	APIKeysUpdatePayloadV1RoleNamesEscalationCreator                   APIKeysUpdatePayloadV1RoleNames = "escalation_creator"
@@ -366,6 +373,8 @@ func (e APIKeysUpdatePayloadV1RoleNames) Valid() bool {
 	case APIKeysUpdatePayloadV1RoleNamesActOnBehalfOfUsers:
 		return true
 	case APIKeysUpdatePayloadV1RoleNamesApiKeysManage:
+		return true
+	case APIKeysUpdatePayloadV1RoleNamesCallTranscriptsViewer:
 		return true
 	case APIKeysUpdatePayloadV1RoleNamesCatalogEditor:
 		return true
@@ -1164,6 +1173,165 @@ func (e AlertSourcesCreatePayloadV2SourceType) Valid() bool {
 	}
 }
 
+// Defines values for AlertSourcesValidatePayloadV2SourceType.
+const (
+	AlertSourcesValidatePayloadV2SourceTypeAlertmanager      AlertSourcesValidatePayloadV2SourceType = "alertmanager"
+	AlertSourcesValidatePayloadV2SourceTypeAppOptics         AlertSourcesValidatePayloadV2SourceType = "app_optics"
+	AlertSourcesValidatePayloadV2SourceTypeAzureMonitor      AlertSourcesValidatePayloadV2SourceType = "azure_monitor"
+	AlertSourcesValidatePayloadV2SourceTypeBigPanda          AlertSourcesValidatePayloadV2SourceType = "big_panda"
+	AlertSourcesValidatePayloadV2SourceTypeBugsnag           AlertSourcesValidatePayloadV2SourceType = "bugsnag"
+	AlertSourcesValidatePayloadV2SourceTypeCheckly           AlertSourcesValidatePayloadV2SourceType = "checkly"
+	AlertSourcesValidatePayloadV2SourceTypeChronosphere      AlertSourcesValidatePayloadV2SourceType = "chronosphere"
+	AlertSourcesValidatePayloadV2SourceTypeCloudflare        AlertSourcesValidatePayloadV2SourceType = "cloudflare"
+	AlertSourcesValidatePayloadV2SourceTypeCloudwatch        AlertSourcesValidatePayloadV2SourceType = "cloudwatch"
+	AlertSourcesValidatePayloadV2SourceTypeCoralogix         AlertSourcesValidatePayloadV2SourceType = "coralogix"
+	AlertSourcesValidatePayloadV2SourceTypeCronitor          AlertSourcesValidatePayloadV2SourceType = "cronitor"
+	AlertSourcesValidatePayloadV2SourceTypeCrowdstrikeFalcon AlertSourcesValidatePayloadV2SourceType = "crowdstrike_falcon"
+	AlertSourcesValidatePayloadV2SourceTypeDash0             AlertSourcesValidatePayloadV2SourceType = "dash0"
+	AlertSourcesValidatePayloadV2SourceTypeDatadog           AlertSourcesValidatePayloadV2SourceType = "datadog"
+	AlertSourcesValidatePayloadV2SourceTypeDynatrace         AlertSourcesValidatePayloadV2SourceType = "dynatrace"
+	AlertSourcesValidatePayloadV2SourceTypeElasticsearch     AlertSourcesValidatePayloadV2SourceType = "elasticsearch"
+	AlertSourcesValidatePayloadV2SourceTypeEmail             AlertSourcesValidatePayloadV2SourceType = "email"
+	AlertSourcesValidatePayloadV2SourceTypeExpel             AlertSourcesValidatePayloadV2SourceType = "expel"
+	AlertSourcesValidatePayloadV2SourceTypeGithubIssue       AlertSourcesValidatePayloadV2SourceType = "github_issue"
+	AlertSourcesValidatePayloadV2SourceTypeGoogleCloud       AlertSourcesValidatePayloadV2SourceType = "google_cloud"
+	AlertSourcesValidatePayloadV2SourceTypeGrafana           AlertSourcesValidatePayloadV2SourceType = "grafana"
+	AlertSourcesValidatePayloadV2SourceTypeHeartbeat         AlertSourcesValidatePayloadV2SourceType = "heartbeat"
+	AlertSourcesValidatePayloadV2SourceTypeHoneycomb         AlertSourcesValidatePayloadV2SourceType = "honeycomb"
+	AlertSourcesValidatePayloadV2SourceTypeHttp              AlertSourcesValidatePayloadV2SourceType = "http"
+	AlertSourcesValidatePayloadV2SourceTypeHttpCustom        AlertSourcesValidatePayloadV2SourceType = "http_custom"
+	AlertSourcesValidatePayloadV2SourceTypeIncomingCalls     AlertSourcesValidatePayloadV2SourceType = "incoming_calls"
+	AlertSourcesValidatePayloadV2SourceTypeJira              AlertSourcesValidatePayloadV2SourceType = "jira"
+	AlertSourcesValidatePayloadV2SourceTypeJsm               AlertSourcesValidatePayloadV2SourceType = "jsm"
+	AlertSourcesValidatePayloadV2SourceTypeMonteCarlo        AlertSourcesValidatePayloadV2SourceType = "monte_carlo"
+	AlertSourcesValidatePayloadV2SourceTypeNagios            AlertSourcesValidatePayloadV2SourceType = "nagios"
+	AlertSourcesValidatePayloadV2SourceTypeNewRelic          AlertSourcesValidatePayloadV2SourceType = "new_relic"
+	AlertSourcesValidatePayloadV2SourceTypeOpsgenie          AlertSourcesValidatePayloadV2SourceType = "opsgenie"
+	AlertSourcesValidatePayloadV2SourceTypePagerDuty         AlertSourcesValidatePayloadV2SourceType = "pager_duty"
+	AlertSourcesValidatePayloadV2SourceTypePanther           AlertSourcesValidatePayloadV2SourceType = "panther"
+	AlertSourcesValidatePayloadV2SourceTypePingdom           AlertSourcesValidatePayloadV2SourceType = "pingdom"
+	AlertSourcesValidatePayloadV2SourceTypePrtg              AlertSourcesValidatePayloadV2SourceType = "prtg"
+	AlertSourcesValidatePayloadV2SourceTypeRunscope          AlertSourcesValidatePayloadV2SourceType = "runscope"
+	AlertSourcesValidatePayloadV2SourceTypeSentry            AlertSourcesValidatePayloadV2SourceType = "sentry"
+	AlertSourcesValidatePayloadV2SourceTypeSentryMetric      AlertSourcesValidatePayloadV2SourceType = "sentry_metric"
+	AlertSourcesValidatePayloadV2SourceTypeServiceNow        AlertSourcesValidatePayloadV2SourceType = "service_now"
+	AlertSourcesValidatePayloadV2SourceTypeSns               AlertSourcesValidatePayloadV2SourceType = "sns"
+	AlertSourcesValidatePayloadV2SourceTypeSplunk            AlertSourcesValidatePayloadV2SourceType = "splunk"
+	AlertSourcesValidatePayloadV2SourceTypeStatusCake        AlertSourcesValidatePayloadV2SourceType = "status_cake"
+	AlertSourcesValidatePayloadV2SourceTypeStatusPageViews   AlertSourcesValidatePayloadV2SourceType = "status_page_views"
+	AlertSourcesValidatePayloadV2SourceTypeSumoLogic         AlertSourcesValidatePayloadV2SourceType = "sumo_logic"
+	AlertSourcesValidatePayloadV2SourceTypeUptime            AlertSourcesValidatePayloadV2SourceType = "uptime"
+	AlertSourcesValidatePayloadV2SourceTypeVercel            AlertSourcesValidatePayloadV2SourceType = "vercel"
+	AlertSourcesValidatePayloadV2SourceTypeWiz               AlertSourcesValidatePayloadV2SourceType = "wiz"
+	AlertSourcesValidatePayloadV2SourceTypeZendesk           AlertSourcesValidatePayloadV2SourceType = "zendesk"
+)
+
+// Valid indicates whether the value is a known member of the AlertSourcesValidatePayloadV2SourceType enum.
+func (e AlertSourcesValidatePayloadV2SourceType) Valid() bool {
+	switch e {
+	case AlertSourcesValidatePayloadV2SourceTypeAlertmanager:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeAppOptics:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeAzureMonitor:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeBigPanda:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeBugsnag:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeCheckly:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeChronosphere:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeCloudflare:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeCloudwatch:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeCoralogix:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeCronitor:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeCrowdstrikeFalcon:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeDash0:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeDatadog:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeDynatrace:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeElasticsearch:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeEmail:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeExpel:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeGithubIssue:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeGoogleCloud:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeGrafana:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeHeartbeat:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeHoneycomb:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeHttp:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeHttpCustom:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeIncomingCalls:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeJira:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeJsm:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeMonteCarlo:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeNagios:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeNewRelic:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeOpsgenie:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypePagerDuty:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypePanther:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypePingdom:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypePrtg:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeRunscope:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeSentry:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeSentryMetric:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeServiceNow:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeSns:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeSplunk:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeStatusCake:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeStatusPageViews:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeSumoLogic:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeUptime:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeVercel:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeWiz:
+		return true
+	case AlertSourcesValidatePayloadV2SourceTypeZendesk:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AlertTemplateAttributeBindingPayloadV2MergeStrategy.
 const (
 	AlertTemplateAttributeBindingPayloadV2MergeStrategyAppend    AlertTemplateAttributeBindingPayloadV2MergeStrategy = "append"
@@ -1230,6 +1398,24 @@ func (e AlertV2Status) Valid() bool {
 	case AlertV2StatusFiring:
 		return true
 	case AlertV2StatusResolved:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CallTranscriptEntryV2Medium.
+const (
+	CallChat CallTranscriptEntryV2Medium = "call_chat"
+	Spoken   CallTranscriptEntryV2Medium = "spoken"
+)
+
+// Valid indicates whether the value is a known member of the CallTranscriptEntryV2Medium enum.
+func (e CallTranscriptEntryV2Medium) Valid() bool {
+	switch e {
+	case CallChat:
+		return true
+	case Spoken:
 		return true
 	default:
 		return false
@@ -3484,6 +3670,7 @@ func (e GroupingSettingsV3WindowType) Valid() bool {
 const (
 	IdentityV1RolesActOnBehalfOfUsers                  IdentityV1Roles = "act_on_behalf_of_users"
 	IdentityV1RolesApiKeysManage                       IdentityV1Roles = "api_keys_manage"
+	IdentityV1RolesCallTranscriptsViewer               IdentityV1Roles = "call_transcripts_viewer"
 	IdentityV1RolesCatalogEditor                       IdentityV1Roles = "catalog_editor"
 	IdentityV1RolesCatalogViewer                       IdentityV1Roles = "catalog_viewer"
 	IdentityV1RolesEscalationCreator                   IdentityV1Roles = "escalation_creator"
@@ -3522,6 +3709,8 @@ func (e IdentityV1Roles) Valid() bool {
 	case IdentityV1RolesActOnBehalfOfUsers:
 		return true
 	case IdentityV1RolesApiKeysManage:
+		return true
+	case IdentityV1RolesCallTranscriptsViewer:
 		return true
 	case IdentityV1RolesCatalogEditor:
 		return true
@@ -3690,6 +3879,30 @@ func (e IncidentAttachmentsCreatePayloadV1ResourceResourceType) Valid() bool {
 	case IncidentAttachmentsCreatePayloadV1ResourceResourceTypeStatuspageIncident:
 		return true
 	case IncidentAttachmentsCreatePayloadV1ResourceResourceTypeZendeskTicket:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for IncidentDurationMetricWithValueV2Status.
+const (
+	IncidentDurationMetricWithValueV2StatusCalculating       IncidentDurationMetricWithValueV2Status = "calculating"
+	IncidentDurationMetricWithValueV2StatusInvalidTimestamps IncidentDurationMetricWithValueV2Status = "invalid_timestamps"
+	IncidentDurationMetricWithValueV2StatusSuccess           IncidentDurationMetricWithValueV2Status = "success"
+	IncidentDurationMetricWithValueV2StatusTimestampsMissing IncidentDurationMetricWithValueV2Status = "timestamps_missing"
+)
+
+// Valid indicates whether the value is a known member of the IncidentDurationMetricWithValueV2Status enum.
+func (e IncidentDurationMetricWithValueV2Status) Valid() bool {
+	switch e {
+	case IncidentDurationMetricWithValueV2StatusCalculating:
+		return true
+	case IncidentDurationMetricWithValueV2StatusInvalidTimestamps:
+		return true
+	case IncidentDurationMetricWithValueV2StatusSuccess:
+		return true
+	case IncidentDurationMetricWithValueV2StatusTimestampsMissing:
 		return true
 	default:
 		return false
@@ -4844,14 +5057,17 @@ func (e ScheduleRotationWorkingIntervalV2Weekday) Valid() bool {
 
 // Defines values for ScheduleSyncRuleCreatePayloadV2SyncType.
 const (
-	ScheduleSyncRuleCreatePayloadV2SyncTypeAllUsers ScheduleSyncRuleCreatePayloadV2SyncType = "all_users"
-	ScheduleSyncRuleCreatePayloadV2SyncTypeOnCall   ScheduleSyncRuleCreatePayloadV2SyncType = "on_call"
+	ScheduleSyncRuleCreatePayloadV2SyncTypeAllUsers   ScheduleSyncRuleCreatePayloadV2SyncType = "all_users"
+	ScheduleSyncRuleCreatePayloadV2SyncTypeNextOnCall ScheduleSyncRuleCreatePayloadV2SyncType = "next_on_call"
+	ScheduleSyncRuleCreatePayloadV2SyncTypeOnCall     ScheduleSyncRuleCreatePayloadV2SyncType = "on_call"
 )
 
 // Valid indicates whether the value is a known member of the ScheduleSyncRuleCreatePayloadV2SyncType enum.
 func (e ScheduleSyncRuleCreatePayloadV2SyncType) Valid() bool {
 	switch e {
 	case ScheduleSyncRuleCreatePayloadV2SyncTypeAllUsers:
+		return true
+	case ScheduleSyncRuleCreatePayloadV2SyncTypeNextOnCall:
 		return true
 	case ScheduleSyncRuleCreatePayloadV2SyncTypeOnCall:
 		return true
@@ -4862,14 +5078,17 @@ func (e ScheduleSyncRuleCreatePayloadV2SyncType) Valid() bool {
 
 // Defines values for ScheduleSyncRuleV2SyncType.
 const (
-	ScheduleSyncRuleV2SyncTypeAllUsers ScheduleSyncRuleV2SyncType = "all_users"
-	ScheduleSyncRuleV2SyncTypeOnCall   ScheduleSyncRuleV2SyncType = "on_call"
+	ScheduleSyncRuleV2SyncTypeAllUsers   ScheduleSyncRuleV2SyncType = "all_users"
+	ScheduleSyncRuleV2SyncTypeNextOnCall ScheduleSyncRuleV2SyncType = "next_on_call"
+	ScheduleSyncRuleV2SyncTypeOnCall     ScheduleSyncRuleV2SyncType = "on_call"
 )
 
 // Valid indicates whether the value is a known member of the ScheduleSyncRuleV2SyncType enum.
 func (e ScheduleSyncRuleV2SyncType) Valid() bool {
 	switch e {
 	case ScheduleSyncRuleV2SyncTypeAllUsers:
+		return true
+	case ScheduleSyncRuleV2SyncTypeNextOnCall:
 		return true
 	case ScheduleSyncRuleV2SyncTypeOnCall:
 		return true
@@ -4922,14 +5141,17 @@ func (e SchedulesUpdateRotationPayloadV3Rollout) Valid() bool {
 
 // Defines values for SchedulesUpdateScheduleSyncRulePayloadV2SyncType.
 const (
-	SchedulesUpdateScheduleSyncRulePayloadV2SyncTypeAllUsers SchedulesUpdateScheduleSyncRulePayloadV2SyncType = "all_users"
-	SchedulesUpdateScheduleSyncRulePayloadV2SyncTypeOnCall   SchedulesUpdateScheduleSyncRulePayloadV2SyncType = "on_call"
+	SchedulesUpdateScheduleSyncRulePayloadV2SyncTypeAllUsers   SchedulesUpdateScheduleSyncRulePayloadV2SyncType = "all_users"
+	SchedulesUpdateScheduleSyncRulePayloadV2SyncTypeNextOnCall SchedulesUpdateScheduleSyncRulePayloadV2SyncType = "next_on_call"
+	SchedulesUpdateScheduleSyncRulePayloadV2SyncTypeOnCall     SchedulesUpdateScheduleSyncRulePayloadV2SyncType = "on_call"
 )
 
 // Valid indicates whether the value is a known member of the SchedulesUpdateScheduleSyncRulePayloadV2SyncType enum.
 func (e SchedulesUpdateScheduleSyncRulePayloadV2SyncType) Valid() bool {
 	switch e {
 	case SchedulesUpdateScheduleSyncRulePayloadV2SyncTypeAllUsers:
+		return true
+	case SchedulesUpdateScheduleSyncRulePayloadV2SyncTypeNextOnCall:
 		return true
 	case SchedulesUpdateScheduleSyncRulePayloadV2SyncTypeOnCall:
 		return true
@@ -8512,6 +8734,27 @@ type AlertSourcesUpdateResultV2 struct {
 	AlertSource AlertSourceV2 `json:"alert_source"`
 }
 
+// AlertSourcesValidatePayloadV2 Example: {"owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"source_type":"alertmanager","template":{"attributes":[{"alert_attribute_id":"abc123","binding":{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"merge_strategy":"first_wins","value":{"literal":"SEV123","reference":"incident.severity"}}}],"description":{"literal":"SEV123","reference":"incident.severity"},"expressions":[{"else_branch":{"result":{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}},"label":"Team Slack channel","operations":[{"branches":{"branches":[{"condition_groups":[{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}]}],"result":{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}}],"returns":{"array":true,"type":"IncidentStatus"}},"cast":{"returns":{"array":true,"type":"IncidentStatus"}},"concatenate":{"reference":"catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"},"filter":{"condition_groups":[{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}]}]},"navigate":{"reference":"catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"},"operation_type":"navigate","parse":{"returns":{"array":true,"type":"IncidentStatus"},"source":"metadata.annotations[\"github.com/repo\"]"}}],"reference":"abc123","root_reference":"incident.status"}],"is_private":false,"title":{"literal":"SEV123","reference":"incident.severity"},"visible_to_teams":{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}}}
+type AlertSourcesValidatePayloadV2 struct {
+	// OwningTeamIds IDs of teams that own this alert source
+	//
+	// Example: ["01G0J1EXE7AXZ2C93K61WBPYEH"]
+	OwningTeamIds *[]string `json:"owning_team_ids,omitempty"`
+
+	// SourceType Type of alert source
+	//
+	// Example: alertmanager
+	SourceType AlertSourcesValidatePayloadV2SourceType `json:"source_type"`
+
+	// Template Example: {"attributes":[{"alert_attribute_id":"abc123","binding":{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"merge_strategy":"first_wins","value":{"literal":"SEV123","reference":"incident.severity"}}}],"description":{"literal":"SEV123","reference":"incident.severity"},"expressions":[{"else_branch":{"result":{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}},"label":"Team Slack channel","operations":[{"branches":{"branches":[{"condition_groups":[{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}]}],"result":{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}}],"returns":{"array":true,"type":"IncidentStatus"}},"cast":{"returns":{"array":true,"type":"IncidentStatus"}},"concatenate":{"reference":"catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"},"filter":{"condition_groups":[{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}]}]},"navigate":{"reference":"catalog_attribute[\"01FCNDV6P870EA6S7TK1DSYD5H\"]"},"operation_type":"navigate","parse":{"returns":{"array":true,"type":"IncidentStatus"},"source":"metadata.annotations[\"github.com/repo\"]"}}],"reference":"abc123","root_reference":"incident.status"}],"is_private":false,"title":{"literal":"SEV123","reference":"incident.severity"},"visible_to_teams":{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}}
+	Template AlertTemplatePayloadV2 `json:"template"`
+}
+
+// AlertSourcesValidatePayloadV2SourceType Type of alert source
+//
+// Example: alertmanager
+type AlertSourcesValidatePayloadV2SourceType string
+
 // AlertTemplateAttributeBindingPayloadV2 Example: {"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"merge_strategy":"first_wins","value":{"literal":"SEV123","reference":"incident.severity"}}
 type AlertTemplateAttributeBindingPayloadV2 struct {
 	// ArrayValue If set, this is the array value of the step parameter
@@ -8729,6 +8972,90 @@ type AlertsShowResultV2 struct {
 	// Alert Example: {"alert_group_ids":["01GW2G3V0S59R238FAHPDS1R66"],"alert_source_id":"01GW2G3V0S59R238FAHPDS1R66","attributes":[{"array_value":[{"catalog_entry":{"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"label":"Payments Team","literal":"SEV123"}],"attribute":{"array":false,"emoji":"fire","id":"01GW2G3V0S59R238FAHPDS1R66","name":"service","required":false,"type":"CatalogEntry[\"01GW2G3V0S59R238FAHPDS1R67\"]"},"value":{"catalog_entry":{"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"label":"Payments Team","literal":"SEV123"}}],"created_at":"2021-08-17T13:28:57.801578Z","deduplication_key":"4293868629","description":"CPU on the payments service has exceeded 75 percent for 5 minutes","id":"01GW2G3V0S59R238FAHPDS1R66","resolved_at":"2021-08-17T14:28:57.801578Z","source_url":"https://www.my-alerting-platform.com/alerts/my-alert-123","status":"firing","title":"*errors.withMessage: PG::Error failed to connect","updated_at":"2021-08-17T13:28:57.801578Z"}
 	Alert AlertV2 `json:"alert"`
 }
+
+// CallSessionV2 A call session is a single occurrence of a call that Scribe attended,
+// for example one Zoom or Google Meet meeting. Several call sessions can exist for
+// the same context: one for each time a call was started.
+//
+// Use the Call Transcript Entries endpoint to page through what Scribe transcribed
+// during a session.
+//
+// Example: {"ended_at":"2021-08-17T14:28:57.801578Z","id":"01FCNDV6P870EA6S7TK1DSYDG0","incident_id":"01G0J1EXE7AXZ2C93K61WBPYEH","started_at":"2021-08-17T13:28:57.801578Z"}
+type CallSessionV2 struct {
+	// EndedAt When the call session ended. Absent while the call is still in progress.
+	//
+	// Example: 2021-08-17T14:28:57.801578Z
+	EndedAt *time.Time `json:"ended_at,omitempty"`
+
+	// Id Unique identifier for this call session
+	//
+	// Example: 01FCNDV6P870EA6S7TK1DSYDG0
+	Id string `json:"id"`
+
+	// IncidentId The incident this call session belongs to
+	//
+	// Example: 01G0J1EXE7AXZ2C93K61WBPYEH
+	IncidentId string `json:"incident_id"`
+
+	// StartedAt When the call session started
+	//
+	// Example: 2021-08-17T13:28:57.801578Z
+	StartedAt time.Time `json:"started_at"`
+}
+
+// CallSessionsListResultV2 Example: {"call_sessions":[{"ended_at":"2021-08-17T14:28:57.801578Z","id":"01FCNDV6P870EA6S7TK1DSYDG0","incident_id":"01G0J1EXE7AXZ2C93K61WBPYEH","started_at":"2021-08-17T13:28:57.801578Z"}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}}
+type CallSessionsListResultV2 struct {
+	// CallSessions Example: [{"ended_at":"2021-08-17T14:28:57.801578Z","id":"01FCNDV6P870EA6S7TK1DSYDG0","incident_id":"01G0J1EXE7AXZ2C93K61WBPYEH","started_at":"2021-08-17T13:28:57.801578Z"}]
+	CallSessions []CallSessionV2 `json:"call_sessions"`
+
+	// PaginationMeta Example: {"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}
+	PaginationMeta *PaginationMetaResultV2 `json:"pagination_meta,omitempty"`
+}
+
+// CallTranscriptEntriesListResultV2 Example: {"call_transcript_entries":[{"content":"I think we should roll back the deploy.","id":"01FCNDV6P870EA6S7TK1DSYDG0","medium":"spoken","participant_name":"Alice Smith","timestamp":"2021-08-17T13:28:57.801578Z"}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}}
+type CallTranscriptEntriesListResultV2 struct {
+	// CallTranscriptEntries Example: [{"content":"I think we should roll back the deploy.","id":"01FCNDV6P870EA6S7TK1DSYDG0","medium":"spoken","participant_name":"Alice Smith","timestamp":"2021-08-17T13:28:57.801578Z"}]
+	CallTranscriptEntries []CallTranscriptEntryV2 `json:"call_transcript_entries"`
+
+	// PaginationMeta Example: {"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}
+	PaginationMeta *PaginationMetaResultV2 `json:"pagination_meta,omitempty"`
+}
+
+// CallTranscriptEntryV2 A single entry of a Scribe call transcript: one contiguous run of
+// speech, or one in-call chat message, from one participant.
+//
+// Example: {"content":"I think we should roll back the deploy.","id":"01FCNDV6P870EA6S7TK1DSYDG0","medium":"spoken","participant_name":"Alice Smith","timestamp":"2021-08-17T13:28:57.801578Z"}
+type CallTranscriptEntryV2 struct {
+	// Content What was said
+	//
+	// Example: I think we should roll back the deploy.
+	Content string `json:"content"`
+
+	// Id Unique identifier for this transcript entry
+	//
+	// Example: 01FCNDV6P870EA6S7TK1DSYDG0
+	Id string `json:"id"`
+
+	// Medium Whether this entry was spoken aloud or sent as an in-call chat message
+	//
+	// Example: spoken
+	Medium CallTranscriptEntryV2Medium `json:"medium"`
+
+	// ParticipantName Name of the participant who spoke or sent the message, as reported by the call provider
+	//
+	// Example: Alice Smith
+	ParticipantName string `json:"participant_name"`
+
+	// Timestamp When the participant started speaking
+	//
+	// Example: 2021-08-17T13:28:57.801578Z
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// CallTranscriptEntryV2Medium Whether this entry was spoken aloud or sent as an in-call chat message
+//
+// Example: spoken
+type CallTranscriptEntryV2Medium string
 
 // CatalogBulkUpdateEntriesPayloadV3 Example: {"catalog_type_id":"01GW2G3V0S59R238FAHPDS1R66","entries":[{"aliases":["abc123"],"attribute_values":{"abc123":{"array_value":[{"literal":"SEV123"}],"value":{"literal":"SEV123"}}},"entry_id":"abc123","external_id":"abc123","name":"abc123","rank":1},{"aliases":["abc123"],"attribute_values":{"abc123":{"array_value":[{"literal":"SEV123"}],"value":{"literal":"SEV123"}}},"entry_id":"abc123","external_id":"abc123","name":"abc123","rank":1}],"update_attributes":["01GW2G3V0S59R238FAHPDS1R66","01GW2G3V0S59R238FAHPDS1R67"]}
 type CatalogBulkUpdateEntriesPayloadV3 struct {
@@ -8964,9 +9291,9 @@ type CatalogCreateTypeResultV2 struct {
 	CatalogType CatalogTypeV2 `json:"catalog_type"`
 }
 
-// CatalogCreateTypeResultV3 Example: {"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
+// CatalogCreateTypeResultV3 Example: {"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
 type CatalogCreateTypeResultV3 struct {
-	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
+	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
 	CatalogType CatalogTypeV3 `json:"catalog_type"`
 }
 
@@ -9236,27 +9563,27 @@ type CatalogListEntriesResultV2 struct {
 	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
 }
 
-// CatalogListEntriesResultV3 Example: {"catalog_entries":[{"aliases":["lawrence@incident.io","lawrence"],"archived_at":"2021-08-17T14:28:57.801578Z","attribute_values":{"abc123":{"array_value":[{"label":"Lawrence Jones","literal":"SEV123"}],"value":{"label":"Lawrence Jones","literal":"SEV123"}}},"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","created_at":"2021-08-17T13:28:57.801578Z","external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call","rank":3,"updated_at":"2021-08-17T13:28:57.801578Z"}],"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true},"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25,"total_record_count":238}}
+// CatalogListEntriesResultV3 Example: {"catalog_entries":[{"aliases":["lawrence@incident.io","lawrence"],"archived_at":"2021-08-17T14:28:57.801578Z","attribute_values":{"abc123":{"array_value":[{"label":"Lawrence Jones","literal":"SEV123"}],"value":{"label":"Lawrence Jones","literal":"SEV123"}}},"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","created_at":"2021-08-17T13:28:57.801578Z","external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call","rank":3,"updated_at":"2021-08-17T13:28:57.801578Z"}],"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true},"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25,"total_record_count":238}}
 type CatalogListEntriesResultV3 struct {
 	// CatalogEntries Example: [{"aliases":["lawrence@incident.io","lawrence"],"archived_at":"2021-08-17T14:28:57.801578Z","attribute_values":{"abc123":{"array_value":[{"label":"Lawrence Jones","literal":"SEV123"}],"value":{"label":"Lawrence Jones","literal":"SEV123"}}},"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","created_at":"2021-08-17T13:28:57.801578Z","external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call","rank":3,"updated_at":"2021-08-17T13:28:57.801578Z"}]
 	CatalogEntries []CatalogEntryV3 `json:"catalog_entries"`
 
-	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
+	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
 	CatalogType CatalogTypeV3 `json:"catalog_type"`
 
 	// PaginationMeta Example: {"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25,"total_record_count":238}
 	PaginationMeta PaginationMetaResultWithTotalV3 `json:"pagination_meta"`
 }
 
-// CatalogListResourcesResultV2 Example: {"resources":[{"category":"custom","description":"Boolean true or false value","label":"GitHub Repository","type":"CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}]}
+// CatalogListResourcesResultV2 Example: {"resources":[{"category":"custom","description":"Boolean true or false value","label":"GitHub Repository","type":"Custom[\"Team\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}]}
 type CatalogListResourcesResultV2 struct {
-	// Resources Example: [{"category":"custom","description":"Boolean true or false value","label":"GitHub Repository","type":"CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}]
+	// Resources Example: [{"category":"custom","description":"Boolean true or false value","label":"GitHub Repository","type":"Custom[\"Team\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}]
 	Resources []CatalogResourceV2 `json:"resources"`
 }
 
-// CatalogListResourcesResultV3 Example: {"resources":[{"category":"custom","description":"Boolean true or false value","label":"GitHub Repository","type":"CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}]}
+// CatalogListResourcesResultV3 Example: {"resources":[{"category":"custom","description":"Boolean true or false value","engine_resource_type":"CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]","label":"GitHub Repository","type":"Custom[\"Team\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}]}
 type CatalogListResourcesResultV3 struct {
-	// Resources Example: [{"category":"custom","description":"Boolean true or false value","label":"GitHub Repository","type":"CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}]
+	// Resources Example: [{"category":"custom","description":"Boolean true or false value","engine_resource_type":"CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]","label":"GitHub Repository","type":"Custom[\"Team\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}]
 	Resources []CatalogResourceV3 `json:"resources"`
 }
 
@@ -9266,13 +9593,13 @@ type CatalogListTypesResultV2 struct {
 	CatalogTypes []CatalogTypeV2 `json:"catalog_types"`
 }
 
-// CatalogListTypesResultV3 Example: {"catalog_types":[{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}]}
+// CatalogListTypesResultV3 Example: {"catalog_types":[{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}]}
 type CatalogListTypesResultV3 struct {
-	// CatalogTypes Example: [{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}]
+	// CatalogTypes Example: [{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}]
 	CatalogTypes []CatalogTypeV3 `json:"catalog_types"`
 }
 
-// CatalogResourceV2 Example: {"category":"custom","description":"Boolean true or false value","label":"GitHub Repository","type":"CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}
+// CatalogResourceV2 Example: {"category":"custom","description":"Boolean true or false value","label":"GitHub Repository","type":"Custom[\"Team\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}
 type CatalogResourceV2 struct {
 	// Category Which category of resource
 	//
@@ -9289,9 +9616,9 @@ type CatalogResourceV2 struct {
 	// Example: GitHub Repository
 	Label string `json:"label"`
 
-	// Type Catalog type name for this resource
+	// Type Catalog type name for this resource, as used when setting the type of a catalog type attribute
 	//
-	// Example: CatalogEntry["01GVGYJSD39FRKVDWACK9NDS4E"]
+	// Example: Custom["Team"]
 	Type string `json:"type"`
 
 	// ValueDocstring Documentation for the literal string value of this resource
@@ -9305,7 +9632,7 @@ type CatalogResourceV2 struct {
 // Example: custom
 type CatalogResourceV2Category string
 
-// CatalogResourceV3 Example: {"category":"custom","description":"Boolean true or false value","label":"GitHub Repository","type":"CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}
+// CatalogResourceV3 Example: {"category":"custom","description":"Boolean true or false value","engine_resource_type":"CatalogEntry[\"01GVGYJSD39FRKVDWACK9NDS4E\"]","label":"GitHub Repository","type":"Custom[\"Team\"]","value_docstring":"Either the GraphQL node ID of the repository or a string of \u003cowner\u003e/\u003crepo\u003e, e.g. incident-io/website"}
 type CatalogResourceV3 struct {
 	// Category Which category of resource
 	//
@@ -9317,14 +9644,19 @@ type CatalogResourceV3 struct {
 	// Example: Boolean true or false value
 	Description string `json:"description"`
 
+	// EngineResourceType The way this resource type is referenced in the engine, as used when setting the type of an alert attribute
+	//
+	// Example: CatalogEntry["01GVGYJSD39FRKVDWACK9NDS4E"]
+	EngineResourceType string `json:"engine_resource_type"`
+
 	// Label Label for this catalog resource type
 	//
 	// Example: GitHub Repository
 	Label string `json:"label"`
 
-	// Type Catalog type name for this resource
+	// Type Catalog type name for this resource, as used when setting the type of a catalog type attribute
 	//
-	// Example: CatalogEntry["01GVGYJSD39FRKVDWACK9NDS4E"]
+	// Example: Custom["Team"]
 	Type string `json:"type"`
 
 	// ValueDocstring Documentation for the literal string value of this resource
@@ -9347,12 +9679,12 @@ type CatalogShowEntryResultV2 struct {
 	CatalogType CatalogTypeV2 `json:"catalog_type"`
 }
 
-// CatalogShowEntryResultV3 Example: {"catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"archived_at":"2021-08-17T14:28:57.801578Z","attribute_values":{"abc123":{"array_value":[{"label":"Lawrence Jones","literal":"SEV123"}],"value":{"label":"Lawrence Jones","literal":"SEV123"}}},"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","created_at":"2021-08-17T13:28:57.801578Z","external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call","rank":3,"updated_at":"2021-08-17T13:28:57.801578Z"},"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
+// CatalogShowEntryResultV3 Example: {"catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"archived_at":"2021-08-17T14:28:57.801578Z","attribute_values":{"abc123":{"array_value":[{"label":"Lawrence Jones","literal":"SEV123"}],"value":{"label":"Lawrence Jones","literal":"SEV123"}}},"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","created_at":"2021-08-17T13:28:57.801578Z","external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call","rank":3,"updated_at":"2021-08-17T13:28:57.801578Z"},"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
 type CatalogShowEntryResultV3 struct {
 	// CatalogEntry Example: {"aliases":["lawrence@incident.io","lawrence"],"archived_at":"2021-08-17T14:28:57.801578Z","attribute_values":{"abc123":{"array_value":[{"label":"Lawrence Jones","literal":"SEV123"}],"value":{"label":"Lawrence Jones","literal":"SEV123"}}},"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","created_at":"2021-08-17T13:28:57.801578Z","external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call","rank":3,"updated_at":"2021-08-17T13:28:57.801578Z"}
 	CatalogEntry CatalogEntryV3 `json:"catalog_entry"`
 
-	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
+	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
 	CatalogType CatalogTypeV3 `json:"catalog_type"`
 }
 
@@ -9362,9 +9694,9 @@ type CatalogShowTypeResultV2 struct {
 	CatalogType CatalogTypeV2 `json:"catalog_type"`
 }
 
-// CatalogShowTypeResultV3 Example: {"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
+// CatalogShowTypeResultV3 Example: {"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
 type CatalogShowTypeResultV3 struct {
-	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
+	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
 	CatalogType CatalogTypeV3 `json:"catalog_type"`
 }
 
@@ -9722,7 +10054,7 @@ type CatalogTypeV2Color string
 // Example: alert
 type CatalogTypeV2Icon string
 
-// CatalogTypeV3 Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
+// CatalogTypeV3 Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
 type CatalogTypeV3 struct {
 	// Annotations Annotations that can track metadata about this type
 	//
@@ -9753,6 +10085,11 @@ type CatalogTypeV3 struct {
 	//
 	// Example: abc123
 	DynamicResourceParameter *string `json:"dynamic_resource_parameter,omitempty"`
+
+	// EngineResourceType The way this resource type is referenced in the engine, as used when setting the type of an alert attribute
+	//
+	// Example: CatalogEntry["PagerDutyService"]
+	EngineResourceType string `json:"engine_resource_type"`
 
 	// EstimatedCount If populated, gives an estimated count of entries for this type
 	//
@@ -9917,12 +10254,12 @@ type CatalogUpdateEntryResultV2 struct {
 	CatalogType CatalogTypeV2 `json:"catalog_type"`
 }
 
-// CatalogUpdateEntryResultV3 Example: {"catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"archived_at":"2021-08-17T14:28:57.801578Z","attribute_values":{"abc123":{"array_value":[{"label":"Lawrence Jones","literal":"SEV123"}],"value":{"label":"Lawrence Jones","literal":"SEV123"}}},"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","created_at":"2021-08-17T13:28:57.801578Z","external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call","rank":3,"updated_at":"2021-08-17T13:28:57.801578Z"},"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
+// CatalogUpdateEntryResultV3 Example: {"catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"archived_at":"2021-08-17T14:28:57.801578Z","attribute_values":{"abc123":{"array_value":[{"label":"Lawrence Jones","literal":"SEV123"}],"value":{"label":"Lawrence Jones","literal":"SEV123"}}},"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","created_at":"2021-08-17T13:28:57.801578Z","external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call","rank":3,"updated_at":"2021-08-17T13:28:57.801578Z"},"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
 type CatalogUpdateEntryResultV3 struct {
 	// CatalogEntry Example: {"aliases":["lawrence@incident.io","lawrence"],"archived_at":"2021-08-17T14:28:57.801578Z","attribute_values":{"abc123":{"array_value":[{"label":"Lawrence Jones","literal":"SEV123"}],"value":{"label":"Lawrence Jones","literal":"SEV123"}}},"catalog_type_id":"01FCNDV6P870EA6S7TK1DSYDG0","created_at":"2021-08-17T13:28:57.801578Z","external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call","rank":3,"updated_at":"2021-08-17T13:28:57.801578Z"}
 	CatalogEntry CatalogEntryV3 `json:"catalog_entry"`
 
-	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
+	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
 	CatalogType CatalogTypeV3 `json:"catalog_type"`
 }
 
@@ -10054,9 +10391,9 @@ type CatalogUpdateTypeResultV2 struct {
 	CatalogType CatalogTypeV2 `json:"catalog_type"`
 }
 
-// CatalogUpdateTypeResultV3 Example: {"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
+// CatalogUpdateTypeResultV3 Example: {"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
 type CatalogUpdateTypeResultV3 struct {
-	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
+	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
 	CatalogType CatalogTypeV3 `json:"catalog_type"`
 }
 
@@ -10084,9 +10421,9 @@ type CatalogUpdateTypeSchemaResultV2 struct {
 	CatalogType CatalogTypeV2 `json:"catalog_type"`
 }
 
-// CatalogUpdateTypeSchemaResultV3 Example: {"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
+// CatalogUpdateTypeSchemaResultV3 Example: {"catalog_type":{"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}}
 type CatalogUpdateTypeSchemaResultV3 struct {
-	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
+	// CatalogType Example: {"annotations":{"incident.io/catalog-importer/id":"id-of-config"},"categories":["customer"],"color":"yellow","created_at":"2021-08-17T13:28:57.801578Z","description":"Represents Kubernetes clusters that we run inside of GKE.","dynamic_resource_parameter":"abc123","engine_resource_type":"CatalogEntry[\"PagerDutyService\"]","estimated_count":7,"icon":"alert","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_editable":false,"is_team_type":false,"last_synced_at":"2021-08-17T13:28:57.801578Z","name":"Kubernetes Cluster","owning_team_ids":["01G0J1EXE7AXZ2C93K61WBPYEH"],"ranked":true,"registry_type":"PagerDutyService","required_integrations":["pager_duty"],"schema":{"attributes":[{"array":false,"backlink_attribute":"abc123","id":"01GW2G3V0S59R238FAHPDS1R66","mode":"","name":"tier","path":[{"attribute_id":"abc123","attribute_name":"abc123"}],"type":"Custom[\"Service\"]"}],"version":1},"source_repo_url":"https://github.com/my-company/incident-io-catalog","type_name":"Custom[\"BackstageGroup\"]","updated_at":"2021-08-17T13:28:57.801578Z","use_name_as_identifier":true}
 	CatalogType CatalogTypeV3 `json:"catalog_type"`
 }
 
@@ -11318,7 +11655,7 @@ type EscalationPathNodeDelayV2 struct {
 // Example: active
 type EscalationPathNodeDelayV2DelayIntervalCondition string
 
-// EscalationPathNodeIfElsePayloadV2 Example: {"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
+// EscalationPathNodeIfElsePayloadV2 Example: {"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
 type EscalationPathNodeIfElsePayloadV2 struct {
 	// Conditions The condition that defines which branch to take
 	//
@@ -11327,16 +11664,16 @@ type EscalationPathNodeIfElsePayloadV2 struct {
 
 	// ElsePath The nodes that form the levels if our condition is not met
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	ElsePath []EscalationPathNodePayloadV2 `json:"else_path"`
 
 	// ThenPath The nodes that form the levels if our condition is met
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	ThenPath []EscalationPathNodePayloadV2 `json:"then_path"`
 }
 
-// EscalationPathNodeIfElseV2 Example: {"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
+// EscalationPathNodeIfElseV2 Example: {"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
 type EscalationPathNodeIfElseV2 struct {
 	// Conditions The condition that defines which branch to take
 	//
@@ -11345,16 +11682,16 @@ type EscalationPathNodeIfElseV2 struct {
 
 	// ElsePath The nodes that form the levels if our condition is not met
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	ElsePath []EscalationPathNodeV2 `json:"else_path"`
 
 	// ThenPath The nodes that form the levels if our condition is met
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	ThenPath []EscalationPathNodeV2 `json:"then_path"`
 }
 
-// EscalationPathNodeLevelV2 Example: {"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
+// EscalationPathNodeLevelV2 Example: {"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
 type EscalationPathNodeLevelV2 struct {
 	// AckMode Controls the behaviour of acknowledgements for this level, with 'first' cancelling all other escalations on the same level when someone acks
 	//
@@ -11426,7 +11763,7 @@ type EscalationPathNodeNotifyChannelV2 struct {
 // Example: active
 type EscalationPathNodeNotifyChannelV2TimeToAckIntervalCondition string
 
-// EscalationPathNodePayloadV2 Example: {"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}
+// EscalationPathNodePayloadV2 Example: {"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}
 type EscalationPathNodePayloadV2 struct {
 	// Delay Example: {"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
 	Delay *EscalationPathNodeDelayV2 `json:"delay,omitempty"`
@@ -11438,10 +11775,10 @@ type EscalationPathNodePayloadV2 struct {
 	// Example: 01FCNDV6P870EA6S7TK1DSYDG0
 	Id string `json:"id"`
 
-	// IfElse Example: {"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
+	// IfElse Example: {"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
 	IfElse *EscalationPathNodeIfElsePayloadV2 `json:"if_else,omitempty"`
 
-	// Level Example: {"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
+	// Level Example: {"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
 	Level *EscalationPathNodeLevelV2 `json:"level,omitempty"`
 
 	// NotifyChannel Example: {"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
@@ -11486,7 +11823,7 @@ type EscalationPathNodeRepeatV2 struct {
 	ToNode string `json:"to_node"`
 }
 
-// EscalationPathNodeV2 Example: {"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}
+// EscalationPathNodeV2 Example: {"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}
 type EscalationPathNodeV2 struct {
 	// Delay Example: {"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
 	Delay *EscalationPathNodeDelayV2 `json:"delay,omitempty"`
@@ -11498,10 +11835,10 @@ type EscalationPathNodeV2 struct {
 	// Example: 01FCNDV6P870EA6S7TK1DSYDG0
 	Id string `json:"id"`
 
-	// IfElse Example: {"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
+	// IfElse Example: {"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"then_path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]}
 	IfElse *EscalationPathNodeIfElseV2 `json:"if_else,omitempty"`
 
-	// Level Example: {"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
+	// Level Example: {"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
 	Level *EscalationPathNodeLevelV2 `json:"level,omitempty"`
 
 	// NotifyChannel Example: {"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"}
@@ -11615,7 +11952,7 @@ type EscalationPathTargetV2Type string
 // Example: high
 type EscalationPathTargetV2Urgency string
 
-// EscalationPathV2 Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+// EscalationPathV2 Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 type EscalationPathV2 struct {
 	// CurrentResponders Users who are currently on-call for this escalation path
 	//
@@ -11634,7 +11971,7 @@ type EscalationPathV2 struct {
 
 	// Path The nodes that form the levels and branches of this escalation path.
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	Path []EscalationPathNodeV2 `json:"path"`
 
 	// RepeatConfig Example: {"delay_repeat_on_activity":false,"repeat_after_seconds":1800}
@@ -11732,13 +12069,13 @@ type EscalationsCreateExternalEscalationPathPayloadV2 struct {
 	ExternalEscalationPathId string `json:"external_escalation_path_id"`
 }
 
-// EscalationsCreateExternalEscalationPathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
+// EscalationsCreateExternalEscalationPathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
 type EscalationsCreateExternalEscalationPathResultV2 struct {
-	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
 }
 
-// EscalationsCreatePathPayloadV2 Example: {"name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+// EscalationsCreatePathPayloadV2 Example: {"name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 type EscalationsCreatePathPayloadV2 struct {
 	// Name The name of this escalation path, for the user's reference.
 	//
@@ -11747,7 +12084,7 @@ type EscalationsCreatePathPayloadV2 struct {
 
 	// Path The nodes that form the levels and branches of this escalation path.
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	Path []EscalationPathNodePayloadV2 `json:"path"`
 
 	// RepeatConfig Example: {"delay_repeat_on_activity":false,"repeat_after_seconds":1800}
@@ -11764,9 +12101,9 @@ type EscalationsCreatePathPayloadV2 struct {
 	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
 }
 
-// EscalationsCreatePathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
+// EscalationsCreatePathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
 type EscalationsCreatePathResultV2 struct {
-	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
 }
 
@@ -11818,9 +12155,9 @@ type EscalationsListExternalEscalationPathsResultV2 struct {
 	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
 }
 
-// EscalationsListPathsResultV2 Example: {"escalation_paths":[{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}}
+// EscalationsListPathsResultV2 Example: {"escalation_paths":[{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}}
 type EscalationsListPathsResultV2 struct {
-	// EscalationPaths Example: [{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}]
+	// EscalationPaths Example: [{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}]
 	EscalationPaths []EscalationPathV2 `json:"escalation_paths"`
 
 	// PaginationMeta Example: {"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25}
@@ -11836,9 +12173,9 @@ type EscalationsListResultV2 struct {
 	PaginationMeta PaginationMetaResultV2 `json:"pagination_meta"`
 }
 
-// EscalationsShowPathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
+// EscalationsShowPathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
 type EscalationsShowPathResultV2 struct {
-	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
 }
 
@@ -11848,7 +12185,7 @@ type EscalationsShowResultV2 struct {
 	Escalation EscalationV2 `json:"escalation"`
 }
 
-// EscalationsUpdatePathPayloadV2 Example: {"name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+// EscalationsUpdatePathPayloadV2 Example: {"name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 type EscalationsUpdatePathPayloadV2 struct {
 	// Name The name of this escalation path, for the user's reference.
 	//
@@ -11857,7 +12194,7 @@ type EscalationsUpdatePathPayloadV2 struct {
 
 	// Path The nodes that form the levels and branches of this escalation path.
 	//
-	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
+	// Example: [{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":"one_of","param_bindings":[{"array_value":[{"literal":"SEV123","reference":"incident.severity"}],"value":{"literal":"SEV123","reference":"incident.severity"}}],"subject":"incident.severity"}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}]
 	Path []EscalationPathNodePayloadV2 `json:"path"`
 
 	// RepeatConfig Example: {"delay_repeat_on_activity":false,"repeat_after_seconds":1800}
@@ -11874,9 +12211,9 @@ type EscalationsUpdatePathPayloadV2 struct {
 	WorkingHours *[]WeekdayIntervalConfigV2 `json:"working_hours,omitempty"`
 }
 
-// EscalationsUpdatePathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
+// EscalationsUpdatePathResultV2 Example: {"escalation_path":{"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}}
 type EscalationsUpdatePathResultV2 struct {
-	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
+	// EscalationPath Example: {"current_responders":[{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"}],"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Urgent Support","path":[{"delay":{"delay_interval_condition":"active","delay_seconds":300,"delay_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"id":"01FCNDV6P870EA6S7TK1DSYDG0","if_else":{"conditions":[{"operation":{"label":"Lawrence Jones","value":"01FCQSP07Z74QMMYPDDGQB9FTG"},"param_bindings":[{"array_value":[{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}],"value":{"label":"Lawrence Jones","literal":"SEV123","reference":"incident.severity"}}],"subject":{"label":"Incident Severity","reference":"incident.severity"}}],"else_path":[{}],"then_path":[{}]},"level":{"ack_mode":"all","retry_config":{"attempts":3,"interval_seconds":300},"round_robin_config":{"enabled":false,"rotate_after_seconds":120},"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"notify_channel":{"targets":[{"id":"lawrencejones","schedule_mode":"currently_on_call","selected_rota_id":"01FCNDV6P870EA6S7TK1DSYDG0","type":"schedule","urgency":"high"}],"time_to_ack_interval_condition":"active","time_to_ack_seconds":1800,"time_to_ack_weekday_interval_config_id":"01FCNDV6P870EA6S7TK1DSYDG0"},"repeat":{"repeat_times":3,"to_node":"01FCNDV6P870EA6S7TK1DSYDG0"},"type":"if_else"}],"repeat_config":{"delay_repeat_on_activity":false,"repeat_after_seconds":1800},"team_ids":["01JPQA75EPNEES4479P16P4XAB"],"working_hours":[{"id":"abc123","name":"abc123","timezone":"abc123","weekday_intervals":[{"end_time":"17:00","start_time":"09:00","weekday":"monday"}]}]}
 	EscalationPath EscalationPathV2 `json:"escalation_path"`
 }
 
@@ -13030,16 +13367,26 @@ type IncidentDurationMetricV2 struct {
 	Name string `json:"name"`
 }
 
-// IncidentDurationMetricWithValueV2 Example: {"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}
+// IncidentDurationMetricWithValueV2 Example: {"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}
 type IncidentDurationMetricWithValueV2 struct {
 	// DurationMetric Example: {"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"}
 	DurationMetric IncidentDurationMetricV2 `json:"duration_metric"`
 
-	// ValueSeconds The calculated durations for this metric
+	// Status Whether value_seconds matches this incident's current timestamps ('success'), or why it doesn't
+	//
+	// Example: success
+	Status IncidentDurationMetricWithValueV2Status `json:"status"`
+
+	// ValueSeconds The duration we last calculated for this metric, omitted if we've never calculated one. If status isn't 'success', this incident's timestamps have changed since and no longer match this value
 	//
 	// Example: 10800
 	ValueSeconds *int64 `json:"value_seconds,omitempty"`
 }
+
+// IncidentDurationMetricWithValueV2Status Whether value_seconds matches this incident's current timestamps ('success'), or why it doesn't
+//
+// Example: success
+type IncidentDurationMetricWithValueV2Status string
 
 // IncidentEditPayloadV2 Example: {"call_url":"https://zoom.us/foo","custom_field_entries":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","values":[{"id":"01FCNDV6P870EA6S7TK1DSYDG0","value_catalog_entry_id":"01FCNDV6P870EA6S7TK1DSYDG0","value_link":"https://google.com/","value_numeric":"123.456","value_option_id":"01FCNDV6P870EA6S7TK1DSYDG0","value_text":"This is my text field, I hope you like it","value_timestamp":""}]}],"incident_role_assignments":[{"assignee":{"email":"bob@example.com","id":"01G0J1EXE7AXZ2C93K61WBPYEH","slack_user_id":"USER123"},"incident_role_id":"01FH5TZRWMNAFB0DZ23FD1TV96"}],"incident_status_id":"abc123","incident_timestamp_values":[{"incident_timestamp_id":"01FCNDV6P870EA6S7TK1DSYD5H","value":"2021-08-17T13:28:57.801578Z"}],"name":"Our database is sad","severity_id":"01G0J1EXE7AXZ2C93K61WBPYEH","slack_channel_name_override":"inc-123-database-down","summary":"Our database is really really sad, and we don't know why yet."}
 type IncidentEditPayloadV2 struct {
@@ -14155,7 +14502,7 @@ type IncidentV1Status string
 // Example: public
 type IncidentV1Visibility string
 
-// IncidentV2 Example: {"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}
+// IncidentV2 Example: {"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}
 type IncidentV2 struct {
 	// CallUrl The call URL attached to this incident
 	//
@@ -14177,7 +14524,7 @@ type IncidentV2 struct {
 
 	// DurationMetrics Incident duration metrics and their measurements for this incident
 	//
-	// Example: [{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}]
+	// Example: [{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}]
 	DurationMetrics *[]IncidentDurationMetricWithValueV2 `json:"duration_metrics,omitempty"`
 
 	// ExternalIssueReference Example: {"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"}
@@ -14473,9 +14820,9 @@ type IncidentsCreateResultV1 struct {
 	Incident IncidentV1 `json:"incident"`
 }
 
-// IncidentsCreateResultV2 Example: {"incident":{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}}
+// IncidentsCreateResultV2 Example: {"incident":{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}}
 type IncidentsCreateResultV2 struct {
-	// Incident Example: {"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}
+	// Incident Example: {"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}
 	Incident IncidentV2 `json:"incident"`
 }
 
@@ -14490,9 +14837,9 @@ type IncidentsEditPayloadV2 struct {
 	NotifyIncidentChannel bool `json:"notify_incident_channel"`
 }
 
-// IncidentsEditResultV2 Example: {"incident":{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}}
+// IncidentsEditResultV2 Example: {"incident":{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}}
 type IncidentsEditResultV2 struct {
-	// Incident Example: {"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}
+	// Incident Example: {"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}
 	Incident IncidentV2 `json:"incident"`
 }
 
@@ -14526,9 +14873,9 @@ type IncidentsListResultV1 struct {
 	PaginationMeta *PaginationMetaResultWithTotalV1 `json:"pagination_meta,omitempty"`
 }
 
-// IncidentsListResultV2 Example: {"incidents":[{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25,"total_record_count":238}}
+// IncidentsListResultV2 Example: {"incidents":[{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}],"pagination_meta":{"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25,"total_record_count":238}}
 type IncidentsListResultV2 struct {
-	// Incidents Example: [{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}]
+	// Incidents Example: [{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}]
 	Incidents []IncidentV2 `json:"incidents"`
 
 	// PaginationMeta Example: {"after":"01FCNDV6P870EA6S7TK1DSYDG0","page_size":25,"total_record_count":238}
@@ -14541,9 +14888,9 @@ type IncidentsShowResultV1 struct {
 	Incident IncidentV1 `json:"incident"`
 }
 
-// IncidentsShowResultV2 Example: {"incident":{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}}
+// IncidentsShowResultV2 Example: {"incident":{"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}}
 type IncidentsShowResultV2 struct {
-	// Incident Example: {"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}
+	// Incident Example: {"call_url":"https://zoom.us/foo","created_at":"2021-08-17T13:28:57.801578Z","creator":{"alert":{"id":"01GW2G3V0S59R238FAHPDS1R66","title":"*errors.withMessage: PG::Error failed to connect"},"api_key":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My test API key"},"user":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"workflow":{"id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"My little workflow"}},"custom_field_entries":[{"custom_field":{"description":"Which team is impacted by this issue","field_type":"single_select","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Affected Team","options":[{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"}]},"values":[{"value_catalog_entry":{"aliases":["lawrence@incident.io","lawrence"],"external_id":"761722cd-d1d7-477b-ac7e-90f9e079dc33","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Primary On-call"},"value_link":"https://google.com/","value_numeric":"123.456","value_option":{"custom_field_id":"01FCNDV6P870EA6S7TK1DSYDG0","id":"01FCNDV6P870EA6S7TK1DSYDG0","sort_key":10,"value":"Product"},"value_text":"This is my text field, I hope you like it"}]}],"duration_metrics":[{"duration_metric":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Lasted"},"status":"success","value_seconds":10800}],"external_issue_reference":{"issue_name":"INC-123","issue_permalink":"https://linear.app/incident-io/issue/INC-1609/find-copywriter-to-write-up","provider":"asana"},"has_debrief":false,"id":"01FDAG4SAP5TYPT98WGR2N7W91","incident_role_assignments":[{"assignee":{"email":"lisa@incident.io","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Lisa Karlin Curtis","role":"owner","slack_user_id":"U02AYNF2XJM"},"role":{"created_at":"2021-08-17T13:28:57.801578Z","description":"The person currently coordinating the incident","id":"01FCNDV6P870EA6S7TK1DSYDG0","instructions":"Take point on the incident; Make sure people are clear on responsibilities","name":"Incident Lead","required":false,"role_type":"lead","shortform":"lead","updated_at":"2021-08-17T13:28:57.801578Z"}}],"incident_status":{"category":"triage","created_at":"2021-08-17T13:28:57.801578Z","description":"Impact has been **fully mitigated**, and we're ready to learn from this incident.","id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Closed","rank":4,"updated_at":"2021-08-17T13:28:57.801578Z"},"incident_timestamp_values":[{"incident_timestamp":{"id":"01FCNDV6P870EA6S7TK1DSYD5H","name":"Impact started","rank":1},"value":{"value":"2021-08-17T13:28:57.801578Z"}}],"incident_type":{"create_in_triage":"always","created_at":"2021-08-17T13:28:57.801578Z","description":"Customer facing production outages","id":"01FCNDV6P870EA6S7TK1DSYDG0","is_default":false,"name":"Production Outage","private_incidents_only":false,"updated_at":"2021-08-17T13:28:57.801578Z"},"mode":"standard","name":"Our database is sad","permalink":"https://app.incident.io/incidents/123","postmortem_document_ids":["01FCNDV6P870EA6S7TK1DSYD5H"],"postmortem_document_url":"https://docs.google.com/my_doc_id","reference":"INC-123","severity":{"created_at":"2021-08-17T13:28:57.801578Z","description":"Issues with **low impact**.","id":"01FCNDV6P870EA6S7TK1DSYDG0","name":"Minor","rank":1,"updated_at":"2021-08-17T13:28:57.801578Z"},"slack_channel_id":"C02AW36C1M5","slack_channel_name":"inc-165-green-parrot","slack_team_id":"T02A1FSLE8J","summary":"Our database is really really sad, and we don't know why yet.","updated_at":"2021-08-17T13:28:57.801578Z","visibility":"public","workload_minutes_late":40.7,"workload_minutes_sleeping":0,"workload_minutes_total":60.7,"workload_minutes_working":20}
 	Incident IncidentV2 `json:"incident"`
 }
 
@@ -16363,10 +16710,11 @@ type ScheduleSyncRuleCreatePayloadV2SyncType string
 // schedule's members should flow into the target's Slack user group.
 //
 // sync_type decides who is synced: on_call syncs only the people currently on
-// call, while all_users syncs everyone on the schedule. By default every
-// rotation on the schedule is included; set rotation_id to scope the rule to a
-// single rotation. As the schedule's shifts change hands, we keep the target's
-// Slack user group membership in step with the rule.
+// call, next_on_call syncs the people on the next upcoming shift, and all_users
+// syncs everyone on the schedule. By default every rotation on the schedule is
+// included; set rotation_id to scope the rule to a single rotation. As the
+// schedule's shifts change hands, we keep the target's Slack user group
+// membership in step with the rule.
 //
 // permanent_member_user_ids names users who stay in the group whichever way the
 // shifts fall, on top of whoever sync_type selects.
@@ -16823,10 +17171,11 @@ type SchedulesCreateScheduleSyncRuleResultV2 struct {
 	// schedule's members should flow into the target's Slack user group.
 	//
 	// sync_type decides who is synced: on_call syncs only the people currently on
-	// call, while all_users syncs everyone on the schedule. By default every
-	// rotation on the schedule is included; set rotation_id to scope the rule to a
-	// single rotation. As the schedule's shifts change hands, we keep the target's
-	// Slack user group membership in step with the rule.
+	// call, next_on_call syncs the people on the next upcoming shift, and all_users
+	// syncs everyone on the schedule. By default every rotation on the schedule is
+	// included; set rotation_id to scope the rule to a single rotation. As the
+	// schedule's shifts change hands, we keep the target's Slack user group
+	// membership in step with the rule.
 	//
 	// permanent_member_user_ids names users who stay in the group whichever way the
 	// shifts fall, on top of whoever sync_type selects.
@@ -16990,10 +17339,11 @@ type SchedulesShowScheduleSyncRuleResultV2 struct {
 	// schedule's members should flow into the target's Slack user group.
 	//
 	// sync_type decides who is synced: on_call syncs only the people currently on
-	// call, while all_users syncs everyone on the schedule. By default every
-	// rotation on the schedule is included; set rotation_id to scope the rule to a
-	// single rotation. As the schedule's shifts change hands, we keep the target's
-	// Slack user group membership in step with the rule.
+	// call, next_on_call syncs the people on the next upcoming shift, and all_users
+	// syncs everyone on the schedule. By default every rotation on the schedule is
+	// included; set rotation_id to scope the rule to a single rotation. As the
+	// schedule's shifts change hands, we keep the target's Slack user group
+	// membership in step with the rule.
 	//
 	// permanent_member_user_ids names users who stay in the group whichever way the
 	// shifts fall, on top of whoever sync_type selects.
@@ -17087,10 +17437,11 @@ type SchedulesUpdateScheduleSyncRuleResultV2 struct {
 	// schedule's members should flow into the target's Slack user group.
 	//
 	// sync_type decides who is synced: on_call syncs only the people currently on
-	// call, while all_users syncs everyone on the schedule. By default every
-	// rotation on the schedule is included; set rotation_id to scope the rule to a
-	// single rotation. As the schedule's shifts change hands, we keep the target's
-	// Slack user group membership in step with the rule.
+	// call, next_on_call syncs the people on the next upcoming shift, and all_users
+	// syncs everyone on the schedule. By default every rotation on the schedule is
+	// included; set rotation_id to scope the rule to a single rotation. As the
+	// schedule's shifts change hands, we keep the target's Slack user group
+	// membership in step with the rule.
 	//
 	// permanent_member_user_ids names users who stay in the group whichever way the
 	// shifts fall, on top of whoever sync_type selects.
@@ -19826,6 +20177,30 @@ type AlertsV2ListParams struct {
 	IncludeMaintenanceWindow *map[string][]string `form:"include_maintenance_window,omitempty" json:"include_maintenance_window,omitempty"`
 }
 
+// CallSessionsV2ListParams defines parameters for CallSessionsV2List.
+type CallSessionsV2ListParams struct {
+	// PageSize Integer number of records to return
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// After A call session's ID. This endpoint will return a list of call sessions after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
+
+	// IncidentId Incident whose call sessions you want to list
+	IncidentId string `form:"incident_id" json:"incident_id"`
+}
+
+// CallTranscriptEntriesV2ListParams defines parameters for CallTranscriptEntriesV2List.
+type CallTranscriptEntriesV2ListParams struct {
+	// PageSize Integer number of records to return
+	PageSize *int64 `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// After A transcript entry's ID. This endpoint will return a list of entries after this ID in relation to the API response order.
+	After *string `form:"after,omitempty" json:"after,omitempty"`
+
+	// CallSessionId Call session whose transcript entries you want to list
+	CallSessionId string `form:"call_session_id" json:"call_session_id"`
+}
+
 // CatalogV2ListEntriesParams defines parameters for CatalogV2ListEntries.
 type CatalogV2ListEntriesParams struct {
 	// CatalogTypeId ID of this catalog type
@@ -20356,6 +20731,9 @@ type AlertRoutesV2UpdateJSONRequestBody = AlertRoutesUpdatePayloadV2
 
 // AlertSourcesV2CreateJSONRequestBody defines body for AlertSourcesV2Create for application/json ContentType.
 type AlertSourcesV2CreateJSONRequestBody = AlertSourcesCreatePayloadV2
+
+// AlertSourcesV2ValidateJSONRequestBody defines body for AlertSourcesV2Validate for application/json ContentType.
+type AlertSourcesV2ValidateJSONRequestBody = AlertSourcesValidatePayloadV2
 
 // AlertSourcesV2UpdateJSONRequestBody defines body for AlertSourcesV2Update for application/json ContentType.
 type AlertSourcesV2UpdateJSONRequestBody = AlertSourcesUpdatePayloadV2
@@ -21691,6 +22069,34 @@ type ClientInterface interface {
 	// Corresponds with POST /v2/alert_sources (the `AlertSourcesV2Create` operationId).
 	AlertSourcesV2Create(ctx context.Context, body AlertSourcesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// AlertSourcesV2ValidateWithBody Validate Alert Sources V2
+	//
+	// Check whether an alert source template is valid, without creating or updating anything.
+	//
+	// This validates the template in the same way a create or update would: expressions are
+	// compiled and checked against your alert schema and catalog, and merge strategies are checked
+	// against the attributes they bind to. Values that are only known once an alert source exists
+	// are not validated.
+	//
+	// Takes any type of body and a specified content type.
+	//
+	// Corresponds with POST /v2/alert_sources/actions/validate (the `AlertSourcesV2Validate` operationId).
+	AlertSourcesV2ValidateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AlertSourcesV2Validate Validate Alert Sources V2
+	//
+	// Check whether an alert source template is valid, without creating or updating anything.
+	//
+	// This validates the template in the same way a create or update would: expressions are
+	// compiled and checked against your alert schema and catalog, and merge strategies are checked
+	// against the attributes they bind to. Values that are only known once an alert source exists
+	// are not validated.
+	//
+	// Takes a body of the `application/json` content type.
+	//
+	// Corresponds with POST /v2/alert_sources/actions/validate (the `AlertSourcesV2Validate` operationId).
+	AlertSourcesV2Validate(ctx context.Context, body AlertSourcesV2ValidateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// AlertSourcesV2Delete Delete Alert Sources V2
 	//
 	// Delete an existing alert source in your account.
@@ -21840,6 +22246,22 @@ type ClientInterface interface {
 	//
 	// Corresponds with POST /v2/alerts/{id}/actions/resolve (the `AlertsV2Resolve` operationId).
 	AlertsV2Resolve(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CallSessionsV2List List Call Sessions V2
+	//
+	// List Scribe call sessions, newest first, filtered by incident.
+	//
+	// Corresponds with GET /v2/call_sessions (the `CallSessionsV2List` operationId).
+	CallSessionsV2List(ctx context.Context, params *CallSessionsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CallTranscriptEntriesV2List List Call Transcript Entries V2
+	//
+	// List transcript entries for a call session, oldest first.
+	//
+	// Returns an empty list if your organisation has disabled viewing transcripts.
+	//
+	// Corresponds with GET /v2/call_transcript_entries (the `CallTranscriptEntriesV2List` operationId).
+	CallTranscriptEntriesV2List(ctx context.Context, params *CallTranscriptEntriesV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CatalogV2ListEntries ListEntries Catalog V2
 	//
@@ -22607,8 +23029,23 @@ type ClientInterface interface {
 	//
 	// ### By status category
 	//
-	// Find all incidents that are in a status category. Possible values are "triage",
-	// "declined", "merged", "canceled", "live", "learning" and "closed":
+	// Find all incidents that are in a status category. Some categories use a different
+	// name in the API than the one shown in the dashboard — most notably "live" (shown as
+	// "Active") and "learning" (shown as "Post-incident"). The full mapping is:
+	//
+	// | API value  | Shown in app as |
+	// | ---------- | --------------- |
+	// | triage     | Triage          |
+	// | live       | Active          |
+	// | learning   | Post-incident   |
+	// | paused     | Paused          |
+	// | closed     | Closed          |
+	// | declined   | Declined        |
+	// | canceled   | Canceled        |
+	// | merged     | Merged          |
+	//
+	// For example, to find all incidents the dashboard shows as "Active", filter on the
+	// "live" category:
 	//
 	// 		curl --get 'https://api.incident.io/v2/incidents' \
 	// 			--data 'status_category[one_of]=live'
@@ -26340,6 +26777,54 @@ func (c *Client) AlertSourcesV2Create(ctx context.Context, body AlertSourcesV2Cr
 	return c.Client.Do(req)
 }
 
+// AlertSourcesV2ValidateWithBody Validate Alert Sources V2
+//
+// Check whether an alert source template is valid, without creating or updating anything.
+//
+// This validates the template in the same way a create or update would: expressions are
+// compiled and checked against your alert schema and catalog, and merge strategies are checked
+// against the attributes they bind to. Values that are only known once an alert source exists
+// are not validated.
+//
+// Takes any type of body and a specified content type.
+//
+// Corresponds with POST /v2/alert_sources/actions/validate (the `AlertSourcesV2Validate` operationId).
+func (c *Client) AlertSourcesV2ValidateWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertSourcesV2ValidateRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// AlertSourcesV2Validate Validate Alert Sources V2
+//
+// Check whether an alert source template is valid, without creating or updating anything.
+//
+// This validates the template in the same way a create or update would: expressions are
+// compiled and checked against your alert schema and catalog, and merge strategies are checked
+// against the attributes they bind to. Values that are only known once an alert source exists
+// are not validated.
+//
+// Takes a body of the `application/json` content type.
+//
+// Corresponds with POST /v2/alert_sources/actions/validate (the `AlertSourcesV2Validate` operationId).
+func (c *Client) AlertSourcesV2Validate(ctx context.Context, body AlertSourcesV2ValidateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAlertSourcesV2ValidateRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 // AlertSourcesV2Delete Delete Alert Sources V2
 //
 // Delete an existing alert source in your account.
@@ -26549,6 +27034,42 @@ func (c *Client) AlertsV2Show(ctx context.Context, id string, reqEditors ...Requ
 // Corresponds with POST /v2/alerts/{id}/actions/resolve (the `AlertsV2Resolve` operationId).
 func (c *Client) AlertsV2Resolve(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewAlertsV2ResolveRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CallSessionsV2List List Call Sessions V2
+//
+// List Scribe call sessions, newest first, filtered by incident.
+//
+// Corresponds with GET /v2/call_sessions (the `CallSessionsV2List` operationId).
+func (c *Client) CallSessionsV2List(ctx context.Context, params *CallSessionsV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCallSessionsV2ListRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CallTranscriptEntriesV2List List Call Transcript Entries V2
+//
+// List transcript entries for a call session, oldest first.
+//
+// Returns an empty list if your organisation has disabled viewing transcripts.
+//
+// Corresponds with GET /v2/call_transcript_entries (the `CallTranscriptEntriesV2List` operationId).
+func (c *Client) CallTranscriptEntriesV2List(ctx context.Context, params *CallTranscriptEntriesV2ListParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCallTranscriptEntriesV2ListRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -27938,8 +28459,23 @@ func (c *Client) IncidentUpdatesV2List(ctx context.Context, params *IncidentUpda
 //
 // ### By status category
 //
-// Find all incidents that are in a status category. Possible values are "triage",
-// "declined", "merged", "canceled", "live", "learning" and "closed":
+// Find all incidents that are in a status category. Some categories use a different
+// name in the API than the one shown in the dashboard — most notably "live" (shown as
+// "Active") and "learning" (shown as "Post-incident"). The full mapping is:
+//
+// | API value  | Shown in app as |
+// | ---------- | --------------- |
+// | triage     | Triage          |
+// | live       | Active          |
+// | learning   | Post-incident   |
+// | paused     | Paused          |
+// | closed     | Closed          |
+// | declined   | Declined        |
+// | canceled   | Canceled        |
+// | merged     | Merged          |
+//
+// For example, to find all incidents the dashboard shows as "Active", filter on the
+// "live" category:
 //
 //	curl --get 'https://api.incident.io/v2/incidents' \
 //		--data 'status_category[one_of]=live'
@@ -34401,6 +34937,46 @@ func NewAlertSourcesV2CreateRequestWithBody(server string, contentType string, b
 	return req, nil
 }
 
+// NewAlertSourcesV2ValidateRequest calls the generic AlertSourcesV2Validate builder with application/json body
+func NewAlertSourcesV2ValidateRequest(server string, body AlertSourcesV2ValidateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAlertSourcesV2ValidateRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAlertSourcesV2ValidateRequestWithBody constructs an http.Request for the AlertSourcesV2Validate method, with any body, and a specified content type
+func NewAlertSourcesV2ValidateRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/alert_sources/actions/validate")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewAlertSourcesV2DeleteRequest constructs an http.Request for the AlertSourcesV2Delete method
 func NewAlertSourcesV2DeleteRequest(server string, id string) (*http.Request, error) {
 	var err error
@@ -34735,6 +35311,154 @@ func NewAlertsV2ResolveRequest(server string, id string) (*http.Request, error) 
 	}
 
 	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCallSessionsV2ListRequest constructs an http.Request for the CallSessionsV2List method
+func NewCallSessionsV2ListRequest(server string, params *CallSessionsV2ListParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/call_sessions")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.PageSize != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "page_size", *params.PageSize, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.After != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "after", *params.After, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "incident_id", params.IncidentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCallTranscriptEntriesV2ListRequest constructs an http.Request for the CallTranscriptEntriesV2List method
+func NewCallTranscriptEntriesV2ListRequest(server string, params *CallTranscriptEntriesV2ListParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/call_transcript_entries")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.PageSize != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "page_size", *params.PageSize, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.After != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "after", *params.After, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "call_session_id", params.CallSessionId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -42890,6 +43614,34 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with POST /v2/alert_sources (the `AlertSourcesV2Create` operationId).
 	AlertSourcesV2CreateWithResponse(ctx context.Context, body AlertSourcesV2CreateJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertSourcesV2CreateResponse, error)
 
+	// AlertSourcesV2ValidateWithBodyWithResponse Validate Alert Sources V2
+	//
+	// Check whether an alert source template is valid, without creating or updating anything.
+	//
+	// This validates the template in the same way a create or update would: expressions are
+	// compiled and checked against your alert schema and catalog, and merge strategies are checked
+	// against the attributes they bind to. Values that are only known once an alert source exists
+	// are not validated.
+	//
+	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /v2/alert_sources/actions/validate (the `AlertSourcesV2Validate` operationId).
+	AlertSourcesV2ValidateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AlertSourcesV2ValidateResponse, error)
+
+	// AlertSourcesV2ValidateWithResponse Validate Alert Sources V2
+	//
+	// Check whether an alert source template is valid, without creating or updating anything.
+	//
+	// This validates the template in the same way a create or update would: expressions are
+	// compiled and checked against your alert schema and catalog, and merge strategies are checked
+	// against the attributes they bind to. Values that are only known once an alert source exists
+	// are not validated.
+	//
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /v2/alert_sources/actions/validate (the `AlertSourcesV2Validate` operationId).
+	AlertSourcesV2ValidateWithResponse(ctx context.Context, body AlertSourcesV2ValidateJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertSourcesV2ValidateResponse, error)
+
 	// AlertSourcesV2DeleteWithResponse Delete Alert Sources V2
 	//
 	// Delete an existing alert source in your account.
@@ -43049,6 +43801,26 @@ type ClientWithResponsesInterface interface {
 	//
 	// Corresponds with POST /v2/alerts/{id}/actions/resolve (the `AlertsV2Resolve` operationId).
 	AlertsV2ResolveWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*AlertsV2ResolveResponse, error)
+
+	// CallSessionsV2ListWithResponse List Call Sessions V2
+	//
+	// List Scribe call sessions, newest first, filtered by incident.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /v2/call_sessions (the `CallSessionsV2List` operationId).
+	CallSessionsV2ListWithResponse(ctx context.Context, params *CallSessionsV2ListParams, reqEditors ...RequestEditorFn) (*CallSessionsV2ListResponse, error)
+
+	// CallTranscriptEntriesV2ListWithResponse List Call Transcript Entries V2
+	//
+	// List transcript entries for a call session, oldest first.
+	//
+	// Returns an empty list if your organisation has disabled viewing transcripts.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /v2/call_transcript_entries (the `CallTranscriptEntriesV2List` operationId).
+	CallTranscriptEntriesV2ListWithResponse(ctx context.Context, params *CallTranscriptEntriesV2ListParams, reqEditors ...RequestEditorFn) (*CallTranscriptEntriesV2ListResponse, error)
 
 	// CatalogV2ListEntriesWithResponse ListEntries Catalog V2
 	//
@@ -43878,8 +44650,23 @@ type ClientWithResponsesInterface interface {
 	//
 	// ### By status category
 	//
-	// Find all incidents that are in a status category. Possible values are "triage",
-	// "declined", "merged", "canceled", "live", "learning" and "closed":
+	// Find all incidents that are in a status category. Some categories use a different
+	// name in the API than the one shown in the dashboard — most notably "live" (shown as
+	// "Active") and "learning" (shown as "Post-incident"). The full mapping is:
+	//
+	// | API value  | Shown in app as |
+	// | ---------- | --------------- |
+	// | triage     | Triage          |
+	// | live       | Active          |
+	// | learning   | Post-incident   |
+	// | paused     | Paused          |
+	// | closed     | Closed          |
+	// | declined   | Declined        |
+	// | canceled   | Canceled        |
+	// | merged     | Merged          |
+	//
+	// For example, to find all incidents the dashboard shows as "Active", filter on the
+	// "live" category:
 	//
 	// 		curl --get 'https://api.incident.io/v2/incidents' \
 	// 			--data 'status_category[one_of]=live'
@@ -48829,6 +49616,40 @@ func (r AlertSourcesV2CreateResponse) ContentType() string {
 	return ""
 }
 
+type AlertSourcesV2ValidateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// GetBody returns the raw response body bytes
+func (r AlertSourcesV2ValidateResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r AlertSourcesV2ValidateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AlertSourcesV2ValidateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r AlertSourcesV2ValidateResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type AlertSourcesV2DeleteResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -49062,6 +49883,88 @@ func (r AlertsV2ResolveResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r AlertsV2ResolveResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CallSessionsV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *CallSessionsListResultV2
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r CallSessionsV2ListResponse) GetJSON200() *CallSessionsListResultV2 {
+	return r.JSON200
+}
+
+// GetBody returns the raw response body bytes
+func (r CallSessionsV2ListResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r CallSessionsV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CallSessionsV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CallSessionsV2ListResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CallTranscriptEntriesV2ListResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *CallTranscriptEntriesListResultV2
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r CallTranscriptEntriesV2ListResponse) GetJSON200() *CallTranscriptEntriesListResultV2 {
+	return r.JSON200
+}
+
+// GetBody returns the raw response body bytes
+func (r CallTranscriptEntriesV2ListResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r CallTranscriptEntriesV2ListResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CallTranscriptEntriesV2ListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CallTranscriptEntriesV2ListResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -56622,6 +57525,46 @@ func (c *ClientWithResponses) AlertSourcesV2CreateWithResponse(ctx context.Conte
 	return ParseAlertSourcesV2CreateResponse(rsp)
 }
 
+// AlertSourcesV2ValidateWithBodyWithResponse Validate Alert Sources V2
+//
+// Check whether an alert source template is valid, without creating or updating anything.
+//
+// This validates the template in the same way a create or update would: expressions are
+// compiled and checked against your alert schema and catalog, and merge strategies are checked
+// against the attributes they bind to. Values that are only known once an alert source exists
+// are not validated.
+//
+// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /v2/alert_sources/actions/validate (the `AlertSourcesV2Validate` operationId).
+func (c *ClientWithResponses) AlertSourcesV2ValidateWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AlertSourcesV2ValidateResponse, error) {
+	rsp, err := c.AlertSourcesV2ValidateWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertSourcesV2ValidateResponse(rsp)
+}
+
+// AlertSourcesV2ValidateWithResponse Validate Alert Sources V2
+//
+// Check whether an alert source template is valid, without creating or updating anything.
+//
+// This validates the template in the same way a create or update would: expressions are
+// compiled and checked against your alert schema and catalog, and merge strategies are checked
+// against the attributes they bind to. Values that are only known once an alert source exists
+// are not validated.
+//
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /v2/alert_sources/actions/validate (the `AlertSourcesV2Validate` operationId).
+func (c *ClientWithResponses) AlertSourcesV2ValidateWithResponse(ctx context.Context, body AlertSourcesV2ValidateJSONRequestBody, reqEditors ...RequestEditorFn) (*AlertSourcesV2ValidateResponse, error) {
+	rsp, err := c.AlertSourcesV2Validate(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAlertSourcesV2ValidateResponse(rsp)
+}
+
 // AlertSourcesV2DeleteWithResponse Delete Alert Sources V2
 //
 // Delete an existing alert source in your account.
@@ -56821,6 +57764,38 @@ func (c *ClientWithResponses) AlertsV2ResolveWithResponse(ctx context.Context, i
 		return nil, err
 	}
 	return ParseAlertsV2ResolveResponse(rsp)
+}
+
+// CallSessionsV2ListWithResponse List Call Sessions V2
+//
+// List Scribe call sessions, newest first, filtered by incident.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /v2/call_sessions (the `CallSessionsV2List` operationId).
+func (c *ClientWithResponses) CallSessionsV2ListWithResponse(ctx context.Context, params *CallSessionsV2ListParams, reqEditors ...RequestEditorFn) (*CallSessionsV2ListResponse, error) {
+	rsp, err := c.CallSessionsV2List(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCallSessionsV2ListResponse(rsp)
+}
+
+// CallTranscriptEntriesV2ListWithResponse List Call Transcript Entries V2
+//
+// List transcript entries for a call session, oldest first.
+//
+// Returns an empty list if your organisation has disabled viewing transcripts.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /v2/call_transcript_entries (the `CallTranscriptEntriesV2List` operationId).
+func (c *ClientWithResponses) CallTranscriptEntriesV2ListWithResponse(ctx context.Context, params *CallTranscriptEntriesV2ListParams, reqEditors ...RequestEditorFn) (*CallTranscriptEntriesV2ListResponse, error) {
+	rsp, err := c.CallTranscriptEntriesV2List(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCallTranscriptEntriesV2ListResponse(rsp)
 }
 
 // CatalogV2ListEntriesWithResponse ListEntries Catalog V2
@@ -58024,8 +58999,23 @@ func (c *ClientWithResponses) IncidentUpdatesV2ListWithResponse(ctx context.Cont
 //
 // ### By status category
 //
-// Find all incidents that are in a status category. Possible values are "triage",
-// "declined", "merged", "canceled", "live", "learning" and "closed":
+// Find all incidents that are in a status category. Some categories use a different
+// name in the API than the one shown in the dashboard — most notably "live" (shown as
+// "Active") and "learning" (shown as "Post-incident"). The full mapping is:
+//
+// | API value  | Shown in app as |
+// | ---------- | --------------- |
+// | triage     | Triage          |
+// | live       | Active          |
+// | learning   | Post-incident   |
+// | paused     | Paused          |
+// | closed     | Closed          |
+// | declined   | Declined        |
+// | canceled   | Canceled        |
+// | merged     | Merged          |
+//
+// For example, to find all incidents the dashboard shows as "Active", filter on the
+// "live" category:
 //
 //	curl --get 'https://api.incident.io/v2/incidents' \
 //		--data 'status_category[one_of]=live'
@@ -62486,6 +63476,22 @@ func ParseAlertSourcesV2CreateResponse(rsp *http.Response) (*AlertSourcesV2Creat
 	return response, nil
 }
 
+// ParseAlertSourcesV2ValidateResponse parses an HTTP response from a AlertSourcesV2ValidateWithResponse call
+func ParseAlertSourcesV2ValidateResponse(rsp *http.Response) (*AlertSourcesV2ValidateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AlertSourcesV2ValidateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
 // ParseAlertSourcesV2DeleteResponse parses an HTTP response from a AlertSourcesV2DeleteWithResponse call
 func ParseAlertSourcesV2DeleteResponse(rsp *http.Response) (*AlertSourcesV2DeleteResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -62622,6 +63628,58 @@ func ParseAlertsV2ResolveResponse(rsp *http.Response) (*AlertsV2ResolveResponse,
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AlertsResolveResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCallSessionsV2ListResponse parses an HTTP response from a CallSessionsV2ListWithResponse call
+func ParseCallSessionsV2ListResponse(rsp *http.Response) (*CallSessionsV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CallSessionsV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CallSessionsListResultV2
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCallTranscriptEntriesV2ListResponse parses an HTTP response from a CallTranscriptEntriesV2ListWithResponse call
+func ParseCallTranscriptEntriesV2ListResponse(rsp *http.Response) (*CallTranscriptEntriesV2ListResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CallTranscriptEntriesV2ListResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CallTranscriptEntriesListResultV2
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/provider/incident_alert_source_modify_plan_test.go
+++ b/internal/provider/incident_alert_source_modify_plan_test.go
@@ -1,8 +1,10 @@
 package provider
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +25,9 @@ type fakeValidateAPI struct {
 	body   string
 
 	requests int
+	// lastPayload is what the provider sent, for cases that care about the request rather
+	// than the response.
+	lastPayload client.AlertSourcesValidatePayloadV2
 }
 
 func (f *fakeValidateAPI) start(t *testing.T) *client.ClientWithResponses {
@@ -31,6 +36,11 @@ func (f *fakeValidateAPI) start(t *testing.T) *client.ClientWithResponses {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/alert_sources/actions/validate", func(w http.ResponseWriter, r *http.Request) {
 		f.requests++
+
+		f.lastPayload = client.AlertSourcesValidatePayloadV2{}
+		if err := json.NewDecoder(r.Body).Decode(&f.lastPayload); err != nil {
+			t.Errorf("decoding the validate payload: %v", err)
+		}
 
 		status := f.status
 		if status == 0 {
@@ -134,6 +144,25 @@ func alertSourcePlanWithBinding(t *testing.T) tftypes.Value {
 	}
 	attributes["source_type"] = tftypes.NewValue(tftypes.String, "http")
 	attributes["template"] = tftypes.NewValue(templateType, template)
+
+	return tftypes.NewValue(objType, attributes)
+}
+
+// alertSourcePlanWithOwningTeamIDs builds a plan owned by one team that exists and one the
+// same apply creates, which Terraform plans as a known set holding an unknown element.
+func alertSourcePlanWithOwningTeamIDs(t *testing.T) tftypes.Value {
+	t.Helper()
+
+	objType := alertSourceSchemaType(t)
+
+	attributes := map[string]tftypes.Value{}
+	if err := alertSourcePlan(t, false).As(&attributes); err != nil {
+		t.Fatalf("reading the plan back: %v", err)
+	}
+	attributes["owning_team_ids"] = tftypes.NewValue(objType.AttributeTypes["owning_team_ids"], []tftypes.Value{
+		tftypes.NewValue(tftypes.String, "01TEAM"),
+		tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	})
 
 	return tftypes.NewValue(objType, attributes)
 }
@@ -271,6 +300,29 @@ func TestAlertSourceModifyPlanValidatesWhenOnlyComputedValuesAreUnknown(t *testi
 	}
 	if api.requests != 1 {
 		t.Errorf("expected the template to be checked, got %d requests", api.requests)
+	}
+}
+
+// owning_team_ids only gates permission on the validate endpoint, so an unknown team ID is
+// no reason to skip the check. Sending it as "" would be, though: the API reads that as a
+// team the caller has no permission on, and the plan would warn about a config that is fine.
+func TestAlertSourceModifyPlanOmitsUnknownOwningTeamIDs(t *testing.T) {
+	api := &fakeValidateAPI{}
+	plan := alertSourcePlanWithOwningTeamIDs(t)
+
+	resp := modifyAlertSourcePlan(t, api, &plan)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 1 {
+		t.Fatalf("expected the template to be checked, got %d requests", api.requests)
+	}
+	if api.lastPayload.OwningTeamIds == nil {
+		t.Fatal("expected the known team ID to be sent")
+	}
+	if got := *api.lastPayload.OwningTeamIds; !slices.Equal(got, []string{"01TEAM"}) {
+		t.Errorf("expected only the known team ID to be sent, got %v", got)
 	}
 }
 

--- a/internal/provider/incident_alert_source_modify_plan_test.go
+++ b/internal/provider/incident_alert_source_modify_plan_test.go
@@ -1,0 +1,304 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/incident-io/terraform-provider-incident/internal/client"
+)
+
+// fakeValidateAPI stands in for the validate endpoint during a plan. Counting requests is
+// what proves the plan stays quiet when there is nothing it could usefully check.
+type fakeValidateAPI struct {
+	// status is the response code, 204 when unset. body is served with it, so a case can
+	// assert the API's own words reach the user.
+	status int
+	body   string
+
+	requests int
+}
+
+func (f *fakeValidateAPI) start(t *testing.T) *client.ClientWithResponses {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/alert_sources/actions/validate", func(w http.ResponseWriter, r *http.Request) {
+		f.requests++
+
+		status := f.status
+		if status == 0 {
+			status = http.StatusNoContent
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if f.body != "" {
+			_, _ = w.Write([]byte(f.body))
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	api, err := client.New(t.Context(), "test-key", server.URL, "test")
+	if err != nil {
+		t.Fatalf("building client: %v", err)
+	}
+
+	return api
+}
+
+// alertSourcePlan builds a plan with every attribute null but source_type and template,
+// which is all validation reads. Filling from the schema's own type keeps these cases
+// working as the schema grows.
+func alertSourcePlan(t *testing.T, templateUnknown bool) tftypes.Value {
+	t.Helper()
+
+	objType := alertSourceSchemaType(t)
+
+	attributes := map[string]tftypes.Value{}
+	for name, attrType := range objType.AttributeTypes {
+		attributes[name] = tftypes.NewValue(attrType, nil)
+	}
+	attributes["source_type"] = tftypes.NewValue(tftypes.String, "http")
+
+	templateType := objType.AttributeTypes["template"]
+	if templateUnknown {
+		attributes["template"] = tftypes.NewValue(templateType, tftypes.UnknownValue)
+	} else {
+		attributes["template"] = nullFilledObject(t, templateType)
+	}
+
+	return tftypes.NewValue(objType, attributes)
+}
+
+// alertSourcePlanWithBinding builds a plan carrying one attribute binding whose
+// merge_strategy is unknown, which is how Terraform plans a binding the config doesn't set
+// one on.
+func alertSourcePlanWithBinding(t *testing.T) tftypes.Value {
+	t.Helper()
+
+	objType := alertSourceSchemaType(t)
+	templateType, ok := objType.AttributeTypes["template"].(tftypes.Object)
+	if !ok {
+		t.Fatal("expected template to be an object")
+	}
+
+	attributesType, ok := templateType.AttributeTypes["attributes"].(tftypes.Set)
+	if !ok {
+		t.Fatalf("expected template.attributes to be a set, got %s", templateType.AttributeTypes["attributes"])
+	}
+
+	bindingType, ok := attributesType.ElementType.(tftypes.Object)
+	if !ok {
+		t.Fatal("expected template.attributes elements to be objects")
+	}
+
+	binding := nullFilledObject(t, bindingType)
+	bindingAttributes := map[string]tftypes.Value{}
+	if err := binding.As(&bindingAttributes); err != nil {
+		t.Fatalf("reading the binding back: %v", err)
+	}
+	bindingAttributes["alert_attribute_id"] = tftypes.NewValue(tftypes.String, "01ATTRIBUTE")
+
+	// The binding object holds merge_strategy, and Terraform leaves it unknown.
+	inner, ok := bindingType.AttributeTypes["binding"].(tftypes.Object)
+	if !ok {
+		t.Fatal("expected the binding attribute to be an object")
+	}
+	innerAttributes := map[string]tftypes.Value{}
+	if err := nullFilledObject(t, inner).As(&innerAttributes); err != nil {
+		t.Fatalf("reading the inner binding back: %v", err)
+	}
+	innerAttributes["merge_strategy"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+	bindingAttributes["binding"] = tftypes.NewValue(inner, innerAttributes)
+
+	template := map[string]tftypes.Value{}
+	if err := nullFilledObject(t, templateType).As(&template); err != nil {
+		t.Fatalf("reading the template back: %v", err)
+	}
+	template["attributes"] = tftypes.NewValue(attributesType, []tftypes.Value{
+		tftypes.NewValue(bindingType, bindingAttributes),
+	})
+
+	attributes := map[string]tftypes.Value{}
+	for name, attrType := range objType.AttributeTypes {
+		attributes[name] = tftypes.NewValue(attrType, nil)
+	}
+	attributes["source_type"] = tftypes.NewValue(tftypes.String, "http")
+	attributes["template"] = tftypes.NewValue(templateType, template)
+
+	return tftypes.NewValue(objType, attributes)
+}
+
+func alertSourceSchemaType(t *testing.T) tftypes.Object {
+	t.Helper()
+
+	var schemaResp resource.SchemaResponse
+	NewIncidentAlertSourceResource().Schema(t.Context(), resource.SchemaRequest{}, &schemaResp)
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(t.Context()).(tftypes.Object)
+	if !ok {
+		t.Fatal("expected the alert source schema to be an object")
+	}
+
+	return objType
+}
+
+// nullFilledObject builds an object whose leaves are all null. Nested objects are built
+// rather than nulled, because the model's param-binding types don't accept a null.
+func nullFilledObject(t *testing.T, attrType tftypes.Type) tftypes.Value {
+	t.Helper()
+
+	objType, ok := attrType.(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected an object type, got %s", attrType)
+	}
+
+	attributes := map[string]tftypes.Value{}
+	for name, nested := range objType.AttributeTypes {
+		if _, nestedIsObject := nested.(tftypes.Object); nestedIsObject {
+			attributes[name] = nullFilledObject(t, nested)
+			continue
+		}
+
+		attributes[name] = tftypes.NewValue(nested, nil)
+	}
+
+	return tftypes.NewValue(objType, attributes)
+}
+
+// modifyAlertSourcePlan runs ModifyPlan against the fake API. A nil plan is a destroy.
+func modifyAlertSourcePlan(t *testing.T, api *fakeValidateAPI, plan *tftypes.Value) resource.ModifyPlanResponse {
+	t.Helper()
+
+	var schemaResp resource.SchemaResponse
+	NewIncidentAlertSourceResource().Schema(t.Context(), resource.SchemaRequest{}, &schemaResp)
+
+	planRaw := tftypes.NewValue(alertSourceSchemaType(t), nil)
+	if plan != nil {
+		planRaw = *plan
+	}
+
+	r := &IncidentAlertSourceResource{client: api.start(t)}
+
+	var resp resource.ModifyPlanResponse
+	r.ModifyPlan(t.Context(), resource.ModifyPlanRequest{
+		Plan: tfsdk.Plan{Schema: schemaResp.Schema, Raw: planRaw},
+	}, &resp)
+
+	return resp
+}
+
+func TestAlertSourceModifyPlanAcceptsValidTemplate(t *testing.T) {
+	api := &fakeValidateAPI{}
+	plan := alertSourcePlan(t, false)
+
+	resp := modifyAlertSourcePlan(t, api, &plan)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 1 {
+		t.Errorf("expected 1 request, got %d", api.requests)
+	}
+}
+
+// A 422 is the API rejecting this template, which is the whole point of the check, so it
+// fails the plan and repeats what the API said.
+func TestAlertSourceModifyPlanRejectsInvalidTemplate(t *testing.T) {
+	api := &fakeValidateAPI{
+		status: http.StatusUnprocessableEntity,
+		body:   `{"type":"validation_error","errors":[{"code":"invalid_value","message":"referenced resource not found in scope","source":{"field":"template.attributes.01ABC.binding"}}]}`,
+	}
+	plan := alertSourcePlan(t, false)
+
+	resp := modifyAlertSourcePlan(t, api, &plan)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected an error, got %+v", resp.Diagnostics)
+	}
+
+	detail := resp.Diagnostics.Errors()[0].Detail()
+	if !strings.Contains(detail, "template.attributes.01ABC.binding") {
+		t.Errorf("expected the field path in the diagnostic, got %q", detail)
+	}
+}
+
+// Any other status means the check didn't run: the endpoint isn't deployed yet, the API is
+// down. The config may be perfectly good, so this warns rather than failing the plan.
+// The 500 also covers the timeout: the shared client would retry it for minutes, so this
+// passing quickly is the bound doing its job.
+func TestAlertSourceModifyPlanWarnsWhenCheckUnavailable(t *testing.T) {
+	original := alertSourceValidateTimeout
+	alertSourceValidateTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { alertSourceValidateTimeout = original })
+
+	for _, status := range []int{http.StatusNotFound, http.StatusInternalServerError} {
+		api := &fakeValidateAPI{status: status}
+		plan := alertSourcePlan(t, false)
+
+		resp := modifyAlertSourcePlan(t, api, &plan)
+
+		if resp.Diagnostics.HasError() {
+			t.Errorf("status %d: expected no error, got %+v", status, resp.Diagnostics)
+		}
+		if resp.Diagnostics.WarningsCount() != 1 {
+			t.Errorf("status %d: expected 1 warning, got %+v", status, resp.Diagnostics)
+		}
+	}
+}
+
+// merge_strategy is Optional+Computed, so it is unknown in the plan for every binding the
+// config doesn't set it on — which is most of them. Treating that as unsettled skipped the
+// check on exactly the configs worth checking, so this guards the gate against tightening
+// back to "everything known".
+func TestAlertSourceModifyPlanValidatesWhenOnlyComputedValuesAreUnknown(t *testing.T) {
+	api := &fakeValidateAPI{}
+	plan := alertSourcePlanWithBinding(t)
+
+	resp := modifyAlertSourcePlan(t, api, &plan)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 1 {
+		t.Errorf("expected the template to be checked, got %d requests", api.requests)
+	}
+}
+
+// A template Terraform hasn't settled yet would validate against values that aren't there,
+// reporting errors the apply won't hit. So we don't ask.
+func TestAlertSourceModifyPlanSkipsUnknownTemplate(t *testing.T) {
+	api := &fakeValidateAPI{}
+	plan := alertSourcePlan(t, true)
+
+	resp := modifyAlertSourcePlan(t, api, &plan)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 0 {
+		t.Errorf("expected no request for an unsettled template, got %d", api.requests)
+	}
+}
+
+func TestAlertSourceModifyPlanSkipsDestroy(t *testing.T) {
+	api := &fakeValidateAPI{}
+
+	resp := modifyAlertSourcePlan(t, api, nil)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 0 {
+		t.Errorf("expected no request for a destroy, got %d", api.requests)
+	}
+}

--- a/internal/provider/incident_alert_source_modify_plan_test.go
+++ b/internal/provider/incident_alert_source_modify_plan_test.go
@@ -204,8 +204,17 @@ func nullFilledObject(t *testing.T, attrType tftypes.Type) tftypes.Value {
 	return tftypes.NewValue(objType, attributes)
 }
 
-// modifyAlertSourcePlan runs ModifyPlan against the fake API. A nil plan is a destroy.
+// modifyAlertSourcePlan runs ModifyPlan against the fake API, as a create: no prior state.
+// A nil plan is a destroy.
 func modifyAlertSourcePlan(t *testing.T, api *fakeValidateAPI, plan *tftypes.Value) resource.ModifyPlanResponse {
+	t.Helper()
+
+	return modifyAlertSourcePlanWithState(t, api, plan, tftypes.NewValue(alertSourceSchemaType(t), nil))
+}
+
+// modifyAlertSourcePlanWithState runs ModifyPlan against a resource that already exists,
+// for the cases that turn on how the plan differs from its state.
+func modifyAlertSourcePlanWithState(t *testing.T, api *fakeValidateAPI, plan *tftypes.Value, state tftypes.Value) resource.ModifyPlanResponse {
 	t.Helper()
 
 	var schemaResp resource.SchemaResponse
@@ -220,7 +229,8 @@ func modifyAlertSourcePlan(t *testing.T, api *fakeValidateAPI, plan *tftypes.Val
 
 	var resp resource.ModifyPlanResponse
 	r.ModifyPlan(t.Context(), resource.ModifyPlanRequest{
-		Plan: tfsdk.Plan{Schema: schemaResp.Schema, Raw: planRaw},
+		Plan:  tfsdk.Plan{Schema: schemaResp.Schema, Raw: planRaw},
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: state},
 	}, &resp)
 
 	return resp
@@ -323,6 +333,22 @@ func TestAlertSourceModifyPlanOmitsUnknownOwningTeamIDs(t *testing.T) {
 	}
 	if got := *api.lastPayload.OwningTeamIds; !slices.Equal(got, []string{"01TEAM"}) {
 		t.Errorf("expected only the known team ID to be sent, got %v", got)
+	}
+}
+
+// A plan that matches state changes nothing, so there is no apply to fail — and checking
+// anyway would cost a request per alert source on every plan.
+func TestAlertSourceModifyPlanSkipsUnchangedSource(t *testing.T) {
+	api := &fakeValidateAPI{}
+	plan := alertSourcePlan(t, false)
+
+	resp := modifyAlertSourcePlanWithState(t, api, &plan, plan)
+
+	if resp.Diagnostics.HasError() || resp.Diagnostics.WarningsCount() > 0 {
+		t.Errorf("expected no diagnostics, got %+v", resp.Diagnostics)
+	}
+	if api.requests != 0 {
+		t.Errorf("expected no request for an unchanged source, got %d", api.requests)
 	}
 }
 

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -14,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/incident-io/terraform-provider-incident/internal/apischema"
@@ -25,6 +28,7 @@ var (
 	_ resource.ResourceWithConfigure      = &IncidentAlertSourceResource{}
 	_ resource.ResourceWithImportState    = &IncidentAlertSourceResource{}
 	_ resource.ResourceWithValidateConfig = &IncidentAlertSourceResource{}
+	_ resource.ResourceWithModifyPlan     = &IncidentAlertSourceResource{}
 )
 
 type IncidentAlertSourceResource struct {
@@ -250,6 +254,141 @@ func (m useStateForUnknownIncludingNull) PlanModifyBool(ctx context.Context, req
 
 func NewIncidentAlertSourceResource() resource.Resource {
 	return &IncidentAlertSourceResource{}
+}
+
+// alertSourceValidateTimeout bounds the plan-time template check. Long enough that a
+// slow-but-working API still answers, short enough that an unhealthy one costs a plan
+// seconds rather than minutes. A var so tests don't have to wait it out.
+var alertSourceValidateTimeout = 10 * time.Second
+
+// ModifyPlan asks the API whether the planned template would be accepted, so a broken
+// expression shows up in the plan instead of part way through an apply.
+//
+// It can't live in ValidateConfig, which is also called by `terraform validate` — that
+// runs the provider without configuring it, so there's no client to ask with.
+func (r *IncidentAlertSourceResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// A destroy plans no template, and an unconfigured provider has no client.
+	if r.client == nil || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// An expression pointing at, say, a catalog type this same apply creates is unknown
+	// until it exists. Validating around the gaps would report errors the apply won't hit,
+	// so leave those configs alone.
+	if !alertSourceTemplateSettled(req.Plan.Raw) {
+		return
+	}
+
+	var data models.AlertSourceResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The schema makes template required, so this shouldn't happen — but ToPayload has a
+	// value receiver, and a panic in a plan modifier takes the whole provider down over a
+	// check that is only advisory.
+	if data.Template == nil {
+		return
+	}
+
+	// The shared client retries a 5xx ten times with exponential backoff, which is right
+	// for a read an apply depends on and far too patient for an advisory check: it would
+	// stall a plan for minutes per alert source. Give up quickly and warn instead.
+	ctx, cancel := context.WithTimeout(ctx, alertSourceValidateTimeout)
+	defer cancel()
+
+	_, err := r.client.AlertSourcesV2ValidateWithResponse(ctx, client.AlertSourcesValidatePayloadV2{
+		SourceType:    client.AlertSourcesValidatePayloadV2SourceType(data.SourceType.ValueString()),
+		Template:      data.Template.ToPayload(),
+		OwningTeamIds: owningTeamIDsPayload(data.OwningTeamIDs),
+	})
+	if err == nil {
+		return
+	}
+
+	// 422 is the API telling us this template is wrong, which is the whole point.
+	var httpErr client.HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnprocessableEntity {
+		resp.Diagnostics.AddAttributeError(path.Root("template"),
+			"Invalid alert source template", httpErr.Error())
+		return
+	}
+
+	// Anything else means the check didn't run, not that the config is bad: the endpoint
+	// isn't deployed yet, the API is down, the request timed out. Warn, because failing
+	// here would break plans over a config that may be perfectly good.
+	resp.Diagnostics.AddAttributeWarning(path.Root("template"),
+		"Could not validate the alert source template",
+		fmt.Sprintf("The template was not checked, and may still be rejected when you apply: %s", err))
+}
+
+// alertSourceComputedLeaves are the template's Optional+Computed attributes, which sit
+// unknown in the plan whenever the config leaves them out. The API fills them in, and the
+// payload we send leaves them out too, so validation still describes what an apply would
+// do — treating them as unsettled would skip the check on any config with a binding.
+var alertSourceComputedLeaves = map[string]bool{
+	"merge_strategy": true,
+	"is_private":     true,
+}
+
+// alertSourceTemplateSettled reports whether the values validation reads are known. An
+// expression pointing at a catalog type this same apply creates is unknown until it
+// exists, and checking around that reports errors the apply won't hit.
+func alertSourceTemplateSettled(plan tftypes.Value) bool {
+	var attributes map[string]tftypes.Value
+	if err := plan.As(&attributes); err != nil {
+		return false
+	}
+
+	if !attributes["source_type"].IsKnown() {
+		return false
+	}
+
+	settled := true
+	err := tftypes.Walk(attributes["template"], func(steps *tftypes.AttributePath, value tftypes.Value) (bool, error) {
+		if value.IsKnown() {
+			return true, nil
+		}
+
+		if name, ok := lastAttributeName(steps); ok && alertSourceComputedLeaves[name] {
+			return false, nil
+		}
+
+		settled = false
+
+		return false, nil
+	})
+	if err != nil {
+		return false
+	}
+
+	return settled
+}
+
+func lastAttributeName(steps *tftypes.AttributePath) (string, bool) {
+	if steps == nil || len(steps.Steps()) == 0 {
+		return "", false
+	}
+
+	name, ok := steps.Steps()[len(steps.Steps())-1].(tftypes.AttributeName)
+
+	return string(name), ok
+}
+
+func owningTeamIDsPayload(configured types.Set) *[]string {
+	if configured.IsNull() || configured.IsUnknown() {
+		return nil
+	}
+
+	teamIDs := []string{}
+	for _, elem := range configured.Elements() {
+		if str, ok := elem.(types.String); ok {
+			teamIDs = append(teamIDs, str.ValueString())
+		}
+	}
+
+	return &teamIDs
 }
 
 func (r *IncidentAlertSourceResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -494,17 +633,7 @@ func (r *IncidentAlertSourceResource) Create(ctx context.Context, req resource.C
 	}
 
 	result, err := lockForAlertConfig(ctx, func(ctx context.Context) (*client.AlertSourcesV2CreateResponse, error) {
-		var owningTeamIDs *[]string
-		if !data.OwningTeamIDs.IsNull() {
-			teamIDs := []string{}
-			for _, elem := range data.OwningTeamIDs.Elements() {
-				if str, ok := elem.(types.String); ok {
-					teamIDs = append(teamIDs, str.ValueString())
-				}
-			}
-
-			owningTeamIDs = &teamIDs
-		}
+		owningTeamIDs := owningTeamIDsPayload(data.OwningTeamIDs)
 
 		payload := client.AlertSourcesCreatePayloadV2{
 			Name:              data.Name.ValueString(),

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -272,6 +272,12 @@ func (r *IncidentAlertSourceResource) ModifyPlan(ctx context.Context, req resour
 		return
 	}
 
+	// A source the plan doesn't change isn't going to be applied, so there is nothing to
+	// warn about — and checking every source on every plan is a request each.
+	if req.Plan.Raw.Equal(req.State.Raw) {
+		return
+	}
+
 	// An expression pointing at, say, a catalog type this same apply creates is unknown
 	// until it exists. Validating around the gaps would report errors the apply won't hit,
 	// so leave those configs alone.

--- a/internal/provider/incident_alert_source_resource.go
+++ b/internal/provider/incident_alert_source_resource.go
@@ -376,6 +376,8 @@ func lastAttributeName(steps *tftypes.AttributePath) (string, bool) {
 	return string(name), ok
 }
 
+// owningTeamIDsPayload drops unknown elements, which only a plan has: sending them would
+// send "" as a team ID, which the API reads as a team the caller has no permission on.
 func owningTeamIDsPayload(configured types.Set) *[]string {
 	if configured.IsNull() || configured.IsUnknown() {
 		return nil
@@ -383,7 +385,7 @@ func owningTeamIDsPayload(configured types.Set) *[]string {
 
 	teamIDs := []string{}
 	for _, elem := range configured.Elements() {
-		if str, ok := elem.(types.String); ok {
+		if str, ok := elem.(types.String); ok && !str.IsUnknown() {
 			teamIDs = append(teamIDs, str.ValueString())
 		}
 	}


### PR DESCRIPTION
An `incident_alert_source`'s expressions were only checked when you applied. A reference that didn't resolve, or a merge strategy the attribute doesn't support, failed part way through the apply — after Terraform had already created other resources.

`ModifyPlan` now asks the API whether the planned template would be accepted, using `POST /v2/alert_sources/actions/validate`. A rejection fails the plan and repeats what the API said, field path included, so the plan-time error reads like the apply-time one.

It isn't in `ValidateConfig`, which `terraform validate` also calls: that runs the provider without configuring it, so there's no client to ask with.

## What it deliberately doesn't check

**Templates Terraform hasn't settled.** An expression pointing at a catalog type the same apply creates is unknown until it exists, and checking around the gaps would report errors the apply won't hit.

Optional+Computed attributes are exempt from that, which matters more than it sounds: `merge_strategy` is unknown for every binding whose config doesn't set one, so counting it would have skipped the check on most configs that have a binding at all. The API fills it in either way, and the payload leaves it out. There's a test for this specifically.

**Sources the plan doesn't change.** There's no apply to fail, and checking anyway would cost a request per alert source on every plan.

**Anything that isn't a rejection warns rather than fails.** A 404 before the endpoint is available, a 500, a timeout — the check didn't run, which doesn't mean the config is wrong. The call is bounded by a short timeout for the same reason: the shared client retries a 5xx ten times with backoff, which would otherwise stall a plan for minutes per alert source over an advisory check.

## Testing

Unit tests cover a valid template, a rejection, an unavailable check, a template with unknown values, an unchanged source, a destroy, and the computed-values case above. The last one was verified to fail against the earlier, coarser gate.

Also driven end to end against the real endpoint, with this provider wired in via `dev_overrides`:

- a template binding a non-existent attribute fails the plan with the API's own message and `"pointer": "template.attributes"`
- the same config with that attribute removed plans cleanly

## Notes for review

- The vendored client is a wholesale refresh, so `client.gen.go` and the schema carry unrelated API surface that had accumulated since they were last regenerated. The hand-written change is `incident_alert_source_resource.go` plus the test.
- `owningTeamIDsPayload` is extracted because plan and apply have to send the same team IDs — the permission check depends on them. Unknown elements are dropped, so a plan doesn't send `""` as a team ID.
- Merging should wait until the endpoint is available, or every plan warns until it is.
